### PR TITLE
Add spacing above bottom pane text in iOS

### DIFF
--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -99,7 +99,7 @@ struct TripSelectionView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal)
-                .padding(.top, (ratSenseService.suggestedJourney != nil && !isSearching) ? 8 : 20)
+                .padding(.top, (ratSenseService.suggestedJourney != nil && !isSearching) ? 16 : 28)
                 
                 // Search results and content container
                 VStack(alignment: .leading, spacing: 16) {


### PR DESCRIPTION
Increase top padding on "Where would you like to leave from?" text to provide more breathing room from the swipe indicator.