### PR TITLE
docs: Update documentation for PATH/PATCO, soft trial, and system filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,12 +68,22 @@ npm run build                        # TypeScript compile + build check
 
 ### Architecture Patterns
 
-**Backend Data Collection (Multi-Phase):**
+**Backend Data Collection (NJT/Amtrak - Multi-Phase):**
 1. Schedule Generation (daily) - creates SCHEDULED records
 2. Discovery (30min) - updates to OBSERVED when trains appear
 3. Collection (15min) - fetches full journey details
 4. JIT Updates (on-demand) - refreshes stale data (>60s)
 5. Validation (hourly) - ensures coverage
+
+**Backend Data Collection (PATH - Unified):**
+- Single collector runs every 4 minutes using native RidePATH API
+- Discovers trains at all 13 stations (not just terminus)
+- Handles both discovery and journey updates in one pass
+- Infers train origin from route when seen mid-journey
+
+**Backend Data Collection (PATCO - Schedule-only):**
+- Uses GTFS static schedules from SEPTA feed
+- No real-time API available; times are scheduled only
 
 **Key Design Principles:**
 - Single Journey Record: One database row per train per day

--- a/backend_v2/PATH_REALTIME_DESIGN.md
+++ b/backend_v2/PATH_REALTIME_DESIGN.md
@@ -1,10 +1,12 @@
 # PATH Real-Time Tracking Implementation Design
 
+> **Status**: ✅ IMPLEMENTED (January 2026)
+
 ## Executive Summary
 
-This document proposes implementing real-time tracking for PATH trains using the **native PATH RidePATH API** (`ridepath.json`). This API provides real-time arrival predictions at ALL 13 stations, enabling full intermediate stop tracking similar to NJT and Amtrak.
+This document describes the implementation of real-time tracking for PATH trains using the **native PATH RidePATH API** (`ridepath.json`). This API provides real-time arrival predictions at ALL 13 stations, enabling full intermediate stop tracking similar to NJT and Amtrak.
 
-**Key discovery**: The Transiter API (used for discovery) only exposes terminus data, but the native PATH API provides arrivals at every station along each route.
+**Key insight**: The native PATH API provides arrivals at every station along each route, unlike the Transiter API which only exposes terminus data.
 
 ---
 
@@ -76,32 +78,31 @@ By correlating headsign + arrival time progression, we can identify the same tra
 
 ## Architecture
 
-### Data Flow
+### Data Flow (Implemented)
 
 ```
                     ┌─────────────────────────────────┐
-                    │  PATH Discovery (Transiter)     │
-                    │  - Creates TrainJourney records │
-                    │  - Populates stops from GTFS    │
-                    │  - Runs every 30 min            │
-                    └─────────────┬───────────────────┘
-                                  │
-                                  ▼
-                    ┌─────────────────────────────────┐
-                    │  PATH Journey Collection        │
-                    │  (Native ridepath.json API)     │
-                    │  - Updates stop arrival times   │
-                    │  - Tracks train progression     │
-                    │  - Runs every 1-2 min           │
+                    │  Unified PATH Collector         │
+                    │  (RidePATH API + GTFS routes)   │
+                    │  - Discovers trains at all 13   │
+                    │    stations (not just terminus) │
+                    │  - Updates journey stops with   │
+                    │    real-time arrival times      │
+                    │  - Runs every 4 minutes         │
                     └─────────────────────────────────┘
 ```
 
-### New Components
+### Implemented Components
 
-1. **`collectors/path/ridepath_client.py`** - Client for native PATH API
-2. **`collectors/path/journey.py`** - Journey collector using native API
-3. **Updates to `services/jit.py`** - PATH collector support
-4. **Updates to `services/scheduler.py`** - PATH collection job
+| File | Description |
+|------|-------------|
+| `collectors/path/collector.py` | Unified discovery + journey collection |
+| `collectors/path/ridepath_client.py` | Native PATH API client with 30s caching |
+| `config/stations.py` | PATH station code mappings (API → internal) |
+| `services/jit.py` | PATH collector support for on-demand refresh |
+| `services/scheduler.py` | 4-minute PATH collection job |
+
+**Note**: The original design proposed separate discovery (Transiter) and journey (RidePATH) collectors. Implementation unified these into a single `PathCollector` using only RidePATH for both operations, eliminating redundant API calls.
 
 ---
 
@@ -587,27 +588,34 @@ With actual arrival times at intermediate stops:
 
 ---
 
-## File Summary
+## Implementation Summary
 
-| File | Action | Lines (Est.) |
+| File | Status | Description |
 |------|--------|-------------|
-| `collectors/path/ridepath_client.py` | Create | ~100 |
-| `collectors/path/journey.py` | Create | ~250 |
-| `services/jit.py` | Modify | +15 |
-| `services/scheduler.py` | Modify | +25 |
-| `config/stations.py` | Modify | +15 |
-| `tests/unit/collectors/test_path_journey.py` | Create | ~150 |
+| `collectors/path/collector.py` | ✅ Implemented | Unified discovery + journey collection |
+| `collectors/path/ridepath_client.py` | ✅ Implemented | Native PATH API client |
+| `services/jit.py` | ✅ Updated | PATH collector support |
+| `services/scheduler.py` | ✅ Updated | 4-minute PATH collection job |
+| `config/stations.py` | ✅ Updated | Station code mappings |
+| `tests/unit/collectors/path/test_collector.py` | ✅ Implemented | 56 tests for collector |
+| `tests/unit/collectors/path/test_ridepath_client.py` | ✅ Implemented | Client tests |
 
-**Total estimated changes**: ~555 lines
+**Deleted files** (consolidated into unified collector):
+- `collectors/path/discovery.py`
+- `collectors/path/journey.py`
+- `tests/unit/collectors/path/test_discovery.py`
+- `tests/unit/collectors/path/test_journey.py`
 
 ---
 
-## Remaining Questions
+## Implementation Decisions (Resolved)
 
-1. **Polling frequency**: 2 minutes seems reasonable. Should we go faster (1 min) for better granularity?
+1. **Polling frequency**: Settled on 4 minutes - balances API load with data freshness for PATH's ~5-10 minute headways.
 
-2. **Train matching**: If multiple trains have the same headsign, we take the soonest. Should we try to correlate by scheduled departure time?
+2. **Train matching**: Uses scheduled time correlation with 10-minute tolerance. When multiple trains head to the same destination, matches arrivals to journeys by comparing predicted vs scheduled times to prevent data collision.
 
-3. **Transit analysis**: Run after each update, or batch at the end of collection?
+3. **Transit analysis**: Runs after each journey update within the unified collector pass.
 
-4. **Error handling**: If the RidePATH API is unavailable, should we fall back to Transiter for terminus-only data?
+4. **Error handling**: No Transiter fallback implemented. If RidePATH is unavailable, journeys retain their last known state. Errors increment `api_error_count`; journeys marked expired after 2 consecutive failures.
+
+5. **Train discovery**: Discovers at all 13 stations (not just terminus). Infers true origin from route when train is seen mid-journey, generating consistent `train_id` for deduplication.

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -78,10 +78,13 @@ poetry run uvicorn trackrat.main:app --reload
 - **Daily 4:00 AM ET**: NJT 27-hour schedule collection
 - **Daily 4:30 AM ET**: Amtrak pattern-based schedule generation
 - **Every 30 minutes**: Train discovery for NJT and Amtrak
-- **Every 15 minutes**: Journey collection for active trains
+- **Every 15 minutes**: Journey collection for active NJT/Amtrak trains
+- **Every 4 minutes**: PATH train collection (unified discovery + updates)
 - **Every 5 minutes**: Update checks for active journeys
 - **Hourly at :05**: Validation across key routes
 - Monitor scheduler status at `/scheduler/status` endpoint
+
+**Note**: PATH uses a unified collector that handles both discovery and journey updates in a single pass. PATCO uses GTFS static schedules only (no real-time API).
 
 ## Configuration
 
@@ -139,12 +142,13 @@ All configuration is done via environment variables. See `.env.example` for avai
 
 #### Train Departures
 ```
-GET /api/v2/trains/departures?from=NY&to=TR&limit=50&data_source=ALL
+GET /api/v2/trains/departures?from=NY&to=TR&limit=50&data_source=ALL&hide_departed=true
 ```
 Get trains between stations with filtering:
 - `from`/`to`: Station codes (works for any segment)
 - `limit`: Max results (default: 50)
-- `data_source`: NJT, AMTRAK, or ALL
+- `data_source`: NJT, AMTRAK, PATH, PATCO, or ALL
+- `hide_departed`: Skip trains that have already departed (default: false). When true, also skips expensive past-train refresh for better performance.
 - Returns both SCHEDULED and OBSERVED trains
 
 #### Train Details
@@ -347,11 +351,23 @@ The system uses a sophisticated multi-phase approach:
   - Identifies trains that run regularly (≥2 times in 3 weeks)
   - Generates SCHEDULED records for expected trains
 
-#### 2. Train Discovery (Every 30 minutes)
+#### 2. Train Discovery (Every 30 minutes for NJT/Amtrak)
 - Polls major stations for active trains
 - NJT: NY, NP, PJ, TR, LB, PL, DN stations
 - Amtrak: Major corridor stations
 - Updates journey status from SCHEDULED to OBSERVED
+
+#### PATH Collection (Every 4 minutes - Unified)
+- Uses native RidePATH API (`panynj.gov/bin/portauthority/ridepath.json`)
+- Discovers trains at all 13 PATH stations (not just terminus)
+- Unified collector handles both discovery and journey updates in single pass
+- Infers train origin from route when seen mid-journey
+- Calculates consistent train_id for deduplication across stations
+
+#### PATCO Collection (Schedule-based only)
+- Uses GTFS static schedules from SEPTA feed
+- 14 stations from Lindenwold to 15-16th & Locust
+- No real-time API available; times are scheduled only
 
 #### 3. Journey Collection (Every 15 minutes)
 - Fetches complete journey details for active trains
@@ -383,7 +399,11 @@ The scheduler supports multiple replicas:
 - **SchedulerService**: Orchestrates all background tasks
 - **NJTScheduleCollector**: Daily NJT schedule fetching
 - **AmtrakPatternScheduler**: Pattern-based Amtrak schedules
-- **JustInTimeUpdateService**: On-demand data refresh
+- **PathCollector**: Unified PATH discovery + journey collection using RidePATH API
+- **RidePathClient**: Native PATH API client with 30-second caching
+- **JustInTimeUpdateService**: On-demand data refresh (supports NJT, Amtrak, PATH)
+
+**Note**: PATCO uses GTFS static schedules only (no dedicated collector).
 
 #### API & Analytics
 - **DepartureService**: Train departure queries

--- a/ios/README.md
+++ b/ios/README.md
@@ -26,7 +26,19 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, and PATCO trains 
 
 ### Pro Subscription Features
 - **Congestion Maps**: Premium map overlay showing network congestion levels
-- **StoreKit 2 Integration**: Modern subscription management
+- **Historical Analytics**: Performance data, delay statistics, and track usage patterns
+- **Penn Station Boarding Guide**: Interactive navigation assistance
+- **Delay Forecasts**: AI-powered delay predictions
+- **24-Hour Soft Trial**: New users get full Pro access for 24 hours with countdown banner
+- **StoreKit 2 Integration**: Modern subscription management with PaywallView
+- **SoftTrialBannerView**: Countdown timer during trial period linking to paywall
+
+### Train System Filtering
+- **Opt-in PATH/PATCO**: Users can enable/disable transit systems in Advanced Configuration
+- **Default Systems**: NJT and Amtrak enabled by default; PATH and PATCO require opt-in
+- **Map Layer Filtering**: Disabled systems hidden from congestion map and route overlays
+- **Station Filtering**: Disabled systems excluded from station picker and onboarding
+- **TrainSystem.swift**: Model for system preferences with UserDefaults persistence
 
 ### User Experience
 - **Native iOS Design**: SwiftUI with glassmorphism and smooth animations
@@ -70,6 +82,7 @@ TrackRat/
 ├── Models/                      # Data layer
 │   ├── TrainV2.swift           # Pure data model with context-aware calculations
 │   ├── V2APIModels.swift       # Backend V2 API models
+│   ├── TrainSystem.swift       # Train system enum (NJT, Amtrak, PATH, PATCO)
 │   ├── DeepLink.swift          # URL scheme handling
 │   └── Train.swift             # Legacy compatibility model
 │
@@ -102,7 +115,7 @@ TrackRat/
 │   │   ├── OnboardingView.swift         # User onboarding
 │   │   └── AdvancedConfigurationView.swift # Developer settings
 │   │
-│   └── Components/              # Reusable UI components (16 files)
+│   └── Components/              # Reusable UI components (17+ files)
 │       ├── ActiveTripsSection.swift     # Live Activity cards
 │       ├── LegacyBottomSheetView.swift  # Draggable sheets
 │       ├── LegacySheetAwareScrollView.swift # Coordinated scrolling
@@ -112,7 +125,12 @@ TrackRat/
 │       ├── FeedbackButton.swift         # Issue reporting
 │       ├── OperationsSummaryView.swift  # Operations summary
 │       ├── TrainStatsSummaryView.swift  # Train performance
-│       └── TrainDistributionChart.swift # Delay visualization
+│       ├── TrainDistributionChart.swift # Delay visualization
+│       └── SoftTrialBannerView.swift    # 24-hour trial countdown
+│
+├── Views/Paywall/               # Subscription UI
+│   ├── PaywallView.swift        # Subscription purchase flow
+│   └── ProFeatureLockView.swift # Feature lock overlay with upgrade prompt
 │
 ├── Shared/                      # Cross-target code
 │   ├── Stations.swift          # Station database


### PR DESCRIPTION
Backend documentation:
- Add hide_departed query parameter to departures endpoint docs
- Document PATH unified collector architecture (4-min intervals)
- Document PATCO schedule-based approach (GTFS only)
- Update scheduler job descriptions with PATH collection
- Add PathCollector and RidePathClient to Key Services
- Update PATH_REALTIME_DESIGN.md to reflect implementation status

iOS documentation:
- Add 24-hour soft trial feature details
- Add train system filtering section (opt-in PATH/PATCO)
- Add TrainSystem.swift to project structure
- Add Paywall views and SoftTrialBannerView to components

Main CLAUDE.md:
- Add PATH unified collection pattern to Architecture section
- Add PATCO schedule-only pattern to Architecture section