### PR TITLE
Add in-journey feedback and app review prompts

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		A14A4ABE2E1949A400E13005 /* V2APIModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14A4ABD2E1949A400E13005 /* V2APIModels.swift */; };
 		A16C81EE2EEEFFEE00F34F00 /* FeedbackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16C81ED2EEEFFEE00F34F00 /* FeedbackButton.swift */; };
 		A16C81EF2EEEFFEE00F34F00 /* FeedbackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16C81ED2EEEFFEE00F34F00 /* FeedbackButton.swift */; };
+		A1JF00012F00000100000001 /* JourneyFeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1JF00012F00000000000001 /* JourneyFeedbackService.swift */; };
+		A1JF00022F00000100000002 /* JourneyFeedbackPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1JF00022F00000000000002 /* JourneyFeedbackPromptView.swift */; };
+		A1JF00032F00000100000003 /* ImprovementFeedbackSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1JF00032F00000000000003 /* ImprovementFeedbackSheet.swift */; };
 		A16D6EEC2E1703C7008C6996 /* rat-train-icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A16D6EE92E1703C7008C6996 /* rat-train-icon@2x.png */; };
 		A16D6EED2E1703C7008C6996 /* rat-train-icon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = A16D6EEA2E1703C7008C6996 /* rat-train-icon@3x.png */; };
 		A16D6EEE2E1703C7008C6996 /* Contents.json in Resources */ = {isa = PBXBuildFile; fileRef = A16D6EE72E1703C7008C6996 /* Contents.json */; };
@@ -162,6 +165,9 @@
 		A14A4ABB2E19499800E13005 /* TrainV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TrainV2.swift; path = TrackRat/Models/TrainV2.swift; sourceTree = "<group>"; };
 		A14A4ABD2E1949A400E13005 /* V2APIModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = V2APIModels.swift; path = TrackRat/Models/V2APIModels.swift; sourceTree = "<group>"; };
 		A16C81ED2EEEFFEE00F34F00 /* FeedbackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FeedbackButton.swift; path = TrackRat/Views/Components/FeedbackButton.swift; sourceTree = "<group>"; };
+		A1JF00012F00000000000001 /* JourneyFeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JourneyFeedbackService.swift; path = TrackRat/Services/JourneyFeedbackService.swift; sourceTree = "<group>"; };
+		A1JF00022F00000000000002 /* JourneyFeedbackPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JourneyFeedbackPromptView.swift; path = TrackRat/Views/Components/JourneyFeedbackPromptView.swift; sourceTree = "<group>"; };
+		A1JF00032F00000000000003 /* ImprovementFeedbackSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ImprovementFeedbackSheet.swift; path = TrackRat/Views/Components/ImprovementFeedbackSheet.swift; sourceTree = "<group>"; };
 		A16D6EE72E1703C7008C6996 /* Contents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Contents.json; sourceTree = "<group>"; };
 		A16D6EE82E1703C7008C6996 /* rat-train-icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "rat-train-icon.png"; sourceTree = "<group>"; };
 		A16D6EE92E1703C7008C6996 /* rat-train-icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "rat-train-icon@2x.png"; sourceTree = "<group>"; };
@@ -278,6 +284,9 @@
 				A16C81ED2EEEFFEE00F34F00 /* FeedbackButton.swift */,
 				A1F670E82EFEE4E700E040AA /* TrackRatNavigationHeader.swift */,
 				A1B2375C2F002DCF0011A16E /* TrackTrainInlineButton.swift */,
+				A1JF00012F00000000000001 /* JourneyFeedbackService.swift */,
+				A1JF00022F00000000000002 /* JourneyFeedbackPromptView.swift */,
+				A1JF00032F00000000000003 /* ImprovementFeedbackSheet.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -614,6 +623,9 @@
 				A10E98062DE39F23002F3214 /* DeparturePickerView.swift in Sources */,
 				A10E98DBA82DE39F23002F3214 /* TripSelectionView.swift in Sources */,
 				A16C81EE2EEEFFEE00F34F00 /* FeedbackButton.swift in Sources */,
+				A1JF00012F00000100000001 /* JourneyFeedbackService.swift in Sources */,
+				A1JF00022F00000100000002 /* JourneyFeedbackPromptView.swift in Sources */,
+				A1JF00032F00000100000003 /* ImprovementFeedbackSheet.swift in Sources */,
 				A1CB28332E3D634C004A49E6 /* JourneyCongestionMapView.swift in Sources */,
 				A10684812E36B6EC0052C4AE /* ThemeManager.swift in Sources */,
 				A1AA1BB32DEF00BB001FA904 /* TrackRatTheme.swift in Sources */,

--- a/ios/TrackRat/App/ContentView.swift
+++ b/ios/TrackRat/App/ContentView.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject private var appState: AppState
-    
+    @ObservedObject private var feedbackService = JourneyFeedbackService.shared
+
     var body: some View {
         MapContainerView()
+            .sheet(isPresented: $feedbackService.shouldShowFeedbackPrompt) {
+                JourneyFeedbackPromptView()
+            }
     }
 }
 

--- a/ios/TrackRat/Services/JourneyFeedbackService.swift
+++ b/ios/TrackRat/Services/JourneyFeedbackService.swift
@@ -1,0 +1,185 @@
+import Foundation
+import StoreKit
+import UIKit
+
+/// Service that manages prompting users for feedback during their train journey.
+/// Shows a feedback prompt at 2/3 journey completion, with a 30-day cooldown if dismissed.
+@MainActor
+class JourneyFeedbackService: ObservableObject {
+    static let shared = JourneyFeedbackService()
+
+    // MARK: - Published State
+
+    /// When true, the UI should present the feedback prompt
+    @Published var shouldShowFeedbackPrompt: Bool = false
+
+    /// Context for the current journey (used for feedback submission)
+    @Published var currentJourneyContext: JourneyFeedbackContext?
+
+    // MARK: - Private State
+
+    /// Tracks whether we've already prompted during this Live Activity session
+    private var hasPromptedDuringCurrentActivity: Bool = false
+
+    /// Whether a prompt is queued for when the app returns to foreground
+    private var promptQueuedForForeground: Bool = false
+
+    // MARK: - UserDefaults Keys
+
+    private let lastPromptDismissedDateKey = "journeyFeedback_lastPromptDismissedDate"
+    private let cooldownDays: Int = 30
+
+    // MARK: - Progress Threshold
+
+    /// The journey progress threshold at which we prompt for feedback (2/3)
+    private let feedbackThreshold: Double = 0.666
+
+    private init() {
+        // Observe app becoming active to show queued prompts
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Public API
+
+    /// Called when a new Live Activity starts. Resets the per-activity prompt state.
+    func onActivityStarted() {
+        hasPromptedDuringCurrentActivity = false
+        promptQueuedForForeground = false
+        currentJourneyContext = nil
+    }
+
+    /// Called when a Live Activity ends. Clears any pending state.
+    func onActivityEnded() {
+        hasPromptedDuringCurrentActivity = false
+        promptQueuedForForeground = false
+        shouldShowFeedbackPrompt = false
+        currentJourneyContext = nil
+    }
+
+    /// Called on each progress update to check if we should prompt for feedback.
+    /// - Parameters:
+    ///   - progress: The current journey progress (0.0 to 1.0)
+    ///   - trainId: The train ID
+    ///   - originCode: Origin station code
+    ///   - destinationCode: Destination station code
+    func checkProgressMilestone(
+        progress: Double,
+        trainId: String,
+        originCode: String,
+        destinationCode: String
+    ) {
+        // Skip if we've already prompted during this activity
+        guard !hasPromptedDuringCurrentActivity else { return }
+
+        // Skip if we haven't reached the threshold yet
+        guard progress >= feedbackThreshold else { return }
+
+        // Skip if we're in cooldown period
+        guard !isInCooldownPeriod() else {
+            print("📊 Journey feedback: Skipping prompt (in cooldown period)")
+            return
+        }
+
+        // Mark that we've handled the prompt for this activity
+        hasPromptedDuringCurrentActivity = true
+
+        // Store context for the feedback form
+        currentJourneyContext = JourneyFeedbackContext(
+            trainId: trainId,
+            originCode: originCode,
+            destinationCode: destinationCode
+        )
+
+        // Check if app is in foreground
+        if UIApplication.shared.applicationState == .active {
+            print("📊 Journey feedback: Showing prompt (app active, progress: \(progress))")
+            shouldShowFeedbackPrompt = true
+        } else {
+            print("📊 Journey feedback: Queuing prompt for foreground (progress: \(progress))")
+            promptQueuedForForeground = true
+        }
+    }
+
+    /// Called when user taps "Yes!" - they're enjoying TrackRat
+    func userRespondedPositively() {
+        shouldShowFeedbackPrompt = false
+        promptQueuedForForeground = false
+
+        print("📊 Journey feedback: User responded positively, requesting App Store review")
+
+        // Request App Store review using the recommended API
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            SKStoreReviewController.requestReview(in: windowScene)
+        }
+    }
+
+    /// Called when user taps "Not really" - show feedback form
+    /// Returns true to indicate the caller should present the feedback form
+    func userRespondedNegatively() -> Bool {
+        shouldShowFeedbackPrompt = false
+        promptQueuedForForeground = false
+
+        print("📊 Journey feedback: User responded negatively, showing feedback form")
+
+        // Return true to signal that caller should show the improvement feedback form
+        return true
+    }
+
+    /// Called when user dismisses the prompt without responding
+    func userDismissedPrompt() {
+        shouldShowFeedbackPrompt = false
+        promptQueuedForForeground = false
+
+        // Record the dismissal to start cooldown
+        recordDismissal()
+
+        print("📊 Journey feedback: User dismissed prompt, starting 30-day cooldown")
+    }
+
+    // MARK: - Private Methods
+
+    @objc private func appDidBecomeActive() {
+        // If we have a queued prompt and we're not already showing one, show it now
+        if promptQueuedForForeground && !shouldShowFeedbackPrompt {
+            print("📊 Journey feedback: App became active, showing queued prompt")
+            promptQueuedForForeground = false
+            shouldShowFeedbackPrompt = true
+        }
+    }
+
+    private func isInCooldownPeriod() -> Bool {
+        guard let lastDismissedDate = UserDefaults.standard.object(forKey: lastPromptDismissedDateKey) as? Date else {
+            // Never dismissed before, not in cooldown
+            return false
+        }
+
+        let calendar = Calendar.current
+        guard let cooldownEndDate = calendar.date(byAdding: .day, value: cooldownDays, to: lastDismissedDate) else {
+            return false
+        }
+
+        return Date() < cooldownEndDate
+    }
+
+    private func recordDismissal() {
+        UserDefaults.standard.set(Date(), forKey: lastPromptDismissedDateKey)
+    }
+}
+
+// MARK: - Supporting Types
+
+/// Context about the current journey for feedback submission
+struct JourneyFeedbackContext {
+    let trainId: String
+    let originCode: String
+    let destinationCode: String
+}

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -132,6 +132,9 @@ class LiveActivityService: ObservableObject {
             // Start periodic updates every 30 seconds
             startPeriodicUpdates()
 
+            // Reset journey feedback state for new activity
+            await JourneyFeedbackService.shared.onActivityStarted()
+
             print("✅ Live Activity started successfully")
             print("  - Activity ID: \(activity.id)")
 
@@ -187,6 +190,9 @@ class LiveActivityService: ObservableObject {
             self?.currentPushToken = nil
             self?.journeyStationCodes = []
         }
+
+        // Clear journey feedback state
+        await JourneyFeedbackService.shared.onActivityEnded()
 
         print("🛑 Live Activity ended and cleaned up")
     }
@@ -283,6 +289,14 @@ class LiveActivityService: ObservableObject {
             )
 
             print("✅ Live Activity updated successfully")
+
+            // Check if we should prompt for journey feedback at 2/3 progress
+            await JourneyFeedbackService.shared.checkProgressMilestone(
+                progress: progress,
+                trainId: activity.attributes.trainId,
+                originCode: activity.attributes.originStationCode,
+                destinationCode: activity.attributes.destinationStationCode
+            )
 
             // Auto-end if journey is complete using comprehensive check
             if shouldEndActivity(train: train, activity: activity) {

--- a/ios/TrackRat/Views/Components/ImprovementFeedbackSheet.swift
+++ b/ios/TrackRat/Views/Components/ImprovementFeedbackSheet.swift
@@ -1,0 +1,190 @@
+import SwiftUI
+
+/// Sheet for collecting improvement suggestions when user isn't fully satisfied.
+/// Similar to FeedbackSheet but with messaging focused on improvement.
+struct ImprovementFeedbackSheet: View {
+    let context: JourneyFeedbackContext?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var message = ""
+    @State private var isSubmitting = false
+    @State private var showingConfirmation = false
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                if showingConfirmation {
+                    confirmationView
+                } else {
+                    formView
+                }
+            }
+            .padding()
+            .navigationTitle("Help Us Improve")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .foregroundColor(.white.opacity(0.7))
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(.ultraThinMaterial)
+        .preferredColorScheme(.dark)
+    }
+
+    private var formView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("We'd love to hear how we can make TrackRat better for you.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.7))
+
+            // Message input
+            VStack(alignment: .leading, spacing: 8) {
+                Text("What could we improve?")
+                    .font(.headline)
+                    .foregroundColor(.white)
+
+                TextEditor(text: $message)
+                    .font(.body)
+                    .foregroundColor(.white)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 100, maxHeight: 150)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.ultraThinMaterial)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                    )
+                    .focused($isTextFieldFocused)
+                    .overlay(alignment: .topLeading) {
+                        if message.isEmpty {
+                            Text("Tell us what's on your mind...")
+                                .font(.body)
+                                .foregroundColor(.white.opacity(0.4))
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 20)
+                                .allowsHitTesting(false)
+                        }
+                    }
+            }
+
+            Spacer()
+
+            // Submit button
+            Button {
+                submitFeedback()
+            } label: {
+                if isSubmitting {
+                    ProgressView()
+                        .tint(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                } else {
+                    Text("Send Feedback")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.orange)
+            .disabled(message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting)
+        }
+        .onAppear {
+            isTextFieldFocused = true
+        }
+    }
+
+    private var confirmationView: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: "heart.fill")
+                .font(.system(size: 72))
+                .foregroundColor(.orange)
+                .shadow(color: .orange.opacity(0.3), radius: 12, x: 0, y: 4)
+
+            Text("Thank you!")
+                .font(.title)
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+
+            Text("Your feedback helps us make TrackRat better for everyone.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Done")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.orange)
+        }
+    }
+
+    private func submitFeedback() {
+        guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+
+        isSubmitting = true
+        isTextFieldFocused = false
+
+        Task {
+            do {
+                try await APIService.shared.submitFeedback(
+                    message: "[Improvement Suggestion] \(message)",
+                    screen: "journey_feedback_prompt",
+                    trainId: context?.trainId,
+                    originCode: context?.originCode,
+                    destinationCode: context?.destinationCode
+                )
+
+                await MainActor.run {
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                    withAnimation {
+                        showingConfirmation = true
+                    }
+                }
+            } catch {
+                print("Failed to submit improvement feedback: \(error)")
+                await MainActor.run {
+                    UINotificationFeedbackGenerator().notificationOccurred(.error)
+                    // Still show confirmation - the feedback attempt was made
+                    withAnimation {
+                        showingConfirmation = true
+                    }
+                }
+            }
+
+            await MainActor.run {
+                isSubmitting = false
+            }
+        }
+    }
+}
+
+#Preview {
+    Color.black
+        .ignoresSafeArea()
+        .sheet(isPresented: .constant(true)) {
+            ImprovementFeedbackSheet(context: nil)
+        }
+}

--- a/ios/TrackRat/Views/Components/JourneyFeedbackPromptView.swift
+++ b/ios/TrackRat/Views/Components/JourneyFeedbackPromptView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// A simple prompt shown at 2/3 journey completion asking if the user is enjoying TrackRat.
+/// Positive responses trigger an App Store review request.
+/// Negative responses show a feedback form.
+struct JourneyFeedbackPromptView: View {
+    @ObservedObject private var feedbackService = JourneyFeedbackService.shared
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showImprovementForm = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+
+                // Friendly rat icon
+                Image(systemName: "hand.wave.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.orange)
+
+                // Main question
+                Text("Enjoying TrackRat so far?")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+
+                Text("Your feedback helps us improve")
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.7))
+
+                Spacer()
+
+                // Response buttons
+                VStack(spacing: 12) {
+                    Button {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        feedbackService.userRespondedPositively()
+                        dismiss()
+                    } label: {
+                        Text("Yes!")
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
+
+                    Button {
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        if feedbackService.userRespondedNegatively() {
+                            showImprovementForm = true
+                        }
+                    } label: {
+                        Text("Not really")
+                            .fontWeight(.medium)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 50)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.white.opacity(0.6))
+                }
+                .padding(.bottom, 20)
+            }
+            .padding(.horizontal, 32)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        feedbackService.userDismissedPrompt()
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.white.opacity(0.6))
+                    }
+                }
+            }
+        }
+        .presentationDetents([.height(320)])
+        .presentationDragIndicator(.visible)
+        .presentationBackground(.ultraThinMaterial)
+        .preferredColorScheme(.dark)
+        .sheet(isPresented: $showImprovementForm) {
+            ImprovementFeedbackSheet(context: feedbackService.currentJourneyContext)
+        }
+    }
+}
+
+#Preview {
+    Color.black
+        .ignoresSafeArea()
+        .sheet(isPresented: .constant(true)) {
+            JourneyFeedbackPromptView()
+        }
+}


### PR DESCRIPTION
Implements a feedback flow that prompts users when they reach 2/3 of their train journey:
- JourneyFeedbackService: Manages prompt timing, 30-day cooldown, and foreground queuing
- JourneyFeedbackPromptView: Clean sheet asking "Enjoying TrackRat so far?"
- ImprovementFeedbackSheet: Collects improvement suggestions if user isn't satisfied

Flow:
- At 2/3 progress, check if prompt should show (respects 30-day cooldown)
- If app is backgrounded, queue prompt for next foreground
- "Yes!" triggers SKStoreReviewController for App Store review
- "Not really" opens improvement feedback form (submits via existing API)
- Dismiss starts 30-day cooldown before next prompt