### PR TITLE
fix: prevent track predictions from reloading when stops finish loading

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -132,8 +132,8 @@ struct TrainDetailsView: View {
                             )
                         }
                         .padding()
-                        // Force view update by using a composite ID that includes changing data
-                        .id("\(train.id)-\(train.calculateStatus(fromStationCode: appState.departureStationCode ?? "").rawValue)-\(viewModel.stopStatesHash)")
+                        // Force view recreation when train identity or status changes
+                        .id("\(train.id)-\(train.calculateStatus(fromStationCode: appState.departureStationCode ?? "").rawValue)")
                     }
                 } // VStack
             }
@@ -868,13 +868,7 @@ class TrainDetailsViewModel: ObservableObject {
     @Published var journeyProgressPercentage: Int = 0
     @Published var journeyStopsCompleted: Int = 0
     @Published var journeyTotalStops: Int = 0
-    
-    /// Hash of stop departure states for SwiftUI view update detection
-    var stopStatesHash: String {
-        let departedStates = displayableTrainStops.map { $0.hasDepartedStation }
-        return String(departedStates.hashValue)
-    }
-    
+
     private func updateComputedProperties() {
         updateDisplayableTrainStops()
         updateJourneyProgress()


### PR DESCRIPTION
The .id() modifier included stopStatesHash, which changed when stops
finished loading. This caused SwiftUI to recreate the entire view
hierarchy, resetting SegmentedTrackPredictionView's @State and
triggering a re-fetch of predictions.

Removed stopStatesHash from .id() since displayableTrainStops is
@Published and SwiftUI already handles updates automatically.
Also removed the now-unused stopStatesHash computed property.