### PR TITLE
Convert MyProfileView from navigation destination to dismissable sheet

### DIFF
--- a/ios/TrackRat/App/ContentView.swift
+++ b/ios/TrackRat/App/ContentView.swift
@@ -16,7 +16,6 @@ enum NavigationDestination: Hashable {
     case trainDetails(trainId: Int)  // Legacy database ID navigation
     case trainDetailsFlexible(trainNumber: String, fromStation: String?, journeyDate: Date?, dataSource: String?)  // New train number navigation with data source for disambiguation
     case advancedConfiguration
-    case myProfile
     case congestionMap
     case favoriteStations
     case tripHistory

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -707,8 +707,6 @@ struct MapContainerView: View {
                 TrainDetailsView(trainNumber: trainNumber, fromStation: fromStation, journeyDate: journeyDate, dataSource: dataSource)
             case .advancedConfiguration:
                 AdvancedConfigurationView()
-            case .myProfile:
-                MyProfileView()
             case .favoriteStations:
                 OnboardingView(isRepeating: true)
             case .congestionMap:

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -4,6 +4,7 @@ struct MyProfileView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.openURL) private var openURL
+    @Environment(\.dismiss) private var dismiss
     @ObservedObject private var subscriptionService = SubscriptionService.shared
 
     @State private var showingPaywall = false
@@ -12,15 +13,13 @@ struct MyProfileView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Fixed header - replaces system navigation bar to avoid layout shift
+            // Fixed header with close button for sheet presentation
             HStack {
-                // Back button
+                // Close button
                 Button {
-                    if !appState.navigationPath.isEmpty {
-                        appState.navigationPath.removeLast()
-                    }
+                    dismiss()
                 } label: {
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "xmark")
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.white)
                         .frame(width: 44, height: 44)

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -12,7 +12,7 @@ struct TripSelectionView: View {
     @Environment(\.openURL) private var openURL
     @State private var searchText = ""
     @State private var isSearching = false
-    @State private var isNavigatingToProfile = false
+    @State private var showingProfile = false
     @FocusState private var searchFieldFocused: Bool
     @StateObject private var liveActivityService = LiveActivityService.shared
     @StateObject private var ratSenseService = RatSenseService.shared
@@ -80,7 +80,7 @@ struct TripSelectionView: View {
                        Stations.isStationVisible(suggestion.toStation, withSystems: appState.selectedSystems),
                        !liveActivityService.isActivityActive,
                        !isSearching,
-                       !isNavigatingToProfile {
+                       !showingProfile {
                         Button {
                             selectRatSenseSuggestion(suggestion)
                         } label: {
@@ -114,7 +114,7 @@ struct TripSelectionView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal)
-                .padding(.top, (subscriptionService.isPro && ratSenseService.suggestedJourney != nil && !liveActivityService.isActivityActive && !isSearching && !isNavigatingToProfile) ? 8 : 28)
+                .padding(.top, (subscriptionService.isPro && ratSenseService.suggestedJourney != nil && !liveActivityService.isActivityActive && !isSearching && !showingProfile) ? 8 : 28)
                 
                 // Search results and content container
                 VStack(alignment: .leading, spacing: 16) {
@@ -155,13 +155,9 @@ struct TripSelectionView: View {
                                 }
                             }
                         
-                        // Profile icon - moved from top navigation
+                        // Profile icon - presented as dismissable sheet
                         Button {
-                            // Immediately hide RatSense to prevent content shift during navigation
-                            isNavigatingToProfile = true
-                            // Use pendingNavigation to expand sheet FIRST, then navigate
-                            // This prevents the glitch where sheet expands with empty space
-                            appState.pendingNavigation = .myProfile
+                            showingProfile = true
                         } label: {
                             Image(systemName: "person.circle.fill")
                                 .font(.system(size: 24))
@@ -262,9 +258,6 @@ struct TripSelectionView: View {
         .onAppear {
             print("🐀🐀🐀 TripSelectionView appeared - updating Rat Sense")
 
-            // Reset navigation flag when returning to this view
-            isNavigatingToProfile = false
-
             // Debug: Check what's in storage
             print("🐀 DEBUG: Home station = \(ratSenseService.getHomeStation() ?? "nil")")
             print("🐀 DEBUG: Work station = \(ratSenseService.getWorkStation() ?? "nil")")
@@ -272,6 +265,11 @@ struct TripSelectionView: View {
             ratSenseService.updateSuggestion()
             appState.loadRecentTrips()
             appState.loadFavoriteStations()
+        }
+        .sheet(isPresented: $showingProfile) {
+            MyProfileView()
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
         .onDisappear {
             // Cancel any pending validation tasks


### PR DESCRIPTION
Present profile as a full-screen sheet with swipe-to-dismiss gesture,
matching the existing paywall pattern for easier navigation back to main view.