### PR TITLE
Fix train listing header title alignment

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -59,10 +59,12 @@ struct TrainListView: View {
                     Text(destination)
                         .font(.headline)
                         .foregroundColor(.white)
+                        .multilineTextAlignment(.center)
                     if !departureName.isEmpty {
                         Text("from \(departureName)")
                             .font(.caption2)
                             .foregroundColor(.white.opacity(0.8))
+                            .multilineTextAlignment(.center)
                     }
                 }
 


### PR DESCRIPTION
Center-align both destination and departure station text in the
header to ensure proper centering regardless of text length differences.