### PR TITLE
Investigate TrackRat iOS slowness with production data

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -8,9 +8,9 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import and_, distinct, func, select
+from sqlalchemy import and_, distinct, exists, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 from structlog import get_logger
 
 from trackrat.api.utils import handle_errors
@@ -74,7 +74,31 @@ async def get_route_history(
     end_date = now_et().date()
     start_date = end_date - timedelta(days=days)
 
-    # Query all journeys for this data source and date range
+    # PERFORMANCE FIX: Use database-level filtering with EXISTS subqueries
+    # to avoid loading all journeys into memory then filtering in Python.
+    # This uses aliases to check that the journey has both stations in correct order.
+    from_stop_alias = aliased(JourneyStop, name="from_stop")
+    to_stop_alias = aliased(JourneyStop, name="to_stop")
+
+    # Subquery: journey has from_station with stop_sequence < to_station's sequence
+    route_filter = exists(
+        select(from_stop_alias.id).where(
+            and_(
+                from_stop_alias.journey_id == TrainJourney.id,
+                from_stop_alias.station_code == from_station,
+                exists(
+                    select(to_stop_alias.id).where(
+                        and_(
+                            to_stop_alias.journey_id == TrainJourney.id,
+                            to_stop_alias.station_code == to_station,
+                            to_stop_alias.stop_sequence > from_stop_alias.stop_sequence,
+                        )
+                    )
+                ),
+            )
+        )
+    )
+
     stmt = (
         select(TrainJourney)
         .where(
@@ -82,40 +106,22 @@ async def get_route_history(
                 TrainJourney.data_source == data_source,
                 TrainJourney.journey_date >= start_date,
                 TrainJourney.journey_date <= end_date,
+                route_filter,
             )
         )
         .options(selectinload(TrainJourney.stops))
+        .limit(5000)  # Safety limit to prevent memory issues with large date ranges
     )
 
     result = await db.execute(stmt)
-    all_journeys = list(result.scalars().all())
+    route_journeys = list(result.scalars().all())
 
-    # Filter to only journeys that travel from origin to destination
-    route_journeys = []
+    # Filter highlighted train journeys from the already-filtered route journeys
     highlighted_train_journeys = []
-
-    for journey in all_journeys:
-        from_stop = None
-        to_stop = None
-
-        # Find the origin and destination stops
-        for stop in journey.stops:
-            if stop.station_code == from_station:
-                from_stop = stop
-            elif stop.station_code == to_station:
-                to_stop = stop
-
-        # Include if both stations found and in correct order
-        if (
-            from_stop
-            and to_stop
-            and (from_stop.stop_sequence or 0) < (to_stop.stop_sequence or 0)
-        ):
-            route_journeys.append(journey)
-
-            # Also collect for highlighted train if specified
-            if highlight_train and journey.train_id == highlight_train:
-                highlighted_train_journeys.append(journey)
+    if highlight_train:
+        highlighted_train_journeys = [
+            j for j in route_journeys if j.train_id == highlight_train
+        ]
 
     # Calculate aggregate statistics for all route journeys
     aggregate_stats = _calculate_route_stats(route_journeys, from_station)

--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -7,9 +7,9 @@ Implements the V2 API design documented in backend_v2/CLAUDE.md.
 from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from sqlalchemy import and_, select
+from sqlalchemy import and_, exists, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 from structlog import get_logger
 
 from trackrat.api.utils import handle_errors
@@ -66,6 +66,9 @@ async def get_departures(
     time_to: datetime | None = Query(
         None, description="End time (defaults to +24 hours)"
     ),
+    hide_departed: bool = Query(
+        False, description="Hide trains that have already departed from the origin station"
+    ),
     limit: int = Query(50, le=1000, description="Maximum results"),
     db: AsyncSession = Depends(get_db),
 ) -> DeparturesResponse:
@@ -77,11 +80,15 @@ async def get_departures(
         date=date,
         time_from=time_from,
         time_to=time_to,
+        hide_departed=hide_departed,
     )
 
     cache_service = ApiCacheService()
 
-    use_cache = date is None and time_from is None and time_to is None
+    # Only use cache when using default parameters (no hide_departed since it's dynamic)
+    use_cache = (
+        date is None and time_from is None and time_to is None and not hide_departed
+    )
 
     if use_cache:
         cache_params = {
@@ -102,7 +109,7 @@ async def get_departures(
 
     service = DepartureService()
     response = await service.get_departures(
-        db, from_station, to_station, date, time_from, time_to, limit
+        db, from_station, to_station, date, time_from, time_to, limit, hide_departed
     )
 
     if use_cache:
@@ -344,7 +351,31 @@ async def get_train_history(
         # Get the data source from the first journey
         train_data_source = journeys[0].data_source
 
-        # Query all trains with same data source on this route
+        # PERFORMANCE FIX: Use database-level filtering with EXISTS subqueries
+        # to avoid loading all journeys into memory then filtering in Python.
+        from_stop_alias = aliased(JourneyStop, name="from_stop")
+        to_stop_alias = aliased(JourneyStop, name="to_stop")
+
+        # Subquery: journey has from_station with stop_sequence < to_station's sequence
+        route_filter = exists(
+            select(from_stop_alias.id).where(
+                and_(
+                    from_stop_alias.journey_id == TrainJourney.id,
+                    from_stop_alias.station_code == from_station,
+                    exists(
+                        select(to_stop_alias.id).where(
+                            and_(
+                                to_stop_alias.journey_id == TrainJourney.id,
+                                to_stop_alias.station_code == to_station,
+                                to_stop_alias.stop_sequence
+                                > from_stop_alias.stop_sequence,
+                            )
+                        )
+                    ),
+                )
+            )
+        )
+
         route_stmt = (
             select(TrainJourney)
             .where(
@@ -352,32 +383,15 @@ async def get_train_history(
                     TrainJourney.journey_date >= start_date,
                     TrainJourney.journey_date <= end_date,
                     TrainJourney.data_source == train_data_source,
+                    route_filter,
                 )
             )
             .options(selectinload(TrainJourney.stops))
+            .limit(5000)  # Safety limit to prevent memory issues
         )
 
         route_result = await db.execute(route_stmt)
-        all_route_journeys = list(route_result.scalars().all())
-
-        # Filter to only journeys that contain both stations in correct order
-        for journey in all_route_journeys:
-            from_stop = None
-            to_stop = None
-
-            for stop in journey.stops:
-                if stop.station_code == from_station:
-                    from_stop = stop
-                elif stop.station_code == to_station:
-                    to_stop = stop
-
-            # Include if both stations found and in correct order
-            if (
-                from_stop
-                and to_stop
-                and (from_stop.stop_sequence or 0) < (to_stop.stop_sequence or 0)
-            ):
-                route_journeys.append(journey)
+        route_journeys = list(route_result.scalars().all())
 
     # Build historical data
     historical_journeys = []

--- a/backend_v2/src/trackrat/db/migrations/versions/20251202_1000-a1b2c3d4e5f6_add_scaling_performance_indexes.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20251202_1000-a1b2c3d4e5f6_add_scaling_performance_indexes.py
@@ -1,0 +1,47 @@
+"""add_scaling_performance_indexes
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5b4681856a79
+Create Date: 2025-12-02 10:00:00.000000
+
+Adds composite indexes to optimize queries that degrade as database scales:
+- idx_track_occupancy_lookup: Optimizes track occupancy queries
+- idx_stop_track_distribution: Optimizes track distribution aggregations
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "5b4681856a79"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    # Add composite index for track occupancy queries
+    # Used by track_occupancy.py to find occupied tracks at a station
+    # Optimizes: WHERE station_code = ? AND has_departed_station = ? AND scheduled_departure BETWEEN ? AND ?
+    op.create_index(
+        "idx_track_occupancy_lookup",
+        "journey_stops",
+        ["station_code", "has_departed_station", "scheduled_departure"],
+        unique=False,
+    )
+
+    # Add composite index for track distribution queries
+    # Used by historical_track_predictor.py for GROUP BY aggregations
+    # Optimizes: SELECT track, COUNT(*) FROM journey_stops WHERE station_code = ? GROUP BY track
+    op.create_index(
+        "idx_stop_track_distribution",
+        "journey_stops",
+        ["station_code", "track"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_index("idx_stop_track_distribution", table_name="journey_stops")
+    op.drop_index("idx_track_occupancy_lookup", table_name="journey_stops")

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -163,6 +163,17 @@ class JourneyStop(Base):
         UniqueConstraint("journey_id", "station_code", name="unique_journey_stop"),
         Index("idx_station_times", "station_code", "scheduled_departure"),
         Index("idx_journey_sequence", "journey_id", "stop_sequence"),
+        # Performance optimization: composite index for track occupancy queries
+        # Used by track_occupancy.py to find occupied tracks at a station
+        Index(
+            "idx_track_occupancy_lookup",
+            "station_code",
+            "has_departed_station",
+            "scheduled_departure",
+        ),
+        # Performance optimization: composite index for track distribution queries
+        # Used by historical_track_predictor.py for GROUP BY aggregations
+        Index("idx_stop_track_distribution", "station_code", "track"),
     )
 
 

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -38,6 +38,7 @@ class DepartureService:
         time_from: datetime | None = None,
         time_to: datetime | None = None,
         limit: int = 50,
+        hide_departed: bool = False,
     ) -> DeparturesResponse:
         """Get train departures between stations."""
 
@@ -83,6 +84,20 @@ class DepartureService:
         # Determine the target date for prioritization
         target_date = date if date else now_et().date()
 
+        # Build additional filters for hide_departed
+        departure_filters = [
+            JourneyStop.scheduled_departure >= time_from,
+            JourneyStop.scheduled_departure <= time_to,
+            journey_date_filter,
+            # Include both data sources
+            TrainJourney.data_source.in_(["NJT", "AMTRAK"]),
+        ]
+
+        # PERFORMANCE: Filter out trains that have already departed from origin station
+        # This reduces payload size significantly when using hide_departed=true
+        if hide_departed:
+            departure_filters.append(JourneyStop.has_departed_station.is_(False))
+
         stmt = (
             select(TrainJourney)
             .join(
@@ -92,15 +107,7 @@ class DepartureService:
                     JourneyStop.station_code == from_station,
                 ),
             )
-            .where(
-                and_(
-                    JourneyStop.scheduled_departure >= time_from,
-                    JourneyStop.scheduled_departure <= time_to,
-                    journey_date_filter,
-                    # Include both data sources
-                    TrainJourney.data_source.in_(["NJT", "AMTRAK"]),
-                )
-            )
+            .where(and_(*departure_filters))
             .options(selectinload(TrainJourney.stops))
             .order_by(
                 # Prioritize trains with the target journey_date

--- a/backend_v2/src/trackrat/services/jit.py
+++ b/backend_v2/src/trackrat/services/jit.py
@@ -322,8 +322,6 @@ class JustInTimeUpdateService:
             session, train_id, journey_date, force_refresh
         )
 
-        if journey:
-            # Ensure stops are loaded
-            await session.refresh(journey, ["stops"])
-
+        # Note: stops are already loaded via selectinload in ensure_fresh_data()
+        # No need to refresh - that would cause a redundant database query
         return journey

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -375,25 +375,26 @@ class SchedulerService:
         window_start = now_et()
         window_end = window_start + timedelta(minutes=10)
 
-        # Get candidates without timezone comparison in SQL
-        stmt = select(TrainJourney).where(
-            and_(
-                TrainJourney.data_source == "NJT",
-                TrainJourney.has_complete_journey.is_not(True),
-                TrainJourney.is_cancelled.is_not(True),
+        # PERFORMANCE FIX: Add time window filtering at database level to avoid
+        # loading all incomplete journeys into memory as the database scales.
+        # Also limit results to prevent memory issues.
+        stmt = (
+            select(TrainJourney)
+            .where(
+                and_(
+                    TrainJourney.data_source == "NJT",
+                    TrainJourney.has_complete_journey.is_not(True),
+                    TrainJourney.is_cancelled.is_not(True),
+                    # Filter at database level - trains departing within window
+                    TrainJourney.scheduled_departure >= window_start,
+                    TrainJourney.scheduled_departure <= window_end,
+                )
             )
+            .limit(100)  # Safety limit to prevent memory issues
         )
 
         result = await session.execute(stmt)
-        all_trains = result.scalars().all()
-
-        # Filter with proper timezone handling
-        trains = []
-        for train in all_trains:
-            if train.scheduled_departure:
-                scheduled_dep = ensure_timezone_aware(train.scheduled_departure)
-                if window_start <= scheduled_dep <= window_end:
-                    trains.append(train)
+        trains = list(result.scalars().all())
 
         scheduled_count = 0
         for train in trains:

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -4,17 +4,76 @@ import Combine
 // MARK: - Clean API Service for V2 Backend
 final class APIService: ObservableObject {
     static let shared = APIService()
-    
+
     private var baseURL: String
-    private let session = URLSession.shared
+    private let session: URLSession
     private let storageService = StorageService()
 
     // Configuration constants
-    private static let DEPARTURE_LIMIT = "1000"
+    // PERFORMANCE: Reduced from 1000 to 50 to minimize payload size and parsing time.
+    // The app filters to 6-hour window anyway, and pagination can be added later if needed.
+    private static let DEPARTURE_LIMIT = "50"
+    // PERFORMANCE: Configure shorter timeout (15s) instead of default 60s
+    private static let REQUEST_TIMEOUT: TimeInterval = 15
+    // PERFORMANCE: Retry configuration for transient failures
+    private static let MAX_RETRIES = 2
+    private static let RETRY_DELAY_BASE: TimeInterval = 1.0
 
     init() {
         let environment = storageService.loadServerEnvironment()
         self.baseURL = environment.baseURL
+
+        // PERFORMANCE: Configure URLSession with shorter timeout
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = APIService.REQUEST_TIMEOUT
+        configuration.timeoutIntervalForResource = APIService.REQUEST_TIMEOUT * 2
+        self.session = URLSession(configuration: configuration)
+    }
+
+    // MARK: - Retry Logic
+
+    /// Execute a request with automatic retry on transient failures
+    private func executeWithRetry<T>(
+        operation: @escaping () async throws -> T,
+        retries: Int = MAX_RETRIES
+    ) async throws -> T {
+        var lastError: Error?
+        var attempt = 0
+
+        while attempt <= retries {
+            do {
+                return try await operation()
+            } catch {
+                lastError = error
+
+                // Only retry on network/timeout errors, not on HTTP errors
+                let shouldRetry = isRetryableError(error) && attempt < retries
+                if shouldRetry {
+                    attempt += 1
+                    let delay = APIService.RETRY_DELAY_BASE * pow(2.0, Double(attempt - 1))
+                    print("⚠️ Request failed, retrying in \(delay)s (attempt \(attempt)/\(retries)): \(error.localizedDescription)")
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                } else {
+                    throw error
+                }
+            }
+        }
+
+        throw lastError ?? APIError.noData
+    }
+
+    /// Determine if an error is retryable (transient network issues)
+    private func isRetryableError(_ error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut, .networkConnectionLost, .notConnectedToInternet,
+                 .cannotConnectToHost, .cannotFindHost:
+                return true
+            default:
+                return false
+            }
+        }
+        return false
     }
     
     func updateServerEnvironment(_ environment: ServerEnvironment) {
@@ -42,7 +101,10 @@ final class APIService: ObservableObject {
         var queryItems = [
             URLQueryItem(name: "from", value: fromStationCode),
             URLQueryItem(name: "to", value: toStationCode),
-            URLQueryItem(name: "limit", value: APIService.DEPARTURE_LIMIT)
+            URLQueryItem(name: "limit", value: APIService.DEPARTURE_LIMIT),
+            // PERFORMANCE: Filter out already-departed trains server-side
+            // This reduces payload size and eliminates redundant client filtering
+            URLQueryItem(name: "hide_departed", value: "true")
         ]
 
         if let date = date {
@@ -60,23 +122,26 @@ final class APIService: ObservableObject {
 
         print("🔵 DEBUG API: Fetching trains from URL: \(url)")
 
-        let (data, response) = try await session.data(from: url)
+        // PERFORMANCE: Use retry logic for transient network failures
+        return try await executeWithRetry {
+            let (data, _) = try await self.session.data(from: url)
 
-        do {
-            let response = try decoder.decode(V2DeparturesResponse.self, from: data)
-            print("🔵 DEBUG API: Decoded \(response.departures.count) departures from API")
-            print("🔵 DEBUG API: Train IDs in response: \(response.departures.map { $0.trainId })")
+            do {
+                let response = try self.decoder.decode(V2DeparturesResponse.self, from: data)
+                print("🔵 DEBUG API: Decoded \(response.departures.count) departures from API")
+                print("🔵 DEBUG API: Train IDs in response: \(response.departures.map { $0.trainId })")
 
-            let adaptedTrains = response.departures.map { adaptV2DepartureToTrainV2($0) }
-            print("🔵 DEBUG API: Adapted to \(adaptedTrains.count) TrainV2 objects")
+                let adaptedTrains = response.departures.map { self.adaptV2DepartureToTrainV2($0) }
+                print("🔵 DEBUG API: Adapted to \(adaptedTrains.count) TrainV2 objects")
 
-            return adaptedTrains
-        } catch {
-            print("🔴 V2 DECODING ERROR (searchTrains): \(error)")
-            if let jsonString = String(data: data, encoding: .utf8) {
-                print("🔴 RAW DATA: \(jsonString.prefix(500))")
+                return adaptedTrains
+            } catch {
+                print("🔴 V2 DECODING ERROR (searchTrains): \(error)")
+                if let jsonString = String(data: data, encoding: .utf8) {
+                    print("🔴 RAW DATA: \(jsonString.prefix(500))")
+                }
+                throw error
             }
-            throw error
         }
     }
     
@@ -106,19 +171,22 @@ final class APIService: ObservableObject {
         guard let url = components.url else {
             throw APIError.invalidURL
         }
-        
-        let (data, response) = try await session.data(from: url)
-        
-        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
-            throw APIError.noData
-        }
-        
-        do {
-            let detailsResponse = try decoder.decode(V2TrainDetailsResponse.self, from: data)
-            return adaptV2TrainDetailsToTrainV2(detailsResponse.train, fromStationCode: fromStationCode)
-        } catch {
-            print("🔴 V2 DECODING ERROR (fetchTrainDetails for id: \(id)): \(error)")
-            throw error
+
+        // PERFORMANCE: Use retry logic for transient network failures
+        return try await executeWithRetry {
+            let (data, response) = try await self.session.data(from: url)
+
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
+                throw APIError.noData
+            }
+
+            do {
+                let detailsResponse = try self.decoder.decode(V2TrainDetailsResponse.self, from: data)
+                return self.adaptV2TrainDetailsToTrainV2(detailsResponse.train, fromStationCode: fromStationCode)
+            } catch {
+                print("🔴 V2 DECODING ERROR (fetchTrainDetails for id: \(id)): \(error)")
+                throw error
+            }
         }
     }
     

--- a/ios/TrackRat/Services/TrainCacheService.swift
+++ b/ios/TrackRat/Services/TrainCacheService.swift
@@ -19,6 +19,10 @@ class TrainCacheService {
 
     // In-memory cache for fast access during active session
     private var memoryCache: [String: CachedTrain] = [:]
+    // PERFORMANCE: Track access order for LRU eviction
+    private var memoryCacheAccessOrder: [String] = []
+    // PERFORMANCE: Maximum number of entries in memory cache to prevent unbounded growth
+    private let maxMemoryCacheSize = 50
 
     // Maximum age for cached data (5 minutes = 300 seconds)
     // This is separate from API data freshness - it's how long we trust our local cache
@@ -97,10 +101,13 @@ class TrainCacheService {
         if let cached = memoryCache[cacheKey] {
             if !cached.isExpired {
                 print("✅ Cache HIT (memory): \(cacheKey) - age: \(cached.ageSeconds)s")
+                // Update LRU access order
+                updateAccessOrder(for: cacheKey)
                 return cached.train
             } else {
                 print("⏰ Cache EXPIRED (memory): \(cacheKey) - age: \(cached.ageSeconds)s")
                 memoryCache.removeValue(forKey: cacheKey)
+                memoryCacheAccessOrder.removeAll { $0 == cacheKey }
             }
         }
 
@@ -110,8 +117,8 @@ class TrainCacheService {
            let cached = try? JSONDecoder().decode(CachedTrain.self, from: data) {
             if !cached.isExpired {
                 print("✅ Cache HIT (persistent): \(cacheKey) - age: \(cached.ageSeconds)s")
-                // Restore to memory cache
-                memoryCache[cacheKey] = cached
+                // Restore to memory cache with LRU tracking
+                addToMemoryCache(key: cacheKey, value: cached)
                 return cached.train
             } else {
                 print("⏰ Cache EXPIRED (persistent): \(cacheKey) - age: \(cached.ageSeconds)s")
@@ -120,6 +127,37 @@ class TrainCacheService {
         }
 
         print("❌ Cache MISS: \(cacheKey)")
+        return nil
+    }
+
+    /// Returns the age of the cache in seconds, or nil if not cached
+    /// PERFORMANCE: Used to determine if we should skip background refresh on cache hit
+    func getCacheAge(
+        trainId: String? = nil,
+        trainNumber: String? = nil,
+        date: Date? = nil,
+        fromStation: String? = nil
+    ) -> TimeInterval? {
+        let cacheKey = generateCacheKey(
+            trainId: trainId,
+            trainNumber: trainNumber,
+            date: date,
+            fromStation: fromStation
+        )
+
+        // Check in-memory cache first
+        if let cached = memoryCache[cacheKey], !cached.isExpired {
+            return TimeInterval(cached.ageSeconds)
+        }
+
+        // Check persistent cache
+        let persistentKey = cacheKeyPrefix + cacheKey
+        if let data = userDefaults.data(forKey: persistentKey),
+           let cached = try? JSONDecoder().decode(CachedTrain.self, from: data),
+           !cached.isExpired {
+            return TimeInterval(cached.ageSeconds)
+        }
+
         return nil
     }
 
@@ -146,8 +184,8 @@ class TrainCacheService {
             cacheKey: cacheKey
         )
 
-        // Store in memory cache
-        memoryCache[cacheKey] = cached
+        // Store in memory cache with LRU tracking
+        addToMemoryCache(key: cacheKey, value: cached)
 
         // Store in persistent cache
         if let encoded = try? JSONEncoder().encode(cached) {
@@ -163,11 +201,45 @@ class TrainCacheService {
         }
     }
 
+    // MARK: - LRU Cache Management
+
+    /// Update the access order for LRU tracking
+    private func updateAccessOrder(for key: String) {
+        // Remove from current position and add to end (most recently used)
+        memoryCacheAccessOrder.removeAll { $0 == key }
+        memoryCacheAccessOrder.append(key)
+    }
+
+    /// Add item to memory cache with LRU eviction
+    private func addToMemoryCache(key: String, value: CachedTrain) {
+        // If key already exists, update access order
+        if memoryCache[key] != nil {
+            updateAccessOrder(for: key)
+        } else {
+            // New entry - add to access order
+            memoryCacheAccessOrder.append(key)
+        }
+
+        memoryCache[key] = value
+
+        // PERFORMANCE: Evict least recently used entries if over limit
+        while memoryCache.count > maxMemoryCacheSize {
+            if let oldestKey = memoryCacheAccessOrder.first {
+                memoryCache.removeValue(forKey: oldestKey)
+                memoryCacheAccessOrder.removeFirst()
+                print("🧹 LRU evicted: \(oldestKey)")
+            } else {
+                break
+            }
+        }
+    }
+
     // MARK: - Cache Management
 
     /// Clears all cached train data
     func clearAllCache() {
         memoryCache.removeAll()
+        memoryCacheAccessOrder.removeAll()
 
         let metadata = getCacheMetadata()
         for cacheKey in metadata.keys.keys {
@@ -194,6 +266,7 @@ class TrainCacheService {
         )
 
         memoryCache.removeValue(forKey: cacheKey)
+        memoryCacheAccessOrder.removeAll { $0 == cacheKey }
 
         let persistentKey = cacheKeyPrefix + cacheKey
         userDefaults.removeObject(forKey: persistentKey)

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -7,6 +7,8 @@ struct TrainDetailsView: View {
     @StateObject private var viewModel: TrainDetailsViewModel
     @ObservedObject private var liveActivityService = LiveActivityService.shared
     @State private var isClosing = false
+    // PERFORMANCE: Track visibility to prevent polling when view is not visible
+    @State private var isViewVisible = false
 
     let trainId: Int  // Keep for backwards compatibility
 
@@ -116,13 +118,28 @@ struct TrainDetailsView: View {
             )
         }
         .onReceive(viewModel.timer) { _ in
-            // Always refresh when the view is visible
+            // PERFORMANCE: Only refresh when view is visible AND LiveActivity isn't polling
+            // for the same train (to prevent duplicate API calls)
+            guard isViewVisible else { return }
+
+            // Skip polling if LiveActivity is already tracking this train
+            if let activity = liveActivityService.currentActivity,
+               activity.attributes.trainNumber == viewModel.train?.trainId {
+                return
+            }
+
             Task {
                 await viewModel.refreshTrainDetails(
                     fromStationCode: appState.departureStationCode,
                     selectedDestinationName: appState.selectedDestination
                 )
             }
+        }
+        .onAppear {
+            isViewVisible = true
+        }
+        .onDisappear {
+            isViewVisible = false
         }
         .onChange(of: viewModel.triggerBoardingHaptic) { oldValue, newValue in
             if newValue {
@@ -901,8 +918,21 @@ class TrainDetailsViewModel: ObservableObject {
             train = cachedTrain
             updateComputedProperties()
 
-            // Now fetch fresh data in background (silent)
-            await refreshTrainDetailsInBackground(fromStationCode: fromStationCode, selectedDestinationName: selectedDestinationName)
+            // PERFORMANCE FIX: Only fetch fresh data in background if cache is older than 30 seconds
+            // This prevents the double-fetch issue where we always hit the API even with a fresh cache.
+            // The 30-second timer will refresh the data anyway, so no need for immediate background fetch
+            // when cache is fresh.
+            let cacheAge = cacheService.getCacheAge(
+                trainId: databaseId.map(String.init),
+                trainNumber: trainNumber,
+                date: journeyDate,
+                fromStation: fromStationCode ?? preferredStationCode
+            )
+            if cacheAge == nil || cacheAge! > 30 {
+                await refreshTrainDetailsInBackground(fromStationCode: fromStationCode, selectedDestinationName: selectedDestinationName)
+            } else {
+                print("📦 Cache is fresh (\(Int(cacheAge!))s old) - skipping background refresh")
+            }
         } else {
             // No cache available - show loading indicator and fetch
             print("🌐 No cache available - fetching from network")

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -12,6 +12,8 @@ struct TrainListView: View {
     @State private var departureStationCode: String
     @State private var departureName: String
     @State private var isClosing = false
+    // PERFORMANCE: Track visibility to prevent polling when view is not visible
+    @State private var isViewVisible = false
 
 
     init(destination: String) {
@@ -118,11 +120,15 @@ struct TrainListView: View {
             )
         }
         .onReceive(viewModel.timer) { _ in
+            // PERFORMANCE: Only refresh when view is visible to prevent API stampede
+            // when multiple views have timers running
+            guard isViewVisible else { return }
             Task {
                 await viewModel.refreshTrains()
             }
         }
         .onAppear {
+            isViewVisible = true
             // Initialize state from app state
             if departureStationCode.isEmpty {
                 departureStationCode = appState.departureStationCode ?? "NY"
@@ -149,6 +155,10 @@ struct TrainListView: View {
                     isFavorite: false
                 )
             }
+        }
+        .onDisappear {
+            // PERFORMANCE: Stop polling when view is not visible
+            isViewVisible = false
         }
     }
 }


### PR DESCRIPTION
Backend changes:
- Add composite indexes for track occupancy and track distribution queries
- Fix unbounded scheduler query with time window filtering and LIMIT
- Add hide_departed parameter to departures endpoint for server-side filtering
- Fix route history endpoint to use EXISTS subquery instead of loading all data
- Fix train history endpoint with database-level station filtering
- Remove redundant JIT refresh after eager load

iOS changes:
- Reduce DEPARTURE_LIMIT from 1000 to 50
- Use hide_departed=true to filter departed trains server-side
- Add visibility tracking to stop polling when views are not visible
- Skip TrainDetailsView background refresh if cache is < 30 seconds old
- Add LRU eviction to memory cache (max 50 entries)
- Add request timeout (15s) with exponential backoff retry