### PR TITLE
Fix PATH train ID display for users

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1295,6 +1295,9 @@ class SummaryService:
         # Total cancellations from similar trains
         total_cancellations = similar_dep_stats.cancellation_count
 
+        # Get destination for display (used for PATH/PATCO friendly names)
+        destination = train_journeys[0].destination if train_journeys else None
+
         # Generate headline and body
         headline, body = self._format_train_headline_body(
             similar_dep_stats,
@@ -1303,6 +1306,8 @@ class SummaryService:
             train_id,
             carrier_name,
             total_cancellations,
+            destination=destination,
+            data_source=data_source,
         )
 
         if not headline:
@@ -1364,6 +1369,8 @@ class SummaryService:
         train_id: str,
         carrier_name: str | None,
         cancellations: int,
+        destination: str | None = None,
+        data_source: str | None = None,
     ) -> tuple[str, str]:
         """
         Format headline and body for train summary.
@@ -1413,8 +1420,13 @@ class SummaryService:
                 )
 
         # Historical stats for this train
+        # For PATH/PATCO, use destination instead of synthetic train_id
         if train_stats.has_data:
-            hist_text = f"Train {train_id} historically departs on time {train_stats.on_time_percentage:.0f}% of the time."
+            if data_source in ("PATH", "PATCO") and destination:
+                train_display = f"This {destination} train"
+            else:
+                train_display = f"Train {train_id}"
+            hist_text = f"{train_display} historically departs on time {train_stats.on_time_percentage:.0f}% of the time."
             if train_stats.cancellation_count > 0:
                 hist_text += (
                     f" Cancelled {train_stats.cancellation_count} "

--- a/ios/TrackRat/Models/V2APIModels.swift
+++ b/ios/TrackRat/Models/V2APIModels.swift
@@ -845,7 +845,11 @@ extension IndividualJourneySegment {
     }
     
     var trainDisplayName: String {
-        "Train \(trainId)"
+        // For PATH/PATCO trains with synthetic IDs, show destination instead
+        if dataSource == "PATH" || dataSource == "PATCO" {
+            return toStationName.isEmpty ? Stations.displayName(for: toStation) : toStationName
+        }
+        return "Train \(trainId)"
     }
 }
 

--- a/ios/TrackRat/Views/Components/ActiveTripsSection.swift
+++ b/ios/TrackRat/Views/Components/ActiveTripsSection.swift
@@ -68,10 +68,15 @@ struct ActiveTripsSection: View {
                     } label: {
                         HStack {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text("Train \(activity.attributes.trainNumber)")
+                                // For PATH/PATCO trains with synthetic IDs, show destination instead
+                                let trainLabel = activity.attributes.trainNumber.hasPrefix("PATH_") ||
+                                                 activity.attributes.trainNumber.hasPrefix("PATCO_")
+                                    ? activity.attributes.destination
+                                    : "Train \(activity.attributes.trainNumber)"
+                                Text(trainLabel)
                                     .font(.headline)
                                     .foregroundColor(.white)
-                                
+
                                 Text("\(activity.attributes.origin) → \(activity.attributes.destination)")
                                     .font(.subheadline)
                                     .foregroundColor(.white.opacity(0.8))

--- a/ios/TrainLiveActivityExtension/LiveActivityWidget.swift
+++ b/ios/TrainLiveActivityExtension/LiveActivityWidget.swift
@@ -237,7 +237,12 @@ struct TrainLiveActivityView: View {
         VStack(spacing: 8) {
             // Header
             HStack {
-                Label("Train \(context.attributes.trainNumber)", systemImage: "tram.fill")
+                // For PATH/PATCO trains with synthetic IDs, show destination instead
+                let trainLabel = context.attributes.trainNumber.hasPrefix("PATH_") ||
+                                 context.attributes.trainNumber.hasPrefix("PATCO_")
+                    ? context.attributes.destination
+                    : "Train \(context.attributes.trainNumber)"
+                Label(trainLabel, systemImage: "tram.fill")
                     .font(.headline)
                     .foregroundColor(.white)
                 Spacer()


### PR DESCRIPTION
… trains

PATH trains use synthetic IDs like "PATH_PJS_33rdstree_1768863697" which are not user-friendly. This change shows the destination (e.g., "33rd Street") instead in:
- Backend operations summary text
- iOS Live Activity lock screen
- iOS Active Trips section
- iOS congestion segment display

PATCO trains get the same treatment since they also lack meaningful train numbers.