### PR TITLE
feat: Add blue route highlight to congestion map

### DIFF
--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -339,6 +339,11 @@ struct CongestionMapKitView: UIViewRepresentable {
             }
         }
         
+        // Add the main route polyline
+        let routeCoordinates = stations.map { $0.coordinate }
+        let routePolyline = RoutePolyline(coordinates: routeCoordinates, count: routeCoordinates.count)
+        mapView.addOverlay(routePolyline)
+
         // Add station annotations
         for station in stations {
             let annotation = StationAnnotation()
@@ -391,6 +396,16 @@ struct CongestionMapKitView: UIViewRepresentable {
         
         // MARK: - Polyline Rendering
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+            if let routePolyline = overlay as? RoutePolyline {
+                let renderer = MKPolylineRenderer(polyline: routePolyline)
+                renderer.strokeColor = UIColor.blue
+                renderer.lineWidth = 4
+                renderer.lineCap = .round
+                renderer.lineJoin = .round
+                renderer.zPosition = 1 // Ensure it's on top of congestion
+                return renderer
+            }
+
             if let polyline = overlay as? CongestionPolyline {
                 let renderer = MKPolylineRenderer(polyline: polyline)
                 
@@ -402,6 +417,7 @@ struct CongestionMapKitView: UIViewRepresentable {
                 }
                 renderer.lineWidth = getCongestionLineWidth(polyline.segment?.congestionFactor ?? 1.0)
                 renderer.alpha = 0.8
+                renderer.zPosition = 0 // Ensure it's below the route line
                 return renderer
             }
             return MKOverlayRenderer(overlay: overlay)
@@ -578,10 +594,12 @@ struct CongestionMapKitView: UIViewRepresentable {
     }
 }
 
-// MARK: - Custom Polyline Class
+// MARK: - Custom Polyline Classes
 class CongestionPolyline: MKPolyline {
     var segment: CongestionSegment?
 }
+
+class RoutePolyline: MKPolyline {}
 
 // MARK: - Custom Annotation Class
 class StationAnnotation: NSObject, MKAnnotation {


### PR DESCRIPTION
This commit introduces a feature to display a blue line on the congestion map, highlighting your selected station-to-station route.

The key changes are in `ios/TrackRat/Views/Components/JourneyCongestionMapView.swift`:

1.  A new `RoutePolyline` class, a subclass of `MKPolyline`, has been created to represent your route.
2.  The `CongestionMapKitView` now creates and adds a `RoutePolyline` overlay to the map, tracing the coordinates of the stations in the selected journey.
3.  The `MKMapViewDelegate`'s `rendererFor` method has been updated to handle the new `RoutePolyline` type. It renders the polyline with a distinct blue color, a line width of 4, and a `zPosition` of 1.
4.  The existing `CongestionPolyline` renderer has been updated to have a `zPosition` of 0, ensuring that the new route highlight is always drawn on top of the congestion segments.

This change directly addresses your request to show a clear, blue line for the selected route on top of the existing congestion map.