### PR TITLE
Clarify train details update timestamp meaning

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -53,13 +53,6 @@ struct TrainListView: View {
                             .font(.caption2)
                             .foregroundColor(.white.opacity(0.8))
                     }
-                    // Data freshness indicator
-                    if let freshness = viewModel.trains.first?.dataFreshness,
-                       freshness.ageSeconds >= 30 {
-                        Text(freshness.formattedAge)
-                            .font(.caption2)
-                            .foregroundColor(.white.opacity(0.5))
-                    }
                 }
 
                 Spacer()


### PR DESCRIPTION
The "Updated Xm ago" text was crowding the header bar. Users can still see per-train "Scheduled" labels for trains not yet observed.