### PR TITLE
Design delay and cancellation forecasts feature

### DIFF
--- a/backend_v2/src/trackrat/api/predictions.py
+++ b/backend_v2/src/trackrat/api/predictions.py
@@ -20,6 +20,8 @@ from trackrat.config.station_configs import (
 )
 from trackrat.db.engine import get_db
 from trackrat.models.database import TrainJourney
+from trackrat.models.api import DelayBreakdownProbabilities, DelayForecastResponse
+from trackrat.services.delay_forecaster import delay_forecaster
 from trackrat.services.historical_track_predictor import historical_track_predictor
 
 logger = get_logger()
@@ -258,4 +260,114 @@ async def get_supported_stations() -> SupportedStationsResponse:
 
     return SupportedStationsResponse(
         stations=stations, total_ml_enabled=ml_enabled_count
+    )
+
+
+@router.get("/delay", response_model=DelayForecastResponse)
+@handle_errors
+async def predict_delay(
+    train_id: str = Query(..., description="Train ID (e.g., '3123' or 'A2301')"),
+    station_code: str = Query(..., description="Origin station code (e.g., 'NY')"),
+    journey_date: date = Query(..., description="Date of journey (YYYY-MM-DD)"),
+    db: AsyncSession = Depends(get_db),
+) -> DelayForecastResponse:
+    """
+    Get delay and cancellation forecast for a train.
+
+    Uses hierarchical historical data:
+    1. Exact train ID (if >= 10 records)
+    2. Line code (if >= 25 records)
+    3. Service provider fallback
+
+    Adjusts for time-of-day patterns and live congestion.
+
+    Args:
+        train_id: Train identifier
+        station_code: Origin station code
+        journey_date: Date of the journey
+
+    Returns:
+        Delay forecast with probabilities and confidence
+    """
+    import time
+
+    logger.info(
+        "delay_forecast_request_start",
+        train_id=train_id,
+        station_code=station_code,
+        journey_date=journey_date,
+    )
+
+    # Look up the train to get line code and data source
+    from sqlalchemy import and_, select
+
+    query = (
+        select(TrainJourney)
+        .where(
+            and_(
+                TrainJourney.train_id == train_id,
+                TrainJourney.journey_date == journey_date,
+            )
+        )
+        .limit(1)
+    )
+
+    result = await db.execute(query)
+    train_journey = result.scalar_one_or_none()
+
+    if not train_journey:
+        # Try to find any journey for this train ID to get metadata
+        query = select(TrainJourney).where(TrainJourney.train_id == train_id).limit(1)
+        result = await db.execute(query)
+        train_journey = result.scalar_one_or_none()
+
+        if not train_journey:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Train {train_id} not found",
+            )
+
+    # Generate forecast
+    prediction_start = time.time()
+
+    from datetime import datetime
+
+    from trackrat.utils.time import now_et
+
+    scheduled_departure = train_journey.scheduled_departure or now_et()
+    data_source = train_journey.data_source or "NJT"
+
+    forecast = await delay_forecaster.forecast(
+        train_id=train_id,
+        station_code=station_code,
+        line_code=train_journey.line_code,
+        data_source=data_source,
+        journey_date=journey_date,
+        scheduled_departure=scheduled_departure,
+        db=db,
+    )
+
+    prediction_duration = time.time() - prediction_start
+
+    logger.info(
+        "delay_forecast_timing",
+        train_id=train_id,
+        prediction_duration_ms=round(prediction_duration * 1000, 2),
+    )
+
+    return DelayForecastResponse(
+        train_id=train_id,
+        station_code=station_code,
+        journey_date=journey_date,
+        cancellation_probability=forecast.cancellation_probability,
+        delay_probabilities=DelayBreakdownProbabilities(
+            on_time=forecast.on_time_probability,
+            slight=forecast.slight_delay_probability,
+            significant=forecast.significant_delay_probability,
+            major=forecast.major_delay_probability,
+        ),
+        expected_delay_minutes=forecast.expected_delay_minutes,
+        confidence=forecast.confidence,
+        sample_count=forecast.sample_count,
+        factors=forecast.factors,
     )

--- a/backend_v2/src/trackrat/models/api.py
+++ b/backend_v2/src/trackrat/models/api.py
@@ -683,3 +683,55 @@ class OperationsSummaryResponse(BaseModel):
     @field_serializer("generated_at")
     def serialize_dt(self, dt: datetime) -> str:
         return serialize_eastern_datetime(dt) or ""
+
+
+# Delay Forecast API Models
+
+
+class DelayBreakdownProbabilities(BaseModel):
+    """Delay probability breakdown."""
+
+    on_time: float = Field(..., ge=0.0, le=1.0, description="Probability <= 5 min delay")
+    slight: float = Field(
+        ..., ge=0.0, le=1.0, description="Probability 6-15 min delay"
+    )
+    significant: float = Field(
+        ..., ge=0.0, le=1.0, description="Probability 16-30 min delay"
+    )
+    major: float = Field(..., ge=0.0, le=1.0, description="Probability > 30 min delay")
+
+
+class DelayForecastResponse(BaseModel):
+    """Response for delay/cancellation forecast endpoint."""
+
+    train_id: str
+    station_code: str
+    journey_date: date
+
+    # Cancellation probability
+    cancellation_probability: float = Field(
+        ..., ge=0.0, le=1.0, description="Probability of cancellation"
+    )
+
+    # Delay probabilities (sum to 1.0 for non-cancelled scenario)
+    delay_probabilities: DelayBreakdownProbabilities
+
+    # Point estimate
+    expected_delay_minutes: int = Field(
+        ..., ge=0, description="Expected delay in minutes"
+    )
+
+    # Metadata
+    confidence: Literal["high", "medium", "low"] = Field(
+        ..., description="Confidence level based on sample size"
+    )
+    sample_count: int = Field(..., ge=0, description="Historical samples used")
+    factors: list[str] = Field(
+        default_factory=list,
+        description="Factors used in forecast",
+        examples=[["train_history", "line_pattern", "congestion"]],
+    )
+
+    @field_serializer("journey_date")
+    def serialize_journey_date(self, journey_date: date) -> str:
+        return journey_date.isoformat()

--- a/backend_v2/src/trackrat/services/delay_forecaster.py
+++ b/backend_v2/src/trackrat/services/delay_forecaster.py
@@ -1,0 +1,816 @@
+"""
+Delay and cancellation forecaster service.
+
+Uses hierarchical historical data to predict delays and cancellations.
+Pattern follows HistoricalTrackPredictor with train_id -> line_code -> data_source fallbacks.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Literal
+
+from sqlalchemy import and_, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
+
+from trackrat.models.database import TrainJourney
+from trackrat.services.congestion import CongestionAnalyzer
+from trackrat.utils.time import now_et
+
+logger = get_logger(__name__)
+
+# Configuration thresholds (same as track predictor)
+MIN_TRAIN_ID_SAMPLES = 10
+MIN_LINE_CODE_SAMPLES = 25
+MIN_DATA_SOURCE_SAMPLES = 250
+
+# Delay category thresholds (in minutes)
+ON_TIME_THRESHOLD = 5
+SLIGHT_DELAY_THRESHOLD = 15
+SIGNIFICANT_DELAY_THRESHOLD = 30
+
+# Historical lookback period (days)
+HISTORICAL_LOOKBACK_DAYS = 365
+
+
+@dataclass
+class DelayStats:
+    """Statistics for delay/cancellation at a given hierarchy level."""
+
+    sample_count: int
+    cancellation_count: int
+    on_time_count: int
+    slight_delay_count: int
+    significant_delay_count: int
+    major_delay_count: int
+    total_delay_minutes: int
+    level: str  # "train_id", "line_code", "data_source"
+
+
+@dataclass
+class DelayForecast:
+    """Internal delay forecast result."""
+
+    cancellation_probability: float
+    on_time_probability: float
+    slight_delay_probability: float
+    significant_delay_probability: float
+    major_delay_probability: float
+    expected_delay_minutes: int
+    confidence: Literal["high", "medium", "low"]
+    sample_count: int
+    factors: list[str]
+
+
+class DelayForecaster:
+    """
+    Delay and cancellation forecaster using historical patterns.
+
+    Hierarchical approach (same as track predictor):
+    1. Try exact train ID (if >= 10 records)
+    2. Fallback to line code (if >= 25 records)
+    3. Fallback to data source (if >= 250 records)
+    4. Fallback to static defaults
+
+    Then apply live congestion multiplier if available.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the forecaster."""
+        self.congestion_analyzer = CongestionAnalyzer()
+
+    async def forecast(
+        self,
+        train_id: str,
+        station_code: str,
+        line_code: str | None,
+        data_source: str,
+        journey_date: date,
+        scheduled_departure: datetime,
+        db: AsyncSession,
+    ) -> DelayForecast:
+        """
+        Forecast delay and cancellation probability for a train.
+
+        Args:
+            train_id: Train identifier (e.g., '3427')
+            station_code: Origin station code (e.g., 'NY')
+            line_code: Line code (e.g., 'NE', 'Mo')
+            data_source: Service provider ('NJT' or 'AMTRAK')
+            journey_date: Date of journey
+            scheduled_departure: Scheduled departure time
+            db: Database session
+
+        Returns:
+            DelayForecast with probabilities and metadata
+        """
+        logger.info(
+            "delay_forecast_start",
+            train_id=train_id,
+            station_code=station_code,
+            line_code=line_code,
+            data_source=data_source,
+        )
+
+        factors: list[str] = []
+
+        # Step 1: Get historical stats at each hierarchy level
+        train_id_stats = await self._get_train_id_stats(
+            db, train_id, station_code, data_source
+        )
+        line_code_stats = None
+        if line_code:
+            line_code_stats = await self._get_line_code_stats(
+                db, line_code, station_code, data_source
+            )
+        data_source_stats = await self._get_data_source_stats(
+            db, station_code, data_source
+        )
+
+        # Step 2: Select which stats to use (hierarchical)
+        selected_stats: DelayStats | None = None
+
+        if train_id_stats and train_id_stats.sample_count >= MIN_TRAIN_ID_SAMPLES:
+            selected_stats = train_id_stats
+            factors.append("train_history")
+            logger.info(
+                "using_train_id_stats",
+                train_id=train_id,
+                samples=train_id_stats.sample_count,
+            )
+        elif line_code_stats and line_code_stats.sample_count >= MIN_LINE_CODE_SAMPLES:
+            selected_stats = line_code_stats
+            factors.append("line_pattern")
+            logger.info(
+                "using_line_code_stats",
+                line_code=line_code,
+                samples=line_code_stats.sample_count,
+            )
+        elif (
+            data_source_stats
+            and data_source_stats.sample_count >= MIN_DATA_SOURCE_SAMPLES
+        ):
+            selected_stats = data_source_stats
+            factors.append("service_pattern")
+            logger.info(
+                "using_data_source_stats",
+                data_source=data_source,
+                samples=data_source_stats.sample_count,
+            )
+        else:
+            # Use static fallback
+            logger.info(
+                "using_static_fallback",
+                train_id=train_id,
+                data_source=data_source,
+                reason="insufficient_historical_data",
+            )
+            return self._create_static_fallback(data_source)
+
+        # Step 3: Calculate base probabilities from historical stats
+        forecast = self._calculate_probabilities(selected_stats)
+        forecast.factors = factors
+
+        # Step 4: Apply hour/day-of-week adjustment
+        hour_adjustment = await self._get_hour_day_adjustment(
+            db,
+            station_code,
+            data_source,
+            scheduled_departure.hour,
+            scheduled_departure.weekday(),
+        )
+        if hour_adjustment != 1.0:
+            forecast = self._apply_adjustment(forecast, hour_adjustment)
+            factors.append("time_pattern")
+
+        # Step 5: Apply live congestion multiplier
+        congestion_multiplier = await self._get_congestion_multiplier(
+            db, station_code, data_source
+        )
+        if congestion_multiplier > 1.0:
+            forecast = self._apply_adjustment(forecast, congestion_multiplier)
+            factors.append("live_congestion")
+            logger.info(
+                "applied_congestion_multiplier",
+                multiplier=congestion_multiplier,
+            )
+
+        logger.info(
+            "delay_forecast_complete",
+            train_id=train_id,
+            cancellation_prob=round(forecast.cancellation_probability, 3),
+            on_time_prob=round(forecast.on_time_probability, 3),
+            expected_delay=forecast.expected_delay_minutes,
+            confidence=forecast.confidence,
+            factors=factors,
+        )
+
+        return forecast
+
+    async def _get_train_id_stats(
+        self,
+        db: AsyncSession,
+        train_id: str,
+        station_code: str,
+        data_source: str,
+    ) -> DelayStats | None:
+        """Get delay stats for a specific train ID."""
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
+        query = select(
+            func.count(TrainJourney.id).label("total"),
+            func.count(TrainJourney.id)
+            .filter(TrainJourney.is_cancelled.is_(True))
+            .label("cancelled"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= ON_TIME_THRESHOLD * 60,
+                )
+            )
+            .label("on_time"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > ON_TIME_THRESHOLD * 60,
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= SLIGHT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("slight"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > SLIGHT_DELAY_THRESHOLD * 60,
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= SIGNIFICANT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("significant"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > SIGNIFICANT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("major"),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            TrainJourney.is_cancelled.is_not(True),
+                            TrainJourney.actual_departure.is_not(None),
+                            TrainJourney.scheduled_departure.is_not(None),
+                        ),
+                        func.greatest(
+                            0,
+                            (
+                                func.extract("epoch", TrainJourney.actual_departure)
+                                - func.extract("epoch", TrainJourney.scheduled_departure)
+                            )
+                            / 60,
+                        ),
+                    ),
+                    else_=0,
+                )
+            ).label("total_delay"),
+        ).where(
+            and_(
+                TrainJourney.train_id == train_id,
+                TrainJourney.origin_station_code == station_code,
+                TrainJourney.data_source == data_source,
+                TrainJourney.journey_date >= cutoff_date,
+            )
+        )
+
+        result = await db.execute(query)
+        row = result.one_or_none()
+
+        if not row or row.total == 0:
+            return None
+
+        return DelayStats(
+            sample_count=row.total,
+            cancellation_count=row.cancelled or 0,
+            on_time_count=row.on_time or 0,
+            slight_delay_count=row.slight or 0,
+            significant_delay_count=row.significant or 0,
+            major_delay_count=row.major or 0,
+            total_delay_minutes=int(row.total_delay or 0),
+            level="train_id",
+        )
+
+    async def _get_line_code_stats(
+        self,
+        db: AsyncSession,
+        line_code: str,
+        station_code: str,
+        data_source: str,
+    ) -> DelayStats | None:
+        """Get delay stats for a line code."""
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
+        query = select(
+            func.count(TrainJourney.id).label("total"),
+            func.count(TrainJourney.id)
+            .filter(TrainJourney.is_cancelled.is_(True))
+            .label("cancelled"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= ON_TIME_THRESHOLD * 60,
+                )
+            )
+            .label("on_time"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > ON_TIME_THRESHOLD * 60,
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= SLIGHT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("slight"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > SLIGHT_DELAY_THRESHOLD * 60,
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= SIGNIFICANT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("significant"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > SIGNIFICANT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("major"),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            TrainJourney.is_cancelled.is_not(True),
+                            TrainJourney.actual_departure.is_not(None),
+                            TrainJourney.scheduled_departure.is_not(None),
+                        ),
+                        func.greatest(
+                            0,
+                            (
+                                func.extract("epoch", TrainJourney.actual_departure)
+                                - func.extract("epoch", TrainJourney.scheduled_departure)
+                            )
+                            / 60,
+                        ),
+                    ),
+                    else_=0,
+                )
+            ).label("total_delay"),
+        ).where(
+            and_(
+                TrainJourney.line_code == line_code,
+                TrainJourney.origin_station_code == station_code,
+                TrainJourney.data_source == data_source,
+                TrainJourney.journey_date >= cutoff_date,
+            )
+        )
+
+        result = await db.execute(query)
+        row = result.one_or_none()
+
+        if not row or row.total == 0:
+            return None
+
+        return DelayStats(
+            sample_count=row.total,
+            cancellation_count=row.cancelled or 0,
+            on_time_count=row.on_time or 0,
+            slight_delay_count=row.slight or 0,
+            significant_delay_count=row.significant or 0,
+            major_delay_count=row.major or 0,
+            total_delay_minutes=int(row.total_delay or 0),
+            level="line_code",
+        )
+
+    async def _get_data_source_stats(
+        self,
+        db: AsyncSession,
+        station_code: str,
+        data_source: str,
+    ) -> DelayStats | None:
+        """Get delay stats for a data source (NJT or AMTRAK)."""
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
+        query = select(
+            func.count(TrainJourney.id).label("total"),
+            func.count(TrainJourney.id)
+            .filter(TrainJourney.is_cancelled.is_(True))
+            .label("cancelled"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= ON_TIME_THRESHOLD * 60,
+                )
+            )
+            .label("on_time"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > ON_TIME_THRESHOLD * 60,
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= SLIGHT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("slight"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > SLIGHT_DELAY_THRESHOLD * 60,
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    <= SIGNIFICANT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("significant"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > SIGNIFICANT_DELAY_THRESHOLD * 60,
+                )
+            )
+            .label("major"),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            TrainJourney.is_cancelled.is_not(True),
+                            TrainJourney.actual_departure.is_not(None),
+                            TrainJourney.scheduled_departure.is_not(None),
+                        ),
+                        func.greatest(
+                            0,
+                            (
+                                func.extract("epoch", TrainJourney.actual_departure)
+                                - func.extract("epoch", TrainJourney.scheduled_departure)
+                            )
+                            / 60,
+                        ),
+                    ),
+                    else_=0,
+                )
+            ).label("total_delay"),
+        ).where(
+            and_(
+                TrainJourney.origin_station_code == station_code,
+                TrainJourney.data_source == data_source,
+                TrainJourney.journey_date >= cutoff_date,
+            )
+        )
+
+        result = await db.execute(query)
+        row = result.one_or_none()
+
+        if not row or row.total == 0:
+            return None
+
+        return DelayStats(
+            sample_count=row.total,
+            cancellation_count=row.cancelled or 0,
+            on_time_count=row.on_time or 0,
+            slight_delay_count=row.slight or 0,
+            significant_delay_count=row.significant or 0,
+            major_delay_count=row.major or 0,
+            total_delay_minutes=int(row.total_delay or 0),
+            level="data_source",
+        )
+
+    async def _get_hour_day_adjustment(
+        self,
+        db: AsyncSession,
+        station_code: str,
+        data_source: str,
+        hour: int,
+        day_of_week: int,
+    ) -> float:
+        """
+        Get adjustment multiplier based on hour and day of week.
+
+        Compares delay rate at this hour/day vs overall average.
+        Returns multiplier > 1.0 if delays are more common at this time.
+        """
+        cutoff_date = now_et().date() - timedelta(days=90)  # Use 90 days for time patterns
+
+        # Get overall delay rate
+        overall_query = select(
+            func.count(TrainJourney.id).label("total"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > ON_TIME_THRESHOLD * 60,
+                )
+            )
+            .label("delayed"),
+        ).where(
+            and_(
+                TrainJourney.origin_station_code == station_code,
+                TrainJourney.data_source == data_source,
+                TrainJourney.journey_date >= cutoff_date,
+            )
+        )
+
+        overall_result = await db.execute(overall_query)
+        overall_row = overall_result.one_or_none()
+
+        if not overall_row or overall_row.total < 100:
+            return 1.0
+
+        overall_delay_rate = overall_row.delayed / overall_row.total
+
+        # Get delay rate at this hour/day
+        hourday_query = select(
+            func.count(TrainJourney.id).label("total"),
+            func.count(TrainJourney.id)
+            .filter(
+                and_(
+                    TrainJourney.is_cancelled.is_not(True),
+                    TrainJourney.actual_departure.is_not(None),
+                    TrainJourney.scheduled_departure.is_not(None),
+                    func.extract("epoch", TrainJourney.actual_departure)
+                    - func.extract("epoch", TrainJourney.scheduled_departure)
+                    > ON_TIME_THRESHOLD * 60,
+                )
+            )
+            .label("delayed"),
+        ).where(
+            and_(
+                TrainJourney.origin_station_code == station_code,
+                TrainJourney.data_source == data_source,
+                TrainJourney.journey_date >= cutoff_date,
+                func.extract("hour", TrainJourney.scheduled_departure) == hour,
+                func.extract("dow", TrainJourney.scheduled_departure) == day_of_week,
+            )
+        )
+
+        hourday_result = await db.execute(hourday_query)
+        hourday_row = hourday_result.one_or_none()
+
+        if not hourday_row or hourday_row.total < 20:
+            return 1.0
+
+        hourday_delay_rate = hourday_row.delayed / hourday_row.total
+
+        # Calculate adjustment (cap at 2.0 to prevent extreme values)
+        if overall_delay_rate > 0:
+            adjustment = min(2.0, max(0.5, hourday_delay_rate / overall_delay_rate))
+        else:
+            adjustment = 1.0
+
+        logger.debug(
+            "hour_day_adjustment",
+            hour=hour,
+            day_of_week=day_of_week,
+            overall_rate=round(overall_delay_rate, 3),
+            hourday_rate=round(hourday_delay_rate, 3),
+            adjustment=round(adjustment, 3),
+        )
+
+        return adjustment
+
+    async def _get_congestion_multiplier(
+        self,
+        db: AsyncSession,
+        station_code: str,
+        data_source: str,
+    ) -> float:
+        """
+        Get live congestion multiplier for the origin station.
+
+        Uses the congestion analyzer to check current network conditions.
+        """
+        try:
+            congestion_data = await self.congestion_analyzer.get_network_congestion_optimized(
+                db, time_window_hours=2, data_source=data_source
+            )
+
+            # Find segments departing from this station
+            relevant_segments = [
+                s for s in congestion_data if s.from_station == station_code
+            ]
+
+            if not relevant_segments:
+                return 1.0
+
+            # Average congestion factor across relevant segments
+            avg_factor = sum(s.congestion_factor for s in relevant_segments) / len(
+                relevant_segments
+            )
+
+            # Cap the multiplier to prevent extreme values
+            return min(2.0, max(1.0, avg_factor))
+
+        except Exception as e:
+            logger.warning("congestion_multiplier_failed", error=str(e))
+            return 1.0
+
+    def _calculate_probabilities(self, stats: DelayStats) -> DelayForecast:
+        """Calculate probabilities from delay stats."""
+        total = stats.sample_count
+        non_cancelled = total - stats.cancellation_count
+
+        # Cancellation probability
+        cancellation_prob = stats.cancellation_count / total if total > 0 else 0.0
+
+        # Delay probabilities (among non-cancelled journeys)
+        if non_cancelled > 0:
+            on_time_prob = stats.on_time_count / non_cancelled
+            slight_prob = stats.slight_delay_count / non_cancelled
+            significant_prob = stats.significant_delay_count / non_cancelled
+            major_prob = stats.major_delay_count / non_cancelled
+        else:
+            on_time_prob = 0.8
+            slight_prob = 0.15
+            significant_prob = 0.04
+            major_prob = 0.01
+
+        # Normalize to ensure they sum to 1.0
+        delay_total = on_time_prob + slight_prob + significant_prob + major_prob
+        if delay_total > 0:
+            on_time_prob /= delay_total
+            slight_prob /= delay_total
+            significant_prob /= delay_total
+            major_prob /= delay_total
+
+        # Expected delay (average of non-cancelled journeys)
+        if non_cancelled > 0:
+            expected_delay = int(stats.total_delay_minutes / non_cancelled)
+        else:
+            expected_delay = 0
+
+        # Confidence based on sample count
+        if stats.sample_count >= MIN_TRAIN_ID_SAMPLES:
+            if stats.level == "train_id":
+                confidence: Literal["high", "medium", "low"] = "high"
+            elif stats.level == "line_code":
+                confidence = "medium"
+            else:
+                confidence = "low"
+        else:
+            confidence = "low"
+
+        return DelayForecast(
+            cancellation_probability=cancellation_prob,
+            on_time_probability=on_time_prob,
+            slight_delay_probability=slight_prob,
+            significant_delay_probability=significant_prob,
+            major_delay_probability=major_prob,
+            expected_delay_minutes=expected_delay,
+            confidence=confidence,
+            sample_count=stats.sample_count,
+            factors=[],
+        )
+
+    def _apply_adjustment(
+        self, forecast: DelayForecast, multiplier: float
+    ) -> DelayForecast:
+        """
+        Apply adjustment multiplier to delay probabilities.
+
+        Increases delay probabilities proportionally while keeping them normalized.
+        """
+        if multiplier <= 1.0:
+            return forecast
+
+        # Shift probability from on_time to delays proportionally
+        shift_amount = forecast.on_time_probability * (multiplier - 1) * 0.5
+
+        new_on_time = max(0.1, forecast.on_time_probability - shift_amount)
+        new_slight = forecast.slight_delay_probability + shift_amount * 0.5
+        new_significant = forecast.significant_delay_probability + shift_amount * 0.3
+        new_major = forecast.major_delay_probability + shift_amount * 0.2
+
+        # Normalize
+        total = new_on_time + new_slight + new_significant + new_major
+        new_on_time /= total
+        new_slight /= total
+        new_significant /= total
+        new_major /= total
+
+        # Adjust expected delay
+        new_expected = int(forecast.expected_delay_minutes * multiplier)
+
+        return DelayForecast(
+            cancellation_probability=forecast.cancellation_probability,
+            on_time_probability=new_on_time,
+            slight_delay_probability=new_slight,
+            significant_delay_probability=new_significant,
+            major_delay_probability=new_major,
+            expected_delay_minutes=new_expected,
+            confidence=forecast.confidence,
+            sample_count=forecast.sample_count,
+            factors=forecast.factors,
+        )
+
+    def _create_static_fallback(self, data_source: str) -> DelayForecast:
+        """Create static fallback when no historical data available."""
+        # Conservative defaults based on general transit statistics
+        if data_source == "AMTRAK":
+            # Amtrak historically has slightly higher delay rates
+            return DelayForecast(
+                cancellation_probability=0.02,
+                on_time_probability=0.70,
+                slight_delay_probability=0.20,
+                significant_delay_probability=0.07,
+                major_delay_probability=0.03,
+                expected_delay_minutes=8,
+                confidence="low",
+                sample_count=0,
+                factors=["static_fallback"],
+            )
+        else:
+            # NJT defaults
+            return DelayForecast(
+                cancellation_probability=0.03,
+                on_time_probability=0.75,
+                slight_delay_probability=0.17,
+                significant_delay_probability=0.06,
+                major_delay_probability=0.02,
+                expected_delay_minutes=5,
+                confidence="low",
+                sample_count=0,
+                factors=["static_fallback"],
+            )
+
+
+# Singleton instance
+delay_forecaster = DelayForecaster()

--- a/backend_v2/tests/unit/test_delay_forecaster.py
+++ b/backend_v2/tests/unit/test_delay_forecaster.py
@@ -1,0 +1,582 @@
+"""
+Unit tests for the delay forecaster service.
+
+Tests the DelayForecaster which predicts delays and cancellations
+using hierarchical historical data.
+"""
+
+from datetime import date, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from trackrat.services.delay_forecaster import (
+    DelayForecaster,
+    DelayStats,
+    MIN_TRAIN_ID_SAMPLES,
+    MIN_LINE_CODE_SAMPLES,
+    MIN_DATA_SOURCE_SAMPLES,
+)
+
+
+@pytest.fixture
+def forecaster():
+    """Create a DelayForecaster instance."""
+    return DelayForecaster()
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock database session."""
+    return AsyncMock(spec=AsyncSession)
+
+
+@pytest.fixture
+def sample_train_stats():
+    """Create sample delay stats for a specific train."""
+    return DelayStats(
+        sample_count=50,
+        cancellation_count=2,
+        on_time_count=35,
+        slight_delay_count=10,
+        significant_delay_count=2,
+        major_delay_count=1,
+        total_delay_minutes=150,
+        level="train_id",
+    )
+
+
+@pytest.fixture
+def sample_line_stats():
+    """Create sample delay stats for a line code."""
+    return DelayStats(
+        sample_count=500,
+        cancellation_count=15,
+        on_time_count=350,
+        slight_delay_count=100,
+        significant_delay_count=25,
+        major_delay_count=10,
+        total_delay_minutes=2000,
+        level="line_code",
+    )
+
+
+class TestDelayForecaster:
+    """Test class for DelayForecaster."""
+
+    def test_calculate_probabilities_with_train_stats(
+        self, forecaster, sample_train_stats
+    ):
+        """Test probability calculation from train-level stats."""
+        forecast = forecaster._calculate_probabilities(sample_train_stats)
+
+        # Check cancellation probability
+        assert forecast.cancellation_probability == pytest.approx(2 / 50, rel=0.01)
+
+        # Check delay probabilities sum to ~1.0
+        total_delay_prob = (
+            forecast.on_time_probability
+            + forecast.slight_delay_probability
+            + forecast.significant_delay_probability
+            + forecast.major_delay_probability
+        )
+        assert total_delay_prob == pytest.approx(1.0, rel=0.01)
+
+        # Check expected delay
+        non_cancelled = 50 - 2
+        expected = 150 // non_cancelled
+        assert forecast.expected_delay_minutes == expected
+
+        # High confidence for train_id level
+        assert forecast.confidence == "high"
+
+    def test_calculate_probabilities_with_line_stats(
+        self, forecaster, sample_line_stats
+    ):
+        """Test probability calculation from line-level stats."""
+        forecast = forecaster._calculate_probabilities(sample_line_stats)
+
+        # Check cancellation probability
+        assert forecast.cancellation_probability == pytest.approx(15 / 500, rel=0.01)
+
+        # Medium confidence for line_code level
+        assert forecast.confidence == "medium"
+
+    def test_apply_adjustment_increases_delay_probability(self, forecaster):
+        """Test that adjustment multiplier shifts probability toward delays."""
+        # Create a baseline forecast
+        base_stats = DelayStats(
+            sample_count=100,
+            cancellation_count=5,
+            on_time_count=70,
+            slight_delay_count=15,
+            significant_delay_count=7,
+            major_delay_count=3,
+            total_delay_minutes=400,
+            level="train_id",
+        )
+        base_forecast = forecaster._calculate_probabilities(base_stats)
+
+        # Apply 1.5x multiplier
+        adjusted = forecaster._apply_adjustment(base_forecast, 1.5)
+
+        # On-time probability should decrease
+        assert adjusted.on_time_probability < base_forecast.on_time_probability
+
+        # Delay probabilities should increase
+        assert adjusted.slight_delay_probability >= base_forecast.slight_delay_probability
+
+        # Expected delay should increase
+        assert adjusted.expected_delay_minutes > base_forecast.expected_delay_minutes
+
+        # Probabilities should still sum to 1.0
+        total = (
+            adjusted.on_time_probability
+            + adjusted.slight_delay_probability
+            + adjusted.significant_delay_probability
+            + adjusted.major_delay_probability
+        )
+        assert total == pytest.approx(1.0, rel=0.01)
+
+    def test_apply_adjustment_no_change_for_multiplier_1(self, forecaster):
+        """Test that multiplier of 1.0 doesn't change probabilities."""
+        base_stats = DelayStats(
+            sample_count=100,
+            cancellation_count=5,
+            on_time_count=70,
+            slight_delay_count=15,
+            significant_delay_count=7,
+            major_delay_count=3,
+            total_delay_minutes=400,
+            level="train_id",
+        )
+        base_forecast = forecaster._calculate_probabilities(base_stats)
+
+        adjusted = forecaster._apply_adjustment(base_forecast, 1.0)
+
+        assert adjusted.on_time_probability == base_forecast.on_time_probability
+        assert adjusted.expected_delay_minutes == base_forecast.expected_delay_minutes
+
+    def test_static_fallback_njt(self, forecaster):
+        """Test static fallback for NJT."""
+        fallback = forecaster._create_static_fallback("NJT")
+
+        assert fallback.confidence == "low"
+        assert fallback.sample_count == 0
+        assert "static_fallback" in fallback.factors
+
+        # Check reasonable defaults
+        assert 0.01 <= fallback.cancellation_probability <= 0.10
+        assert 0.50 <= fallback.on_time_probability <= 0.90
+
+        # Probabilities should sum to 1.0
+        total = (
+            fallback.on_time_probability
+            + fallback.slight_delay_probability
+            + fallback.significant_delay_probability
+            + fallback.major_delay_probability
+        )
+        assert total == pytest.approx(1.0, rel=0.01)
+
+    def test_static_fallback_amtrak(self, forecaster):
+        """Test static fallback for AMTRAK."""
+        fallback = forecaster._create_static_fallback("AMTRAK")
+
+        assert fallback.confidence == "low"
+
+        # Amtrak should have slightly different defaults than NJT
+        # (historically higher delay rates)
+        assert fallback.expected_delay_minutes >= 5
+
+    @pytest.mark.asyncio
+    async def test_forecast_uses_train_id_when_sufficient_samples(
+        self, forecaster, mock_db
+    ):
+        """Test that forecast uses train_id stats when sufficient samples exist."""
+        # Mock the stats methods
+        with patch.object(
+            forecaster,
+            "_get_train_id_stats",
+            return_value=DelayStats(
+                sample_count=50,  # Above MIN_TRAIN_ID_SAMPLES (10)
+                cancellation_count=2,
+                on_time_count=40,
+                slight_delay_count=5,
+                significant_delay_count=2,
+                major_delay_count=1,
+                total_delay_minutes=100,
+                level="train_id",
+            ),
+        ) as mock_train, patch.object(
+            forecaster, "_get_line_code_stats", return_value=None
+        ) as mock_line, patch.object(
+            forecaster, "_get_data_source_stats", return_value=None
+        ) as mock_ds, patch.object(
+            forecaster, "_get_hour_day_adjustment", return_value=1.0
+        ), patch.object(
+            forecaster, "_get_congestion_multiplier", return_value=1.0
+        ):
+            forecast = await forecaster.forecast(
+                train_id="TEST123",
+                station_code="NY",
+                line_code="NE",
+                data_source="NJT",
+                journey_date=date.today(),
+                scheduled_departure=datetime.now(),
+                db=mock_db,
+            )
+
+            assert "train_history" in forecast.factors
+            assert forecast.confidence == "high"
+            mock_train.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_forecast_falls_back_to_line_code(self, forecaster, mock_db):
+        """Test fallback to line_code when train_id has insufficient samples."""
+        with patch.object(
+            forecaster,
+            "_get_train_id_stats",
+            return_value=DelayStats(
+                sample_count=5,  # Below MIN_TRAIN_ID_SAMPLES
+                cancellation_count=0,
+                on_time_count=4,
+                slight_delay_count=1,
+                significant_delay_count=0,
+                major_delay_count=0,
+                total_delay_minutes=10,
+                level="train_id",
+            ),
+        ), patch.object(
+            forecaster,
+            "_get_line_code_stats",
+            return_value=DelayStats(
+                sample_count=100,  # Above MIN_LINE_CODE_SAMPLES (25)
+                cancellation_count=5,
+                on_time_count=70,
+                slight_delay_count=15,
+                significant_delay_count=7,
+                major_delay_count=3,
+                total_delay_minutes=500,
+                level="line_code",
+            ),
+        ), patch.object(
+            forecaster, "_get_data_source_stats", return_value=None
+        ), patch.object(
+            forecaster, "_get_hour_day_adjustment", return_value=1.0
+        ), patch.object(
+            forecaster, "_get_congestion_multiplier", return_value=1.0
+        ):
+            forecast = await forecaster.forecast(
+                train_id="TEST123",
+                station_code="NY",
+                line_code="NE",
+                data_source="NJT",
+                journey_date=date.today(),
+                scheduled_departure=datetime.now(),
+                db=mock_db,
+            )
+
+            assert "line_pattern" in forecast.factors
+            assert "train_history" not in forecast.factors
+            assert forecast.confidence == "medium"
+
+    @pytest.mark.asyncio
+    async def test_forecast_falls_back_to_static(self, forecaster, mock_db):
+        """Test fallback to static when all historical data is insufficient."""
+        with patch.object(
+            forecaster,
+            "_get_train_id_stats",
+            return_value=None,
+        ), patch.object(
+            forecaster,
+            "_get_line_code_stats",
+            return_value=None,
+        ), patch.object(
+            forecaster,
+            "_get_data_source_stats",
+            return_value=DelayStats(
+                sample_count=100,  # Below MIN_DATA_SOURCE_SAMPLES (250)
+                cancellation_count=5,
+                on_time_count=70,
+                slight_delay_count=15,
+                significant_delay_count=7,
+                major_delay_count=3,
+                total_delay_minutes=500,
+                level="data_source",
+            ),
+        ):
+            forecast = await forecaster.forecast(
+                train_id="TEST123",
+                station_code="NY",
+                line_code="NE",
+                data_source="NJT",
+                journey_date=date.today(),
+                scheduled_departure=datetime.now(),
+                db=mock_db,
+            )
+
+            assert "static_fallback" in forecast.factors
+            assert forecast.confidence == "low"
+
+    @pytest.mark.asyncio
+    async def test_forecast_applies_congestion_multiplier(self, forecaster, mock_db):
+        """Test that live congestion affects forecast."""
+        with patch.object(
+            forecaster,
+            "_get_train_id_stats",
+            return_value=DelayStats(
+                sample_count=50,
+                cancellation_count=2,
+                on_time_count=40,
+                slight_delay_count=5,
+                significant_delay_count=2,
+                major_delay_count=1,
+                total_delay_minutes=100,
+                level="train_id",
+            ),
+        ), patch.object(
+            forecaster, "_get_line_code_stats", return_value=None
+        ), patch.object(
+            forecaster, "_get_data_source_stats", return_value=None
+        ), patch.object(
+            forecaster, "_get_hour_day_adjustment", return_value=1.0
+        ), patch.object(
+            forecaster, "_get_congestion_multiplier", return_value=1.5
+        ):
+            forecast = await forecaster.forecast(
+                train_id="TEST123",
+                station_code="NY",
+                line_code="NE",
+                data_source="NJT",
+                journey_date=date.today(),
+                scheduled_departure=datetime.now(),
+                db=mock_db,
+            )
+
+            assert "live_congestion" in forecast.factors
+
+    @pytest.mark.asyncio
+    async def test_forecast_applies_time_pattern(self, forecaster, mock_db):
+        """Test that hour/day pattern affects forecast."""
+        with patch.object(
+            forecaster,
+            "_get_train_id_stats",
+            return_value=DelayStats(
+                sample_count=50,
+                cancellation_count=2,
+                on_time_count=40,
+                slight_delay_count=5,
+                significant_delay_count=2,
+                major_delay_count=1,
+                total_delay_minutes=100,
+                level="train_id",
+            ),
+        ), patch.object(
+            forecaster, "_get_line_code_stats", return_value=None
+        ), patch.object(
+            forecaster, "_get_data_source_stats", return_value=None
+        ), patch.object(
+            forecaster, "_get_hour_day_adjustment", return_value=1.3
+        ), patch.object(
+            forecaster, "_get_congestion_multiplier", return_value=1.0
+        ):
+            forecast = await forecaster.forecast(
+                train_id="TEST123",
+                station_code="NY",
+                line_code="NE",
+                data_source="NJT",
+                journey_date=date.today(),
+                scheduled_departure=datetime.now(),
+                db=mock_db,
+            )
+
+            assert "time_pattern" in forecast.factors
+
+
+class TestDelayStatsQueries:
+    """Test the database query methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_train_id_stats_returns_none_for_no_data(self, forecaster):
+        """Test that missing data returns None."""
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        # Mock empty result
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = None
+        mock_db.execute.return_value = mock_result
+
+        stats = await forecaster._get_train_id_stats(
+            mock_db, "NONEXISTENT", "XX", "NJT"
+        )
+
+        assert stats is None
+
+    @pytest.mark.asyncio
+    async def test_get_train_id_stats_returns_stats_for_valid_data(self, forecaster):
+        """Test that valid data returns DelayStats."""
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        # Mock result with data
+        mock_row = MagicMock()
+        mock_row.total = 50
+        mock_row.cancelled = 2
+        mock_row.on_time = 40
+        mock_row.slight = 5
+        mock_row.significant = 2
+        mock_row.major = 1
+        mock_row.total_delay = 100
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        stats = await forecaster._get_train_id_stats(
+            mock_db, "TEST123", "NY", "NJT"
+        )
+
+        assert stats is not None
+        assert stats.sample_count == 50
+        assert stats.cancellation_count == 2
+        assert stats.level == "train_id"
+
+    @pytest.mark.asyncio
+    async def test_get_hour_day_adjustment_returns_1_for_insufficient_data(
+        self, forecaster
+    ):
+        """Test that insufficient data returns neutral adjustment."""
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        # Mock insufficient overall data
+        mock_row = MagicMock()
+        mock_row.total = 50  # Below 100 threshold
+        mock_row.delayed = 10
+
+        mock_result = MagicMock()
+        mock_result.one_or_none.return_value = mock_row
+        mock_db.execute.return_value = mock_result
+
+        adjustment = await forecaster._get_hour_day_adjustment(
+            mock_db, "NY", "NJT", hour=8, day_of_week=1
+        )
+
+        assert adjustment == 1.0
+
+    @pytest.mark.asyncio
+    async def test_get_congestion_multiplier_handles_errors(self, forecaster):
+        """Test graceful handling of congestion service errors."""
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        # Mock congestion analyzer to raise exception
+        with patch.object(
+            forecaster.congestion_analyzer,
+            "get_network_congestion_optimized",
+            side_effect=Exception("Database error"),
+        ):
+            multiplier = await forecaster._get_congestion_multiplier(
+                mock_db, "NY", "NJT"
+            )
+
+            # Should return neutral multiplier on error
+            assert multiplier == 1.0
+
+    @pytest.mark.asyncio
+    async def test_get_congestion_multiplier_returns_average_factor(self, forecaster):
+        """Test congestion multiplier calculation."""
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        # Create mock congestion segments
+        mock_segment_1 = MagicMock()
+        mock_segment_1.from_station = "NY"
+        mock_segment_1.congestion_factor = 1.3
+
+        mock_segment_2 = MagicMock()
+        mock_segment_2.from_station = "NY"
+        mock_segment_2.congestion_factor = 1.5
+
+        mock_segment_3 = MagicMock()
+        mock_segment_3.from_station = "NP"  # Different station
+        mock_segment_3.congestion_factor = 2.0
+
+        with patch.object(
+            forecaster.congestion_analyzer,
+            "get_network_congestion_optimized",
+            return_value=[mock_segment_1, mock_segment_2, mock_segment_3],
+        ):
+            multiplier = await forecaster._get_congestion_multiplier(
+                mock_db, "NY", "NJT"
+            )
+
+            # Should average only NY segments (1.3 + 1.5) / 2 = 1.4
+            assert multiplier == pytest.approx(1.4, rel=0.01)
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_zero_non_cancelled_journeys(self, forecaster):
+        """Test handling when all journeys are cancelled."""
+        stats = DelayStats(
+            sample_count=10,
+            cancellation_count=10,  # All cancelled
+            on_time_count=0,
+            slight_delay_count=0,
+            significant_delay_count=0,
+            major_delay_count=0,
+            total_delay_minutes=0,
+            level="train_id",
+        )
+
+        forecast = forecaster._calculate_probabilities(stats)
+
+        # Should use defaults for delay breakdown
+        assert forecast.cancellation_probability == 1.0
+        assert forecast.on_time_probability > 0  # Default values
+        assert forecast.expected_delay_minutes == 0
+
+    def test_high_cancellation_rate(self, forecaster):
+        """Test handling of high cancellation rates."""
+        stats = DelayStats(
+            sample_count=100,
+            cancellation_count=50,  # 50% cancelled
+            on_time_count=40,
+            slight_delay_count=7,
+            significant_delay_count=2,
+            major_delay_count=1,
+            total_delay_minutes=200,
+            level="train_id",
+        )
+
+        forecast = forecaster._calculate_probabilities(stats)
+
+        assert forecast.cancellation_probability == pytest.approx(0.5, rel=0.01)
+
+    def test_adjustment_capped_at_maximum(self, forecaster):
+        """Test that on_time probability doesn't go below minimum."""
+        stats = DelayStats(
+            sample_count=100,
+            cancellation_count=5,
+            on_time_count=70,
+            slight_delay_count=15,
+            significant_delay_count=7,
+            major_delay_count=3,
+            total_delay_minutes=400,
+            level="train_id",
+        )
+        base_forecast = forecaster._calculate_probabilities(stats)
+
+        # Apply very high multiplier
+        adjusted = forecaster._apply_adjustment(base_forecast, 10.0)
+
+        # On-time should not go below 0.1
+        assert adjusted.on_time_probability >= 0.1
+
+        # Total should still sum to 1.0
+        total = (
+            adjusted.on_time_probability
+            + adjusted.slight_delay_probability
+            + adjusted.significant_delay_probability
+            + adjusted.major_delay_probability
+        )
+        assert total == pytest.approx(1.0, rel=0.01)

--- a/ios/TrackRat/Models/V2APIModels.swift
+++ b/ios/TrackRat/Models/V2APIModels.swift
@@ -984,3 +984,106 @@ struct OperationsSummaryResponse: Codable {
         }
     }
 }
+
+// MARK: - Delay Forecast Models
+
+/// Delay probability breakdown
+struct DelayBreakdownProbabilities: Codable {
+    let onTime: Double
+    let slight: Double
+    let significant: Double
+    let major: Double
+
+    enum CodingKeys: String, CodingKey {
+        case onTime = "on_time"
+        case slight
+        case significant
+        case major
+    }
+}
+
+/// Response for delay/cancellation forecast endpoint
+struct DelayForecastResponse: Codable {
+    let trainId: String
+    let stationCode: String
+    let journeyDate: String
+
+    /// Probability of cancellation (0.0-1.0)
+    let cancellationProbability: Double
+
+    /// Delay probabilities (sum to 1.0 for non-cancelled scenario)
+    let delayProbabilities: DelayBreakdownProbabilities
+
+    /// Expected delay in minutes
+    let expectedDelayMinutes: Int
+
+    /// Confidence level: "high", "medium", or "low"
+    let confidence: String
+
+    /// Historical samples used
+    let sampleCount: Int
+
+    /// Factors used in forecast
+    let factors: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case trainId = "train_id"
+        case stationCode = "station_code"
+        case journeyDate = "journey_date"
+        case cancellationProbability = "cancellation_probability"
+        case delayProbabilities = "delay_probabilities"
+        case expectedDelayMinutes = "expected_delay_minutes"
+        case confidence
+        case sampleCount = "sample_count"
+        case factors
+    }
+
+    // MARK: - Display Helpers
+
+    /// Formatted on-time probability as percentage
+    var onTimePercentage: Int {
+        Int(delayProbabilities.onTime * 100)
+    }
+
+    /// Formatted cancellation probability as percentage
+    var cancellationPercentage: Int {
+        Int(cancellationProbability * 100)
+    }
+
+    /// Whether to show cancellation warning (> 5%)
+    var showCancellationWarning: Bool {
+        cancellationProbability > 0.05
+    }
+
+    /// Color for on-time probability
+    var onTimeColor: Color {
+        if delayProbabilities.onTime >= 0.80 {
+            return .green
+        } else if delayProbabilities.onTime >= 0.60 {
+            return .yellow
+        } else {
+            return .orange
+        }
+    }
+
+    /// Display text for delay breakdown
+    var delayBreakdownText: String {
+        let onTime = onTimePercentage
+        let slight = Int(delayProbabilities.slight * 100)
+
+        if slight > 5 {
+            return "\(onTime)% on-time · \(slight)% slight delay"
+        } else {
+            return "\(onTime)% on-time"
+        }
+    }
+
+    /// Confidence display text
+    var confidenceText: String {
+        switch confidence {
+        case "high": return "High confidence"
+        case "medium": return "Medium confidence"
+        default: return "Low confidence"
+        }
+    }
+}

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -1070,6 +1070,58 @@ final class APIService: ObservableObject {
         }
     }
 
+    // MARK: - Delay Forecasts
+
+    /// Get delay and cancellation forecast for a train
+    func getDelayForecast(
+        trainId: String,
+        stationCode: String,
+        journeyDate: Date
+    ) async throws -> DelayForecastResponse {
+        var components = URLComponents(string: "\(baseURL)/v2/predictions/delay")!
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(identifier: "America/New_York")
+        let dateString = dateFormatter.string(from: journeyDate)
+
+        components.queryItems = [
+            URLQueryItem(name: "train_id", value: trainId),
+            URLQueryItem(name: "station_code", value: stationCode),
+            URLQueryItem(name: "journey_date", value: dateString)
+        ]
+
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+
+        print("🌐 [APIService] Fetching delay forecast from: \(url.absoluteString)")
+
+        let (data, response) = try await session.data(from: url)
+
+        if let httpResponse = response as? HTTPURLResponse {
+            print("📡 [APIService] Response status: \(httpResponse.statusCode)")
+            if httpResponse.statusCode != 200 {
+                print("⚠️ [APIService] Non-200 status code")
+                if let responseStr = String(data: data, encoding: .utf8) {
+                    print("   Response body: \(responseStr)")
+                }
+            }
+        }
+
+        do {
+            let forecast = try decoder.decode(DelayForecastResponse.self, from: data)
+            print("✅ [APIService] Successfully decoded delay forecast")
+            return forecast
+        } catch {
+            print("❌ [APIService] Decoding error: \(error)")
+            if let responseStr = String(data: data, encoding: .utf8) {
+                print("   Raw response: \(responseStr.prefix(500))...")
+            }
+            throw error
+        }
+    }
+
     // MARK: - User Feedback
 
     /// Submit user feedback about data issues

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -352,6 +352,16 @@ struct CombinedDetailsCard: View {
                     )
                     .allowsHitTesting(true)  // Ensure predictions card is interactive
                 }
+
+                // Delay forecast section
+                // Show when train hasn't departed from user's origin
+                if let originCode = appState.departureStationCode,
+                   !train.hasTrainDepartedFromStation(originCode) {
+                    DelayForecastView(
+                        train: train,
+                        originStationCode: originCode
+                    )
+                }
             }
             .padding([.horizontal, .top])
 
@@ -1583,6 +1593,164 @@ struct PredictionExplanationSheet: View {
         .presentationDragIndicator(.visible)
         .presentationBackground(.ultraThinMaterial)
         .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Delay Forecast View
+struct DelayForecastView: View {
+    let train: TrainV2
+    let originStationCode: String?
+
+    @State private var delayForecast: DelayForecastResponse?
+    @State private var isLoading = true
+    @State private var loadError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Image(systemName: "clock.badge.questionmark")
+                    .foregroundColor(.black)
+                    .font(.title2)
+
+                Text("Delay Forecast")
+                    .font(.headline)
+                    .foregroundColor(.black)
+
+                Spacer()
+
+                if let forecast = delayForecast {
+                    Text(forecast.confidenceText)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            }
+
+            if isLoading {
+                ProgressView()
+                    .frame(height: 50)
+                    .frame(maxWidth: .infinity)
+            } else if let forecast = delayForecast {
+                VStack(alignment: .leading, spacing: 8) {
+                    // Main delay probability bar
+                    DelayProbabilityBar(forecast: forecast)
+                        .frame(height: 32)
+
+                    // Summary text
+                    HStack {
+                        Text(forecast.delayBreakdownText)
+                            .font(.subheadline)
+                            .foregroundColor(forecast.onTimeColor)
+
+                        Spacer()
+
+                        if forecast.showCancellationWarning {
+                            HStack(spacing: 4) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.caption)
+                                Text("\(forecast.cancellationPercentage)% cancel risk")
+                                    .font(.caption)
+                            }
+                            .foregroundColor(.red)
+                        }
+                    }
+
+                    // Sample count info
+                    if forecast.sampleCount > 0 {
+                        Text("Based on \(forecast.sampleCount) historical journeys")
+                            .font(.caption2)
+                            .foregroundColor(.gray)
+                    }
+                }
+            } else if let error = loadError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .italic()
+            } else {
+                Text("No forecast available")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                    .italic()
+            }
+        }
+        .padding()
+        .background(Color.blue.opacity(0.05))
+        .cornerRadius(TrackRatTheme.CornerRadius.md)
+        .overlay(
+            RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.md)
+                .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+        )
+        .task {
+            await loadDelayForecast()
+        }
+    }
+
+    private func loadDelayForecast() async {
+        guard let stationCode = originStationCode else {
+            loadError = "No origin station"
+            isLoading = false
+            return
+        }
+
+        isLoading = true
+        loadError = nil
+
+        do {
+            let forecast = try await APIService.shared.getDelayForecast(
+                trainId: train.trainId,
+                stationCode: stationCode,
+                journeyDate: train.journeyDate
+            )
+            self.delayForecast = forecast
+        } catch {
+            print("❌ [DelayForecastView] Error loading forecast: \(error)")
+            loadError = "Could not load forecast"
+        }
+
+        isLoading = false
+    }
+}
+
+// MARK: - Delay Probability Bar
+struct DelayProbabilityBar: View {
+    let forecast: DelayForecastResponse
+
+    var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                // On-time segment (green)
+                Rectangle()
+                    .fill(Color.green)
+                    .frame(width: geometry.size.width * forecast.delayProbabilities.onTime)
+
+                // Slight delay segment (yellow)
+                if forecast.delayProbabilities.slight > 0.02 {
+                    Rectangle()
+                        .fill(Color.yellow)
+                        .frame(width: geometry.size.width * forecast.delayProbabilities.slight)
+                }
+
+                // Significant delay segment (orange)
+                if forecast.delayProbabilities.significant > 0.02 {
+                    Rectangle()
+                        .fill(Color.orange)
+                        .frame(width: geometry.size.width * forecast.delayProbabilities.significant)
+                }
+
+                // Major delay segment (red)
+                if forecast.delayProbabilities.major > 0.02 {
+                    Rectangle()
+                        .fill(Color.red)
+                        .frame(width: geometry.size.width * forecast.delayProbabilities.major)
+                }
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.sm))
+        .overlay(
+            RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.sm)
+                .stroke(Color.black.opacity(0.2), lineWidth: 1)
+        )
     }
 }
 


### PR DESCRIPTION
Backend:
- Add DelayForecaster service with hierarchical prediction pattern (train_id -> line_code -> data_source -> static fallback)
- Add /api/v2/predictions/delay endpoint
- Add DelayForecastResponse and DelayBreakdownProbabilities models
- Include hour/day-of-week adjustments and live congestion multipliers
- Add comprehensive unit tests for delay forecaster

iOS:
- Add DelayForecastResponse model with display helpers
- Add getDelayForecast API method
- Add DelayForecastView with probability bar visualization
- Show forecast in TrainDetailsView before train departure