### PR TITLE
Bump iOS Sentry SDK to version 8.56.2

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -1013,7 +1013,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa/";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.56.0;
+				minimumVersion = 8.56.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/TrackRat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/TrackRat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa/",
       "state" : {
-        "revision" : "3365d74b0ac74a10c87f41a1229526b3ba97a460",
-        "version" : "8.56.0"
+        "revision" : "9e193ac0b71760603aa666bad7e9e303dd7031a8",
+        "version" : "8.56.2"
       }
     }
   ],


### PR DESCRIPTION
## Summary
• Updated Sentry SDK from version 8.56.0 to 8.56.2 in iOS project
• Updated minimum version requirement in project.pbxproj  
• Updated Package.resolved with correct revision hash for version 8.56.2

## Test plan
- [ ] Verify iOS app builds successfully with new Sentry version
- [ ] Test crash reporting functionality still works
- [ ] Confirm no breaking changes in Sentry API usage

🤖 Generated with [Claude Code](https://claude.ai/code)