### PR TITLE
Show congestion lines for all users, gate "On your route" to Pro

### DIFF
--- a/ios/TrackRat/Views/Components/OperationsSummaryView.swift
+++ b/ios/TrackRat/Views/Components/OperationsSummaryView.swift
@@ -40,17 +40,17 @@ struct OperationsSummaryView: View {
         self.ratSenseRoute = ratSenseRoute
     }
 
-    /// Combined display text: network summary or route summary
+    /// Combined display text: network summary or route summary (Pro only)
     private var combinedBodyText: String? {
         guard let summary = summary, !summary.body.isEmpty else { return nil }
 
-        // If we have a route summary, show "On your route:" + route body
-        if let routeSummary = routeSummary, !routeSummary.body.isEmpty {
+        // "On your route" is a Pro feature - only show route-specific summary for Pro users
+        if SubscriptionService.shared.isPro,
+           let routeSummary = routeSummary, !routeSummary.body.isEmpty {
             return "On your route: \(routeSummary.body)"
         }
 
-        // No route summary - show body only (it's already a complete summary)
-        // Headline is designed for expandable views, not inline display
+        // No route summary (or not Pro) - show network body only
         return summary.body
     }
 
@@ -120,8 +120,9 @@ struct OperationsSummaryView: View {
             )
             summary = result
 
-            // If we have a RatSense route and this is a network scope, also fetch route summary
-            if scope == .network, let route = ratSenseRoute {
+            // If Pro user with RatSense route and network scope, also fetch route summary
+            // (route summary is a Pro feature - skip the API call for non-Pro users)
+            if SubscriptionService.shared.isPro, scope == .network, let route = ratSenseRoute {
                 do {
                     let routeResult = try await APIService.shared.fetchOperationsSummary(
                         scope: .route,

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -325,13 +325,8 @@ struct MapContainerView: View {
             // Always ensure we start with overall congestion view (but preserve activeTrainRoute)
             appState.mapDisplayMode = .overallCongestion
 
-            // Set default congestion mode based on subscription status
-            // Pro users: show congestion on, non-Pro: keep Off (congestion is Pro-only)
-            if SubscriptionService.shared.isPro {
-                mapViewModel.showCongestion = .aggregated
-            } else {
-                mapViewModel.showCongestion = .off
-            }
+            // Show congestion lines for all users
+            mapViewModel.showCongestion = .aggregated
 
             // IMPORTANT: Don't clear selectedRoute if we're navigating within the app
             // Only clear it if we're at the root (no navigation path)
@@ -850,8 +845,6 @@ struct CongestionMapControlsView: View {
 struct MapLayerControlsView: View {
     @EnvironmentObject private var appState: AppState
     @ObservedObject var viewModel: CongestionMapViewModel
-    @ObservedObject private var subscriptionService = SubscriptionService.shared
-    @State private var showingPaywall = false
 
     // Max height: available space above the bottom sheet (50% of screen),
     // minus top UI elements (~90pt) and safety margin
@@ -866,30 +859,24 @@ struct MapLayerControlsView: View {
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 10) {
-                // Congestion toggle (tri-state: Off -> Summary -> Trains) - Pro only
+                // Congestion toggle (tri-state: Off -> On -> Trains)
                 MapLayerToggleButton(
                     label: "Congestion",
                     icon: "train.side.front.car",
                     isOn: viewModel.showCongestion != .off,
                     detail: viewModel.showCongestion.rawValue,
-                    isPro: subscriptionService.isPro,
-                    showProBadge: viewModel.showCongestion == .off
+                    isPro: true,
+                    showProBadge: false
                 ) {
-                    if subscriptionService.isPro {
-                        let wasOff = viewModel.showCongestion == .off
-                        viewModel.cycleCongestionMode()
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    let wasOff = viewModel.showCongestion == .off
+                    viewModel.cycleCongestionMode()
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
 
-                        // Reload congestion data when turning on (from off state)
-                        if wasOff && viewModel.showCongestion != .off {
-                            Task {
-                                await viewModel.fetchCongestionData()
-                            }
+                    // Reload congestion data when turning on (from off state)
+                    if wasOff && viewModel.showCongestion != .off {
+                        Task {
+                            await viewModel.fetchCongestionData()
                         }
-                    } else {
-                        // Non-Pro user trying to enable congestion - show paywall
-                        showingPaywall = true
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                     }
                 }
 
@@ -938,14 +925,6 @@ struct MapLayerControlsView: View {
                 .fill(.ultraThinMaterial)
         )
         .fixedSize(horizontal: true, vertical: false)
-        .onAppear {
-            // Ensure non-Pro users can't have congestion enabled
-            // (handles edge case if subscription lapses while app is running)
-            if !subscriptionService.isPro && viewModel.showCongestion != .off {
-                viewModel.showCongestion = .off
-            }
-        }
-        .paywallSheet(isPresented: $showingPaywall, context: .congestionMap)
     }
 }
 


### PR DESCRIPTION
- MapContainerView: Always enable congestion (aggregated mode) on appear
- MapLayerControlsView: Remove Pro-only paywall for congestion toggle
- OperationsSummaryView: Only show "On your route:" personalized status for Pro users
- Skip route summary API call for non-Pro users to save bandwidth

This gives free users visibility into network congestion while keeping
personalized route insights as a Pro feature.

https://claude.ai/code/session_01RjRgMzsdYRAFwi4DJ1XjWk