### PR TITLE
Fix profile view bottom panel animation glitch

### DIFF
--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -334,6 +334,11 @@ struct MyProfileView: View {
             .padding(.bottom, 40)
         }
         .navigationTitle("My Profile")
+        .onAppear {
+            // Trigger sheet expansion after view loads to ensure smooth animation
+            // This happens after navigation completes and content is rendered
+            appState.shouldExpandSheet = true
+        }
     }
 }
 

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -142,8 +142,7 @@ struct TripSelectionView: View {
                         
                         // Profile icon - moved from top navigation
                         Button {
-                            // Navigate to profile - sheet will auto-expand
-                            appState.shouldExpandSheet = true
+                            // Navigate to profile - expansion happens in MyProfileView.onAppear
                             appState.navigationPath.append(NavigationDestination.myProfile)
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
                         } label: {


### PR DESCRIPTION
Problem:
- Sheet expansion and navigation happened simultaneously
- Caused race condition between navigation animation and detent change
- Content layout calculated mid-animation → visual glitch

Solution:
- Removed premature shouldExpandSheet flag in TripSelectionView
- Added onAppear handler in MyProfileView to trigger expansion
- Sheet now expands AFTER content loads and renders

Flow:
1. Navigation completes
2. View loads and renders
3. onAppear triggers expansion
4. Smooth animation with no race conditions

Files changed:
- TripSelectionView.swift: Removed flag setting before navigation
- MyProfileView.swift: Added onAppear to trigger expansion after load