### PR TITLE
Analyze train listing real-time updates and delays

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -44,7 +44,7 @@ struct TrainListView: View {
                 Spacer()
 
                 // Center title
-                VStack(spacing: 0) {
+                VStack(spacing: 2) {
                     Text(destination)
                         .font(.headline)
                         .foregroundColor(.white)
@@ -52,6 +52,13 @@ struct TrainListView: View {
                         Text("from \(departureName)")
                             .font(.caption2)
                             .foregroundColor(.white.opacity(0.8))
+                    }
+                    // Data freshness indicator
+                    if let freshness = viewModel.trains.first?.dataFreshness,
+                       freshness.ageSeconds >= 30 {
+                        Text(freshness.formattedAge)
+                            .font(.caption2)
+                            .foregroundColor(.white.opacity(0.5))
                     }
                 }
 
@@ -211,9 +218,9 @@ struct TrainCard: View {
     let departureStationCode: String
     let onTap: () -> Void
     let isExpress: Bool
-    
+
     // Configuration constants
-    private static let DELAY_THRESHOLD_MINUTES = 6
+    private static let DELAY_THRESHOLD_MINUTES = 3
     
     /// Check if train is scheduled only (not observed)
     private var isScheduledOnly: Bool {
@@ -238,7 +245,7 @@ struct TrainCard: View {
     private var departureTime: String {
         return train.getFormattedDepartureTime(fromStationCode: departureStationCode)
     }
-    
+
     private var arrivalTime: String {
         // For V2, we show arrival time if available
         if let arrivalTime = train.arrival?.scheduledTime {
@@ -246,6 +253,20 @@ struct TrainCard: View {
             return formatter.string(from: arrivalTime)
         }
         return "--:--"
+    }
+
+    /// Departure delay text (e.g., "+8m") if delay >= threshold
+    private var departureDelayText: String? {
+        let delay = train.delayMinutes
+        guard delay >= TrainCard.DELAY_THRESHOLD_MINUTES else { return nil }
+        return "+\(delay)m"
+    }
+
+    /// Arrival delay text (e.g., "+12m") if delay >= threshold
+    private var arrivalDelayText: String? {
+        guard let arrivalDelay = train.arrival?.delayMinutes,
+              arrivalDelay >= TrainCard.DELAY_THRESHOLD_MINUTES else { return nil }
+        return "+\(arrivalDelay)m"
     }
     
     var body: some View {
@@ -278,6 +299,11 @@ struct TrainCard: View {
                         .font(.subheadline)
                         .foregroundColor(isCancelled ? .black.opacity(0.5) : (isBoardingAtOrigin ? .white.opacity(0.9) : .black.opacity(0.7)))
 
+                    if let depDelay = departureDelayText, !isCancelled {
+                        Text(depDelay)
+                            .font(.caption)
+                            .foregroundColor(isBoardingAtOrigin ? .white : .orange)
+                    }
 
                     Text(" → ")
                         .font(.subheadline)
@@ -287,28 +313,24 @@ struct TrainCard: View {
                         .font(.subheadline)
                         .foregroundColor(isCancelled ? .black.opacity(0.5) : (isBoardingAtOrigin ? .white.opacity(0.9) : .black.opacity(0.7)))
 
+                    if let arrDelay = arrivalDelayText, !isCancelled {
+                        Text(arrDelay)
+                            .font(.caption)
+                            .foregroundColor(isBoardingAtOrigin ? .white : .orange)
+                    }
                 }
             }
 
-            // Show cancellation location
+            // Show cancellation or scheduled-only status
             if isCancelled {
                 Text("Cancelled")
                     .font(.caption)
                     .foregroundColor(.red.opacity(0.8))
                     .fontWeight(.medium)
-            }
-
-            // Show delay status
-            if !isCancelled {
-                let hasDepDelay = train.delayMinutes >= TrainCard.DELAY_THRESHOLD_MINUTES
-                let hasArrDelay = train.arrival?.delayMinutes ?? 0 >= TrainCard.DELAY_THRESHOLD_MINUTES
-
-                if hasDepDelay || hasArrDelay {
-                    Text("Operating with Delays")
-                        .font(.caption)
-                        .foregroundColor(.red.opacity(0.8))
-                        .fontWeight(.medium)
-                }
+            } else if isScheduledOnly {
+                Text("Scheduled")
+                    .font(.caption)
+                    .foregroundColor(isBoardingAtOrigin ? .white.opacity(0.7) : .gray)
             }
 
             // Track and status - only show for boarding trains at origin


### PR DESCRIPTION
- Show delay inline with times (+Xm in orange) for delays >= 3 minutes
- Replace generic "Operating with Delays" badge with specific delay amounts
- Add "Scheduled" label for trains not yet observed (schedule-only data)
- Add data freshness indicator in header ("Updated Xm ago")
- Lower delay threshold from 6 to 3 minutes for better visibility