### PR TITLE
Shorten Historical Analytics description text

### DIFF
--- a/ios/TrackRat/Services/SubscriptionService.swift
+++ b/ios/TrackRat/Services/SubscriptionService.swift
@@ -89,7 +89,7 @@ enum PaywallContext {
         case .delayForecasts:
             return "Get delay and cancellation predictions before you leave"
         case .historicalData:
-            return "Leverage past on-time performance and track patterns"
+            return "Leverage past performance and patterns"
         case .tripStatistics:
             return "Track every trip and see your on-time percentage"
         case .pennStationGuide:


### PR DESCRIPTION
Simplify the subtext from "Leverage past on-time performance and track patterns"
to "Leverage past performance and patterns" for better display.