### PR TITLE
Find source of train status message on map

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -581,6 +581,11 @@ class SummaryService:
         """Generate network-wide summary from line statistics."""
         if not line_stats:
             # No data - return empty so iOS can hide the section
+            logger.info(
+                "network_summary_empty",
+                reason="no_line_stats",
+                message="Returning empty body - no train data in time window",
+            )
             return OperationsSummary(
                 headline="",
                 body="",
@@ -647,6 +652,17 @@ class SummaryService:
                     )
 
         body = " ".join(body_parts)
+
+        logger.info(
+            "network_summary_generated",
+            total_trains=total_trains,
+            on_time_pct=round(on_time_pct, 1),
+            avg_delay=round(avg_delay, 1),
+            cancellations=total_cancellations,
+            line_count=len(line_stats),
+            headline=headline,
+            body_length=len(body),
+        )
 
         return OperationsSummary(
             headline=headline,

--- a/ios/TrackRat/Views/Components/OperationsSummaryView.swift
+++ b/ios/TrackRat/Views/Components/OperationsSummaryView.swift
@@ -86,16 +86,26 @@ struct OperationsSummaryView: View {
         isLoading = true
         hasError = false
 
+        print("📊 OperationsSummary: Fetching scope=\(scope), from=\(fromStation ?? "nil"), to=\(toStation ?? "nil"), train=\(trainId ?? "nil")")
+
         do {
-            summary = try await APIService.shared.fetchOperationsSummary(
+            let result = try await APIService.shared.fetchOperationsSummary(
                 scope: scope,
                 fromStation: fromStation,
                 toStation: toStation,
                 trainId: trainId
             )
+            summary = result
             isLoading = false
+
+            // Log what we received
+            if result.body.isEmpty {
+                print("📊 OperationsSummary: Received EMPTY body - view will be hidden (headline='\(result.headline)')")
+            } else {
+                print("📊 OperationsSummary: Received body='\(result.body.prefix(80))...' headline='\(result.headline)'")
+            }
         } catch {
-            print("❌ Failed to fetch operations summary: \(error)")
+            print("❌ OperationsSummary: Failed to fetch - \(error) - view will be hidden")
             hasError = true
             isLoading = false
         }


### PR DESCRIPTION
Add logging to debug when the "trains running on time" message appears or is hidden on the iOS map view.

Backend (summary.py):
- Log when returning empty body due to no line_stats
- Log generated summary metrics (trains, on_time_pct, delays)

iOS (OperationsSummaryView.swift):
- Log fetch request with scope/parameters
- Log whether response body is empty (view hidden) or populated