### PR TITLE
Guard token logging with DEBUG flag for production security

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -127,20 +127,22 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let tokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
+
+        #if DEBUG
         print("📱 Device token received: \(tokenString)")
-        
-        // DEBUG: Print actual bundle ID being used
         if let bundleId = Bundle.main.bundleIdentifier {
             print("📱 iOS App Bundle ID: \(bundleId)")
         }
-        
+        #endif
+
         // Store device token for Live Activity registration
         Task { @MainActor in
             AppDelegate.deviceToken = tokenString
         }
-        
-        // Device token received - Live Activities will handle their own registration
-        print("📱 Device token received: \(tokenString) - Live Activities ready")
+
+        #if DEBUG
+        print("📱 Device token stored - Live Activities ready")
+        #endif
     }
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -637,10 +637,12 @@ final class APIService: ObservableObject {
         let encoder = JSONEncoder()
         request.httpBody = try encoder.encode(body)
         
+        #if DEBUG
         print("📱 Registering Live Activity token (V2):")
         print("  Token: \(pushToken.prefix(10))...")
         print("  Train: \(trainNumber)")
         print("  Route: \(originCode) → \(destinationCode)")
+        #endif
         
         let (_, response) = try await session.data(for: request)
         

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -320,7 +320,9 @@ class LiveActivityService: ObservableObject {
                         break
                     }
 
+                    #if DEBUG
                     print("📡 Received Live Activity push token: \(pushToken.prefix(20))...")
+                    #endif
 
                     // Store the token for later use (e.g., unregistration)
                     await MainActor.run { [weak self] in
@@ -345,7 +347,9 @@ class LiveActivityService: ObservableObject {
     
     private func registerPushToken(_ token: Data, for train: TrainV2, from originCode: String, to destinationCode: String) async {
         let tokenString = token.map { String(format: "%02x", $0) }.joined()
+        #if DEBUG
         print("🔧 Converting push token to string: \(tokenString.prefix(20))...")
+        #endif
 
         // Remove nested Task - we're already in async context
         for activity in Activity<TrainActivityAttributes>.activities {


### PR DESCRIPTION
Wrap push token and device token logging in #if DEBUG guards to prevent
sensitive token values from appearing in production system logs. This
addresses the security concern of token exposure via device logs.