### PR TITLE
Filter Amtrak congestion data to NEC + Silver Service corridor only

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import aliased, selectinload
 from structlog import get_logger
 
 from trackrat.api.utils import handle_errors
-from trackrat.config.stations import get_station_name
+from trackrat.config.stations import NEC_SILVER_CORRIDOR_STATIONS, get_station_name
 from trackrat.db.engine import get_db
 from trackrat.models.api import (
     AggregateStats,
@@ -334,6 +334,45 @@ async def get_route_congestion(
             db, time_window_hours, max_per_segment, data_source
         )
     )
+
+    # Filter Amtrak data to only include NEC + Silver Service corridor stations
+    # This excludes trains on other Amtrak routes (California Zephyr, Empire Builder, etc.)
+    if data_source == "AMTRAK":
+        # Filter aggregated segments: both stations must be on the corridor
+        aggregated_segments = [
+            s
+            for s in aggregated_segments
+            if s.from_station in NEC_SILVER_CORRIDOR_STATIONS
+            and s.to_station in NEC_SILVER_CORRIDOR_STATIONS
+        ]
+
+        # Filter individual segments: both stations must be on the corridor
+        individual_segments = [
+            s
+            for s in individual_segments
+            if s.from_station in NEC_SILVER_CORRIDOR_STATIONS
+            and s.to_station in NEC_SILVER_CORRIDOR_STATIONS
+        ]
+
+        # Filter journeys: keep only trains with stops on the corridor
+        # A train is on the corridor if its current position involves corridor stations
+        def journey_on_corridor(journey: TrainJourney) -> bool:
+            if not journey.stops:
+                return False
+            # Check if any stop is on the corridor
+            for stop in journey.stops:
+                if stop.station_code in NEC_SILVER_CORRIDOR_STATIONS:
+                    return True
+            return False
+
+        journeys = [j for j in journeys if journey_on_corridor(j)]
+
+        logger.debug(
+            "amtrak_corridor_filter_applied",
+            aggregated_segments=len(aggregated_segments),
+            individual_segments=len(individual_segments),
+            journeys=len(journeys),
+        )
 
     # Extract train positions from journeys
     departure_service = DepartureService()

--- a/backend_v2/src/trackrat/config/stations.py
+++ b/backend_v2/src/trackrat/config/stations.py
@@ -3202,6 +3202,97 @@ DISCOVERY_STATIONS = [
 
 
 # =============================================================================
+# Amtrak Northeast Corridor + Silver Service Stations
+# =============================================================================
+# Stations on the NEC (Boston-Washington) and Silver Service (Washington-Florida)
+# Used to filter Amtrak congestion data to only include this corridor
+NEC_SILVER_CORRIDOR_STATIONS: frozenset[str] = frozenset(
+    {
+        # NEC Core: Boston - New York (13)
+        "BOS",  # Boston South Station
+        "BBY",  # Boston Back Bay
+        "RTE",  # Route 128
+        "PVD",  # Providence
+        "KIN",  # Kingston (RI)
+        "WLY",  # Westerly
+        "MYS",  # Mystic
+        "NLC",  # New London
+        "OSB",  # Old Saybrook
+        "NHV",  # New Haven
+        "STM",  # Stamford
+        "NRO",  # New Rochelle
+        "NY",  # New York Penn Station
+        # NEC Core: New York - Philadelphia (8)
+        "NP",  # Newark Penn Station
+        "MP",  # Metropark
+        "NB",  # New Brunswick
+        "PJ",  # Princeton Junction
+        "TR",  # Trenton
+        "CWH",  # Cornwells Heights
+        "PHN",  # North Philadelphia
+        "PH",  # Philadelphia 30th Street
+        # NEC Core: Philadelphia - Washington (7)
+        "WI",  # Wilmington Station
+        "NRK",  # Newark (DE)
+        "ABE",  # Aberdeen
+        "BL",  # Baltimore Penn Station
+        "BA",  # BWI Thurgood Marshall Airport
+        "NCR",  # New Carrollton
+        "WS",  # Washington Union Station
+        # Virginia: Washington - Richmond (6)
+        "ALX",  # Alexandria
+        "WDB",  # Woodbridge
+        "QAN",  # Quantico
+        "FBG",  # Fredericksburg
+        "RVR",  # Richmond Staples Mill Road
+        "PTB",  # Petersburg
+        # North Carolina - Silver Meteor coastal route (4)
+        "RMT",  # Rocky Mount
+        "WLN",  # Wilson
+        "SSM",  # Selma
+        "FAY",  # Fayetteville
+        # North Carolina - Silver Star inland route (4)
+        "RGH",  # Raleigh
+        "CYN",  # Cary
+        "SOP",  # Southern Pines
+        "HAM",  # Hamlet
+        # South Carolina (6)
+        "FLO",  # Florence
+        "KTR",  # Kingstree
+        "CHS",  # Charleston
+        "YEM",  # Yemassee
+        "CAM",  # Camden
+        "CLB",  # Columbia SC
+        # Georgia (3)
+        "DNK",  # Denmark
+        "SAV",  # Savannah
+        "JSP",  # Jesup
+        # Florida - North (6)
+        "JAX",  # Jacksonville
+        "PAK",  # Palatka
+        "DLD",  # DeLand
+        "WPK",  # Winter Park
+        "ORL",  # Orlando
+        "KIS",  # Kissimmee
+        # Florida - Tampa branch (Silver Star) (4)
+        "WTH",  # Winter Haven
+        "LAK",  # Lakeland
+        "LKL",  # Lakeland (alternate code)
+        "TPA",  # Tampa
+        # Florida - Miami branch (Silver Meteor) (8)
+        "SBG",  # Sebring
+        "OKE",  # Okeechobee
+        "WPB",  # West Palm Beach
+        "DLB",  # Delray Beach
+        "DFB",  # Deerfield Beach
+        "FTL",  # Fort Lauderdale
+        "HOL",  # Hollywood
+        "MIA",  # Miami
+    }
+)
+
+
+# =============================================================================
 # GTFS Station Mapping
 # =============================================================================
 


### PR DESCRIPTION
Add NEC_SILVER_CORRIDOR_STATIONS constant (68 stations) covering:
- NEC Core: Boston to Washington DC (28 stations)
- Virginia: Washington to Richmond (6 stations)
- NC Silver Meteor/Star routes (8 stations)
- South Carolina (6 stations)
- Georgia (3 stations)
- Florida: Jacksonville to Miami/Tampa (17 stations)

The congestion endpoint now filters Amtrak data to only include
segments and trains on this corridor, excluding other Amtrak routes
like California Zephyr, Empire Builder, etc.

https://claude.ai/code/session_014zGQcpd4YZxrzhcLi1CzsR