### PR TITLE
Design train operations summary feature for iOS

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -22,9 +22,11 @@ from trackrat.models.api import (
     DelayBreakdown,
     HighlightedTrain,
     HistoricalRouteInfo,
+    OperationsSummaryResponse,
     RouteHistoryResponse,
     SegmentTrainDetail,
     SegmentTrainDetailsResponse,
+    SummaryMetricsResponse,
     TrainLocationData,
 )
 from trackrat.models.api import (
@@ -655,3 +657,100 @@ def _calculate_segment_summary(
         "average_congestion_factor": round(avg_congestion_factor, 2),
         "on_time_percentage": round(on_time_percentage, 1),
     }
+
+
+@router.get("/summary", response_model=OperationsSummaryResponse)
+@handle_errors
+async def get_operations_summary(
+    scope: str = Query(
+        ...,
+        description="Summary scope: 'network', 'route', or 'train'",
+        pattern="^(network|route|train)$",
+    ),
+    from_station: str | None = Query(
+        None,
+        min_length=1,
+        max_length=3,
+        description="Origin station code (for route/train)",
+    ),
+    to_station: str | None = Query(
+        None,
+        min_length=1,
+        max_length=3,
+        description="Destination station code (for route)",
+    ),
+    train_id: str | None = Query(None, description="Train ID (for train scope)"),
+    data_source: str | None = Query(None, description="Filter by NJT or AMTRAK"),
+    db: AsyncSession = Depends(get_db),
+) -> OperationsSummaryResponse:
+    """
+    Get a natural language summary of recent train operations.
+
+    Three scopes are available:
+    - network: Overall system status across all lines (past 90 minutes)
+    - route: Performance between origin and destination (past 90 minutes)
+    - train: Historical performance of a specific train (past 30 days)
+
+    The response includes:
+    - headline: Short summary (max 50 chars) for collapsed view
+    - body: Detailed summary (2-4 sentences) for expanded view
+    - metrics: Raw statistics for optional UI display
+    """
+    from trackrat.services.summary import SummaryService
+
+    logger.info(
+        "get_operations_summary_request",
+        scope=scope,
+        from_station=from_station,
+        to_station=to_station,
+        train_id=train_id,
+        data_source=data_source,
+    )
+
+    # Validate parameters based on scope
+    if scope == "route":
+        if not from_station or not to_station:
+            raise HTTPException(
+                status_code=400,
+                detail="from_station and to_station are required for route scope",
+            )
+    elif scope == "train":
+        if not train_id:
+            raise HTTPException(
+                status_code=400,
+                detail="train_id is required for train scope",
+            )
+
+    summary_service = SummaryService()
+
+    if scope == "network":
+        summary = await summary_service.get_network_summary(db, data_source)
+    elif scope == "route":
+        summary = await summary_service.get_route_summary(
+            db, from_station, to_station, data_source  # type: ignore[arg-type]
+        )
+    else:  # train
+        summary = await summary_service.get_train_summary(
+            db, train_id, from_station, to_station  # type: ignore[arg-type]
+        )
+
+    # Convert to response model
+    metrics = None
+    if summary.metrics:
+        metrics = SummaryMetricsResponse(
+            on_time_percentage=summary.metrics.on_time_percentage,
+            average_delay_minutes=summary.metrics.average_delay_minutes,
+            cancellation_count=summary.metrics.cancellation_count,
+            train_count=summary.metrics.train_count,
+            most_common_track=summary.metrics.most_common_track,
+        )
+
+    return OperationsSummaryResponse(
+        headline=summary.headline,
+        body=summary.body,
+        scope=summary.scope,
+        time_window_minutes=summary.time_window_minutes,
+        data_freshness_seconds=summary.data_freshness_seconds,
+        generated_at=summary.generated_at,
+        metrics=metrics,
+    )

--- a/backend_v2/src/trackrat/models/api.py
+++ b/backend_v2/src/trackrat/models/api.py
@@ -617,3 +617,54 @@ class SegmentTrainDetailsResponse(BaseModel):
             }
         ],
     )
+
+
+# Operations Summary API Models
+
+
+class SummaryMetricsResponse(BaseModel):
+    """Raw metrics included with summary response."""
+
+    on_time_percentage: float | None = Field(
+        None, ge=0.0, le=100.0, description="Percentage of trains on time"
+    )
+    average_delay_minutes: float | None = Field(
+        None, ge=0.0, description="Average delay in minutes"
+    )
+    cancellation_count: int | None = Field(
+        None, ge=0, description="Number of cancellations"
+    )
+    train_count: int | None = Field(None, ge=0, description="Total number of trains")
+    most_common_track: str | None = Field(
+        None, description="Most commonly assigned track"
+    )
+
+
+class OperationsSummaryResponse(BaseModel):
+    """Response for operations summary endpoint."""
+
+    headline: str = Field(
+        ...,
+        max_length=50,
+        description="Short headline for collapsed view (max 50 chars)",
+    )
+    body: str = Field(
+        ..., max_length=500, description="Detailed summary (2-4 sentences)"
+    )
+    scope: Literal["network", "route", "train"] = Field(
+        ..., description="Summary scope"
+    )
+    time_window_minutes: int = Field(
+        ...,
+        ge=0,
+        description="Time window in minutes (90 for recent, 43200 for 30-day)",
+    )
+    data_freshness_seconds: int = Field(..., ge=0, description="Age of data in seconds")
+    generated_at: datetime = Field(..., description="When summary was generated")
+    metrics: SummaryMetricsResponse | None = Field(
+        None, description="Raw metrics for optional UI display"
+    )
+
+    @field_serializer("generated_at")
+    def serialize_dt(self, dt: datetime) -> str:
+        return serialize_eastern_datetime(dt) or ""

--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1,0 +1,686 @@
+"""
+Operations summary service - Template-based natural language generation for train operations summaries.
+
+Generates brief, human-readable summaries of recent train operations at three scopes:
+- Network: Overall system status across all lines
+- Route: Performance between specific origin and destination
+- Train: Historical performance of a specific train
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Literal
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from structlog import get_logger
+
+from trackrat.config.stations import get_station_name
+from trackrat.models.database import JourneyStop, TrainJourney
+from trackrat.utils.time import ensure_timezone_aware, now_et
+
+logger = get_logger(__name__)
+
+# Fixed time window for summaries (90 minutes as per requirements)
+SUMMARY_TIME_WINDOW_MINUTES = 90
+
+
+@dataclass
+class LineStats:
+    """Statistics for a single line."""
+
+    line_name: str
+    line_code: str
+    train_count: int
+    on_time_count: int
+    cancellation_count: int
+    total_delay_minutes: float
+    data_source: str
+
+    @property
+    def on_time_percentage(self) -> float:
+        non_cancelled = self.train_count - self.cancellation_count
+        if non_cancelled <= 0:
+            return 0.0
+        return (self.on_time_count / non_cancelled) * 100
+
+    @property
+    def average_delay_minutes(self) -> float:
+        non_cancelled = self.train_count - self.cancellation_count
+        if non_cancelled <= 0:
+            return 0.0
+        return self.total_delay_minutes / non_cancelled
+
+
+@dataclass
+class SummaryMetrics:
+    """Raw metrics for summary generation."""
+
+    on_time_percentage: float | None = None
+    average_delay_minutes: float | None = None
+    cancellation_count: int | None = None
+    train_count: int | None = None
+    most_common_track: str | None = None
+
+
+@dataclass
+class OperationsSummary:
+    """Complete operations summary with headline and body."""
+
+    headline: str
+    body: str
+    scope: Literal["network", "route", "train"]
+    time_window_minutes: int
+    data_freshness_seconds: int
+    generated_at: datetime
+    metrics: SummaryMetrics | None = None
+
+
+class SummaryService:
+    """Service for generating operations summaries."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, tuple[OperationsSummary, datetime]] = {}
+        self._cache_ttl = 300  # 5 minutes cache
+
+    async def get_network_summary(
+        self,
+        db: AsyncSession,
+        data_source: str | None = None,
+    ) -> OperationsSummary:
+        """
+        Generate a network-wide operations summary.
+
+        Args:
+            db: Database session
+            data_source: Optional filter by data source (NJT or AMTRAK)
+
+        Returns:
+            OperationsSummary with headline and body
+        """
+        cache_key = f"network_{data_source or 'all'}"
+        if cache_key in self._cache:
+            cached_data, timestamp = self._cache[cache_key]
+            age_seconds = (now_et() - timestamp).total_seconds()
+            if age_seconds < self._cache_ttl:
+                logger.debug(
+                    "returning_cached_network_summary",
+                    cache_age_seconds=age_seconds,
+                )
+                return cached_data
+
+        cutoff_time = now_et() - timedelta(minutes=SUMMARY_TIME_WINDOW_MINUTES)
+
+        # Query journeys in the time window
+        conditions = [
+            TrainJourney.last_updated_at >= cutoff_time,
+        ]
+        if data_source:
+            conditions.append(TrainJourney.data_source == data_source)
+
+        stmt = (
+            select(TrainJourney)
+            .where(and_(*conditions))
+            .options(selectinload(TrainJourney.stops))
+        )
+
+        result = await db.execute(stmt)
+        journeys = list(result.scalars().all())
+
+        logger.info(
+            "network_summary_query",
+            journey_count=len(journeys),
+            time_window_minutes=SUMMARY_TIME_WINDOW_MINUTES,
+            data_source=data_source,
+        )
+
+        # Calculate per-line statistics
+        line_stats = self._calculate_line_stats(journeys)
+
+        # Generate summary
+        summary = self._generate_network_summary(line_stats)
+
+        # Cache the result
+        self._cache[cache_key] = (summary, now_et())
+
+        return summary
+
+    async def get_route_summary(
+        self,
+        db: AsyncSession,
+        from_station: str,
+        to_station: str,
+        data_source: str | None = None,
+    ) -> OperationsSummary:
+        """
+        Generate a route-specific operations summary.
+
+        Args:
+            db: Database session
+            from_station: Origin station code
+            to_station: Destination station code
+            data_source: Optional filter by data source (NJT or AMTRAK)
+
+        Returns:
+            OperationsSummary with headline and body
+        """
+        cache_key = f"route_{from_station}_{to_station}_{data_source or 'all'}"
+        if cache_key in self._cache:
+            cached_data, timestamp = self._cache[cache_key]
+            age_seconds = (now_et() - timestamp).total_seconds()
+            if age_seconds < self._cache_ttl:
+                logger.debug(
+                    "returning_cached_route_summary",
+                    cache_age_seconds=age_seconds,
+                )
+                return cached_data
+
+        cutoff_time = now_et() - timedelta(minutes=SUMMARY_TIME_WINDOW_MINUTES)
+
+        # Query journeys that include both stations
+        conditions = [
+            TrainJourney.last_updated_at >= cutoff_time,
+        ]
+        if data_source:
+            conditions.append(TrainJourney.data_source == data_source)
+
+        stmt = (
+            select(TrainJourney)
+            .join(
+                JourneyStop,
+                and_(
+                    JourneyStop.journey_id == TrainJourney.id,
+                    JourneyStop.station_code.in_([from_station, to_station]),
+                ),
+            )
+            .where(and_(*conditions))
+            .group_by(TrainJourney.id)
+            .having(func.count(func.distinct(JourneyStop.station_code)) == 2)
+            .options(selectinload(TrainJourney.stops))
+        )
+
+        result = await db.execute(stmt)
+        all_journeys = list(result.scalars().all())
+
+        # Filter to journeys that actually travel from origin to destination
+        route_journeys = []
+        for journey in all_journeys:
+            from_stop = None
+            to_stop = None
+            for stop in journey.stops:
+                if stop.station_code == from_station:
+                    from_stop = stop
+                elif stop.station_code == to_station:
+                    to_stop = stop
+
+            if (
+                from_stop
+                and to_stop
+                and (from_stop.stop_sequence or 0) < (to_stop.stop_sequence or 0)
+            ):
+                route_journeys.append(journey)
+
+        logger.info(
+            "route_summary_query",
+            journey_count=len(route_journeys),
+            from_station=from_station,
+            to_station=to_station,
+        )
+
+        # Generate summary
+        summary = self._generate_route_summary(route_journeys, from_station, to_station)
+
+        # Cache the result
+        self._cache[cache_key] = (summary, now_et())
+
+        return summary
+
+    async def get_train_summary(
+        self,
+        db: AsyncSession,
+        train_id: str,
+        from_station: str | None = None,
+        to_station: str | None = None,
+    ) -> OperationsSummary:
+        """
+        Generate a train-specific operations summary based on historical performance.
+
+        Args:
+            db: Database session
+            train_id: Train number (e.g., "3847")
+            from_station: Optional origin station code for route context
+            to_station: Optional destination station code for route context
+
+        Returns:
+            OperationsSummary with headline and body
+        """
+        cache_key = f"train_{train_id}_{from_station or 'any'}_{to_station or 'any'}"
+        if cache_key in self._cache:
+            cached_data, timestamp = self._cache[cache_key]
+            age_seconds = (now_et() - timestamp).total_seconds()
+            if age_seconds < self._cache_ttl:
+                logger.debug(
+                    "returning_cached_train_summary",
+                    cache_age_seconds=age_seconds,
+                )
+                return cached_data
+
+        # For train summaries, look back 30 days for historical context
+        cutoff_date = now_et().date() - timedelta(days=30)
+
+        stmt = (
+            select(TrainJourney)
+            .where(
+                and_(
+                    TrainJourney.train_id == train_id,
+                    TrainJourney.journey_date >= cutoff_date,
+                )
+            )
+            .options(selectinload(TrainJourney.stops))
+            .order_by(TrainJourney.journey_date.desc())
+        )
+
+        result = await db.execute(stmt)
+        journeys = list(result.scalars().all())
+
+        logger.info(
+            "train_summary_query",
+            train_id=train_id,
+            journey_count=len(journeys),
+            days=30,
+        )
+
+        # Generate summary
+        summary = self._generate_train_summary(
+            journeys, train_id, from_station, to_station
+        )
+
+        # Cache the result
+        self._cache[cache_key] = (summary, now_et())
+
+        return summary
+
+    def _calculate_line_stats(
+        self, journeys: list[TrainJourney]
+    ) -> dict[str, LineStats]:
+        """Calculate statistics grouped by line."""
+        stats: dict[str, dict] = defaultdict(
+            lambda: {
+                "line_name": "",
+                "line_code": "",
+                "train_count": 0,
+                "on_time_count": 0,
+                "cancellation_count": 0,
+                "total_delay_minutes": 0.0,
+                "data_source": "",
+            }
+        )
+
+        for journey in journeys:
+            line_key = journey.line_name or journey.line_code or "Unknown"
+            line_data = stats[line_key]
+
+            line_data["line_name"] = journey.line_name or line_key
+            line_data["line_code"] = journey.line_code or ""
+            line_data["data_source"] = journey.data_source
+            line_data["train_count"] += 1
+
+            if journey.is_cancelled:
+                line_data["cancellation_count"] += 1
+            else:
+                # Calculate delay from last stop
+                if journey.stops:
+                    last_stop = max(journey.stops, key=lambda s: s.stop_sequence or 0)
+                    if last_stop.actual_arrival and last_stop.scheduled_arrival:
+                        delay = (
+                            last_stop.actual_arrival - last_stop.scheduled_arrival
+                        ).total_seconds() / 60
+                        line_data["total_delay_minutes"] += max(0, delay)
+                        if delay <= 5:
+                            line_data["on_time_count"] += 1
+                    else:
+                        # No arrival data, assume on time
+                        line_data["on_time_count"] += 1
+
+        return {
+            key: LineStats(
+                line_name=data["line_name"],
+                line_code=data["line_code"],
+                train_count=data["train_count"],
+                on_time_count=data["on_time_count"],
+                cancellation_count=data["cancellation_count"],
+                total_delay_minutes=data["total_delay_minutes"],
+                data_source=data["data_source"],
+            )
+            for key, data in stats.items()
+        }
+
+    def _generate_network_summary(
+        self, line_stats: dict[str, LineStats]
+    ) -> OperationsSummary:
+        """Generate network-wide summary from line statistics."""
+        if not line_stats:
+            return OperationsSummary(
+                headline="No recent train data",
+                body="No train operations recorded in the past 90 minutes.",
+                scope="network",
+                time_window_minutes=SUMMARY_TIME_WINDOW_MINUTES,
+                data_freshness_seconds=0,
+                generated_at=now_et(),
+                metrics=None,
+            )
+
+        # Aggregate totals
+        total_trains = sum(ls.train_count for ls in line_stats.values())
+        total_on_time = sum(ls.on_time_count for ls in line_stats.values())
+        total_cancellations = sum(ls.cancellation_count for ls in line_stats.values())
+        total_delay = sum(ls.total_delay_minutes for ls in line_stats.values())
+
+        non_cancelled = total_trains - total_cancellations
+        on_time_pct = (total_on_time / non_cancelled * 100) if non_cancelled > 0 else 0
+        avg_delay = total_delay / non_cancelled if non_cancelled > 0 else 0
+
+        # Generate headline
+        headline = self._get_network_headline(
+            on_time_pct, avg_delay, total_cancellations
+        )
+
+        # Generate body
+        body_parts = []
+
+        # Lead sentence
+        if on_time_pct >= 85:
+            body_parts.append(
+                f"Most trains running on time with average delays of {avg_delay:.0f} minutes."
+            )
+        elif on_time_pct >= 70:
+            body_parts.append(
+                f"Some delays across the network. {on_time_pct:.0f}% of trains on schedule, "
+                f"averaging {avg_delay:.0f} minute delays."
+            )
+        else:
+            body_parts.append(
+                f"Widespread delays today. Only {on_time_pct:.0f}% of trains running on time, "
+                f"with delays averaging {avg_delay:.0f} minutes."
+            )
+
+        # Per-line breakdown for lines with issues
+        problem_lines = [
+            ls
+            for ls in line_stats.values()
+            if ls.cancellation_count > 0 or ls.average_delay_minutes > 10
+        ]
+
+        if problem_lines:
+            for ls in sorted(
+                problem_lines, key=lambda x: x.cancellation_count, reverse=True
+            )[:2]:
+                if ls.cancellation_count > 0:
+                    body_parts.append(
+                        f"{ls.line_name}: {ls.cancellation_count} cancellation(s), "
+                        f"averaging {ls.average_delay_minutes:.0f} min delays."
+                    )
+                elif ls.average_delay_minutes > 10:
+                    body_parts.append(
+                        f"{ls.line_name}: averaging {ls.average_delay_minutes:.0f} min delays."
+                    )
+
+        body = " ".join(body_parts)
+
+        return OperationsSummary(
+            headline=headline,
+            body=body,
+            scope="network",
+            time_window_minutes=SUMMARY_TIME_WINDOW_MINUTES,
+            data_freshness_seconds=0,
+            generated_at=now_et(),
+            metrics=SummaryMetrics(
+                on_time_percentage=on_time_pct,
+                average_delay_minutes=avg_delay,
+                cancellation_count=total_cancellations,
+                train_count=total_trains,
+            ),
+        )
+
+    def _get_network_headline(
+        self, on_time_pct: float, avg_delay: float, cancellations: int
+    ) -> str:
+        """Generate a concise headline based on network status."""
+        if on_time_pct >= 95 and avg_delay < 3:
+            return "Trains running smoothly"
+        elif on_time_pct >= 85 and avg_delay < 6:
+            return "Trains mostly on time"
+        elif on_time_pct >= 70 and avg_delay < 10:
+            return "Some delays across network"
+        elif on_time_pct >= 50:
+            return "Widespread delays today"
+        else:
+            return "Major disruptions"
+
+    def _generate_route_summary(
+        self,
+        journeys: list[TrainJourney],
+        from_station: str,
+        to_station: str,
+    ) -> OperationsSummary:
+        """Generate route-specific summary."""
+        from_name = get_station_name(from_station)
+        to_name = get_station_name(to_station)
+
+        if not journeys:
+            return OperationsSummary(
+                headline=f"{from_name} to {to_name}: No data",
+                body=f"No trains have completed this route in the past 90 minutes.",
+                scope="route",
+                time_window_minutes=SUMMARY_TIME_WINDOW_MINUTES,
+                data_freshness_seconds=0,
+                generated_at=now_et(),
+                metrics=None,
+            )
+
+        # Calculate statistics
+        on_time_count = 0
+        cancellation_count = 0
+        total_delay = 0.0
+        track_counts: dict[str, int] = defaultdict(int)
+        late_trains: list[tuple[str, float]] = []
+
+        for journey in journeys:
+            if journey.is_cancelled:
+                cancellation_count += 1
+                continue
+
+            # Find the destination stop for delay calculation
+            to_stop = None
+            from_stop_data = None
+            for stop in journey.stops:
+                if stop.station_code == to_station:
+                    to_stop = stop
+                if stop.station_code == from_station:
+                    from_stop_data = stop
+
+            # Track usage at origin
+            if from_stop_data and from_stop_data.track:
+                track_counts[from_stop_data.track] += 1
+
+            if to_stop and to_stop.actual_arrival and to_stop.scheduled_arrival:
+                delay = (
+                    to_stop.actual_arrival - to_stop.scheduled_arrival
+                ).total_seconds() / 60
+                delay = max(0, delay)
+                total_delay += delay
+                if delay <= 5:
+                    on_time_count += 1
+                elif delay > 10:
+                    late_trains.append((journey.train_id, delay))
+            else:
+                on_time_count += 1
+
+        non_cancelled = len(journeys) - cancellation_count
+        on_time_pct = (on_time_count / non_cancelled * 100) if non_cancelled > 0 else 0
+        avg_delay = total_delay / non_cancelled if non_cancelled > 0 else 0
+
+        # Most common track
+        most_common_track = (
+            max(track_counts, key=track_counts.get) if track_counts else None
+        )
+
+        # Generate headline
+        headline = f"{from_name} to {to_name}: {on_time_pct:.0f}% on time"
+
+        # Generate body
+        body_parts = []
+        body_parts.append(
+            f"{len(journeys)} train(s) have completed this route in the past 90 minutes."
+        )
+
+        if non_cancelled > 0:
+            body_parts.append(f"{on_time_count} arrived within 5 minutes of schedule.")
+
+        if late_trains:
+            worst = max(late_trains, key=lambda x: x[1])
+            body_parts.append(f"Train {worst[0]} ran {worst[1]:.0f} minutes late.")
+
+        if most_common_track:
+            body_parts.append(
+                f"Track {most_common_track} has been the most common departure track."
+            )
+
+        body = " ".join(body_parts)
+
+        return OperationsSummary(
+            headline=headline,
+            body=body,
+            scope="route",
+            time_window_minutes=SUMMARY_TIME_WINDOW_MINUTES,
+            data_freshness_seconds=0,
+            generated_at=now_et(),
+            metrics=SummaryMetrics(
+                on_time_percentage=on_time_pct,
+                average_delay_minutes=avg_delay,
+                cancellation_count=cancellation_count,
+                train_count=len(journeys),
+                most_common_track=most_common_track,
+            ),
+        )
+
+    def _generate_train_summary(
+        self,
+        journeys: list[TrainJourney],
+        train_id: str,
+        from_station: str | None,
+        to_station: str | None,
+    ) -> OperationsSummary:
+        """Generate train-specific summary based on 30-day history."""
+        if not journeys:
+            return OperationsSummary(
+                headline="No historical data",
+                body=f"No historical data available for Train {train_id}.",
+                scope="train",
+                time_window_minutes=30 * 24 * 60,  # 30 days in minutes
+                data_freshness_seconds=0,
+                generated_at=now_et(),
+                metrics=None,
+            )
+
+        # Calculate historical performance
+        on_time_count = 0
+        total_delay = 0.0
+        delay_samples = 0
+        station_delays: dict[str, list[float]] = defaultdict(list)
+
+        for journey in journeys:
+            if journey.is_cancelled:
+                continue
+
+            # Calculate overall delay
+            if journey.stops:
+                last_stop = max(journey.stops, key=lambda s: s.stop_sequence or 0)
+                if last_stop.actual_arrival and last_stop.scheduled_arrival:
+                    delay = (
+                        last_stop.actual_arrival - last_stop.scheduled_arrival
+                    ).total_seconds() / 60
+                    delay = max(0, delay)
+                    total_delay += delay
+                    delay_samples += 1
+                    if delay <= 5:
+                        on_time_count += 1
+
+                # Track per-station delays
+                for stop in journey.stops:
+                    if stop.actual_arrival and stop.scheduled_arrival:
+                        stop_delay = (
+                            stop.actual_arrival - stop.scheduled_arrival
+                        ).total_seconds() / 60
+                        station_delays[stop.station_code].append(stop_delay)
+
+        on_time_pct = (on_time_count / delay_samples * 100) if delay_samples > 0 else 0
+        avg_delay = total_delay / delay_samples if delay_samples > 0 else 0
+
+        # Find problem stations (where delays typically occur)
+        problem_stations = []
+        for station_code, delays in station_delays.items():
+            avg_station_delay = sum(delays) / len(delays)
+            if avg_station_delay > 3 and len(delays) >= 3:
+                problem_stations.append((station_code, avg_station_delay))
+        problem_stations.sort(key=lambda x: x[1], reverse=True)
+
+        # Generate headline based on on-time percentage (primary) and average delay (secondary)
+        if on_time_pct >= 90:
+            headline = "Usually runs on time"
+        elif on_time_pct >= 75:
+            headline = f"Usually runs {avg_delay:.0f} min late"
+        else:
+            headline = f"Often runs {avg_delay:.0f}+ min late"
+
+        # Generate body
+        body_parts = []
+        body_parts.append(
+            f"Over the past 30 days, Train {train_id} has been on time {on_time_pct:.0f}% of the time."
+        )
+
+        if problem_stations:
+            worst_station = problem_stations[0]
+            station_name = get_station_name(worst_station[0])
+            body_parts.append(f"It tends to pick up delays around {station_name}.")
+
+        # Check today's status
+        today = now_et().date()
+        today_journey = next((j for j in journeys if j.journey_date == today), None)
+        if today_journey:
+            if today_journey.is_cancelled:
+                body_parts.append("Today's service was cancelled.")
+            elif today_journey.stops:
+                first_stop = min(
+                    today_journey.stops, key=lambda s: s.stop_sequence or 0
+                )
+                if first_stop.actual_departure and first_stop.scheduled_departure:
+                    dep_delay = (
+                        first_stop.actual_departure - first_stop.scheduled_departure
+                    ).total_seconds() / 60
+                    if dep_delay > 1:
+                        body_parts.append(
+                            f"Today it departed {dep_delay:.0f} minutes late."
+                        )
+                    elif dep_delay < -1:
+                        body_parts.append("Today it departed on time.")
+
+        body = " ".join(body_parts)
+
+        return OperationsSummary(
+            headline=headline,
+            body=body,
+            scope="train",
+            time_window_minutes=30 * 24 * 60,  # 30 days in minutes
+            data_freshness_seconds=0,
+            generated_at=now_et(),
+            metrics=SummaryMetrics(
+                on_time_percentage=on_time_pct,
+                average_delay_minutes=avg_delay,
+                train_count=len(journeys),
+            ),
+        )

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -1,0 +1,454 @@
+"""
+Unit tests for SummaryService - Template-based NLG for train operations summaries.
+
+Tests the summary generation for network, route, and train scopes including
+headline/body generation and metrics calculation.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from trackrat.models.database import TrainJourney
+from trackrat.services.summary import (
+    LineStats,
+    OperationsSummary,
+    SummaryMetrics,
+    SummaryService,
+)
+
+
+class TestLineStats:
+    """Test cases for LineStats data class."""
+
+    def test_line_stats_on_time_percentage_calculation(self):
+        """Test on-time percentage calculation."""
+        stats = LineStats(
+            line_name="Northeast Corridor",
+            line_code="NEC",
+            train_count=10,
+            on_time_count=8,
+            cancellation_count=1,
+            total_delay_minutes=45.0,
+            data_source="NJT",
+        )
+
+        # 8 on-time out of 9 non-cancelled = 88.89%
+        assert abs(stats.on_time_percentage - 88.89) < 0.1
+
+    def test_line_stats_average_delay_calculation(self):
+        """Test average delay calculation."""
+        stats = LineStats(
+            line_name="Northeast Corridor",
+            line_code="NEC",
+            train_count=10,
+            on_time_count=8,
+            cancellation_count=1,
+            total_delay_minutes=45.0,
+            data_source="NJT",
+        )
+
+        # 45 minutes / 9 non-cancelled = 5.0 minutes
+        assert stats.average_delay_minutes == 5.0
+
+    def test_line_stats_all_cancelled(self):
+        """Test stats when all trains are cancelled."""
+        stats = LineStats(
+            line_name="Northeast Corridor",
+            line_code="NEC",
+            train_count=5,
+            on_time_count=0,
+            cancellation_count=5,
+            total_delay_minutes=0.0,
+            data_source="NJT",
+        )
+
+        assert stats.on_time_percentage == 0.0
+        assert stats.average_delay_minutes == 0.0
+
+    def test_line_stats_no_trains(self):
+        """Test stats with no trains."""
+        stats = LineStats(
+            line_name="Northeast Corridor",
+            line_code="NEC",
+            train_count=0,
+            on_time_count=0,
+            cancellation_count=0,
+            total_delay_minutes=0.0,
+            data_source="NJT",
+        )
+
+        assert stats.on_time_percentage == 0.0
+        assert stats.average_delay_minutes == 0.0
+
+
+class TestSummaryService:
+    """Test cases for SummaryService."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        db = AsyncMock(spec=AsyncSession)
+        db.execute = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def summary_service(self):
+        """Create a SummaryService instance for testing."""
+        return SummaryService()
+
+    @pytest.fixture
+    def sample_journeys(self):
+        """Create sample journey data for testing."""
+        current_time = datetime.now(UTC)
+
+        journeys = []
+
+        # Journey 1: On-time train
+        journey1 = Mock(spec=TrainJourney)
+        journey1.id = 1
+        journey1.train_id = "1234"
+        journey1.data_source = "NJT"
+        journey1.line_name = "Northeast Corridor"
+        journey1.line_code = "NEC"
+        journey1.is_cancelled = False
+        journey1.journey_date = current_time.date()
+        journey1.last_updated_at = current_time - timedelta(minutes=30)
+
+        # Stops for on-time journey
+        stop1_1 = Mock()
+        stop1_1.station_code = "NY"
+        stop1_1.stop_sequence = 1
+        stop1_1.scheduled_departure = current_time - timedelta(hours=1)
+        stop1_1.actual_departure = current_time - timedelta(hours=1)
+        stop1_1.scheduled_arrival = None
+        stop1_1.actual_arrival = None
+        stop1_1.track = "7"
+
+        stop1_2 = Mock()
+        stop1_2.station_code = "NP"
+        stop1_2.stop_sequence = 2
+        stop1_2.scheduled_arrival = current_time - timedelta(minutes=45)
+        stop1_2.actual_arrival = current_time - timedelta(minutes=45)
+        stop1_2.scheduled_departure = current_time - timedelta(minutes=43)
+        stop1_2.actual_departure = current_time - timedelta(minutes=43)
+        stop1_2.track = None
+
+        stop1_3 = Mock()
+        stop1_3.station_code = "TR"
+        stop1_3.stop_sequence = 3
+        stop1_3.scheduled_arrival = current_time - timedelta(minutes=15)
+        stop1_3.actual_arrival = current_time - timedelta(minutes=15)
+        stop1_3.scheduled_departure = None
+        stop1_3.actual_departure = None
+        stop1_3.track = None
+
+        journey1.stops = [stop1_1, stop1_2, stop1_3]
+        journeys.append(journey1)
+
+        # Journey 2: Late train (10 minutes delay)
+        journey2 = Mock(spec=TrainJourney)
+        journey2.id = 2
+        journey2.train_id = "5678"
+        journey2.data_source = "NJT"
+        journey2.line_name = "Northeast Corridor"
+        journey2.line_code = "NEC"
+        journey2.is_cancelled = False
+        journey2.journey_date = current_time.date()
+        journey2.last_updated_at = current_time - timedelta(minutes=20)
+
+        stop2_1 = Mock()
+        stop2_1.station_code = "NY"
+        stop2_1.stop_sequence = 1
+        stop2_1.scheduled_departure = current_time - timedelta(hours=2)
+        stop2_1.actual_departure = (
+            current_time - timedelta(hours=2) + timedelta(minutes=5)
+        )
+        stop2_1.scheduled_arrival = None
+        stop2_1.actual_arrival = None
+        stop2_1.track = "8"
+
+        stop2_2 = Mock()
+        stop2_2.station_code = "NP"
+        stop2_2.stop_sequence = 2
+        stop2_2.scheduled_arrival = current_time - timedelta(hours=1, minutes=45)
+        stop2_2.actual_arrival = current_time - timedelta(hours=1, minutes=35)
+        stop2_2.scheduled_departure = None
+        stop2_2.actual_departure = None
+        stop2_2.track = None
+
+        journey2.stops = [stop2_1, stop2_2]
+        journeys.append(journey2)
+
+        # Journey 3: Cancelled train
+        journey3 = Mock(spec=TrainJourney)
+        journey3.id = 3
+        journey3.train_id = "9999"
+        journey3.data_source = "NJT"
+        journey3.line_name = "Northeast Corridor"
+        journey3.line_code = "NEC"
+        journey3.is_cancelled = True
+        journey3.journey_date = current_time.date()
+        journey3.last_updated_at = current_time - timedelta(minutes=60)
+        journey3.stops = []
+        journeys.append(journey3)
+
+        return journeys
+
+    def test_calculate_line_stats(self, summary_service, sample_journeys):
+        """Test line statistics calculation from journeys."""
+        line_stats = summary_service._calculate_line_stats(sample_journeys)
+
+        assert "Northeast Corridor" in line_stats
+        nec_stats = line_stats["Northeast Corridor"]
+
+        assert nec_stats.train_count == 3
+        assert nec_stats.cancellation_count == 1
+        assert nec_stats.line_code == "NEC"
+        assert nec_stats.data_source == "NJT"
+
+    def test_generate_network_summary_excellent(self, summary_service):
+        """Test network summary generation for excellent performance."""
+        line_stats = {
+            "Northeast Corridor": LineStats(
+                line_name="Northeast Corridor",
+                line_code="NEC",
+                train_count=20,
+                on_time_count=19,
+                cancellation_count=0,
+                total_delay_minutes=15.0,
+                data_source="NJT",
+            )
+        }
+
+        summary = summary_service._generate_network_summary(line_stats)
+
+        assert summary.scope == "network"
+        assert (
+            "smoothly" in summary.headline.lower()
+            or "on time" in summary.headline.lower()
+        )
+        assert summary.metrics is not None
+        assert summary.metrics.on_time_percentage >= 90
+
+    def test_generate_network_summary_degraded(self, summary_service):
+        """Test network summary generation for degraded performance."""
+        line_stats = {
+            "Northeast Corridor": LineStats(
+                line_name="Northeast Corridor",
+                line_code="NEC",
+                train_count=20,
+                on_time_count=10,
+                cancellation_count=3,
+                total_delay_minutes=150.0,
+                data_source="NJT",
+            )
+        }
+
+        summary = summary_service._generate_network_summary(line_stats)
+
+        assert summary.scope == "network"
+        assert (
+            "delay" in summary.headline.lower()
+            or "disruption" in summary.headline.lower()
+        )
+
+    def test_generate_network_summary_empty(self, summary_service):
+        """Test network summary with no data."""
+        summary = summary_service._generate_network_summary({})
+
+        assert summary.scope == "network"
+        assert "no" in summary.headline.lower()
+        assert summary.metrics is None
+
+    def test_get_network_headline_thresholds(self, summary_service):
+        """Test headline generation for different performance thresholds."""
+        # Excellent
+        headline = summary_service._get_network_headline(96, 2, 0)
+        assert "smooth" in headline.lower()
+
+        # Good
+        headline = summary_service._get_network_headline(87, 4, 0)
+        assert "on time" in headline.lower()
+
+        # Moderate
+        headline = summary_service._get_network_headline(72, 8, 1)
+        assert "some" in headline.lower() or "delay" in headline.lower()
+
+        # Degraded
+        headline = summary_service._get_network_headline(55, 12, 2)
+        assert "widespread" in headline.lower() or "delay" in headline.lower()
+
+        # Severe
+        headline = summary_service._get_network_headline(40, 20, 5)
+        assert "major" in headline.lower() or "disruption" in headline.lower()
+
+    def test_generate_route_summary_with_data(self, summary_service, sample_journeys):
+        """Test route summary generation with journey data."""
+        # Filter to journeys between NY and NP
+        route_journeys = [j for j in sample_journeys if not j.is_cancelled]
+
+        summary = summary_service._generate_route_summary(route_journeys, "NY", "NP")
+
+        assert summary.scope == "route"
+        assert "NY" in summary.headline or "New York" in summary.headline
+        assert summary.metrics is not None
+        assert summary.metrics.train_count == 2
+
+    def test_generate_route_summary_empty(self, summary_service):
+        """Test route summary with no data."""
+        summary = summary_service._generate_route_summary([], "NY", "NP")
+
+        assert summary.scope == "route"
+        assert "no" in summary.headline.lower() or "no data" in summary.body.lower()
+
+    def test_generate_train_summary_good_performance(self, summary_service):
+        """Test train summary for train with good historical performance."""
+        current_time = datetime.now(UTC)
+
+        # Create 10 on-time journeys
+        journeys = []
+        for i in range(10):
+            journey = Mock(spec=TrainJourney)
+            journey.id = i
+            journey.train_id = "1234"
+            journey.is_cancelled = False
+            journey.journey_date = (current_time - timedelta(days=i)).date()
+
+            # All on-time
+            stop = Mock()
+            stop.station_code = "TR"
+            stop.stop_sequence = 3
+            stop.scheduled_arrival = current_time - timedelta(days=i)
+            stop.actual_arrival = (
+                current_time - timedelta(days=i) + timedelta(minutes=2)
+            )
+            stop.scheduled_departure = None
+            stop.actual_departure = None
+
+            journey.stops = [stop]
+            journeys.append(journey)
+
+        summary = summary_service._generate_train_summary(journeys, "1234", None, None)
+
+        assert summary.scope == "train"
+        assert "on time" in summary.headline.lower()
+        assert summary.metrics.on_time_percentage >= 90
+
+    def test_generate_train_summary_poor_performance(self, summary_service):
+        """Test train summary for train with poor historical performance."""
+        current_time = datetime.now(UTC)
+
+        # Create 10 late journeys
+        journeys = []
+        for i in range(10):
+            journey = Mock(spec=TrainJourney)
+            journey.id = i
+            journey.train_id = "9999"
+            journey.is_cancelled = False
+            journey.journey_date = (current_time - timedelta(days=i)).date()
+
+            stop = Mock()
+            stop.station_code = "TR"
+            stop.stop_sequence = 3
+            stop.scheduled_arrival = current_time - timedelta(days=i)
+            stop.actual_arrival = (
+                current_time - timedelta(days=i) + timedelta(minutes=15)
+            )
+            stop.scheduled_departure = None
+            stop.actual_departure = None
+
+            journey.stops = [stop]
+            journeys.append(journey)
+
+        summary = summary_service._generate_train_summary(journeys, "9999", None, None)
+
+        assert summary.scope == "train"
+        assert "late" in summary.headline.lower()
+
+    def test_generate_train_summary_no_history(self, summary_service):
+        """Test train summary with no historical data."""
+        summary = summary_service._generate_train_summary([], "1234", None, None)
+
+        assert summary.scope == "train"
+        assert "no" in summary.headline.lower()
+
+    def test_cache_works(self, summary_service):
+        """Test that caching prevents redundant calculations."""
+        line_stats = {
+            "Northeast Corridor": LineStats(
+                line_name="Northeast Corridor",
+                line_code="NEC",
+                train_count=20,
+                on_time_count=18,
+                cancellation_count=0,
+                total_delay_minutes=20.0,
+                data_source="NJT",
+            )
+        }
+
+        # Generate summary and store in cache
+        summary1 = summary_service._generate_network_summary(line_stats)
+
+        # Manually set cache
+        from trackrat.utils.time import now_et
+
+        summary_service._cache["network_all"] = (summary1, now_et())
+
+        # Check cache is used (would need to mock now_et for full test)
+        assert "network_all" in summary_service._cache
+
+
+class TestSummaryMetrics:
+    """Test cases for SummaryMetrics data class."""
+
+    def test_summary_metrics_initialization(self):
+        """Test SummaryMetrics initialization with all fields."""
+        metrics = SummaryMetrics(
+            on_time_percentage=85.5,
+            average_delay_minutes=4.2,
+            cancellation_count=2,
+            train_count=24,
+            most_common_track="7",
+        )
+
+        assert metrics.on_time_percentage == 85.5
+        assert metrics.average_delay_minutes == 4.2
+        assert metrics.cancellation_count == 2
+        assert metrics.train_count == 24
+        assert metrics.most_common_track == "7"
+
+    def test_summary_metrics_optional_fields(self):
+        """Test SummaryMetrics with optional fields as None."""
+        metrics = SummaryMetrics()
+
+        assert metrics.on_time_percentage is None
+        assert metrics.average_delay_minutes is None
+        assert metrics.cancellation_count is None
+        assert metrics.train_count is None
+        assert metrics.most_common_track is None
+
+
+class TestOperationsSummary:
+    """Test cases for OperationsSummary data class."""
+
+    def test_operations_summary_initialization(self):
+        """Test OperationsSummary initialization."""
+        from trackrat.utils.time import now_et
+
+        summary = OperationsSummary(
+            headline="Trains running smoothly",
+            body="Most trains on time with average delays under 5 minutes.",
+            scope="network",
+            time_window_minutes=90,
+            data_freshness_seconds=45,
+            generated_at=now_et(),
+            metrics=SummaryMetrics(on_time_percentage=95.0),
+        )
+
+        assert summary.headline == "Trains running smoothly"
+        assert summary.scope == "network"
+        assert summary.time_window_minutes == 90
+        assert summary.metrics.on_time_percentage == 95.0

--- a/ios/TrackRat/Models/V2APIModels.swift
+++ b/ios/TrackRat/Models/V2APIModels.swift
@@ -853,29 +853,102 @@ extension CongestionSegment {
     var fromStationDisplayName: String {
         fromStationName.isEmpty ? Stations.displayNameForCode(fromStation) : fromStationName
     }
-    
+
     var toStationDisplayName: String {
         toStationName.isEmpty ? Stations.displayNameForCode(toStation) : toStationName
     }
-    
+
     var averageTransitTimeText: String {
         return ""
     }
-    
+
     var sampleCountText: String {
         "\(sampleCount) train\(sampleCount == 1 ? "" : "s")"
     }
-    
+
     var delayText: String {
         return ""
     }
-    
+
     var congestionFactorDisplay: String {
         let percentage = Int((congestionFactor - 1) * 100)
         if percentage > 0 {
             return "+\(percentage)% slower"
         } else {
             return "Normal time"
+        }
+    }
+}
+
+// MARK: - Operations Summary Models
+
+/// Summary scope for operations summary API
+enum SummaryScope: String, Codable {
+    case network
+    case route
+    case train
+}
+
+/// Raw metrics included with summary response
+struct SummaryMetrics: Codable {
+    let onTimePercentage: Double?
+    let averageDelayMinutes: Double?
+    let cancellationCount: Int?
+    let trainCount: Int?
+    let mostCommonTrack: String?
+
+    enum CodingKeys: String, CodingKey {
+        case onTimePercentage = "on_time_percentage"
+        case averageDelayMinutes = "average_delay_minutes"
+        case cancellationCount = "cancellation_count"
+        case trainCount = "train_count"
+        case mostCommonTrack = "most_common_track"
+    }
+}
+
+/// Response for operations summary endpoint
+struct OperationsSummaryResponse: Codable {
+    /// Short headline for collapsed view (max 50 chars)
+    let headline: String
+
+    /// Detailed summary (2-4 sentences) for expanded view
+    let body: String
+
+    /// Summary scope: network, route, or train
+    let scope: String
+
+    /// Time window in minutes (90 for recent, 43200 for 30-day)
+    let timeWindowMinutes: Int
+
+    /// Age of data in seconds
+    let dataFreshnessSeconds: Int
+
+    /// When summary was generated
+    let generatedAt: Date
+
+    /// Raw metrics for optional UI display
+    let metrics: SummaryMetrics?
+
+    enum CodingKeys: String, CodingKey {
+        case headline
+        case body
+        case scope
+        case timeWindowMinutes = "time_window_minutes"
+        case dataFreshnessSeconds = "data_freshness_seconds"
+        case generatedAt = "generated_at"
+        case metrics
+    }
+
+    /// Formatted data freshness for display
+    var dataFreshnessFormatted: String {
+        if dataFreshnessSeconds < 60 {
+            return "just now"
+        } else if dataFreshnessSeconds < 3600 {
+            let minutes = dataFreshnessSeconds / 60
+            return "\(minutes) min ago"
+        } else {
+            let hours = dataFreshnessSeconds / 3600
+            return "\(hours) hr ago"
         }
     }
 }

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -727,7 +727,76 @@ final class APIService: ObservableObject {
             throw error
         }
     }
-    
+
+    // MARK: - Operations Summary
+
+    /// Fetch operations summary for network, route, or train scope
+    /// - Parameters:
+    ///   - scope: Summary scope (network, route, or train)
+    ///   - fromStation: Origin station code (required for route, optional for train)
+    ///   - toStation: Destination station code (required for route)
+    ///   - trainId: Train ID (required for train scope)
+    ///   - dataSource: Optional filter by NJT or AMTRAK
+    /// - Returns: OperationsSummaryResponse with headline and body
+    func fetchOperationsSummary(
+        scope: SummaryScope,
+        fromStation: String? = nil,
+        toStation: String? = nil,
+        trainId: String? = nil,
+        dataSource: String? = nil
+    ) async throws -> OperationsSummaryResponse {
+        var components = URLComponents(string: "\(baseURL)/v2/routes/summary")!
+        var queryItems: [URLQueryItem] = [
+            URLQueryItem(name: "scope", value: scope.rawValue)
+        ]
+
+        if let fromStation = fromStation {
+            queryItems.append(URLQueryItem(name: "from_station", value: fromStation))
+        }
+
+        if let toStation = toStation {
+            queryItems.append(URLQueryItem(name: "to_station", value: toStation))
+        }
+
+        if let trainId = trainId {
+            queryItems.append(URLQueryItem(name: "train_id", value: trainId))
+        }
+
+        if let dataSource = dataSource {
+            queryItems.append(URLQueryItem(name: "data_source", value: dataSource))
+        }
+
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+
+        print("📊 Fetching operations summary from: \(url)")
+
+        let (data, response) = try await session.data(from: url)
+
+        if let httpResponse = response as? HTTPURLResponse {
+            if httpResponse.statusCode == 400 {
+                throw APIError.invalidParameters
+            } else if httpResponse.statusCode != 200 {
+                throw APIError.noData
+            }
+        }
+
+        do {
+            let response = try decoder.decode(OperationsSummaryResponse.self, from: data)
+            print("✅ Operations summary decoded: \(response.headline)")
+            return response
+        } catch {
+            print("🔴 DECODING ERROR (fetchOperationsSummary): \(error)")
+            if let jsonString = String(data: data, encoding: .utf8) {
+                print("🔴 RAW DATA: \(jsonString.prefix(500))")
+            }
+            throw error
+        }
+    }
+
     // MARK: - V2 API Adapters
     
     private func adaptV2DepartureToTrainV2(_ departure: V2TrainDeparture) -> TrainV2 {

--- a/ios/TrackRat/Views/Components/OperationsSummaryView.swift
+++ b/ios/TrackRat/Views/Components/OperationsSummaryView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+/// A collapsible info box that displays a brief summary of recent train operations.
+/// Supports three scopes: network (overall), route (origin to destination), and train (specific train).
+struct OperationsSummaryView: View {
+    let scope: SummaryScope
+    let fromStation: String?
+    let toStation: String?
+    let trainId: String?
+
+    @State private var summary: OperationsSummaryResponse?
+    @State private var isExpanded = false
+    @State private var isLoading = true
+    @State private var hasError = false
+    @Environment(\.scenePhase) private var scenePhase
+
+    init(scope: SummaryScope, fromStation: String? = nil, toStation: String? = nil, trainId: String? = nil) {
+        self.scope = scope
+        self.fromStation = fromStation
+        self.toStation = toStation
+        self.trainId = trainId
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Collapsed pill (always visible)
+            Button(action: {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    isExpanded.toggle()
+                }
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }) {
+                HStack(spacing: 8) {
+                    Image(systemName: "info.circle.fill")
+                        .foregroundColor(.orange.opacity(0.8))
+                        .font(.subheadline)
+
+                    if isLoading {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                            .frame(height: 16)
+                    } else if hasError {
+                        Text("Unable to load summary")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    } else if let summary = summary {
+                        Text(summary.headline)
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer()
+
+                    if !isLoading && !hasError && summary != nil {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color(.systemGray6).opacity(0.9))
+                )
+            }
+            .buttonStyle(.plain)
+
+            // Expanded content
+            if isExpanded, let summary = summary {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(summary.body)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .lineSpacing(2)
+
+                    // Metrics row (if available)
+                    if let metrics = summary.metrics {
+                        metricsRow(metrics)
+                    }
+
+                    HStack {
+                        Spacer()
+                        Text("Updated \(summary.dataFreshnessFormatted)")
+                            .font(.caption2)
+                            .foregroundColor(.tertiary)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color(.systemGray6).opacity(0.9))
+                )
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .task {
+            await fetchSummary()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            // Auto-refresh when returning to foreground
+            if newPhase == .active {
+                Task {
+                    await fetchSummary()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func metricsRow(_ metrics: SummaryMetrics) -> some View {
+        HStack(spacing: 16) {
+            if let onTime = metrics.onTimePercentage {
+                metricBadge(
+                    value: "\(Int(onTime))%",
+                    label: "On Time",
+                    color: onTime >= 85 ? .green : (onTime >= 70 ? .yellow : .orange)
+                )
+            }
+
+            if let trainCount = metrics.trainCount, trainCount > 0 {
+                metricBadge(
+                    value: "\(trainCount)",
+                    label: trainCount == 1 ? "Train" : "Trains",
+                    color: .blue
+                )
+            }
+
+            if let cancellations = metrics.cancellationCount, cancellations > 0 {
+                metricBadge(
+                    value: "\(cancellations)",
+                    label: "Cancelled",
+                    color: .red
+                )
+            }
+
+            if let track = metrics.mostCommonTrack {
+                metricBadge(
+                    value: track,
+                    label: "Track",
+                    color: .purple
+                )
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    @ViewBuilder
+    private func metricBadge(value: String, label: String, color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(color)
+
+            Text(label)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func fetchSummary() async {
+        isLoading = true
+        hasError = false
+
+        do {
+            summary = try await APIService.shared.fetchOperationsSummary(
+                scope: scope,
+                fromStation: fromStation,
+                toStation: toStation,
+                trainId: trainId
+            )
+            isLoading = false
+        } catch {
+            print("❌ Failed to fetch operations summary: \(error)")
+            hasError = true
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Network Summary") {
+    VStack(spacing: 20) {
+        OperationsSummaryView(scope: .network)
+
+        OperationsSummaryView(
+            scope: .route,
+            fromStation: "NY",
+            toStation: "NP"
+        )
+
+        OperationsSummaryView(
+            scope: .train,
+            trainId: "3847"
+        )
+    }
+    .padding()
+    .background(Color(.systemBackground))
+}

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -140,15 +140,21 @@ struct MapContainerView: View {
             )
             .ignoresSafeArea()
             
-            // Optional: Show subtle loading indicator when data is loading
-            if mapViewModel.isLoading && mapViewModel.segments.isEmpty {
-                VStack {
-                    Spacer()
+            // Operations summary pill (network scope)
+            VStack {
+                Spacer()
+
+                OperationsSummaryView(scope: .network)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+
+                // Show subtle loading indicator when data is loading
+                if mapViewModel.isLoading && mapViewModel.segments.isEmpty {
                     HStack {
                         ProgressView()
                             .progressViewStyle(CircularProgressViewStyle(tint: .orange))
                             .scaleEffect(0.8)
-                        
+
                         Text("Loading traffic data...")
                             .font(.caption)
                             .foregroundColor(.secondary)
@@ -158,9 +164,9 @@ struct MapContainerView: View {
                         RoundedRectangle(cornerRadius: 8)
                             .fill(.ultraThinMaterial)
                     )
-                    .padding(.bottom, 120) // Above bottom sheet
                 }
             }
+            .padding(.bottom, 120) // Above bottom sheet
             
             // Gradient overlay at top for better readability
             VStack {

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -48,6 +48,14 @@ struct TrainDetailsView: View {
                     }
                 } else if let train = viewModel.train {
                     VStack(spacing: 16) {
+                        // Train historical performance summary
+                        OperationsSummaryView(
+                            scope: .train,
+                            fromStation: appState.departureStationCode,
+                            toStation: appState.destinationStationCode,
+                            trainId: train.trainId
+                        )
+
                         CombinedDetailsCard(
                             train: train,
                             selectedDestination: appState.selectedDestination,

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -40,6 +40,17 @@ struct TrainListView: View {
                 } else if viewModel.trains.isEmpty {
                     EmptyStateView(message: "No trains found")
                 } else {
+                    // Route summary (if we have both origin and destination)
+                    if !departureStationCode.isEmpty,
+                       let destinationCode = Stations.getStationCode(destination) {
+                        OperationsSummaryView(
+                            scope: .route,
+                            fromStation: departureStationCode,
+                            toStation: destinationCode
+                        )
+                        .padding(.bottom, 4)
+                    }
+
                     let expressTrains = viewModel.identifyExpressTrains()
                     ForEach(viewModel.trains) { train in
                         TrainCard(


### PR DESCRIPTION
Implements a new feature that generates brief, natural language summaries of recent train operations, shown as a collapsible info box in the iOS app.

Backend:
- New SummaryService with template-based NLG for 3 scopes:
  - network: Overall system status (past 90 minutes)
  - route: Performance between origin/destination
  - train: Historical performance (past 30 days)
- GET /api/v2/routes/summary endpoint with scope/station params
- Per-line statistics with cancellations and delay breakdowns
- 5-minute cache to reduce database load

iOS:
- New OperationsSummaryView component (collapsible pill)
- Auto-refresh when app returns to foreground
- Integrated into MapContainerView (network), TrainListView (route), and TrainDetailsView (train history)
- Metrics badges for on-time %, train count, cancellations

Tests:
- 18 unit tests covering all summary generation scenarios