### PR TITLE
Cache train details view for instant loading

### DIFF
--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -6,14 +6,15 @@ import UIKit
 @available(iOS 16.1, *)
 class LiveActivityService: ObservableObject {
     static let shared = LiveActivityService()
-    
+
     @Published var currentActivity: Activity<TrainActivityAttributes>?
     @Published var isActivityActive: Bool = false
-    
+
     private var updateTimer: Timer?
     private var pushTokenTask: Task<Void, Never>?
     private var currentPushToken: Data?
-    
+    private let cacheService = TrainCacheService.shared
+
     private init() {
         checkCurrentActivity()
     }
@@ -207,7 +208,18 @@ class LiveActivityService: ObservableObject {
                 id: activity.attributes.trainId,
                 fromStationCode: activity.attributes.originStationCode
             )
-            
+
+            // Cache the fresh train data for instant loading in TrainDetailsView
+            await MainActor.run {
+                cacheService.cacheTrain(
+                    train,
+                    trainId: activity.attributes.trainId,
+                    trainNumber: nil,
+                    date: nil,
+                    fromStation: activity.attributes.originStationCode
+                )
+            }
+
             // Calculate context-aware progress for user's journey
             let context = JourneyContext(from: activity.attributes.originStationCode, to: activity.attributes.destination)
             let progress = train.calculateJourneyProgress(for: context)

--- a/ios/TrackRat/Services/TrainCacheService.swift
+++ b/ios/TrackRat/Services/TrainCacheService.swift
@@ -1,0 +1,260 @@
+//
+//  TrainCacheService.swift
+//  TrackRat
+//
+//  Created by Claude on 2025-11-17.
+//
+
+import Foundation
+
+/// Service responsible for caching train details to enable instant loading
+/// Uses two-tier caching: in-memory for speed, UserDefaults for persistence across app launches
+@MainActor
+class TrainCacheService {
+    static let shared = TrainCacheService()
+
+    private let userDefaults = UserDefaults.standard
+    private let cacheKeyPrefix = "train_cache_"
+    private let cacheMetadataKey = "train_cache_metadata"
+
+    // In-memory cache for fast access during active session
+    private var memoryCache: [String: CachedTrain] = [:]
+
+    // Maximum age for cached data (5 minutes = 300 seconds)
+    // This is separate from API data freshness - it's how long we trust our local cache
+    private let maxCacheAge: TimeInterval = 300
+
+    private init() {
+        // Clean up old cache entries on initialization
+        cleanupExpiredCache()
+    }
+
+    // MARK: - Cache Models
+
+    struct CachedTrain: Codable {
+        let train: TrainV2
+        let cachedAt: Date
+        let cacheKey: String
+
+        var isExpired: Bool {
+            Date().timeIntervalSince(cachedAt) > 300 // 5 minutes
+        }
+
+        var ageSeconds: Int {
+            Int(Date().timeIntervalSince(cachedAt))
+        }
+    }
+
+    struct CacheMetadata: Codable {
+        var keys: [String: Date] // cache key -> cached timestamp
+    }
+
+    // MARK: - Cache Key Generation
+
+    /// Generates a unique cache key for a train based on lookup parameters
+    func generateCacheKey(
+        trainId: String? = nil,
+        trainNumber: String? = nil,
+        date: Date? = nil,
+        fromStation: String? = nil
+    ) -> String {
+        var components: [String] = []
+
+        if let trainId = trainId {
+            components.append("id:\(trainId)")
+        }
+        if let trainNumber = trainNumber {
+            components.append("num:\(trainNumber)")
+        }
+
+        let dateString = date?.formatted(.iso8601.year().month().day()) ?? "today"
+        components.append("date:\(dateString)")
+
+        if let fromStation = fromStation {
+            components.append("from:\(fromStation)")
+        }
+
+        return components.joined(separator: "|")
+    }
+
+    // MARK: - Retrieval
+
+    /// Retrieves cached train details if available and not expired
+    func getCachedTrain(
+        trainId: String? = nil,
+        trainNumber: String? = nil,
+        date: Date? = nil,
+        fromStation: String? = nil
+    ) -> TrainV2? {
+        let cacheKey = generateCacheKey(
+            trainId: trainId,
+            trainNumber: trainNumber,
+            date: date,
+            fromStation: fromStation
+        )
+
+        // Check in-memory cache first (fastest)
+        if let cached = memoryCache[cacheKey] {
+            if !cached.isExpired {
+                print("✅ Cache HIT (memory): \(cacheKey) - age: \(cached.ageSeconds)s")
+                return cached.train
+            } else {
+                print("⏰ Cache EXPIRED (memory): \(cacheKey) - age: \(cached.ageSeconds)s")
+                memoryCache.removeValue(forKey: cacheKey)
+            }
+        }
+
+        // Check persistent cache (UserDefaults)
+        let persistentKey = cacheKeyPrefix + cacheKey
+        if let data = userDefaults.data(forKey: persistentKey),
+           let cached = try? JSONDecoder().decode(CachedTrain.self, from: data) {
+            if !cached.isExpired {
+                print("✅ Cache HIT (persistent): \(cacheKey) - age: \(cached.ageSeconds)s")
+                // Restore to memory cache
+                memoryCache[cacheKey] = cached
+                return cached.train
+            } else {
+                print("⏰ Cache EXPIRED (persistent): \(cacheKey) - age: \(cached.ageSeconds)s")
+                userDefaults.removeObject(forKey: persistentKey)
+            }
+        }
+
+        print("❌ Cache MISS: \(cacheKey)")
+        return nil
+    }
+
+    // MARK: - Storage
+
+    /// Stores train details in both in-memory and persistent cache
+    func cacheTrain(
+        _ train: TrainV2,
+        trainId: String? = nil,
+        trainNumber: String? = nil,
+        date: Date? = nil,
+        fromStation: String? = nil
+    ) {
+        let cacheKey = generateCacheKey(
+            trainId: trainId,
+            trainNumber: trainNumber,
+            date: date,
+            fromStation: fromStation
+        )
+
+        let cached = CachedTrain(
+            train: train,
+            cachedAt: Date(),
+            cacheKey: cacheKey
+        )
+
+        // Store in memory cache
+        memoryCache[cacheKey] = cached
+
+        // Store in persistent cache
+        if let encoded = try? JSONEncoder().encode(cached) {
+            let persistentKey = cacheKeyPrefix + cacheKey
+            userDefaults.set(encoded, forKey: persistentKey)
+
+            // Update metadata
+            var metadata = getCacheMetadata()
+            metadata.keys[cacheKey] = cached.cachedAt
+            saveCacheMetadata(metadata)
+
+            print("💾 Cached train: \(cacheKey)")
+        }
+    }
+
+    // MARK: - Cache Management
+
+    /// Clears all cached train data
+    func clearAllCache() {
+        memoryCache.removeAll()
+
+        let metadata = getCacheMetadata()
+        for cacheKey in metadata.keys.keys {
+            let persistentKey = cacheKeyPrefix + cacheKey
+            userDefaults.removeObject(forKey: persistentKey)
+        }
+
+        userDefaults.removeObject(forKey: cacheMetadataKey)
+        print("🗑️ Cleared all train cache")
+    }
+
+    /// Removes cache for a specific train
+    func clearCache(
+        trainId: String? = nil,
+        trainNumber: String? = nil,
+        date: Date? = nil,
+        fromStation: String? = nil
+    ) {
+        let cacheKey = generateCacheKey(
+            trainId: trainId,
+            trainNumber: trainNumber,
+            date: date,
+            fromStation: fromStation
+        )
+
+        memoryCache.removeValue(forKey: cacheKey)
+
+        let persistentKey = cacheKeyPrefix + cacheKey
+        userDefaults.removeObject(forKey: persistentKey)
+
+        var metadata = getCacheMetadata()
+        metadata.keys.removeValue(forKey: cacheKey)
+        saveCacheMetadata(metadata)
+
+        print("🗑️ Cleared cache: \(cacheKey)")
+    }
+
+    /// Removes expired cache entries from persistent storage
+    private func cleanupExpiredCache() {
+        var metadata = getCacheMetadata()
+        var hasChanges = false
+
+        for (cacheKey, cachedAt) in metadata.keys {
+            let age = Date().timeIntervalSince(cachedAt)
+            if age > maxCacheAge {
+                let persistentKey = cacheKeyPrefix + cacheKey
+                userDefaults.removeObject(forKey: persistentKey)
+                metadata.keys.removeValue(forKey: cacheKey)
+                hasChanges = true
+                print("🧹 Cleaned up expired cache: \(cacheKey)")
+            }
+        }
+
+        if hasChanges {
+            saveCacheMetadata(metadata)
+        }
+    }
+
+    // MARK: - Metadata Helpers
+
+    private func getCacheMetadata() -> CacheMetadata {
+        guard let data = userDefaults.data(forKey: cacheMetadataKey),
+              let metadata = try? JSONDecoder().decode(CacheMetadata.self, from: data) else {
+            return CacheMetadata(keys: [:])
+        }
+        return metadata
+    }
+
+    private func saveCacheMetadata(_ metadata: CacheMetadata) {
+        if let encoded = try? JSONEncoder().encode(metadata) {
+            userDefaults.set(encoded, forKey: cacheMetadataKey)
+        }
+    }
+
+    // MARK: - Debug Helpers
+
+    /// Returns cache statistics for debugging
+    func getCacheStats() -> String {
+        let metadata = getCacheMetadata()
+        let memoryCount = memoryCache.count
+        let persistentCount = metadata.keys.count
+
+        return """
+        📊 Cache Stats:
+        - Memory cache: \(memoryCount) entries
+        - Persistent cache: \(persistentCount) entries
+        - Max age: \(Int(maxCacheAge))s
+        """
+    }
+}

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -753,6 +753,7 @@ class TrainDetailsViewModel: ObservableObject {
     private var currentDestinationName: String?
 
     private let apiService = APIService.shared
+    private let cacheService = TrainCacheService.shared
 
     // Timer for auto-refresh
     let timer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
@@ -875,73 +876,146 @@ class TrainDetailsViewModel: ObservableObject {
     }
     
     func loadTrainDetails(fromStationCode: String? = nil, selectedDestinationName: String? = nil) async {
-        isLoading = true
         error = nil
 
         // Store current origin and destination for filtering
         self.currentOriginStationCode = fromStationCode
         self.currentDestinationName = selectedDestinationName
 
-        do {
-            // Use the flexible API method
-            train = try await apiService.fetchTrainDetailsFlexible(
-                id: databaseId.map(String.init),
-                trainId: trainNumber,
-                fromStationCode: fromStationCode ?? preferredStationCode,
-                date: journeyDate
-            )
-
-            // Update all computed properties after setting train
+        // CACHE-FIRST STRATEGY: Check cache before showing loading indicator
+        if let cachedTrain = cacheService.getCachedTrain(
+            trainId: databaseId.map(String.init),
+            trainNumber: trainNumber,
+            date: journeyDate,
+            fromStation: fromStationCode ?? preferredStationCode
+        ) {
+            // Load from cache immediately - NO loading indicator
+            print("📦 Loading from cache - instant display")
+            train = cachedTrain
             updateComputedProperties()
 
-        } catch {
-            // Handle APIError.noData specifically
-            if let apiError = error as? APIError {
-                switch apiError {
-                case .noData:
-                    self.error = "Train not found"
-                default:
-                    self.error = apiError.localizedDescription
-                }
-            } else {
-                self.error = error.localizedDescription
-            }
-        }
+            // Now fetch fresh data in background (silent)
+            await refreshTrainDetailsInBackground(fromStationCode: fromStationCode, selectedDestinationName: selectedDestinationName)
+        } else {
+            // No cache available - show loading indicator and fetch
+            print("🌐 No cache available - fetching from network")
+            isLoading = true
 
-        isLoading = false
+            do {
+                // Use the flexible API method
+                let fetchedTrain = try await apiService.fetchTrainDetailsFlexible(
+                    id: databaseId.map(String.init),
+                    trainId: trainNumber,
+                    fromStationCode: fromStationCode ?? preferredStationCode,
+                    date: journeyDate
+                )
+
+                train = fetchedTrain
+
+                // Cache the newly fetched train
+                cacheService.cacheTrain(
+                    fetchedTrain,
+                    trainId: databaseId.map(String.init),
+                    trainNumber: trainNumber,
+                    date: journeyDate,
+                    fromStation: fromStationCode ?? preferredStationCode
+                )
+
+                // Update all computed properties after setting train
+                updateComputedProperties()
+
+            } catch {
+                // Handle APIError.noData specifically
+                if let apiError = error as? APIError {
+                    switch apiError {
+                    case .noData:
+                        self.error = "Train not found"
+                    default:
+                        self.error = apiError.localizedDescription
+                    }
+                } else {
+                    self.error = error.localizedDescription
+                }
+            }
+
+            isLoading = false
+        }
     }
-    
-    func refreshTrainDetails(fromStationCode: String? = nil, selectedDestinationName: String? = nil) async {
-        // Store current origin and destination for filtering
-        self.currentOriginStationCode = fromStationCode
-        self.currentDestinationName = selectedDestinationName
-        
-        // Silent refresh
+
+    /// Fetches fresh data in background without showing loading indicator
+    private func refreshTrainDetailsInBackground(fromStationCode: String? = nil, selectedDestinationName: String? = nil) async {
         do {
             let identifier = trainNumber ?? (databaseId.map(String.init) ?? "unknown")
-            print("🔄 TrainDetailsView refreshing train \(identifier) from \(fromStationCode ?? preferredStationCode ?? "none")")
-            
+            print("🔄 Background refresh for train \(identifier)")
+
             let newTrain = try await apiService.fetchTrainDetailsFlexible(
                 id: databaseId.map(String.init),
                 trainId: trainNumber,
                 fromStationCode: fromStationCode ?? preferredStationCode,
                 date: journeyDate
             )
-            
+
+            // Cache the fresh data
+            cacheService.cacheTrain(
+                newTrain,
+                trainId: databaseId.map(String.init),
+                trainNumber: trainNumber,
+                date: journeyDate,
+                fromStation: fromStationCode ?? preferredStationCode
+            )
+
+            print("✅ Background refresh successful - updating UI")
+
+            // Update UI with fresh data (seamless update)
+            train = newTrain
+            updateComputedProperties()
+
+        } catch {
+            // Silent failure for background refresh - user already has cached data
+            print("⚠️ Background refresh failed (not critical): \(error)")
+        }
+    }
+    
+    func refreshTrainDetails(fromStationCode: String? = nil, selectedDestinationName: String? = nil) async {
+        // Store current origin and destination for filtering
+        self.currentOriginStationCode = fromStationCode
+        self.currentDestinationName = selectedDestinationName
+
+        // Silent refresh
+        do {
+            let identifier = trainNumber ?? (databaseId.map(String.init) ?? "unknown")
+            print("🔄 TrainDetailsView refreshing train \(identifier) from \(fromStationCode ?? preferredStationCode ?? "none")")
+
+            let newTrain = try await apiService.fetchTrainDetailsFlexible(
+                id: databaseId.map(String.init),
+                trainId: trainNumber,
+                fromStationCode: fromStationCode ?? preferredStationCode,
+                date: journeyDate
+            )
+
             print("✅ TrainDetailsView refresh successful for train \(identifier)")
-            
+
+            // Cache the fresh data
+            cacheService.cacheTrain(
+                newTrain,
+                trainId: databaseId.map(String.init),
+                trainNumber: trainNumber,
+                date: journeyDate,
+                fromStation: fromStationCode ?? preferredStationCode
+            )
+
             // Check if Live Activity should auto-end (Primary Fix)
             if #available(iOS 16.1, *) {
                 let liveService = LiveActivityService.shared
                 if liveService.isActivityActive,
                    let currentActivity = liveService.currentActivity,
                    currentActivity.attributes.trainNumber == newTrain.trainId {
-                    
+
                     print("🔍 Checking Live Activity auto-end for train \(newTrain.trainId)")
-                    
+
                     if liveService.shouldEndActivity(train: newTrain, activity: currentActivity) {
                         print("🏁 Auto-ending Live Activity from TrainDetailsView refresh")
-                        
+
                         Task {
                             await liveService.endCurrentActivity()
                         }
@@ -950,7 +1024,7 @@ class TrainDetailsViewModel: ObservableObject {
                     }
                 }
             }
-            
+
             // Check for boarding status change
             if let currentTrain = train {
                 // Check for track assignment
@@ -958,7 +1032,7 @@ class TrainDetailsViewModel: ObservableObject {
                     triggerTrackAssignedHaptic = true
                 }
             }
-            
+
             // Ensure UI updates properly on main queue
             DispatchQueue.main.async { [weak self] in
                 self?.objectWillChange.send()


### PR DESCRIPTION
Implements cache-first loading strategy for TrainDetailsView to eliminate loading indicators when re-entering the app or tapping notifications.

Changes:
- Created TrainCacheService with two-tier caching (memory + UserDefaults)
- Updated TrainDetailsViewModel to check cache before showing loading state
- Integrated caching with LiveActivityService background updates
- Fresh data still fetched in background and updates UI seamlessly

User experience:
- Train details load instantly when re-entering app (from cache)
- No loading/progress indicators on cached data
- Background refresh keeps data fresh without user-facing delays
- Cache expires after 5 minutes to ensure data relevance