### PR TITLE
Fix Amtrak scheduled status display logic

### DIFF
--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -37,7 +37,7 @@ from trackrat.services.departure import DepartureService
 from trackrat.services.direct_forecaster import DirectArrivalForecaster
 from trackrat.services.jit import JustInTimeUpdateService
 from trackrat.utils.time import now_et, safe_datetime_subtract
-from trackrat.utils.train import is_amtrak_train
+from trackrat.utils.train import get_effective_observation_type, is_amtrak_train
 
 logger = get_logger(__name__)
 
@@ -306,7 +306,7 @@ async def get_train_details(
             collection_method="just_in_time" if refresh else "scheduled",
         ),
         data_source=journey.data_source or "NJT",
-        observation_type=journey.observation_type,
+        observation_type=get_effective_observation_type(journey),
         raw_train_state="Active" if journey.data_source == "AMTRAK" else None,
         is_cancelled=journey.is_cancelled,
         is_completed=journey.is_completed,

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -25,6 +25,7 @@ from trackrat.models.api import (
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.utils.sanitize import sanitize_track
 from trackrat.utils.time import now_et, parse_njt_time, safe_datetime_subtract
+from trackrat.utils.train import get_effective_observation_type
 
 logger = get_logger(__name__)
 
@@ -224,7 +225,7 @@ class DepartureService:
                     update_count=journey.update_count,
                 ),
                 data_source=journey.data_source,
-                observation_type=journey.observation_type,
+                observation_type=get_effective_observation_type(journey),
                 is_cancelled=journey.is_cancelled,
             )
             departures.append(departure)

--- a/backend_v2/src/trackrat/utils/train.py
+++ b/backend_v2/src/trackrat/utils/train.py
@@ -2,6 +2,46 @@
 Train-related utility functions for TrackRat V2.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from trackrat.models.database import TrainJourney
+
+
+def get_effective_observation_type(journey: "TrainJourney") -> str:
+    """
+    Get the effective observation type for display.
+
+    For SCHEDULED trains, we upgrade to OBSERVED if the train's origin
+    departure time has passed. This prevents showing "Scheduled" for
+    trains that are likely already running but haven't been confirmed
+    via real-time data yet (common with Amtrak pattern-based schedules).
+
+    Args:
+        journey: The train journey record
+
+    Returns:
+        "OBSERVED" or "SCHEDULED"
+    """
+    from trackrat.utils.time import now_et
+
+    if journey.observation_type != "SCHEDULED":
+        return journey.observation_type or "OBSERVED"
+
+    # Find the first stop (train's actual origin)
+    if not journey.stops:
+        return "SCHEDULED"
+
+    sorted_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
+    first_stop = sorted_stops[0]
+
+    # Check if the origin departure time has passed
+    origin_departure = first_stop.scheduled_departure or first_stop.scheduled_arrival
+    if origin_departure and origin_departure <= now_et():
+        return "OBSERVED"
+
+    return "SCHEDULED"
+
 
 def is_amtrak_train(train_id: str) -> bool:
     """Determine if a train ID is for an Amtrak train.


### PR DESCRIPTION
Amtrak trains created from pattern inference remain SCHEDULED in the database until real-time data is fetched. This caused "Scheduled" to display even for trains already running.

Add get_effective_observation_type() utility that returns OBSERVED instead of SCHEDULED when the train's origin departure time has passed. This applies to both the departures list and train details endpoints.