### PR TITLE
Review ocuroot usage in backend and docs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -116,6 +116,27 @@ jobs:
           export CLEANUP_DB=false
           ./run_tests_with_db.sh
 
+      - name: Test Summary
+        if: always()
+        run: |
+          echo "## 🧪 Backend Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "✅ **All tests passed**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Test Suite:**" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Code formatting (black)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Type checking (mypy)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Linting (ruff)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ Unit & integration tests (pytest)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **Tests failed**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Please check the logs above for details." >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Test Time:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+
       - name: Clean up Python environment
         working-directory: ./backend_v2
         run: |
@@ -461,8 +482,13 @@ jobs:
           echo "   Project: ${{ env.PROJECT_ID }}"
           echo "   Image: ${{ env.IMAGE_TAG }}"
           echo ""
+          echo "📝 Note: Ocuroot will run the full test suite as a quality gate"
+          echo "   before deploying. This ensures the pre-built image is validated."
+          echo ""
 
           # Run Ocuroot release
+          # This executes: test-backend task → build-backend task → deploy to staging
+          # The build task uses the pre-built image from earlier in this workflow
           ocuroot release new backend_v2/release.ocu.star --cascade || {
             echo "❌ Ocuroot deployment failed"
             echo "DEPLOYMENT_FAILED=true" >> $GITHUB_ENV
@@ -713,8 +739,13 @@ jobs:
           echo "   Project: ${{ env.PROJECT_ID }}"
           echo "   Image: ${{ env.IMAGE_TAG }}"
           echo ""
+          echo "📝 Note: Ocuroot will run the full test suite as a quality gate"
+          echo "   before deploying. This ensures the pre-built image is validated."
+          echo ""
 
           # Run Ocuroot release
+          # This executes: test-backend task → build-backend task → deploy to production
+          # The build task uses the pre-built image from earlier in this workflow
           ocuroot release new backend_v2/release.ocu.star --cascade || {
             echo "❌ Ocuroot deployment failed"
             echo "DEPLOYMENT_FAILED=true" >> $GITHUB_ENV

--- a/backend_v2/release.ocu.star
+++ b/backend_v2/release.ocu.star
@@ -42,7 +42,66 @@ def is_running_in_ci():
     # Default: assume local environment
     return False
 
-def build(prev_build_number=None, year=None, month=None, day=None, sha=None, gcp_project=None, environment=None):
+def test_backend(prev_test_status=None):
+    """Run backend tests and code quality checks
+
+    Executes the full test suite including:
+    - Code formatting (black)
+    - Type checking (mypy)
+    - Linting (ruff)
+    - Unit and integration tests (pytest)
+
+    The test script manages its own PostgreSQL container if needed.
+
+    Args:
+        prev_test_status: Previous test status for state tracking
+
+    Returns:
+        Dictionary with test outputs (status, timestamp)
+    """
+    print("=" * 60)
+    print("🧪 BACKEND TESTING")
+    print("=" * 60)
+    print("")
+
+    # Check if we're in CI or local environment
+    in_ci = is_running_in_ci()
+    if in_ci:
+        print("📍 Running in CI environment")
+    else:
+        print("📍 Running in local environment")
+    print("")
+
+    # Run the existing test script (handles database setup automatically)
+    print("🚀 Running test suite via run_tests_with_db.sh...")
+    print("")
+
+    result = host.shell("""
+        cd backend_v2 && \
+        chmod +x run_tests_with_db.sh && \
+        ./run_tests_with_db.sh
+    """)
+
+    # If tests failed, the shell command will have non-zero exit code
+    # and ocuroot will automatically fail the release
+
+    timestamp = host.shell("date -u '+%Y-%m-%d %H:%M:%S UTC'").stdout.strip()
+
+    print("")
+    print("=" * 60)
+    print("✅ BACKEND TESTING COMPLETE")
+    print("=" * 60)
+    print("   Timestamp: {}".format(timestamp))
+    print("")
+
+    return done(
+        outputs={
+            "test_status": "passed",
+            "timestamp": timestamp
+        }
+    )
+
+def build(test_status=None, prev_build_number=None, year=None, month=None, day=None, sha=None, gcp_project=None, environment=None):
     """Build and push Docker image to Artifact Registry (local) or use pre-built image (CI)
 
     When running in CI (GitHub Actions):
@@ -56,6 +115,7 @@ def build(prev_build_number=None, year=None, month=None, day=None, sha=None, gcp
         - Returns newly built image tag
 
     Args:
+        test_status: Test status from test-backend task (dependency to ensure tests ran)
         prev_build_number: Previous build number for incrementing
         year: Year for version string (defaults to current year)
         month: Month for version string (defaults to current month)
@@ -376,14 +436,32 @@ def rollback_infrastructure(image_tag, environment):
 # RELEASE PHASES
 # ============================================================================
 
+# Task: Run backend tests and code quality checks
+# This ensures all tests pass before building or deploying
+# The test script (run_tests_with_db.sh) manages its own PostgreSQL container
+task(
+    name="test-backend",
+    fn=test_backend,
+    inputs={
+        "prev_test_status": input(
+            ref="./task/test-backend#output/test_status",
+            default="none"
+        )
+    }
+)
+
 # Task: Build Docker image and push to Artifact Registry
-# This runs before any deployment phases
+# This runs after tests pass (enforced via test_status input dependency)
 # - In CI: Uses pre-built image from GitHub Actions (via OCUROOT_INPUT_image_tag env var)
 # - Locally: Builds Docker image and pushes to registry
 task(
     name="build-backend",
     fn=build,
     inputs={
+        # Depend on test results - build won't run if tests haven't passed
+        "test_status": input(
+            ref="./task/test-backend#output/test_status"
+        ),
         "prev_build_number": input(
             ref="./task/build-backend#output/build_number",
             default=0


### PR DESCRIPTION
This implements a hybrid testing approach:
- CI runs tests for fast PR feedback
- Ocuroot runs tests as a quality gate before deployment

Changes:
1. backend_v2/release.ocu.star:
   - Add test_backend() function that runs run_tests_with_db.sh
   - Register test-backend task with state tracking
   - Make build-backend task depend on test results (enforces quality gate)
   - Tests must pass before Docker build or deployment can proceed

2. .github/workflows/ci-cd.yml:
   - Add test summary step for better PR visibility
   - Add comments explaining ocuroot test integration
   - Tests now run twice: once in CI (fast feedback) and once in ocuroot (quality gate)

Benefits:
- State-aware testing: Ocuroot tracks when tests last passed
- Quality gate: Cannot deploy without passing tests
- Local/CI parity: Same test suite runs everywhere
- Dependency-driven: test → build → deploy chain enforced

Pattern follows ocuroot unit test approach from:
https://github.com/ocuroot/ocuroot/blob/main/release.ocu.star#L8