### PR TITLE
Change beta label color from orange to white

### DIFF
--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -600,7 +600,7 @@ struct SettingsSection: View {
                                 .foregroundColor(.white)
                             Text("(beta)")
                                 .font(.caption)
-                                .foregroundColor(.orange)
+                                .foregroundColor(.white)
                         }
                     }
 
@@ -1082,7 +1082,7 @@ private struct TrainSystemRow: View {
                         if system == .path {
                             Text("(beta)")
                                 .font(.caption)
-                                .foregroundColor(.orange)
+                                .foregroundColor(.white)
                         }
                     }
 


### PR DESCRIPTION
## Summary
Updated the color scheme for beta labels throughout the app to improve visual consistency and readability.

## Changes
- Changed "(beta)" label foreground color from `.orange` to `.white` in the Settings section of MyProfileView
- Changed "(beta)" label foreground color from `.orange` to `.white` for the PATH train system in TrainSystemRow

## Details
These changes affect two locations where beta feature indicators are displayed:
1. Settings section - general beta feature indicator
2. Train system selection - PATH system beta indicator

The white color provides better contrast and visual consistency with the overall UI design compared to the previous orange color.

https://claude.ai/code/session_01UMa9Y6QpSGrdgk3JP8XCGu