### PR TITLE
Add departure odds (beta) feature flag toggle

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -563,6 +563,13 @@ final class AppState: ObservableObject {
         }
     }
 
+    // Beta feature: Show departure odds on train details
+    @Published var showDepartureOdds: Bool = false {
+        didSet {
+            UserDefaults.standard.set(showDepartureOdds, forKey: "showDepartureOdds")
+        }
+    }
+
     init() {
         loadRecentTrips()
         loadFavoriteStations()
@@ -715,6 +722,9 @@ final class AppState: ObservableObject {
 
         // Load stations visibility
         showMapStations = UserDefaults.standard.bool(forKey: "showMapStations")
+
+        // Load beta features
+        showDepartureOdds = UserDefaults.standard.bool(forKey: "showDepartureOdds")
     }
 
     /// Cycle to next highlight mode: Off → Health → Delays → Off

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -581,6 +581,44 @@ struct SettingsSection: View {
             }
             .buttonStyle(.plain)
 
+            // Departure Odds Toggle (Beta)
+            Button {
+                appState.showDepartureOdds.toggle()
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            } label: {
+                HStack(spacing: 16) {
+                    Image(systemName: "percent")
+                        .font(.title2)
+                        .foregroundColor(.orange)
+                        .frame(width: 24, height: 24)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(spacing: 4) {
+                            Text("Show departure odds")
+                                .font(.headline)
+                                .fontWeight(.medium)
+                                .foregroundColor(.white)
+                            Text("(beta)")
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                        }
+                    }
+
+                    Spacer()
+
+                    Toggle("", isOn: $appState.showDepartureOdds)
+                        .labelsHidden()
+                        .tint(.orange)
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(.ultraThinMaterial)
+                )
+            }
+            .buttonStyle(.plain)
+
             // Advanced Configuration
             Button {
                 navigationPath.append(ProfileDestination.advancedConfiguration)

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -93,9 +93,10 @@ struct TrainDetailsView: View {
                         }
                     } else if let train = viewModel.train {
                         VStack(spacing: 16) {
-                            // Train performance summary (similar trains + historical) - Pro feature only
+                            // Train performance summary (similar trains + historical)
+                            // Visible for Pro subscribers or when beta feature flag is enabled
                             // Hide after train departs from user's origin station
-                            if subscriptionService.isPro,
+                            if (subscriptionService.isPro || appState.showDepartureOdds),
                                let originCode = appState.departureStationCode,
                                !train.hasTrainDepartedFromStation(originCode) {
                                 TrainStatsSummaryView(


### PR DESCRIPTION
- Add showDepartureOdds property to AppState with UserDefaults persistence
- Add toggle in My Profile settings section with (beta) label
- Show TrainStatsSummaryView for Pro subscribers OR when feature flag is enabled

https://claude.ai/code/session_017eNr739GHhYx7qkLtRwpXX