### PR TITLE
Refactor: Consolidate experimental features in TrainDetailsView

### DIFF
--- a/ios/TrackRat/Views/Components/LiveActivityControls.swift
+++ b/ios/TrackRat/Views/Components/LiveActivityControls.swift
@@ -39,7 +39,7 @@ struct LiveActivityControls: View {
                         }
                     }
                     .font(.caption.bold())
-                    .foregroundColor(.red)
+                    .foregroundColor(Color(hex: "667eea"))
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                     .background(
@@ -50,7 +50,7 @@ struct LiveActivityControls: View {
                 .padding()
                 .background(
                     RoundedRectangle(cornerRadius: 12)
-                        .fill(.green.opacity(0.8))
+                        .fill(Color.blue.opacity(0.7))
                 )
             } else {
                 // Start Live Activity button

--- a/ios/TrackRat/Views/Screens/ExperimentalFeaturesView.swift
+++ b/ios/TrackRat/Views/Screens/ExperimentalFeaturesView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct ExperimentalFeaturesView: View {
+    @EnvironmentObject private var appState: AppState
+    @ObservedObject var viewModel: TrainDetailsViewModel // Assuming viewModel is passed from TrainDetailsView
+    @State private var isExpanded = false
+    @State private var showingHistory = false // To control the presentation of HistoricalDataView
+
+    // Add a train property that can be passed from the parent view
+    let train: Train
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Image(systemName: "beaker.fill") // Using a science-related icon for experimental features
+                    .foregroundColor(Color(hex: "667eea")) // Consistent with app's purple theme
+                Text("Experimental Features")
+                    .font(.headline)
+                    .foregroundColor(Color.primary) // Adapts to light/dark mode
+                Spacer()
+                Button(action: { isExpanded.toggle() }) {
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundColor(Color.secondary) // Standard secondary color
+                }
+            }
+            .padding()
+            .background(Color(UIColor.systemGray6)) // A light gray background, common in iOS settings
+            .cornerRadius(12)
+            .onTapGesture {
+                isExpanded.toggle()
+            }
+
+            // Expanded details
+            if isExpanded {
+                VStack(spacing: 20) {
+                    // Live Activity controls
+                    if #available(iOS 16.1, *) {
+                        LiveActivityControls(
+                            train: train,
+                            origin: appState.selectedDeparture ?? "",
+                            destination: appState.selectedDestination ?? "",
+                            originCode: appState.departureStationCode ?? "",
+                            destinationCode: Stations.getStationCode(appState.selectedDestination ?? "") ?? ""
+                        )
+                        .padding(.horizontal)
+                    }
+
+                    // Consolidated data section
+                    if train.isConsolidated {
+                        ConsolidatedDataCard(train: train) // Assuming this card is already styled appropriately or will be
+                            .padding(.horizontal)
+                    }
+
+                    // Show history button
+                    Button {
+                        showingHistory = true
+                    } label: {
+                        HStack {
+                            Image(systemName: "clock.arrow.circlepath")
+                            Text("Details from past trains")
+                                .font(.subheadline)
+                        }
+                        .foregroundColor(Color(hex: "667eea")) // Use accent color
+                    }
+                    .padding(.horizontal)
+                    .padding(.bottom) // Add some padding at the bottom of the expanded section
+                }
+                .sheet(isPresented: $showingHistory) {
+                    HistoricalDataView(train: train) // Present HistoricalDataView as a sheet
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: isExpanded)
+    }
+}

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -4,7 +4,7 @@ import Combine
 struct TrainDetailsView: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var viewModel: TrainDetailsViewModel
-    @State private var showingHistory = false
+    // @State private var showingHistory = false // REMOVE THIS LINE
     
     let trainId: Int  // Keep for backwards compatibility
     
@@ -48,37 +48,40 @@ struct TrainDetailsView: View {
                         }
                     } else if let train = viewModel.train {
                         VStack(spacing: 20) {
-                            // Live Activity controls
-                            if #available(iOS 16.1, *) {
-                                LiveActivityControls(
-                                    train: train,
-                                    origin: appState.selectedDeparture ?? "",
-                                    destination: appState.selectedDestination ?? "",
-                                    originCode: appState.departureStationCode ?? "",
-                                    destinationCode: Stations.getStationCode(appState.selectedDestination ?? "") ?? ""
-                                )
-                            }
+                            // Live Activity controls -- REMOVE THIS BLOCK
+                            // if #available(iOS 16.1, *) {
+                            //     LiveActivityControls(
+                            //         train: train,
+                            //         origin: appState.selectedDeparture ?? "",
+                            //         destination: appState.selectedDestination ?? "",
+                            //         originCode: appState.departureStationCode ?? "",
+                            //         destinationCode: Stations.getStationCode(appState.selectedDestination ?? "") ?? ""
+                            //     )
+                            // }
                             
                             // Combined card with all details
                             CombinedDetailsCard(train: train, selectedDestination: appState.selectedDestination)
                             
-                            // Consolidated data section
-                            if train.isConsolidated {
-                                ConsolidatedDataCard(train: train)
-                            }
+                            // Consolidated data section -- REMOVE THIS BLOCK
+                            // if train.isConsolidated {
+                            //     ConsolidatedDataCard(train: train)
+                            // }
                             
-                            // Show history button
-                            Button {
-                                showingHistory = true
-                            } label: {
-                                HStack {
-                                    Image(systemName: "clock.arrow.circlepath")
-                                    Text("details from past trains")
-                                        .font(.subheadline)
-                                }
-                                .foregroundColor(.white.opacity(0.8))
-                            }
-                            .padding(.top)
+                            // Show history button -- REMOVE THIS BLOCK
+                            // Button {
+                            //     showingHistory = true
+                            // } label: {
+                            //     HStack {
+                            //         Image(systemName: "clock.arrow.circlepath")
+                            //         Text("details from past trains")
+                            //             .font(.subheadline)
+                            //     }
+                            //     .foregroundColor(.white.opacity(0.8))
+                            // }
+                            // .padding(.top)
+
+                            // ADD THE NEW VIEW HERE
+                            ExperimentalFeaturesView(viewModel: viewModel, train: train)
                         }
                         .padding()
                     }
@@ -105,11 +108,11 @@ struct TrainDetailsView: View {
                 }
             }
         }
-        .sheet(isPresented: $showingHistory) {
-            if let train = viewModel.train {
-                HistoricalDataView(train: train)
-            }
-        }
+        // .sheet(isPresented: $showingHistory) { // REMOVE THIS BLOCK
+        //     if let train = viewModel.train {
+        //         HistoricalDataView(train: train)
+        //     }
+        // }
     }
 }
 


### PR DESCRIPTION
I've consolidated the "Experimental: Watch This Train," "Experimental: Multi-Source Data," and "Details from past trains" sections into a single collapsible section titled "Experimental Features" at the bottom of the Train Details page.

Key changes:
- I created a new `ExperimentalFeaturesView.swift` to encapsulate the combined functionality and UI.
- I integrated `ExperimentalFeaturesView` into `TrainDetailsView.swift`, removing the previous individual components.
- The "Experimental Features" section is collapsed by default and can be expanded/collapsed by tapping the header.
- I updated styling for a unified color theme:
    - "Live Activity Active" display now uses a blue background instead of green.
    - "Stop" button for Live Activity now uses the app's purple accent color instead of red.
    - I ensured consistent use of theme colors and system semantic colors for better adaptability and visual harmony.

This change improves the organization of the Train Details page by grouping experimental options, reducing clutter, and enhancing your experience with a more consistent design.