### PR TITLE
Add flight statistics to iOS profile view

### DIFF
--- a/ios/TrackRat/App/ContentView.swift
+++ b/ios/TrackRat/App/ContentView.swift
@@ -19,6 +19,7 @@ enum NavigationDestination: Hashable {
     case myProfile
     case congestionMap
     case favoriteStations
+    case tripHistory
 }
 
 #Preview {

--- a/ios/TrackRat/Models/CompletedTrip.swift
+++ b/ios/TrackRat/Models/CompletedTrip.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+// MARK: - Completed Trip Model
+/// Represents a trip that was tracked via Live Activity
+/// Records are created at journey milestones to ensure data capture even if user exits early
+struct CompletedTrip: Codable, Identifiable, Equatable {
+    let id: UUID
+    let trainId: String
+    let trainNumber: String
+    let lineName: String
+
+    // Route information (full journey from user's origin to destination)
+    let originCode: String
+    let originName: String
+    let destinationCode: String
+    let destinationName: String
+
+    // Timing - captures full journey times
+    let tripDate: Date  // Day of travel (normalized to midnight for grouping)
+    let scheduledDeparture: Date
+    let scheduledArrival: Date
+
+    // These get updated as actuals become available
+    var actualDeparture: Date?
+    var actualArrival: Date?  // Best available: actual > updated > scheduled
+    var departureDelayMinutes: Int
+    var arrivalDelayMinutes: Int
+    var track: String?
+
+    // Recording metadata
+    var recordingMilestone: RecordingMilestone
+    var lastUpdated: Date
+
+    enum RecordingMilestone: String, Codable {
+        case halfway       // Created when train reaches ~50% of journey
+        case secondToLast  // Updated when train reaches penultimate stop
+        case completed     // Final update when Live Activity ends
+    }
+
+    // MARK: - Computed Properties
+
+    var isOnTime: Bool {
+        arrivalDelayMinutes <= 5
+    }
+
+    var formattedDelay: String {
+        if arrivalDelayMinutes <= 0 {
+            return "On time"
+        } else if arrivalDelayMinutes < 60 {
+            return "+\(arrivalDelayMinutes)m"
+        } else {
+            let hours = arrivalDelayMinutes / 60
+            let minutes = arrivalDelayMinutes % 60
+            return minutes > 0 ? "+\(hours)h \(minutes)m" : "+\(hours)h"
+        }
+    }
+
+    var routeDescription: String {
+        "\(originName) → \(destinationName)"
+    }
+}
+
+// MARK: - Trip Statistics
+/// Computed statistics from trip history - not persisted, calculated on demand
+struct TripStats {
+    let totalTrips: Int
+    let totalDelayMinutes: Int
+    let totalOnTimeTrips: Int
+    let averageDelayMinutes: Double
+    let mostFrequentRoute: (originName: String, destinationName: String, count: Int)?
+    let firstTripDate: Date?
+    let currentStreakDays: Int
+
+    // MARK: - Computed Properties
+
+    var onTimePercentage: Int {
+        guard totalTrips > 0 else { return 0 }
+        return Int((Double(totalOnTimeTrips) / Double(totalTrips)) * 100)
+    }
+
+    var formattedTotalDelay: String {
+        if totalDelayMinutes < 60 {
+            return "\(totalDelayMinutes)m"
+        } else {
+            let hours = totalDelayMinutes / 60
+            let minutes = totalDelayMinutes % 60
+            return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h"
+        }
+    }
+
+    static let empty = TripStats(
+        totalTrips: 0,
+        totalDelayMinutes: 0,
+        totalOnTimeTrips: 0,
+        averageDelayMinutes: 0,
+        mostFrequentRoute: nil,
+        firstTripDate: nil,
+        currentStreakDays: 0
+    )
+}

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -32,6 +32,9 @@ class LiveActivityService: ObservableObject {
         // End any existing activity first
         await endCurrentActivity()
 
+        // Reset trip recording state for new journey
+        TripRecordingService.shared.reset()
+
         // Record Live Activity start for Rat Sense
         RatSenseService.shared.recordLiveActivityStart(from: originCode, to: destinationCode)
 
@@ -157,6 +160,31 @@ class LiveActivityService: ObservableObject {
         // Stop periodic updates first
         stopPeriodicUpdates()
 
+        // Finalize trip recording with latest train data if available
+        do {
+            let train = try await APIService.shared.fetchTrainDetails(
+                id: activity.attributes.trainId,
+                fromStationCode: activity.attributes.originStationCode
+            )
+            TripRecordingService.shared.finalizeTrip(
+                train: train,
+                originCode: activity.attributes.originStationCode,
+                destinationCode: activity.attributes.destinationStationCode,
+                originName: activity.attributes.origin,
+                destinationName: activity.attributes.destination
+            )
+        } catch {
+            // Finalize without train data if fetch fails
+            print("⚠️ Could not fetch final train data: \(error)")
+            TripRecordingService.shared.finalizeTrip(
+                train: nil,
+                originCode: activity.attributes.originStationCode,
+                destinationCode: activity.attributes.destinationStationCode,
+                originName: activity.attributes.origin,
+                destinationName: activity.attributes.destination
+            )
+        }
+
         // Cancel push token subscription and wait for completion
         if let task = pushTokenTask {
             task.cancel()
@@ -229,6 +257,15 @@ class LiveActivityService: ObservableObject {
                     fromStation: activity.attributes.originStationCode
                 )
             }
+
+            // Record trip progress at milestones (halfway, second-to-last, etc.)
+            TripRecordingService.shared.processTrainUpdate(
+                train: train,
+                originCode: activity.attributes.originStationCode,
+                destinationCode: activity.attributes.destinationStationCode,
+                originName: activity.attributes.origin,
+                destinationName: activity.attributes.destination
+            )
 
             // Calculate context-aware progress for user's journey
             let context = JourneyContext(from: activity.attributes.originStationCode, toCode: activity.attributes.destinationStationCode, toName: activity.attributes.destination)

--- a/ios/TrackRat/Services/StorageService.swift
+++ b/ios/TrackRat/Services/StorageService.swift
@@ -145,13 +145,19 @@ struct TripPair: Codable, Identifiable, Equatable {
 
 // MARK: - Storage Service
 final class StorageService {
+    static let shared = StorageService()
+
     private let recentTripsKey = "trackrat.recentTrips"
     private let favoriteStationsKey = "trackrat.favoriteStations"
     private let serverEnvironmentKey = "trackrat.serverEnvironment"
+    private let completedTripsKey = "trackrat.completedTrips"
     private let maxRecentTrips = 10
     private let maxFavoriteStations = 10
-    
+    private let maxCompletedTrips = 500  // ~2 years of daily commuting
+
     private let userDefaults = UserDefaults.standard
+
+    init() {}
     
     
     // MARK: - Trip Pairs
@@ -339,7 +345,7 @@ final class StorageService {
     func migrateRecentDestinations() {
         // Get existing destinations from UserDefaults directly (since we removed the method)
         let existingDestinations = userDefaults.stringArray(forKey: "trackrat.recentDestinations") ?? []
-        
+
         if !existingDestinations.isEmpty && loadRecentTrips().isEmpty {
             // Create trip pairs with NY Penn as default departure
             for destination in existingDestinations {
@@ -352,10 +358,122 @@ final class StorageService {
                     )
                 }
             }
-            
+
             // Clean up old keys after migration
             userDefaults.removeObject(forKey: "trackrat.recentDestinations")
             userDefaults.removeObject(forKey: "trackrat.recentDepartures")
         }
+    }
+
+    // MARK: - Completed Trips (Trip History)
+
+    func saveCompletedTrip(_ trip: CompletedTrip) {
+        var trips = loadCompletedTrips()
+        trips.insert(trip, at: 0)
+
+        // Trim old trips if over limit
+        if trips.count > maxCompletedTrips {
+            trips = Array(trips.prefix(maxCompletedTrips))
+        }
+
+        persistCompletedTrips(trips)
+    }
+
+    func updateCompletedTrip(id: UUID, update: (inout CompletedTrip) -> Void) {
+        var trips = loadCompletedTrips()
+        if let index = trips.firstIndex(where: { $0.id == id }) {
+            update(&trips[index])
+            persistCompletedTrips(trips)
+        }
+    }
+
+    func deleteCompletedTrip(id: UUID) {
+        var trips = loadCompletedTrips()
+        trips.removeAll { $0.id == id }
+        persistCompletedTrips(trips)
+    }
+
+    func loadCompletedTrips() -> [CompletedTrip] {
+        guard let data = userDefaults.data(forKey: completedTripsKey),
+              let trips = try? JSONDecoder().decode([CompletedTrip].self, from: data) else {
+            return []
+        }
+        return trips
+    }
+
+    func clearCompletedTrips() {
+        userDefaults.removeObject(forKey: completedTripsKey)
+    }
+
+    private func persistCompletedTrips(_ trips: [CompletedTrip]) {
+        if let data = try? JSONEncoder().encode(trips) {
+            userDefaults.set(data, forKey: completedTripsKey)
+        }
+    }
+
+    // MARK: - Trip Statistics
+
+    func computeTripStats() -> TripStats {
+        let trips = loadCompletedTrips()
+
+        guard !trips.isEmpty else {
+            return .empty
+        }
+
+        // Basic counts
+        let totalDelay = trips.reduce(0) { $0 + $1.arrivalDelayMinutes }
+        let onTimeCount = trips.filter { $0.isOnTime }.count
+        let avgDelay = Double(totalDelay) / Double(trips.count)
+
+        // Most frequent route
+        var routeCounts: [String: (originName: String, destinationName: String, count: Int)] = [:]
+        for trip in trips {
+            let key = "\(trip.originCode)-\(trip.destinationCode)"
+            if let existing = routeCounts[key] {
+                routeCounts[key] = (existing.originName, existing.destinationName, existing.count + 1)
+            } else {
+                routeCounts[key] = (trip.originName, trip.destinationName, 1)
+            }
+        }
+        let topRoute = routeCounts.values.max(by: { $0.count < $1.count })
+
+        // First trip date
+        let firstDate = trips.last?.tripDate
+
+        // Current streak calculation
+        let streak = calculateCurrentStreak(trips: trips)
+
+        return TripStats(
+            totalTrips: trips.count,
+            totalDelayMinutes: totalDelay,
+            totalOnTimeTrips: onTimeCount,
+            averageDelayMinutes: avgDelay,
+            mostFrequentRoute: topRoute,
+            firstTripDate: firstDate,
+            currentStreakDays: streak
+        )
+    }
+
+    /// Calculate consecutive days with at least one trip, counting back from today
+    private func calculateCurrentStreak(trips: [CompletedTrip]) -> Int {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        // Get unique trip dates
+        let tripDates = Set(trips.map { calendar.startOfDay(for: $0.tripDate) })
+
+        var streak = 0
+        var checkDate = today
+
+        // Count backwards from today
+        while tripDates.contains(checkDate) {
+            streak += 1
+            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: checkDate) else {
+                break
+            }
+            checkDate = previousDay
+        }
+
+        return streak
     }
 }

--- a/ios/TrackRat/Services/TripRecordingService.swift
+++ b/ios/TrackRat/Services/TripRecordingService.swift
@@ -1,0 +1,257 @@
+import Foundation
+
+/// Service responsible for recording trips at journey milestones
+/// Trips are recorded at: halfway point, second-to-last stop, and journey end
+/// This ensures data capture even if user exits the app early
+final class TripRecordingService {
+    static let shared = TripRecordingService()
+
+    // MARK: - State (per-activity session)
+
+    private var activeTripId: UUID?
+    private var triggeredMilestones: Set<CompletedTrip.RecordingMilestone> = []
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Called on every Live Activity update with fresh train data
+    /// Checks if we've reached a recording milestone and records/updates accordingly
+    func processTrainUpdate(
+        train: TrainV2,
+        originCode: String,
+        destinationCode: String,
+        originName: String,
+        destinationName: String
+    ) {
+        guard let position = calculateJourneyPosition(
+            train: train,
+            originCode: originCode,
+            destinationCode: destinationCode
+        ) else {
+            print("TripRecording: Could not calculate journey position")
+            return
+        }
+
+        let (departedStopCount, totalStops) = position
+
+        // Halfway milestone: triggered when we've departed >= half the stops before destination
+        // For N stops, there are N-1 segments. Halfway = (N-1)/2 segments completed
+        let halfwayThreshold = (totalStops - 1) / 2
+        if departedStopCount >= halfwayThreshold && !triggeredMilestones.contains(.halfway) {
+            print("TripRecording: Reached halfway milestone (departed \(departedStopCount) of \(totalStops) stops)")
+            recordMilestone(
+                .halfway,
+                train: train,
+                originCode: originCode,
+                destinationCode: destinationCode,
+                originName: originName,
+                destinationName: destinationName
+            )
+        }
+
+        // Second-to-last milestone: triggered when we've departed the penultimate stop
+        // This means departedStopCount >= totalStops - 2 (0-indexed, so -2 is second to last)
+        let secondToLastThreshold = max(0, totalStops - 2)
+        if departedStopCount >= secondToLastThreshold && !triggeredMilestones.contains(.secondToLast) {
+            // Don't trigger if it's the same as halfway (short trips)
+            if triggeredMilestones.contains(.halfway) {
+                print("TripRecording: Reached second-to-last milestone (departed \(departedStopCount) stops)")
+                recordMilestone(
+                    .secondToLast,
+                    train: train,
+                    originCode: originCode,
+                    destinationCode: destinationCode,
+                    originName: originName,
+                    destinationName: destinationName
+                )
+            }
+        }
+    }
+
+    /// Called when Live Activity ends (user-initiated or auto)
+    /// Finalizes the trip record if one was created
+    func finalizeTrip(
+        train: TrainV2?,
+        originCode: String,
+        destinationCode: String,
+        originName: String,
+        destinationName: String
+    ) {
+        // Only finalize if we have an active trip (means we hit halfway at minimum)
+        guard activeTripId != nil else {
+            print("TripRecording: No active trip to finalize (user exited before halfway)")
+            reset()
+            return
+        }
+
+        if let train = train {
+            print("TripRecording: Finalizing trip with latest train data")
+            recordMilestone(
+                .completed,
+                train: train,
+                originCode: originCode,
+                destinationCode: destinationCode,
+                originName: originName,
+                destinationName: destinationName
+            )
+        } else {
+            // No train data available, just mark as completed with existing data
+            print("TripRecording: Finalizing trip without new train data")
+            if let tripId = activeTripId {
+                StorageService.shared.updateCompletedTrip(id: tripId) { trip in
+                    trip.recordingMilestone = .completed
+                    trip.lastUpdated = Date()
+                }
+            }
+        }
+
+        reset()
+    }
+
+    /// Reset state - called when activity ends or is cancelled
+    func reset() {
+        print("TripRecording: Resetting state")
+        activeTripId = nil
+        triggeredMilestones = []
+    }
+
+    // MARK: - Private Methods
+
+    /// Calculate how many stops the user has departed within their journey segment
+    /// Returns (departedStopCount, totalStopsInJourney)
+    private func calculateJourneyPosition(
+        train: TrainV2,
+        originCode: String,
+        destinationCode: String
+    ) -> (departedStopCount: Int, totalStops: Int)? {
+        guard let stops = train.stops else {
+            print("TripRecording: No stops data available")
+            return nil
+        }
+
+        // Find origin and destination indices
+        guard let originIdx = stops.firstIndex(where: { $0.stationCode.uppercased() == originCode.uppercased() }),
+              let destIdx = stops.firstIndex(where: { $0.stationCode.uppercased() == destinationCode.uppercased() }),
+              originIdx < destIdx else {
+            print("TripRecording: Could not find origin/destination in stops")
+            return nil
+        }
+
+        // Get journey segment (origin to destination inclusive)
+        let journeyStops = Array(stops[originIdx...destIdx])
+        let totalStops = journeyStops.count
+
+        // Count how many stops have been departed (origin counts when departed)
+        let departedCount = journeyStops.filter { $0.hasDepartedStation }.count
+
+        return (departedCount, totalStops)
+    }
+
+    /// Record or update trip at a milestone
+    private func recordMilestone(
+        _ milestone: CompletedTrip.RecordingMilestone,
+        train: TrainV2,
+        originCode: String,
+        destinationCode: String,
+        originName: String,
+        destinationName: String
+    ) {
+        triggeredMilestones.insert(milestone)
+
+        guard let stops = train.stops else { return }
+
+        // Find origin and destination stops for timing data
+        let originStop = stops.first { $0.stationCode.uppercased() == originCode.uppercased() }
+        let destStop = stops.first { $0.stationCode.uppercased() == destinationCode.uppercased() }
+
+        // Extract timing data - use best available for each field
+        let scheduledDeparture = originStop?.scheduledDeparture ?? Date()
+        let scheduledArrival = destStop?.scheduledArrival ?? Date()
+
+        // Actual departure: use actual if available
+        let actualDeparture = originStop?.actualDeparture
+
+        // Best arrival estimate: actual > updated > scheduled
+        let bestArrivalEstimate = destStop?.actualArrival ?? destStop?.updatedArrival ?? destStop?.scheduledArrival
+
+        // Calculate delays
+        let departureDelay = calculateDepartureDelay(originStop: originStop)
+        let arrivalDelay = calculateArrivalDelay(destStop: destStop, trainDelay: train.delayMinutes)
+
+        if activeTripId == nil {
+            // Create new trip record
+            let trip = CompletedTrip(
+                id: UUID(),
+                trainId: train.trainId,
+                trainNumber: train.trainId,
+                lineName: train.line.name,
+                originCode: originCode,
+                originName: originName,
+                destinationCode: destinationCode,
+                destinationName: destinationName,
+                tripDate: Calendar.current.startOfDay(for: Date()),
+                scheduledDeparture: scheduledDeparture,
+                scheduledArrival: scheduledArrival,
+                actualDeparture: actualDeparture,
+                actualArrival: bestArrivalEstimate,
+                departureDelayMinutes: departureDelay,
+                arrivalDelayMinutes: arrivalDelay,
+                track: originStop?.track,
+                recordingMilestone: milestone,
+                lastUpdated: Date()
+            )
+
+            activeTripId = trip.id
+            StorageService.shared.saveCompletedTrip(trip)
+
+            print("TripRecording: Created trip \(trip.id) at \(milestone.rawValue)")
+            print("  - Route: \(originName) → \(destinationName)")
+            print("  - Scheduled: \(scheduledDeparture) → \(scheduledArrival)")
+            print("  - Delay: \(arrivalDelay) minutes")
+
+        } else {
+            // Update existing trip
+            StorageService.shared.updateCompletedTrip(id: activeTripId!) { trip in
+                // Update with latest data
+                trip.actualDeparture = actualDeparture ?? trip.actualDeparture
+                trip.actualArrival = bestArrivalEstimate ?? trip.actualArrival
+                trip.departureDelayMinutes = departureDelay
+                trip.arrivalDelayMinutes = arrivalDelay
+                trip.track = originStop?.track ?? trip.track
+                trip.recordingMilestone = milestone
+                trip.lastUpdated = Date()
+            }
+
+            print("TripRecording: Updated trip \(activeTripId!) to \(milestone.rawValue)")
+            print("  - Arrival delay: \(arrivalDelay) minutes")
+        }
+    }
+
+    /// Calculate departure delay from origin stop
+    private func calculateDepartureDelay(originStop: StopV2?) -> Int {
+        guard let stop = originStop,
+              let scheduled = stop.scheduledDeparture else {
+            return 0
+        }
+
+        // Use actual if available, otherwise updated
+        let compareTime = stop.actualDeparture ?? stop.updatedDeparture ?? scheduled
+        let delaySeconds = compareTime.timeIntervalSince(scheduled)
+        return max(0, Int(delaySeconds / 60))
+    }
+
+    /// Calculate arrival delay at destination
+    private func calculateArrivalDelay(destStop: StopV2?, trainDelay: Int) -> Int {
+        guard let stop = destStop,
+              let scheduled = stop.scheduledArrival else {
+            // Fallback to train's general delay
+            return trainDelay
+        }
+
+        // Use best available: actual > updated > scheduled
+        let compareTime = stop.actualArrival ?? stop.updatedArrival ?? scheduled
+        let delaySeconds = compareTime.timeIntervalSince(scheduled)
+        return max(0, Int(delaySeconds / 60))
+    }
+}

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -647,6 +647,8 @@ struct MapContainerView: View {
                         selectedDetent = .fraction(0.50)
                     }
                 )
+            case .tripHistory:
+                TripHistoryView()
             }
         }
         .transparentNavigationBackground()

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -5,6 +5,9 @@ struct MyProfileView: View {
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.openURL) private var openURL
 
+    @State private var tripStats: TripStats = .empty
+    @State private var recentTrips: [CompletedTrip] = []
+
     var body: some View {
         VStack(spacing: 0) {
             // Fixed header - replaces system navigation bar to avoid layout shift
@@ -40,6 +43,11 @@ struct MyProfileView: View {
             // Scrollable content
             ScrollView {
                 VStack(spacing: 24) {
+                    // Flight Stats Section (only shown if user has trips)
+                    if tripStats.totalTrips > 0 {
+                        TripStatsSection(stats: tripStats, recentTrips: recentTrips, appState: appState)
+                    }
+
                     // Feedback & Ideas section
                     VStack(spacing: 16) {
                         // Section header
@@ -424,6 +432,225 @@ struct MyProfileView: View {
             }
         }
         .navigationBarHidden(true)
+        .onAppear {
+            tripStats = StorageService.shared.computeTripStats()
+            recentTrips = StorageService.shared.loadCompletedTrips()
+        }
+    }
+}
+
+// MARK: - Trip Stats Section
+
+struct TripStatsSection: View {
+    let stats: TripStats
+    let recentTrips: [CompletedTrip]
+    let appState: AppState
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Section header
+            HStack {
+                Text("Your TrackRat Stats")
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            // Stats card
+            VStack(spacing: 20) {
+                // Main stats row
+                HStack(spacing: 0) {
+                    StatBox(
+                        value: "\(stats.totalTrips)",
+                        label: "Trips Tracked",
+                        icon: "tram.fill"
+                    )
+
+                    Divider()
+                        .frame(height: 50)
+                        .background(Color.white.opacity(0.2))
+
+                    StatBox(
+                        value: stats.formattedTotalDelay,
+                        label: "Lost to Delays",
+                        icon: "clock.badge.exclamationmark",
+                        valueColor: stats.totalDelayMinutes > 0 ? .red : .green
+                    )
+                }
+
+                Divider()
+                    .background(Color.white.opacity(0.2))
+
+                // Secondary stats row
+                HStack(spacing: 0) {
+                    StatBox(
+                        value: "\(stats.onTimePercentage)%",
+                        label: "On Time",
+                        icon: "checkmark.circle.fill",
+                        valueColor: stats.onTimePercentage >= 80 ? .green : (stats.onTimePercentage >= 50 ? .yellow : .red)
+                    )
+
+                    Divider()
+                        .frame(height: 50)
+                        .background(Color.white.opacity(0.2))
+
+                    if stats.currentStreakDays > 0 {
+                        StatBox(
+                            value: "\(stats.currentStreakDays)",
+                            label: "Day Streak",
+                            icon: "flame.fill",
+                            valueColor: .orange
+                        )
+                    } else if let route = stats.mostFrequentRoute {
+                        VStack(spacing: 4) {
+                            Text("\(route.count)")
+                                .font(.title2.bold())
+                                .foregroundColor(.white)
+                            Text("trips on")
+                                .font(.caption2)
+                                .foregroundColor(.white.opacity(0.6))
+                            Text("\(route.originName.components(separatedBy: " ").first ?? route.originName)")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.8))
+                                .lineLimit(1)
+                        }
+                        .frame(maxWidth: .infinity)
+                    } else {
+                        StatBox(
+                            value: "-",
+                            label: "Day Streak",
+                            icon: "flame.fill"
+                        )
+                    }
+                }
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.ultraThinMaterial)
+            )
+
+            // Recent trips
+            if !recentTrips.isEmpty {
+                VStack(spacing: 12) {
+                    HStack {
+                        Text("Recent Trips")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.white.opacity(0.8))
+                        Spacer()
+
+                        if recentTrips.count > 3 {
+                            Button {
+                                appState.navigationPath.append(NavigationDestination.tripHistory)
+                            } label: {
+                                Text("View All")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 4)
+
+                    VStack(spacing: 0) {
+                        ForEach(Array(recentTrips.prefix(3).enumerated()), id: \.element.id) { index, trip in
+                            TripRowView(trip: trip)
+
+                            if index < min(2, recentTrips.count - 1) {
+                                Divider()
+                                    .background(Color.white.opacity(0.1))
+                            }
+                        }
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.ultraThinMaterial)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Stat Box Component
+
+struct StatBox: View {
+    let value: String
+    let label: String
+    var icon: String? = nil
+    var valueColor: Color = .white
+
+    var body: some View {
+        VStack(spacing: 6) {
+            if let icon = icon {
+                Image(systemName: icon)
+                    .font(.caption)
+                    .foregroundColor(valueColor.opacity(0.8))
+            }
+            Text(value)
+                .font(.title2.bold())
+                .foregroundColor(valueColor)
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.6))
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Trip Row Component
+
+struct TripRowView: View {
+    let trip: CompletedTrip
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: trip.tripDate)
+    }
+
+    private var formattedTime: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: trip.scheduledDeparture)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Date column
+            VStack(spacing: 2) {
+                Text(formattedDate)
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(.white.opacity(0.8))
+                Text(formattedTime)
+                    .font(.caption2)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            .frame(width: 50)
+
+            // Route info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(trip.routeDescription)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+
+                Text(trip.lineName)
+                    .font(.caption2)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+
+            Spacer()
+
+            // Delay indicator
+            Text(trip.formattedDelay)
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(trip.isOnTime ? .green : .red)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
     }
 }
 

--- a/ios/TrackRat/Views/Screens/TripHistoryView.swift
+++ b/ios/TrackRat/Views/Screens/TripHistoryView.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+
+struct TripHistoryView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var trips: [CompletedTrip] = []
+    @State private var stats: TripStats = .empty
+
+    // Group trips by month
+    private var groupedTrips: [(String, [CompletedTrip])] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+
+        let grouped = Dictionary(grouping: trips) { trip in
+            formatter.string(from: trip.tripDate)
+        }
+
+        // Sort by date (most recent first)
+        return grouped.sorted { first, second in
+            guard let firstTrip = first.value.first,
+                  let secondTrip = second.value.first else { return false }
+            return firstTrip.tripDate > secondTrip.tripDate
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Fixed header
+            HStack {
+                Button {
+                    if !appState.navigationPath.isEmpty {
+                        appState.navigationPath.removeLast()
+                    }
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(width: 44, height: 44)
+                }
+
+                Spacer()
+
+                Text("Trip History")
+                    .font(.headline)
+                    .foregroundColor(.white)
+
+                Spacer()
+
+                Color.clear
+                    .frame(width: 44, height: 44)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+
+            if trips.isEmpty {
+                // Empty state
+                VStack(spacing: 16) {
+                    Spacer()
+
+                    Image(systemName: "tram.fill")
+                        .font(.system(size: 60))
+                        .foregroundColor(.white.opacity(0.3))
+
+                    Text("No Trips Yet")
+                        .font(.title2.weight(.semibold))
+                        .foregroundColor(.white)
+
+                    Text("Start tracking trains with Live Activity\nto see your trip history here.")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.6))
+                        .multilineTextAlignment(.center)
+
+                    Spacer()
+                }
+                .padding()
+            } else {
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // Summary stats card
+                        SummaryStatsCard(stats: stats)
+                            .padding(.horizontal)
+
+                        // Grouped trips by month
+                        ForEach(groupedTrips, id: \.0) { monthYear, monthTrips in
+                            VStack(spacing: 12) {
+                                // Month header
+                                HStack {
+                                    Text(monthYear)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundColor(.white.opacity(0.8))
+                                    Spacer()
+                                    Text("\(monthTrips.count) trips")
+                                        .font(.caption)
+                                        .foregroundColor(.white.opacity(0.5))
+                                }
+                                .padding(.horizontal, 4)
+
+                                // Trips list
+                                VStack(spacing: 0) {
+                                    ForEach(Array(monthTrips.enumerated()), id: \.element.id) { index, trip in
+                                        TripHistoryRowView(trip: trip)
+
+                                        if index < monthTrips.count - 1 {
+                                            Divider()
+                                                .background(Color.white.opacity(0.1))
+                                        }
+                                    }
+                                }
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(.ultraThinMaterial)
+                                )
+                            }
+                            .padding(.horizontal)
+                        }
+                    }
+                    .padding(.vertical)
+                    .padding(.bottom, 40)
+                }
+            }
+        }
+        .navigationBarHidden(true)
+        .onAppear {
+            trips = StorageService.shared.loadCompletedTrips()
+            stats = StorageService.shared.computeTripStats()
+        }
+    }
+}
+
+// MARK: - Summary Stats Card
+
+struct SummaryStatsCard: View {
+    let stats: TripStats
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("All-Time Stats")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.white.opacity(0.8))
+                Spacer()
+            }
+
+            HStack(spacing: 0) {
+                VStack(spacing: 4) {
+                    Text("\(stats.totalTrips)")
+                        .font(.title.bold())
+                        .foregroundColor(.white)
+                    Text("Trips")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.6))
+                }
+                .frame(maxWidth: .infinity)
+
+                Divider()
+                    .frame(height: 40)
+                    .background(Color.white.opacity(0.2))
+
+                VStack(spacing: 4) {
+                    Text(stats.formattedTotalDelay)
+                        .font(.title.bold())
+                        .foregroundColor(.red)
+                    Text("Delays")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.6))
+                }
+                .frame(maxWidth: .infinity)
+
+                Divider()
+                    .frame(height: 40)
+                    .background(Color.white.opacity(0.2))
+
+                VStack(spacing: 4) {
+                    Text("\(stats.onTimePercentage)%")
+                        .font(.title.bold())
+                        .foregroundColor(stats.onTimePercentage >= 80 ? .green : (stats.onTimePercentage >= 50 ? .yellow : .red))
+                    Text("On Time")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.6))
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            if let route = stats.mostFrequentRoute {
+                Divider()
+                    .background(Color.white.opacity(0.2))
+
+                HStack {
+                    Image(systemName: "arrow.triangle.swap")
+                        .foregroundColor(.orange)
+                    Text("Most traveled: \(route.originName) ↔ \(route.destinationName)")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.7))
+                    Spacer()
+                    Text("\(route.count)×")
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.orange)
+                }
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.ultraThinMaterial)
+        )
+    }
+}
+
+// MARK: - Trip History Row
+
+struct TripHistoryRowView: View {
+    let trip: CompletedTrip
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, MMM d"
+        return formatter.string(from: trip.tripDate)
+    }
+
+    private var formattedTime: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: trip.scheduledDeparture)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Left: Date and time
+            VStack(alignment: .leading, spacing: 2) {
+                Text(formattedDate)
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(.white.opacity(0.9))
+                Text(formattedTime)
+                    .font(.caption2)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+            .frame(width: 80, alignment: .leading)
+
+            // Center: Route info
+            VStack(alignment: .leading, spacing: 4) {
+                Text(trip.routeDescription)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+
+                HStack(spacing: 8) {
+                    Text(trip.lineName)
+                        .font(.caption2)
+                        .foregroundColor(.white.opacity(0.5))
+
+                    if let track = trip.track {
+                        Text("Track \(track)")
+                            .font(.caption2)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Right: Delay indicator
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(trip.formattedDelay)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(trip.isOnTime ? .green : .red)
+
+                if trip.arrivalDelayMinutes > 0 {
+                    Text("late")
+                        .font(.caption2)
+                        .foregroundColor(.red.opacity(0.7))
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TripHistoryView()
+            .environmentObject(AppState())
+    }
+}


### PR DESCRIPTION
- Add CompletedTrip model for persisting trip records
- Add TripRecordingService to capture trips at milestones:
  - Halfway point (creates record - confirms user on train)
  - Second-to-last stop (updates with near-final delay data)
  - Live Activity end (final update)
- Extend StorageService with trip persistence (max 500 trips)
- Add TripStats computation (total trips, delays, on-time %, streak)
- Update MyProfileView with stats header showing:
  - Total trips tracked
  - Total time lost to delays
  - On-time percentage
  - Current streak or most frequent route
  - Recent trips list
- Add TripHistoryView for full trip history grouped by month
- Integrate TripRecordingService with LiveActivityService updates