### PR TITLE
Hide Routes layer toggle from map controls menu

### DIFF
--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -404,7 +404,7 @@ class CongestionMapViewModel: ObservableObject {
     // Note: Congestion defaults to Off since it's a Pro feature
     // Pro users will have it enabled via MapLayerControlsView.onAppear
     @Published var showCongestion: CongestionMode = .off
-    @Published var showRoutes: Bool = true
+    @Published var showRoutes: Bool = false  // Default: Off (hidden from layers menu)
     @Published var showStations: Bool = false  // Default: Off
 
     // MARK: - Data

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -893,19 +893,6 @@ struct MapLayerControlsView: View {
                     }
                 }
 
-                // Routes toggle
-                MapLayerToggleButton(
-                    label: "Routes",
-                    icon: "point.topleft.down.to.point.bottomright.curvepath",
-                    isOn: viewModel.showRoutes,
-                    detail: viewModel.showRoutes ? "On" : "Off",
-                    isPro: true,
-                    showProBadge: false
-                ) {
-                    viewModel.showRoutes.toggle()
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                }
-
                 // Stations toggle
                 MapLayerToggleButton(
                     label: "Stations",


### PR DESCRIPTION
## Summary
Removed the Routes layer toggle from the map layer controls menu and changed its default state to hidden.

## Changes
- Changed `showRoutes` default value from `true` to `false` in `CongestionMapViewModel`
- Removed the Routes toggle button UI component from `MapLayerControlsView`
- Added clarifying comment indicating Routes is hidden from the layers menu

## Details
The Routes layer toggle has been removed from the user-facing map controls menu. The feature remains in the codebase and can still be controlled programmatically via the `showRoutes` property, but users can no longer toggle it through the UI. This aligns with the Pro feature structure already in place for other map layers like Congestion and Stations.

https://claude.ai/code/session_015qmgGdeeFp1tx5rWGGovbM