### PR TITLE
Remove subscription status badge from ProUserCard

### DIFF
--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -697,17 +697,6 @@ struct ProUserCard: View {
                     .font(.headline)
                     .foregroundColor(.white)
                 Spacer()
-
-                // Status badge
-                Text(subscriptionService.subscriptionStatus.statusText)
-                    .font(.caption.bold())
-                    .foregroundColor(.green)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        Capsule()
-                            .fill(.green.opacity(0.2))
-                    )
             }
 
             HStack {


### PR DESCRIPTION
## Summary
Removed the subscription status badge display from the ProUserCard component in MyProfileView.

## Changes
- Removed the status badge Text view that displayed `subscriptionService.subscriptionStatus.statusText`
- Removed associated styling including:
  - Font styling (caption.bold())
  - Green foreground color
  - Horizontal and vertical padding
  - Capsule background with green opacity

## Details
The subscription status badge was displayed in the top-right area of the ProUserCard (after the Spacer in the HStack). This UI element has been completely removed, simplifying the card layout and reducing visual clutter in the user profile section.

https://claude.ai/code/session_01G5FaPkvQygbqRMEUkjpJf3