### PR TITLE
feat: Add 'Close' button to TrainDetailsView

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -90,6 +90,13 @@ struct TrainDetailsView: View {
         .navigationTitle(viewModel.train != nil ? "Train \(viewModel.train!.trainId)" : "Loading...")
         .navigationBarTitleDisplayMode(.inline)
         .glassmorphicNavigationBar()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Close") {
+                    appState.navigationPath.removeAll()
+                }
+            }
+        }
         .task {
             await viewModel.loadTrainDetails(fromStationCode: appState.departureStationCode)
         }


### PR DESCRIPTION
This commit introduces a 'Close' button to the navigation bar of the TrainDetailsView in the iOS app.

The button is positioned on the trailing side of the navigation bar. Tapping this button clears the navigation stack, returning you directly to the initial TripSelectionView (the "Where would you like to go?" screen).

This provides you with a quick way to exit the train details screen and start a new route search, complementing the existing 'Back' button functionality.