### PR TITLE
Review and recommend iOS and backend improvements

### DIFF
--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -105,6 +105,14 @@ class TrainJourney(Base):
         Index("idx_last_updated", "last_updated_at"),
         Index("idx_data_source", "data_source"),
         Index("idx_active_journeys", "is_completed", "is_expired", "is_cancelled"),
+        # Composite index for delay forecaster 365-day lookback queries
+        Index(
+            "idx_delay_forecaster",
+            "train_id",
+            "origin_station_code",
+            "data_source",
+            "journey_date",
+        ),
     )
 
 

--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -19,6 +19,24 @@ from trackrat.utils.time import ensure_timezone_aware, now_et
 
 logger = get_logger(__name__)
 
+# Congestion level thresholds (factor = current_avg / baseline)
+CONGESTION_THRESHOLD_NORMAL = 1.1  # <= 10% slower than baseline
+CONGESTION_THRESHOLD_MODERATE = 1.25  # <= 25% slower than baseline
+CONGESTION_THRESHOLD_HEAVY = 1.5  # <= 50% slower than baseline
+# Above 1.5 = severe
+
+
+def get_congestion_level(congestion_factor: float) -> str:
+    """Determine congestion level from a congestion factor."""
+    if congestion_factor <= CONGESTION_THRESHOLD_NORMAL:
+        return "normal"
+    elif congestion_factor <= CONGESTION_THRESHOLD_MODERATE:
+        return "moderate"
+    elif congestion_factor <= CONGESTION_THRESHOLD_HEAVY:
+        return "heavy"
+    else:
+        return "severe"
+
 
 class SegmentCongestion:
     """Congestion data for a route segment."""
@@ -498,15 +516,7 @@ class CongestionAnalyzer:
             current_avg = float(row.current_avg_minutes or row.avg_actual or baseline)
             congestion_factor = current_avg / baseline if baseline > 0 else 1.0
 
-            # Determine congestion level based on factor
-            if congestion_factor <= 1.1:
-                level = "normal"
-            elif congestion_factor <= 1.25:
-                level = "moderate"
-            elif congestion_factor <= 1.5:
-                level = "heavy"
-            else:
-                level = "severe"
+            level = get_congestion_level(congestion_factor)
 
             # Calculate average delay
             average_delay = current_avg - baseline
@@ -775,14 +785,7 @@ class CongestionAnalyzer:
         for row in rows:
             # Determine congestion level from factor (convert Decimal to float)
             congestion_factor = float(row.congestion_factor)
-            if congestion_factor <= 1.1:
-                level = "normal"
-            elif congestion_factor <= 1.25:
-                level = "moderate"
-            elif congestion_factor <= 1.5:
-                level = "heavy"
-            else:
-                level = "severe"
+            level = get_congestion_level(congestion_factor)
 
             # Convert database types to Python types
             actual_minutes = float(row.actual_minutes)
@@ -1012,15 +1015,7 @@ class CongestionAnalyzer:
             # Calculate average delay
             average_delay_minutes = current_avg - baseline_minutes
 
-            # Determine congestion level (same thresholds as before)
-            if congestion_factor <= 1.1:
-                level = "normal"
-            elif congestion_factor <= 1.25:
-                level = "moderate"
-            elif congestion_factor <= 1.5:
-                level = "heavy"
-            else:
-                level = "severe"
+            level = get_congestion_level(congestion_factor)
 
             congestion_data.append(
                 SegmentCongestion(
@@ -1071,15 +1066,7 @@ class CongestionAnalyzer:
                     congestion_factor = 1.0
                     delay_minutes = 0.0
 
-                # Determine congestion level
-                if congestion_factor <= 1.1:
-                    level = "normal"
-                elif congestion_factor <= 1.25:
-                    level = "moderate"
-                elif congestion_factor <= 1.5:
-                    level = "heavy"
-                else:
-                    level = "severe"
+                level = get_congestion_level(congestion_factor)
 
                 individual_segment = IndividualJourneySegment(
                     journey_id=str(segment_data["journey_id"]),

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -29,6 +29,7 @@ from trackrat.services.jit import JustInTimeUpdateService
 from trackrat.settings import Settings, get_settings
 from trackrat.utils.scheduler_utils import (
     calculate_safe_interval,
+    commit_with_retry,
     run_with_freshness_check,
 )
 from trackrat.utils.time import (
@@ -1242,28 +1243,7 @@ class SchedulerService:
                                 error_count=journey.api_error_count,
                             )
 
-                    # Commit with retry logic
-                    max_retries = 3
-                    for retry in range(max_retries):
-                        try:
-                            session.commit()
-                            break
-                        except Exception as e:
-                            if (
-                                "database is locked" in str(e)
-                                and retry < max_retries - 1
-                            ):
-                                logger.warning(
-                                    "database_locked_retrying_on_error",
-                                    train_id=train_id,
-                                    retry=retry + 1,
-                                    error=str(e),
-                                )
-                                import time
-
-                                time.sleep(0.5 * (retry + 1))
-                            else:
-                                raise
+                    commit_with_retry(session, log_context={"train_id": train_id})
 
                     return {
                         "train_id": train_id,
@@ -1407,70 +1387,15 @@ class SchedulerService:
                         "is_completed": is_completed,
                     }
 
-                    # Commit synchronously with retry logic for database locks
-                    max_retries = 3
-                    for retry in range(max_retries):
-                        try:
-                            session.commit()
-                            break
-                        except Exception as e:
-                            if (
-                                "database is locked" in str(e)
-                                and retry < max_retries - 1
-                            ):
-                                logger.warning(
-                                    "database_locked_retrying",
-                                    train_id=train_id,
-                                    retry=retry + 1,
-                                    error=str(e),
-                                )
-                                import time
-
-                                time.sleep(0.5 * (retry + 1))  # Exponential backoff
-                            else:
-                                raise
+                    commit_with_retry(session, log_context={"train_id": train_id})
 
                     logger.info(
-                        "journey_collected_sync",
+                        "journey_collection_completed_sync",
                         train_id=train_id,
+                        journey_id=journey.id,
                         stops_count=len(train_data.STOPS),
                         is_completed=is_completed,
                     )
-
-                    # Transit time analysis is now done on-the-fly in API endpoints
-
-                    # Commit the journey updates with retry logic
-                    for retry in range(max_retries):
-                        try:
-                            session.commit()
-                            logger.info(
-                                "journey_collection_completed_sync",
-                                train_id=train_id,
-                                journey_id=journey.id,
-                            )
-                            break
-                        except Exception as e:
-                            if (
-                                "database is locked" in str(e)
-                                and retry < max_retries - 1
-                            ):
-                                logger.warning(
-                                    "database_locked_retrying_analysis",
-                                    train_id=train_id,
-                                    retry=retry + 1,
-                                    error=str(e),
-                                )
-                                import time
-
-                                time.sleep(0.5 * (retry + 1))
-                            else:
-                                logger.error(
-                                    "journey_commit_failed",
-                                    train_id=train_id,
-                                    error=str(e),
-                                )
-                                # Don't raise, just log the error
-                                break
 
                     return result_data
                 else:

--- a/backend_v2/src/trackrat/utils/scheduler_utils.py
+++ b/backend_v2/src/trackrat/utils/scheduler_utils.py
@@ -12,11 +12,54 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 from structlog import get_logger
 
 from trackrat.models.database import SchedulerTaskRun
 
 logger = get_logger(__name__)
+
+
+def commit_with_retry(
+    session: Session,
+    max_retries: int = 3,
+    log_context: dict[str, Any] | None = None,
+) -> None:
+    """
+    Commit a synchronous database session with retry logic for SQLite locks.
+
+    SQLite can raise "database is locked" errors when multiple processes
+    access the database simultaneously. This function retries with exponential
+    backoff to handle transient lock contention.
+
+    Args:
+        session: Synchronous SQLAlchemy session to commit
+        max_retries: Maximum number of retry attempts (default: 3)
+        log_context: Optional dict with context for log messages (e.g., train_id)
+
+    Raises:
+        Exception: Re-raises the last exception if all retries fail
+    """
+    context = log_context or {}
+
+    for retry in range(max_retries):
+        try:
+            session.commit()
+            return
+        except Exception as e:
+            is_lock_error = "database is locked" in str(e) or "database is busy" in str(
+                e
+            )
+            if is_lock_error and retry < max_retries - 1:
+                logger.warning(
+                    "database_locked_retrying",
+                    retry=retry + 1,
+                    error=str(e),
+                    **context,
+                )
+                time.sleep(0.5 * (retry + 1))
+            else:
+                raise
 
 
 async def run_with_freshness_check(

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -445,45 +445,6 @@ struct CombinedDetailsCard: View {
 
 // Note: StatusV2 functionality is now integrated directly into TrainV2 model
 
-// MARK: - Stops Card (unused - kept for potential future use)
-struct StopsCard: View {
-    let train: TrainV2
-    let selectedDestination: String?
-    let selectedDestinationCode: String?
-    @EnvironmentObject private var appState: AppState
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            if let stops = train.stops, !stops.isEmpty {
-                ForEach(stops) { stop in
-                    StopRowV2(
-                        stop: stop,
-                        isDestination: selectedDestinationCode != nil &&
-                                     stop.stationCode.uppercased() == selectedDestinationCode!.uppercased(),
-                        isDeparture: appState.departureStationCode != nil &&
-                                   stop.stationCode.uppercased() == appState.departureStationCode!.uppercased(),
-                        isBoarding: train.isBoardingAtStation(stop.stationCode) && (appState.departureStationCode != nil && stop.stationCode.uppercased() == appState.departureStationCode!.uppercased()),
-                        boardingTrack: train.isBoardingAtStation(stop.stationCode) && (appState.departureStationCode != nil && stop.stationCode.uppercased() == appState.departureStationCode!.uppercased()) ? stop.track : nil,
-                        train: train,
-                        departureStationCode: appState.departureStationCode,
-                        shouldShowJourneyPredictions: false
-                    )
-                }
-            } else {
-                Text("No stops information available")
-                    .foregroundColor(.black.opacity(0.6))
-                    .italic()
-                    .frame(maxWidth: .infinity)
-                    .padding()
-            }
-        }
-        .padding()
-        .background(Color.white.opacity(0.9))
-        .cornerRadius(TrackRatTheme.CornerRadius.lg)
-        .trackRatShadow()
-    }
-}
-
 // MARK: - Stop Row V2
 struct StopRowV2: View {
     let stop: StopV2
@@ -544,8 +505,8 @@ struct StopRowV2: View {
             return (nil, nil, [])
         }
         
-        let formatter = DateFormatter.easternTime(time: .short)
-        
+        let formatter = DateFormatter.easternTimeShort
+
         // For departed stops: Show only "Departed X:XX PM" with delay indicator
         if stop.hasDepartedStation {
             if let correctedDepartureTime = stop.actualDeparture {
@@ -677,7 +638,7 @@ struct StopRowV2: View {
                 HStack(spacing: 4) {
                     Text("🐀✨")
                         .font(.system(size: 16))
-                    Text(DateFormatter.easternTime(time: .short).string(from: predictedArrival))
+                    Text(DateFormatter.easternTimeShort.string(from: predictedArrival))
                         .font(.caption)
                         .fontWeight(.medium)
                         .foregroundColor(predictionDelayColor(predicted: predictedArrival, scheduled: stop.scheduledArrival))


### PR DESCRIPTION
iOS:
- Remove unused StopsCard component (dead code)
- Use cached DateFormatter.easternTimeShort instead of creating new formatters

Backend:
- Extract congestion level thresholds to constants and helper function
- Add composite index for delay forecaster queries (performance)
- Extract database commit retry logic to reusable utility function
- Remove redundant double-commit in scheduler

Net reduction: 76 lines of duplicated/dead code