### PR TITLE
Update documentation: expand station coverage and API endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,13 +221,31 @@ terraform apply -var="environment=production"
 ## Common API Endpoints
 
 ```
+# Train Operations
 /api/v2/trains/departures          # List departures for route
 /api/v2/trains/{train_id}          # Train details with all stops
+/api/v2/trains/{train_id}/history  # Historical train performance
+
+# Route Analytics
 /api/v2/routes/congestion          # Network congestion data (iOS only)
+/api/v2/routes/history             # Historical route performance
+/api/v2/routes/summary             # Natural language operations summary
+/api/v2/routes/segments/{from}/{to}/trains  # Segment train details
+
+# ML Predictions
 /api/v2/predictions/track          # ML platform predictions (Web, iOS)
 /api/v2/predictions/delay          # Delay/cancellation forecasts (iOS)
+/api/v2/predictions/supported-stations  # Stations with ML predictions
+
+# System Operations
 /api/v2/live-activities/register   # iOS Live Activity registration
+/api/v2/validation/status          # Validation system status
+/api/v2/validation/results/{route}/{source}  # Route validation details
 /health                            # Health check
+/health/live                       # Kubernetes liveness probe
+/health/ready                      # Kubernetes readiness probe
+/scheduler/status                  # APScheduler job status
+/metrics                           # Prometheus metrics
 ```
 
 **API Environments:**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Real-time train tracking system with ML-powered track predictions for NJ Transit
 - **Track Predictions**: ML models predict platform assignments with confidence levels ("Owl" system)
 - **Real-Time Updates**: Live train status, delays, and journey progress with 30-second refresh
 - **Multi-Transit Support**: NJ Transit, Amtrak, PATH, and PATCO (SEPTA, LIRR placeholders exist)
-- **Station Coverage**: ~144 stations including NY Penn, Newark Penn, Trenton, Princeton Junction, Metropark, plus 44 Southeast Amtrak stations
+- **Station Coverage**: 250+ stations including NY Penn, Newark Penn, Trenton, Princeton Junction, Metropark, plus PATH, PATCO, Southeast Amtrak, and Keystone Service stations
 - **Smart Consolidation**: Merges duplicate trains across data sources with conflict resolution
 
 ### Advanced Features
@@ -101,7 +101,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 
 ### Prerequisites
 - **Backend**: Python 3.11+, Poetry, PostgreSQL 14+
-- **iOS**: macOS 14+, Xcode 15+, iOS 17.0+ deployment target
+- **iOS**: macOS 14+, Xcode 15+, iOS 18.0+ deployment target
 - **Android**: Android Studio, JDK 17, Android SDK 34
 - **Infrastructure**: Terraform 1.0+, Google Cloud SDK
 

--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This guide provides comprehensive information for Claude Code when working with the TrackRat Backend V2, a radical simplification of the train tracking system that reduces API calls by ~95% while maintaining production robustness.
 
-**Last Updated:** January 19, 2026
+**Last Updated:** January 24, 2026
 **Database:** PostgreSQL with asyncpg (production-ready)
 **Key Features:** Multi-transit support (NJT, Amtrak, PATH, PATCO), ML predictions, API caching, schedule generation, GTFS integration
 

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -697,4 +697,4 @@ Ready to enhance train tracking for millions of commuters! 🚂
 
 ## License
 
-Copyright 2025 TrackRat Team
+Copyright 2025-2026 TrackRat Team

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -49,7 +49,8 @@ TrackRat iOS is a comprehensive SwiftUI app for tracking train departures from m
 - Origin station selection for departures
 - Primary stations: NY Penn, Newark Penn, Trenton, Princeton Junction, Metropark
 - Additional Southeast Amtrak stations: Charlotte, Raleigh, Atlanta, Miami, Jacksonville, Tampa, Orlando, and more
-- Total station coverage: ~144 stations (up from ~100)
+- PATH: 13 stations, PATCO: 14 stations, Keystone: 8 Pennsylvania stations
+- Total station coverage: 250+ stations across all transit systems
 - Glassmorphism cards with owl background
 - Navigates to destination picker after selection
 
@@ -691,6 +692,9 @@ Premium features with StoreKit 2 integration:
 - **ProFeatureLockView**: Paywall prompt for premium features
 - **Congestion Map Access**: Pro-only network congestion visualization
 - **StoreKit 2**: Modern subscription purchase and management
+- **Monthly-Only Pricing**: $3.99/month (configured in App Store Connect)
+- **24-Hour Soft Trial**: New users automatically get Pro access for 24 hours
+- **Debug Override**: `debugOverrideEnabled` defaults to `true` - all users currently get Pro features for free during soft launch. Set to `false` in SubscriptionService.swift to enable actual paywall.
 
 #### Map Layer Controls
 Toggleable map visualization options:

--- a/ios/README.md
+++ b/ios/README.md
@@ -12,8 +12,11 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, and PATCO trains 
 
 ### Multi-Station Support
 - **Primary Hubs**: NY Penn, Newark Penn, Trenton, Princeton Junction, Metropark
-- **Southeast Corridor**: 44+ Amtrak stations across NC, SC, GA, FL, VA, WV
-- **Total Coverage**: ~144 stations across the Eastern United States
+- **PATH Stations**: 13 stations (Newark to WTC/33rd Street)
+- **PATCO Speedline**: 14 stations (Lindenwold to Center City Philadelphia)
+- **Southeast Corridor**: 40+ Amtrak stations across NC, SC, GA, FL, VA
+- **Keystone Service**: 8 Pennsylvania stations
+- **Total Coverage**: 250+ stations across the Eastern United States
 - **Train Services**: NJ Transit, Amtrak (Silver Star, Silver Meteor, Carolinian, Piedmont, Crescent), PATH, PATCO
 
 ### Intelligent Features
@@ -32,6 +35,8 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, and PATCO trains 
 - **24-Hour Soft Trial**: New users get full Pro access for 24 hours with countdown banner
 - **StoreKit 2 Integration**: Modern subscription management with PaywallView
 - **SoftTrialBannerView**: Countdown timer during trial period linking to paywall
+- **Monthly-Only Subscription**: $3.99/month pricing (yearly option removed)
+- **Soft Launch Mode**: Debug override currently enabled - all users get Pro features free
 
 ### Train System Filtering
 - **Opt-in PATH/PATCO**: Users can enable/disable transit systems in Advanced Configuration
@@ -162,7 +167,7 @@ TrackRatTests/                   # Test suite
 ### Prerequisites
 - macOS 14.0+ (Sonoma or later)
 - Xcode 15.0+
-- iOS 17.0+ deployment target
+- iOS 18.0+ deployment target
 - Apple Developer account (for device testing)
 
 ### Installation
@@ -316,7 +321,7 @@ See [CLAUDE.md](CLAUDE.md) for complete technical details and improvement areas.
 
 ## 📝 License
 
-Copyright © 2024 TrackRat. All rights reserved.
+Copyright © 2025-2026 TrackRat. All rights reserved.
 
 ## 🤝 Acknowledgments
 

--- a/webpage_v2/CLAUDE.md
+++ b/webpage_v2/CLAUDE.md
@@ -122,7 +122,7 @@ webpage_v2/
 │   ├── store/
 │   │   └── appStore.ts     # Zustand global state
 │   ├── data/
-│   │   └── stations.ts     # Static station list (~144 stations)
+│   │   └── stations.ts     # Static station list (250+ stations)
 │   ├── types/
 │   │   └── index.ts        # TypeScript interfaces
 │   └── utils/


### PR DESCRIPTION
## Summary
Comprehensive documentation updates across the project to reflect expanded station coverage (250+ stations), updated API endpoints, iOS 18 deployment target, and 2026 copyright year.

## Key Changes

### Station Coverage Updates
- Updated station count from ~144 to 250+ stations across all documentation
- Added explicit breakdown: PATH (13 stations), PATCO (14 stations), Keystone Service (8 PA stations)
- Clarified Southeast Amtrak corridor coverage (40+ stations)
- Updated in: README.md, ios/README.md, ios/CLAUDE.md, webpage_v2/CLAUDE.md

### API Endpoints Documentation
- Reorganized `/api/v2` endpoints with logical grouping:
  - Train Operations (departures, details, history)
  - Route Analytics (congestion, history, summary, segments)
  - ML Predictions (track, delay, supported stations)
  - System Operations (validation, health checks, scheduler, metrics)
- Added new endpoints: `/health/live`, `/health/ready`, `/scheduler/status`, `/metrics`
- Added validation endpoints: `/api/v2/validation/status`, `/api/v2/validation/results/{route}/{source}`

### iOS & Development Requirements
- Updated iOS deployment target from 17.0+ to 18.0+ (README.md, ios/README.md)
- Updated macOS requirement to 14.0+ (Sonoma or later)

### Subscription & Premium Features
- Documented monthly-only pricing: $3.99/month (yearly option removed)
- Clarified 24-hour soft trial for new users
- Added debug override note: `debugOverrideEnabled` currently `true` - all users get Pro features free during soft launch

### Maintenance Updates
- Updated last modified date in backend_v2/CLAUDE.md to January 24, 2026
- Updated copyright years to 2025-2026 across backend_v2/README.md and ios/README.md

## Implementation Details
- All changes are documentation-only (no code modifications)
- Maintains consistency across multiple documentation files
- Provides clear API endpoint organization for developers
- Clarifies current soft launch state for subscription features