### PR TITLE
Optimize train listing view performance

### DIFF
--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -86,10 +86,9 @@ async def get_departures(
 
     cache_service = ApiCacheService()
 
-    # Only use cache when using default parameters (no hide_departed since it's dynamic)
-    use_cache = (
-        date is None and time_from is None and time_to is None and not hide_departed
-    )
+    # Use cache when using default time parameters (date, time_from, time_to are None)
+    # Cache supports both hide_departed=true and hide_departed=false
+    use_cache = date is None and time_from is None and time_to is None
 
     if use_cache:
         cache_params = {
@@ -97,6 +96,7 @@ async def get_departures(
             "to_station": to_station,
             "date": None,
             "limit": limit,
+            "hide_departed": hide_departed,
         }
 
         cached_response = await cache_service.get_cached_response(
@@ -117,6 +117,15 @@ async def get_departures(
                 await cache_service.invalidate_cache_entry(
                     db, "/api/v2/trains/departures", cache_params
                 )
+        else:
+            # Cache miss - log for observability
+            logger.info(
+                "cache_miss",
+                endpoint="/api/v2/trains/departures",
+                from_station=from_station,
+                to_station=to_station,
+                hide_departed=hide_departed,
+            )
 
     service = DepartureService()
     response = await service.get_departures(

--- a/backend_v2/src/trackrat/services/api_cache.py
+++ b/backend_v2/src/trackrat/services/api_cache.py
@@ -308,18 +308,35 @@ class ApiCacheService:
         return response.model_dump(mode="json")
 
     async def precompute_departure_responses(self, db: AsyncSession) -> None:
-        """Pre-compute departure responses for popular station pairs."""
+        """Pre-compute departure responses for popular station pairs.
 
-        popular_routes: list[dict[str, Any]] = [
-            {"from_station": "NY", "to_station": "TR", "date": None, "limit": 50},
-            {"from_station": "NY", "to_station": "NP", "date": None, "limit": 50},
-            {"from_station": "TR", "to_station": "NY", "date": None, "limit": 50},
-            {"from_station": "NP", "to_station": "NY", "date": None, "limit": 50},
-            {"from_station": "NY", "to_station": "PJ", "date": None, "limit": 50},
-            {"from_station": "PJ", "to_station": "NY", "date": None, "limit": 50},
-            {"from_station": "NY", "to_station": "LB", "date": None, "limit": 50},
-            {"from_station": "LB", "to_station": "NY", "date": None, "limit": 50},
+        Generates cache entries for both hide_departed=true (iOS) and
+        hide_departed=false (web/default) variants.
+        """
+
+        # Base popular routes
+        base_routes = [
+            {"from_station": "NY", "to_station": "TR"},
+            {"from_station": "NY", "to_station": "NP"},
+            {"from_station": "TR", "to_station": "NY"},
+            {"from_station": "NP", "to_station": "NY"},
+            {"from_station": "NY", "to_station": "PJ"},
+            {"from_station": "PJ", "to_station": "NY"},
+            {"from_station": "NY", "to_station": "LB"},
+            {"from_station": "LB", "to_station": "NY"},
         ]
+
+        # Generate both hide_departed variants for each route
+        popular_routes: list[dict[str, Any]] = []
+        for route in base_routes:
+            # hide_departed=false (web/default)
+            popular_routes.append(
+                {**route, "date": None, "limit": 50, "hide_departed": False}
+            )
+            # hide_departed=true (iOS)
+            popular_routes.append(
+                {**route, "date": None, "limit": 50, "hide_departed": True}
+            )
 
         logger.info("precomputing_departure_responses", route_count=len(popular_routes))
 
@@ -358,6 +375,7 @@ class ApiCacheService:
         assert from_station is not None, "from_station is required"
         to_station = params.get("to_station")
         limit = params.get("limit", 50)
+        hide_departed = params.get("hide_departed", False)
 
         response = await self.departure_service.get_departures(
             db=db,
@@ -367,6 +385,7 @@ class ApiCacheService:
             time_from=None,
             time_to=None,
             limit=limit,
+            hide_departed=hide_departed,
             skip_individual_refresh=True,  # Skip individual train refreshes during precompute
         )
 

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -2,6 +2,7 @@
 Departure service for handling train departure queries.
 """
 
+import time
 from datetime import date, datetime, timedelta
 from typing import Any
 
@@ -100,13 +101,19 @@ class DepartureService:
         if hide_departed:
             departure_filters.append(JourneyStop.has_departed_station.is_(False))
 
+        # PERFORMANCE: Track timing for observability
+        perf_start = time.perf_counter()
+
         # Ensure fresh data for NJT trains BEFORE querying, so the query returns
         # up-to-date departure times. This prevents stale data from causing
         # incorrect delay calculations in the response.
+        jit_start = time.perf_counter()
         await self._ensure_fresh_station_data(
             db, from_station, target_date, skip_individual_refresh
         )
+        jit_duration_ms = (time.perf_counter() - jit_start) * 1000
 
+        query_start = time.perf_counter()
         stmt = (
             select(TrainJourney)
             .join(
@@ -130,6 +137,8 @@ class DepartureService:
 
         result = await db.execute(stmt)
         journeys = list(result.scalars().unique().all())
+        query_duration_ms = (time.perf_counter() - query_start) * 1000
+        journeys_loaded = len(journeys)
 
         # Deduplicate by train_id to handle cases where the same train appears
         # with different journey_dates (e.g., stale records from previous days).
@@ -221,6 +230,21 @@ class DepartureService:
 
             if len(departures) >= limit:
                 break
+
+        # PERFORMANCE: Log timing and result set metrics for observability
+        total_duration_ms = (time.perf_counter() - perf_start) * 1000
+        logger.info(
+            "departures_query_complete",
+            from_station=from_station,
+            to_station=to_station,
+            hide_departed=hide_departed,
+            jit_refresh_ms=round(jit_duration_ms, 1),
+            query_ms=round(query_duration_ms, 1),
+            total_ms=round(total_duration_ms, 1),
+            journeys_loaded=journeys_loaded,
+            journeys_returned=len(departures),
+            skip_individual_refresh=skip_individual_refresh,
+        )
 
         return DeparturesResponse(
             departures=departures,

--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -236,11 +236,8 @@ struct TrainV2: Identifiable, Codable {
         guard let time = getDepartureTime(fromStationCode: fromStationCode) else {
             return "--:--"
         }
-        
-        let formatter = DateFormatter()
-        formatter.timeZone = TimeZone(identifier: "America/New_York")
-        formatter.dateFormat = "h:mm a"
-        return formatter.string(from: time)
+        // PERFORMANCE: Use cached static formatter instead of creating new one each call
+        return DateFormatter.easternTimeShort.string(from: time)
     }
     
     // Check if train is departing soon (within specified minutes)

--- a/ios/TrackRat/Utilities/Extensions.swift
+++ b/ios/TrackRat/Utilities/Extensions.swift
@@ -124,7 +124,16 @@ extension DateFormatter {
         formatter.timeZone = TimeZone(identifier: "America/New_York")
         return formatter
     }()
-    
+
+    /// Cached formatter for "h:mm a" in Eastern Time - used for departure/arrival times
+    /// PERFORMANCE: DateFormatter instantiation is expensive, reuse this static instance
+    static let easternTimeShort: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(identifier: "America/New_York")
+        formatter.dateFormat = "h:mm a"
+        return formatter
+    }()
+
     static func easternTime(date dateStyle: DateFormatter.Style? = nil, time timeStyle: DateFormatter.Style? = nil) -> DateFormatter {
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone(identifier: "America/New_York")

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -70,7 +70,7 @@ struct TrainListView: View {
 
             // Scrollable content
             ScrollView {
-                VStack(spacing: 16) {
+                LazyVStack(spacing: 16) {
                     if viewModel.isLoading || (!viewModel.hasStartedLoading && viewModel.trains.isEmpty) {
                         TrackRatLoadingView(message: "Finding your trains...")
                             .frame(maxWidth: .infinity, minHeight: 200)
@@ -108,7 +108,6 @@ struct TrainListView: View {
                             .padding(.bottom, 4)
                         }
 
-                        let expressTrains = viewModel.identifyExpressTrains()
                         ForEach(viewModel.trains) { train in
                             TrainCard(
                                 train: train,
@@ -138,7 +137,7 @@ struct TrainListView: View {
                                         journeyDate: train.journeyDate
                                     )
                                 },
-                                isExpress: expressTrains.contains(train.trainId)
+                                isExpress: viewModel.expressTrainIds.contains(train.trainId)
                             )
                         }
                     }
@@ -241,9 +240,9 @@ struct TrainCard: View {
     
     private var arrivalTime: String {
         // For V2, we show arrival time if available
+        // PERFORMANCE: Use cached static formatter instead of creating new one each call
         if let arrivalTime = train.arrival?.scheduledTime {
-            let formatter = DateFormatter.easternTime(time: .short)
-            return formatter.string(from: arrivalTime)
+            return DateFormatter.easternTimeShort.string(from: arrivalTime)
         }
         return "--:--"
     }
@@ -410,7 +409,8 @@ class TrainListViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var hasStartedLoading = false
     @Published var error: String?
-    
+    @Published private(set) var expressTrainIds: Set<String> = []
+
     private var currentDestination: String?
     private var currentFromStationCode: String?
     private let apiService: APIService
@@ -520,6 +520,9 @@ class TrainListViewModel: ObservableObject {
             // Sort trains by origin station departure time
             trains = sortTrainsByDepartureTime(uniqueTrains, fromStationCode: fromStationCode)
 
+            // PERFORMANCE: Calculate express trains once, not on every render
+            expressTrainIds = identifyExpressTrains()
+
             print("🔍 DEBUG: Final sorted trains count: \(trains.count)")
         } catch {
             self.error = error.localizedDescription
@@ -571,7 +574,10 @@ class TrainListViewModel: ObservableObject {
             
             // Update trains list with new data
             trains = newTrains
-            
+
+            // PERFORMANCE: Recalculate express trains when data changes
+            expressTrainIds = identifyExpressTrains()
+
         } catch {
             // Silent failure for background refresh
             print("TrainListViewModel: Silent refresh failed: \(error.localizedDescription)")


### PR DESCRIPTION
iOS improvements:
- use LazyVStack instead of VStack for efficient list rendering
- cache expressTrainIds in ViewModel (calculate once, not per render)
- add static DateFormatter for departure/arrival times

Backend improvements:
- fix cache to support hide_departed=true (iOS requests were bypassing cache)
- precompute cache entries for both hide_departed variants
- add performance logging with timing metrics (JIT refresh, query, total)
- add cache hit/miss logging for observability