### PR TITLE
fix(ios): Align close button with content by matching horizontal padding

### DIFF
--- a/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
+++ b/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
@@ -56,12 +56,11 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
                 .foregroundColor(.white)
                 .font(.body)
                 .frame(height: 44)
-                .padding(.trailing, 24)
             } else {
                 Color.clear.frame(width: 44, height: 44)
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 16)
         .padding(.vertical, 8)
         .background(Color(UIColor.systemBackground))
     }

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -63,9 +63,9 @@ struct TrainListView: View {
                 }
                 .foregroundColor(.white)
                 .font(.body)
-                .frame(width: 44, height: 44)
+                .frame(height: 44)
             }
-            .padding(.horizontal, 8)
+            .padding(.horizontal, 16)
             .padding(.vertical, 8)
             .background(Color(UIColor.systemBackground))
 


### PR DESCRIPTION
Remove extra trailing padding from close button and increase header
horizontal padding to 16pt to match content padding below.