### PR TITLE
feat: Implement model prediction accuracy metric (#81) 

### DIFF
--- a/backend/trackcast/db/repository.py
+++ b/backend/trackcast/db/repository.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from trackcast.db.models import ModelData, PredictionData, Train, TrainStop
+from trackcast.services.prediction import MODEL_PREDICTION_ACCURACY
 
 logger = logging.getLogger(__name__)
 
@@ -277,6 +278,20 @@ class TrainRepository(BaseRepository):
                         f"Track {update_data['track']} assigned to train {train.train_id} at %s"
                         % timestamp
                     )
+
+                    # Calculate and record model prediction accuracy
+                    if train.prediction_data and train.prediction_data.top_track:
+                        predicted_track = train.prediction_data.top_track
+                        actual_track = train.track  # This is the newly assigned track
+                        is_correct = predicted_track == actual_track
+                        accuracy_value = 1.0 if is_correct else 0.0
+
+                        # Ensure MODEL_PREDICTION_ACCURACY is imported
+                        # from trackcast.services.prediction import MODEL_PREDICTION_ACCURACY
+                        MODEL_PREDICTION_ACCURACY.labels(station=train.origin_station_code).set(accuracy_value)
+                        logger.info(
+                            f"Updated MODEL_PREDICTION_ACCURACY for train {train.train_id} at station {train.origin_station_code}: {accuracy_value}"
+                        )
 
             # Calculate delay_minutes when track_released_at is set (train has departed)
             # Use "not train.delay_minutes and train.track_released_at" to identify trains needing delay calculation


### PR DESCRIPTION
https://github.com/bokonon1/TrackRat/issues/81

Implements the MODEL_PREDICTION_ACCURACY metric in the TrainRepository.

- When a train's actual track is updated, the metric compares this actual track with the predicted track (if available from PredictionData).
- The accuracy (1.0 for correct, 0.0 for incorrect) is recorded with a station-level label (origin_station_code).
- This enables tracking and alerting on model performance.

A new unit test file (`backend/tests/unit/test_prediction_metrics.py`) has been added with test cases for this metric.
Note: Full execution of these tests was hindered by environment limitations (disk space for torch dependency).