### PR TITLE
fix: add buttonStyle(.plain) to prevent iOS 26 Liquid Glass double highlight

### DIFF
--- a/ios/TrackRat/Views/Components/StationButton.swift
+++ b/ios/TrackRat/Views/Components/StationButton.swift
@@ -26,6 +26,7 @@ struct StationButton: View {
             .background(TrackRatTheme.Colors.surfaceCard)
             .cornerRadius(TrackRatTheme.CornerRadius.md)
         }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ios/TrackRat/Views/Paywall/PaywallView.swift
+++ b/ios/TrackRat/Views/Paywall/PaywallView.swift
@@ -129,6 +129,7 @@ struct PaywallView: View {
                                         .stroke(.orange.opacity(0.5), lineWidth: 1)
                                 )
                             }
+                            .buttonStyle(.plain)
                         }
                         .padding()
                     } else {
@@ -173,6 +174,7 @@ struct PaywallView: View {
                         )
                         .foregroundColor(.white)
                     }
+                    .buttonStyle(.plain)
                     .disabled(selectedProduct == nil || isPurchasing)
                     .padding(.horizontal)
 
@@ -416,6 +418,7 @@ private struct PricingOptionView: View {
                     )
             )
         }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ios/TrackRat/Views/Paywall/ProFeatureLockView.swift
+++ b/ios/TrackRat/Views/Paywall/ProFeatureLockView.swift
@@ -61,6 +61,7 @@ struct ProFeatureLockView: View {
                     )
             )
         }
+        .buttonStyle(.plain)
     }
 }
 
@@ -91,6 +92,7 @@ struct ProBadgeLock: View {
                     )
             )
         }
+        .buttonStyle(.plain)
     }
 }
 
@@ -160,6 +162,7 @@ struct UpgradePromptCard: View {
                     )
             )
         }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ios/TrackRat/Views/Screens/AdvancedConfigurationView.swift
+++ b/ios/TrackRat/Views/Screens/AdvancedConfigurationView.swift
@@ -263,6 +263,7 @@ struct AdvancedConfigurationView: View {
                     .fill(isTestingConnection ? .gray : .orange)
             )
         }
+        .buttonStyle(.plain)
         .disabled(isTestingConnection)
     }
     
@@ -389,6 +390,7 @@ struct AdvancedConfigurationView: View {
                             )
                     )
                 }
+                .buttonStyle(.plain)
 
                 // Reset Feedback Cooldowns
                 Button {
@@ -417,6 +419,7 @@ struct AdvancedConfigurationView: View {
                             )
                     )
                 }
+                .buttonStyle(.plain)
 
                 // Clear Trip History
                 Button {
@@ -445,6 +448,7 @@ struct AdvancedConfigurationView: View {
                             )
                     )
                 }
+                .buttonStyle(.plain)
             }
         }
         .padding()
@@ -560,6 +564,7 @@ struct ServerEnvironmentRow: View {
                     )
             )
         }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ios/TrackRat/Views/Screens/HistoricalDataView.swift
+++ b/ios/TrackRat/Views/Screens/HistoricalDataView.swift
@@ -102,6 +102,7 @@ struct HistoricalDataView: View {
                             .foregroundColor(.white)
                             .cornerRadius(TrackRatTheme.CornerRadius.sm)
                             .font(.body.bold())
+                            .buttonStyle(.plain)
                         }
                         .frame(maxWidth: .infinity, minHeight: 400)
                         .padding()
@@ -689,6 +690,7 @@ struct CongestionDataView: View {
                             .foregroundColor(.white)
                             .cornerRadius(TrackRatTheme.CornerRadius.sm)
                             .font(.body.bold())
+                            .buttonStyle(.plain)
                         }
                         .frame(maxWidth: .infinity, minHeight: 400)
                         .padding()

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -128,6 +128,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
 
                         // Report an Issue
                         Button {
@@ -161,6 +162,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
                         .sheet(isPresented: $showingFeedbackSheet) {
                             FeedbackSheet(
                                 screen: "my_profile",
@@ -288,7 +290,8 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
-                    
+                        .buttonStyle(.plain)
+
                         // Instagram
                         Button {
                             if let instagramURL = URL(string: "https://www.instagram.com/trackratapp/") {
@@ -323,6 +326,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
 
                     }
 
@@ -372,6 +376,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
 
                         // Amtrak Service Alerts
                         Button {
@@ -407,6 +412,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
                     }
 
                     // Settings section
@@ -473,6 +479,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
 
                         // Favorite Stations
                         Button {
@@ -506,6 +513,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
 
                         // Advanced Configuration
                         Button {
@@ -539,6 +547,7 @@ struct MyProfileView: View {
                                     .fill(.ultraThinMaterial)
                             )
                         }
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding()
@@ -745,6 +754,7 @@ struct SoftTrialProCard: View {
                                 .fill(.orange)
                         )
                 }
+                .buttonStyle(.plain)
             }
         }
         .padding()

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -80,6 +80,7 @@ struct OnboardingView: View {
                         .frame(minWidth: 160)
                         .background(Color.orange)
                         .cornerRadius(TrackRatTheme.CornerRadius.md)
+                        .buttonStyle(.plain)
                         .disabled(isCompletingOnboarding)
                     }
                     .padding(.horizontal, 20)

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -93,6 +93,7 @@ struct TrainListView: View {
                     .background(Color.white.opacity(0.15))
                     .cornerRadius(8)
                 }
+                .buttonStyle(.plain)
 
                 Spacer().frame(width: 8)
 


### PR DESCRIPTION
iOS 26 introduces Liquid Glass which automatically applies translucent
highlight effects to SwiftUI buttons. Buttons with custom backgrounds
but no explicit buttonStyle get both the system highlight AND the custom
background, causing a double-layer visual artifact on older devices.

This adds .buttonStyle(.plain) to 26 buttons across 8 files that have
custom backgrounds to opt out of the automatic Liquid Glass styling.