### PR TITLE
Disable debug premium override by default

### DIFF
--- a/ios/TrackRat/Services/SubscriptionService.swift
+++ b/ios/TrackRat/Services/SubscriptionService.swift
@@ -178,10 +178,10 @@ final class SubscriptionService: ObservableObject {
 
     private init() {
         // Load debug override state
-        // Default to true (premium mode enabled) - all users get Pro features
+        // Default to false - users see normal IAP flow
         if userDefaults.object(forKey: debugOverrideKey) == nil {
-            self.debugOverrideEnabled = true
-            userDefaults.set(true, forKey: debugOverrideKey)
+            self.debugOverrideEnabled = false
+            userDefaults.set(false, forKey: debugOverrideKey)
         } else {
             self.debugOverrideEnabled = userDefaults.bool(forKey: debugOverrideKey)
         }


### PR DESCRIPTION
## Summary
Changed the default state of the debug override flag from enabled to disabled, ensuring users see the normal in-app purchase (IAP) flow by default rather than having premium features automatically unlocked.

## Changes
- Updated `debugOverrideEnabled` default initialization from `true` to `false`
- Updated the corresponding UserDefaults value to match
- Updated comment to reflect that users now see the normal IAP flow instead of having Pro features enabled by default

## Details
This change ensures that the app's subscription and in-app purchase flow is properly tested and visible to users in production builds. The debug override can still be manually enabled if needed for testing purposes, but it will no longer bypass the IAP system by default.

https://claude.ai/code/session_011zHUzvfULosJrnMuDZMAF8