### PR TITLE
Fix live activity times not updating with delays

### DIFF
--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -232,6 +232,32 @@ struct TrainV2: Identifiable, Codable {
         // Fallback to train's final destination if station not found
         return arrival?.scheduledTime
     }
+
+    // Get estimated (delay-adjusted) departure time from a specific station
+    // Returns updatedDeparture if available, otherwise falls back to scheduledDeparture
+    func getEstimatedDepartureTime(fromStationCode: String) -> Date? {
+        if let stop = stops?.first(where: { $0.stationCode.uppercased() == fromStationCode.uppercased() }) {
+            return stop.updatedDeparture ?? stop.scheduledDeparture
+        }
+        // Fallback for origin station
+        if fromStationCode.uppercased() == originStationCode.uppercased() {
+            return departure.updatedTime ?? departure.scheduledTime
+        }
+        return nil
+    }
+
+    // Get estimated (delay-adjusted) arrival time at specific destination station
+    // Returns updatedArrival if available, otherwise falls back to scheduledArrival
+    func getEstimatedArrivalTime(toStationCode: String) -> Date? {
+        if let stops = stops,
+           let destinationStop = stops.first(where: {
+               $0.stationCode.uppercased() == toStationCode.uppercased()
+           }) {
+            return destinationStop.updatedArrival ?? destinationStop.scheduledArrival
+        }
+        // Fallback to train's final destination if station not found
+        return arrival?.updatedTime ?? arrival?.scheduledTime
+    }
     
     // Get formatted departure time for display
     func getFormattedDepartureTime(fromStationCode: String) -> String {
@@ -474,27 +500,27 @@ extension TrainV2 {
             delayMinutes: delayMinutes,
             journeyProgress: progress,
             dataTimestamp: Date().timeIntervalSince1970,
-            scheduledDepartureTime: getScheduledDepartureTime(fromStationCode: originCode)?.toISO8601String(),
-            scheduledArrivalTime: getScheduledArrivalTime(toStationCode: destinationCode)?.toISO8601String(),
+            scheduledDepartureTime: getEstimatedDepartureTime(fromStationCode: originCode)?.toISO8601String(),
+            scheduledArrivalTime: getEstimatedArrivalTime(toStationCode: destinationCode)?.toISO8601String(),
             nextStopArrivalTime: nextStopArrivalTime?.toISO8601String(),
             hasTrainDeparted: hasTrainDeparted,
             originStationCode: originCode,
             destinationStationCode: destinationStationCode ?? ""
         )
     }
-    
+
     // Convert to Live Activity content state (simple version)
     func toContentState() -> TrainActivityAttributes.ContentState {
         // Calculate overall progress
         let progress = calculateOverallProgress()
-        
+
         // Get current and next stop names from train position
-        let currentStop = trainPosition?.atStationCode ?? 
-                         stops?.last(where: { $0.hasDepartedStation })?.stationName ?? 
+        let currentStop = trainPosition?.atStationCode ??
+                         stops?.last(where: { $0.hasDepartedStation })?.stationName ??
                          departure.name
         let nextStop = trainPosition?.nextStationCode ??
                       stops?.first(where: { !$0.hasDepartedStation })?.stationName
-        
+
         return TrainActivityAttributes.ContentState(
             status: status.rawValue,
             track: track,
@@ -503,8 +529,8 @@ extension TrainV2 {
             delayMinutes: delayMinutes,
             journeyProgress: progress,
             dataTimestamp: Date().timeIntervalSince1970,
-            scheduledDepartureTime: departure.scheduledTime?.toISO8601String(),
-            scheduledArrivalTime: arrival?.scheduledTime?.toISO8601String(),
+            scheduledDepartureTime: getEstimatedDepartureTime(fromStationCode: originStationCode)?.toISO8601String(),
+            scheduledArrivalTime: getEstimatedArrivalTime(toStationCode: destinationStationCode ?? "")?.toISO8601String(),
             nextStopArrivalTime: getNextStopArrivalTime()?.toISO8601String(),
             hasTrainDeparted: hasTrainDepartedFromStation(originStationCode),
             originStationCode: originStationCode,

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -51,10 +51,11 @@ class LiveActivityService: ObservableObject {
             throw error
         }
 
-        // Get scheduled times for the user's journey using existing train data
+        // Get estimated times for the user's journey using existing train data
         // (We'll refresh with detailed data after the activity starts for snappier UX)
-        let scheduledDepartureTime = train.getScheduledDepartureTime(fromStationCode: originCode)
-        let scheduledArrivalTime = train.getScheduledArrivalTime(toStationCode: destinationCode)
+        // Use estimated times (delay-adjusted) so Live Activity shows accurate arrival times
+        let estimatedDepartureTime = train.getEstimatedDepartureTime(fromStationCode: originCode)
+        let estimatedArrivalTime = train.getEstimatedArrivalTime(toStationCode: destinationCode)
 
         // Extract journey station codes from origin to destination using existing stops
         if let stops = train.stops {
@@ -104,8 +105,8 @@ class LiveActivityService: ObservableObject {
             delayMinutes: train.delayMinutes,
             journeyProgress: 0.0,
             dataTimestamp: Date().timeIntervalSince1970,  // Current timestamp for local data
-            scheduledDepartureTime: scheduledDepartureTime?.toISO8601String(),
-            scheduledArrivalTime: scheduledArrivalTime?.toISO8601String(),
+            scheduledDepartureTime: estimatedDepartureTime?.toISO8601String(),
+            scheduledArrivalTime: estimatedArrivalTime?.toISO8601String(),
             nextStopArrivalTime: nextStopArrivalTime?.toISO8601String(),
             hasTrainDeparted: hasTrainDeparted,
             originStationCode: originCode,
@@ -119,8 +120,8 @@ class LiveActivityService: ObservableObject {
         print("  - Has Departed: \(hasTrainDeparted)")
         print("  - Initial Progress: 0.0")
         print("  - Track: \(train.track ?? "none")")
-        print("  - Scheduled Departure: \(scheduledDepartureTime?.description ?? "none")")
-        print("  - Scheduled Arrival: \(scheduledArrivalTime?.description ?? "none")")
+        print("  - Estimated Departure: \(estimatedDepartureTime?.description ?? "none")")
+        print("  - Estimated Arrival: \(estimatedArrivalTime?.description ?? "none")")
 
         // Start the activity
         do {
@@ -287,10 +288,10 @@ class LiveActivityService: ObservableObject {
             
             print("🔄 Live Activity Update Source: Client calculation (30s timer)")
             print("  - Client calculated progress: \(progress)")
-            
-            // Get scheduled times and departure status
-            let scheduledDepartureTime = train.getScheduledDepartureTime(fromStationCode: activity.attributes.originStationCode)
-            let scheduledArrivalTime = train.getScheduledArrivalTime(toStationCode: activity.attributes.destinationStationCode)
+
+            // Get estimated times (delay-adjusted) and departure status
+            let estimatedDepartureTime = train.getEstimatedDepartureTime(fromStationCode: activity.attributes.originStationCode)
+            let estimatedArrivalTime = train.getEstimatedArrivalTime(toStationCode: activity.attributes.destinationStationCode)
             let hasTrainDeparted = self.hasTrainDeparted(train, fromStation: activity.attributes.originStationCode)
             
             // Get current and next stop names using new fields
@@ -310,8 +311,8 @@ class LiveActivityService: ObservableObject {
                 delayMinutes: train.delayMinutes,
                 journeyProgress: progress,
                 dataTimestamp: Date().timeIntervalSince1970,  // Current timestamp for local update
-                scheduledDepartureTime: scheduledDepartureTime?.toISO8601String(),
-                scheduledArrivalTime: scheduledArrivalTime?.toISO8601String(),
+                scheduledDepartureTime: estimatedDepartureTime?.toISO8601String(),
+                scheduledArrivalTime: estimatedArrivalTime?.toISO8601String(),
                 nextStopArrivalTime: nextStopArrivalTime?.toISO8601String(),
                 hasTrainDeparted: hasTrainDeparted,
                 originStationCode: activity.attributes.originStationCode,
@@ -325,8 +326,8 @@ class LiveActivityService: ObservableObject {
             print("  - Next Stop: \(nextStop ?? "none")")
             print("  - Track: \(train.track ?? "none")")
             print("  - Has Departed: \(hasTrainDeparted)")
-            print("  - Scheduled Departure: \(scheduledDepartureTime?.description ?? "none")")
-            print("  - Scheduled Arrival: \(scheduledArrivalTime?.description ?? "none")")
+            print("  - Estimated Departure: \(estimatedDepartureTime?.description ?? "none")")
+            print("  - Estimated Arrival: \(estimatedArrivalTime?.description ?? "none")")
             
             // Update the activity
             await activity.update(


### PR DESCRIPTION
… times

Live Activities now show delay-adjusted arrival/departure times instead of scheduled times. Previously, the "Next Stop" and "Destination" times shown on lock screen, Dynamic Island, and departure search view would not update when trains were delayed.

Changes:
- Add getEstimatedDepartureTime(fromStationCode:) to TrainV2
- Add getEstimatedArrivalTime(toStationCode:) to TrainV2
- Update LiveActivityService to use estimated time methods
- Update toLiveActivityContentState to use estimated time methods

The estimated methods return updatedArrival/updatedDeparture when available, falling back to scheduled times if no delay information exists.

Note: Existing "delayed" indicator badge (⚠️) already displays when delayMinutes >= 4, so users see both accurate times and delay status.