### PR TITLE
Rename Boston station to Boston North

### DIFF
--- a/backend_v2/src/trackrat/config/stations.py
+++ b/backend_v2/src/trackrat/config/stations.py
@@ -620,7 +620,7 @@ STATION_NAMES: dict[str, str] = {
     "AST": "Aldershot",
     "BFX": "Buffalo",
     "BLF": "Bellows Falls",
-    "BON": "Boston",
+    "BON": "Boston North",
     "BRA": "Brattleboro",
     "BRK": "Brunswick",
     "CBN": "Canadian Border",
@@ -1272,7 +1272,7 @@ AMTRAK_TO_INTERNAL_STATION_MAP: dict[str, str] = {
     "AST": "AST",  # Aldershot
     "BFX": "BFX",  # Buffalo
     "BLF": "BLF",  # Bellows Falls
-    "BON": "BON",  # Boston
+    "BON": "BON",  # Boston North
     "BRA": "BRA",  # Brattleboro
     "BRK": "BRK",  # Brunswick
     "CBN": "CBN",  # Canadian Border
@@ -1880,7 +1880,7 @@ INTERNAL_TO_AMTRAK_STATION_MAP: dict[str, str] = {
     "AST": "AST",  # Aldershot
     "BFX": "BFX",  # Buffalo
     "BLF": "BLF",  # Bellows Falls
-    "BON": "BON",  # Boston
+    "BON": "BON",  # Boston North
     "BRA": "BRA",  # Brattleboro
     "BRK": "BRK",  # Brunswick
     "CBN": "CBN",  # Canadian Border
@@ -3010,7 +3010,7 @@ STATION_COORDINATES = {
     "AST": {"lat": 43.3134, "lon": -79.8557},  # Aldershot
     "BFX": {"lat": 42.8784, "lon": -78.8737},  # Buffalo
     "BLF": {"lat": 43.1365, "lon": -72.4446},  # Bellows Falls
-    "BON": {"lat": 42.3662, "lon": -71.0611},  # Boston
+    "BON": {"lat": 42.3662, "lon": -71.0611},  # Boston North
     "BRA": {"lat": 42.8508, "lon": -72.5565},  # Brattleboro
     "BRK": {"lat": 43.9114, "lon": -69.9655},  # Brunswick
     "CBN": {"lat": 43.1092, "lon": -79.0584},  # Canadian Border

--- a/ios/TrackRat/Shared/Stations.swift
+++ b/ios/TrackRat/Shared/Stations.swift
@@ -182,7 +182,7 @@ struct Stations {
         "San Marcos", "Sanderson", "Staples", "Stanley", "Taylor", "Tomah",
         "Topeka", "Temple", "Trinidad", "Texarkana", "Washington", "Warrensburg",
         "Wellington", "Wichita", "Winona", "Walnut Ridge", "Williston", "Yazoo City",
-        "Amsterdam", "Aldershot", "Buffalo", "Bellows Falls", "Boston", "Brattleboro",
+        "Amsterdam", "Aldershot", "Buffalo", "Bellows Falls", "Boston North", "Brattleboro",
         "Brunswick", "Canadian Border", "Castleton", "Fort Edward", "Framingham", "Freeport",
         "Ticonderoga", "Greenfield", "Grimsby", "Haverhill", "Holyoke", "Hudson",
         "Middlebury", "Montpelier-Berlin", "Niagara Falls NY", "Niagara Falls ON", "Northampton", "Oakville",
@@ -861,7 +861,7 @@ struct Stations {
         "Aldershot": "AST",
         "Buffalo": "BFX",
         "Bellows Falls": "BLF",
-        "Boston": "BON",
+        "Boston North": "BON",
         "Brattleboro": "BRA",
         "Brunswick": "BRK",
         "Canadian Border": "CBN",
@@ -1712,7 +1712,7 @@ struct Stations {
         "AST": CLLocationCoordinate2D(latitude: 43.3134, longitude: -79.8557),  // Aldershot
         "BFX": CLLocationCoordinate2D(latitude: 42.8784, longitude: -78.8737),  // Buffalo
         "BLF": CLLocationCoordinate2D(latitude: 43.1365, longitude: -72.4446),  // Bellows Falls
-        "BON": CLLocationCoordinate2D(latitude: 42.3662, longitude: -71.0611),  // Boston
+        "BON": CLLocationCoordinate2D(latitude: 42.3662, longitude: -71.0611),  // Boston North
         "BRA": CLLocationCoordinate2D(latitude: 42.8508, longitude: -72.5565),  // Brattleboro
         "BRK": CLLocationCoordinate2D(latitude: 43.9114, longitude: -69.9655),  // Brunswick
         "CBN": CLLocationCoordinate2D(latitude: 43.1092, longitude: -79.0584),  // Canadian Border


### PR DESCRIPTION
## Summary
Updated the station name for the BON station code from "Boston" to "Boston North" across both backend and iOS client codebases to provide clearer geographic distinction.

## Changes Made
- **Backend (Python)**: Updated station configuration in `backend_v2/src/trackrat/config/stations.py`
  - Changed station name mapping from "Boston" to "Boston North"
  - Updated comments in three separate station dictionaries to reflect the new name
  
- **iOS Client (Swift)**: Updated station configuration in `ios/TrackRat/Shared/Stations.swift`
  - Changed station name in the stations list array
  - Updated the name-to-code mapping dictionary
  - Updated the code-to-coordinates mapping comment

## Details
All changes maintain the same station code (BON) and geographic coordinates (42.3662, -71.0611). This is purely a naming update to distinguish this Boston location from other potential Boston-area stations. The changes are consistent across all station configuration dictionaries in both platforms.