### PR TITLE
Investigate iOS app route and station bugs

### DIFF
--- a/backend_v2/src/trackrat/config/stations.py
+++ b/backend_v2/src/trackrat/config/stations.py
@@ -207,6 +207,7 @@ STATION_NAMES: dict[str, str] = {
     "ALX": "Alexandria",
     "CVS": "Charlottesville",
     "LOR": "Lorton",
+    "MSS": "Manassas",
     "NFK": "Norfolk",
     "RVR": "Richmond Staples Mill Road",
     "RVM": "Richmond Main Street",
@@ -312,6 +313,7 @@ AMTRAK_TO_INTERNAL_STATION_MAP: dict[str, str] = {
     "ALX": "ALX",  # Alexandria, VA
     "CVS": "CVS",  # Charlottesville, VA
     "LOR": "LOR",  # Lorton, VA
+    "MSS": "MSS",  # Manassas, VA
     "NFK": "NFK",  # Norfolk, VA
     "RVR": "RVR",  # Richmond Staples Mill Road, VA
     "RVM": "RVM",  # Richmond Main Street, VA
@@ -403,6 +405,7 @@ INTERNAL_TO_AMTRAK_STATION_MAP: dict[str, str] = {
     "ALX": "ALX",  # Alexandria, VA
     "CVS": "CVS",  # Charlottesville, VA
     "LOR": "LOR",  # Lorton, VA
+    "MSS": "MSS",  # Manassas, VA
     "NFK": "NFK",  # Norfolk, VA
     "RVR": "RVR",  # Richmond Staples Mill Road, VA
     "RVM": "RVM",  # Richmond Main Street, VA
@@ -689,6 +692,7 @@ STATION_COORDINATES = {
     "ALX": {"lat": 38.8062, "lon": -77.0626},  # Alexandria, VA
     "CVS": {"lat": 38.0320, "lon": -78.4921},  # Charlottesville, VA
     "LOR": {"lat": 38.7060, "lon": -77.2214},  # Lorton, VA
+    "MSS": {"lat": 38.7511, "lon": -77.4752},  # Manassas, VA
     "NFK": {"lat": 36.8583, "lon": -76.2876},  # Norfolk, VA
     "RVR": {"lat": 37.61741, "lon": -77.49755},  # Richmond Staples Mill Road, VA
     "RVM": {"lat": 37.6143, "lon": -77.4966},  # Richmond Main Street, VA

--- a/ios/TrackRat/Shared/Stations.swift
+++ b/ios/TrackRat/Shared/Stations.swift
@@ -85,7 +85,7 @@ struct Stations {
         "Hartford", "Meriden", "Wallingford", "Windsor Locks", "Springfield",
         "Claremont", "Dover NH", "Durham-UNH", "Exeter",
         "New Carrollton", "Aberdeen", "Alexandria", "Charlottesville",
-        "Lorton", "Norfolk", "Richmond Main Street", "Richmond Staples Mill Road", "Roanoke",
+        "Lorton", "Manassas", "Norfolk", "Richmond Main Street", "Richmond Staples Mill Road", "Roanoke",
         "Harrisburg", "Lancaster",
         
         // Southeast Amtrak Stations (Silver Star/Meteor and Carolinian/Piedmont routes)
@@ -300,6 +300,7 @@ struct Stations {
         "Alexandria": "ALX",
         "Charlottesville": "CVS",
         "Lorton": "LOR",
+        "Manassas": "MSS",
         "Norfolk": "NFK",
         "Richmond Main Street": "RVM",
         "Richmond Staples Mill Road": "RVR",
@@ -400,6 +401,7 @@ struct Stations {
         "ALX": CLLocationCoordinate2D(latitude: 38.8062, longitude: -77.0626),  // Alexandria, VA
         "CVS": CLLocationCoordinate2D(latitude: 38.0320, longitude: -78.4921),  // Charlottesville, VA
         "LOR": CLLocationCoordinate2D(latitude: 38.7060, longitude: -77.2214),  // Lorton, VA
+        "MSS": CLLocationCoordinate2D(latitude: 38.7511, longitude: -77.4752),  // Manassas, VA
         "NFK": CLLocationCoordinate2D(latitude: 36.8583, longitude: -76.2876),  // Norfolk, VA
         "RVR": CLLocationCoordinate2D(latitude: 37.61741, longitude: -77.49755),  // Richmond Staples Mill Road, VA
         "RVM": CLLocationCoordinate2D(latitude: 37.6143, longitude: -77.4966),  // Richmond Main Street, VA
@@ -634,6 +636,8 @@ struct Stations {
         ("Baltimore Station", "BL"),
         ("Washington Union Station", "WS"),
         ("Richmond Staples Mill Road", "RVR"),
+        // New England
+        ("Springfield", "SPG"),
         // Southeast hubs
         ("Charlotte", "CLT"),
         ("Raleigh", "RGH"),


### PR DESCRIPTION
- Add Manassas, VA (MSS) to iOS and backend station configs
- Add Springfield, MA (SPG) to iOS departure stations list
- Coordinates: Manassas at 38.7511, -77.4752

Fixes missing station bugs reported by users.