### PR TITLE
Hide Track Predictions section when no prediction data available

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -1297,68 +1297,67 @@ struct SegmentedTrackPredictionView: View {
         !predictionSegments.isEmpty && predictionSegments.allSatisfy { $0.probability < 0.17 }
     }
     
+    @ViewBuilder
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Header
-            HStack {
-                Image(systemName: "tram.circle.fill")
-                    .foregroundColor(.black)
-                    .font(.title2)
-                
-                Text("Track Predictions")
-                    .font(.headline)
-                    .foregroundColor(.black)
-                
-                Spacer()
-            }
-            
-            if isLoadingPredictions {
-                ProgressView()
-                    .frame(height: 64)
-            } else if hasOnlyLowConfidencePredictions {
-                Text("No clear favorite")
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(Color(white: 0.6))
-                    .frame(height: 64)
-                    .frame(maxWidth: .infinity)
-            } else if !predictionSegments.isEmpty {
-                VStack(spacing: 8) {
-                    // Labels for segments that need them above the bar
-                    if hasSegmentsWithTopLabels {
-                        topLabelsView
-                    }
-                    
-                    // Main segmented bar
-                    segmentedBarView
-                        .frame(height: 64)
-                    
-                    // Percentages below the bar
-                    bottomLabelsView
+        // Hide entire section when loading complete and no prediction data (404 from API)
+        if isLoadingPredictions || adjustedPredictions != nil {
+            VStack(alignment: .leading, spacing: 12) {
+                // Header
+                HStack {
+                    Image(systemName: "tram.circle.fill")
+                        .foregroundColor(.black)
+                        .font(.title2)
+
+                    Text("Track Predictions")
+                        .font(.headline)
+                        .foregroundColor(.black)
+
+                    Spacer()
                 }
-                .padding(.top, 4)
-            } else {
-                Text("No prediction data available")
-                    .font(.caption)
-                    .foregroundColor(Color(white: 0.55))
-                    .italic()
+
+                if isLoadingPredictions {
+                    ProgressView()
+                        .frame(height: 64)
+                } else if hasOnlyLowConfidencePredictions {
+                    Text("No clear favorite")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(Color(white: 0.6))
+                        .frame(height: 64)
+                        .frame(maxWidth: .infinity)
+                } else if !predictionSegments.isEmpty {
+                    VStack(spacing: 8) {
+                        // Labels for segments that need them above the bar
+                        if hasSegmentsWithTopLabels {
+                            topLabelsView
+                        }
+
+                        // Main segmented bar
+                        segmentedBarView
+                            .frame(height: 64)
+
+                        // Percentages below the bar
+                        bottomLabelsView
+                    }
+                    .padding(.top, 4)
+                }
+
+                // Penn Station waiting guide link for NY departures
+                if isDepartingFromNYPenn && showWaitingLink {
+                    PennStationWaitingLink(isAmtrak: train.trainId.hasPrefix("A"))
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
-            
-            // Penn Station waiting guide link for NY departures
-            if isDepartingFromNYPenn && showWaitingLink {
-                PennStationWaitingLink(isAmtrak: train.trainId.hasPrefix("A"))
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+            .padding()
+            .background(Color.orange.opacity(0.05))
+            .cornerRadius(TrackRatTheme.CornerRadius.md)
+            .overlay(
+                RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.md)
+                    .stroke(Color.orange.opacity(0.3), lineWidth: 1)
+            )
+            .task {
+                await loadAdjustedPredictions()
             }
-        }
-        .padding()
-        .background(Color.orange.opacity(0.05))
-        .cornerRadius(TrackRatTheme.CornerRadius.md)
-        .overlay(
-            RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.md)
-                .stroke(Color.orange.opacity(0.3), lineWidth: 1)
-        )
-        .task {
-            await loadAdjustedPredictions()
         }
     }
     


### PR DESCRIPTION
## Summary
Modified the `SegmentedTrackPredictionView` to conditionally render the entire section only when predictions are loading or data is available, hiding it completely when the API returns no prediction data (404 response).

## Key Changes
- Added `@ViewBuilder` attribute to the `body` property to enable conditional view composition
- Wrapped the entire VStack in a conditional check: `if isLoadingPredictions || adjustedPredictions != nil`
- Removed the "No prediction data available" fallback text that was previously displayed
- This ensures the section is completely hidden from the UI when there's no data to display, rather than showing a placeholder message

## Implementation Details
- The conditional uses `adjustedPredictions != nil` to determine if valid prediction data exists
- The section remains visible during the loading state (`isLoadingPredictions`) to provide user feedback
- All styling (padding, background, corner radius, overlay) remains intact and only applies when the section is visible
- The `.task` modifier for `loadAdjustedPredictions()` is preserved within the conditional block

https://claude.ai/code/session_01MsZk6BBpfaQJ9iE9iZd28N