### PR TITLE
Remove Preview badge from TrackRat Pro banner

### DIFF
--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -680,17 +680,6 @@ struct SoftTrialProCard: View {
                     .font(.headline)
                     .foregroundColor(.white)
                 Spacer()
-
-                // Preview badge
-                Text("Preview")
-                    .font(.caption.bold())
-                    .foregroundColor(.orange)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        Capsule()
-                            .fill(.orange.opacity(0.2))
-                    )
             }
 
             HStack {


### PR DESCRIPTION
The Preview badge is no longer needed in the subscription section.