### PR TITLE
Add contact support email link to footer

### DIFF
--- a/trackrat.net/index.html
+++ b/trackrat.net/index.html
@@ -311,6 +311,7 @@
     <footer>
         <div class="container">
             <div class="footer-links">
+                <a href="mailto:andy@andymartin.cc">Contact Support</a>
                 <a href="https://trackrat.net/privacy.txt" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
                 <a href="https://trackrat.nolt.io/" target="_blank" rel="noopener noreferrer">Submit Feedback & Ideas!</a>
             </div>


### PR DESCRIPTION
## Summary
Added a "Contact Support" email link to the website footer, providing users with a direct way to reach support.

## Changes
- Added a mailto link (`andy@andymartin.cc`) as the first item in the footer links section
- Link opens the user's default email client when clicked

## Details
The contact support link is positioned at the beginning of the footer navigation, before the Privacy Policy and Feedback links, making it easily discoverable for users who need assistance.

https://claude.ai/code/session_01NkfaPScqRG85FKUKucKWc5