### PR TITLE
Preserve delay through missing transit data segments

### DIFF
--- a/backend_v2/src/trackrat/services/direct_forecaster.py
+++ b/backend_v2/src/trackrat/services/direct_forecaster.py
@@ -149,10 +149,24 @@ class DirectArrivalForecaster:
                         f"No transit data for {from_code}→{to_code} "
                         f"(need {self.MIN_SAMPLES} samples, lookback {self.LOOKBACK_HOURS}h)"
                     )
-                    # Clear prediction and try to reset baseline
+                    # No empirical data for this segment. Fall back to scheduled
+                    # segment duration to preserve accumulated delay through the gap.
                     to_stop.predicted_arrival = None
                     to_stop.predicted_arrival_samples = 0
-                    predicted_time = self._get_scheduled_time(to_stop, "departure")
+                    if predicted_time is not None:
+                        scheduled_duration = self._get_scheduled_segment_duration(
+                            from_stop, to_stop
+                        )
+                        if scheduled_duration is not None:
+                            predicted_time = predicted_time + scheduled_duration
+                            predicted_time = self._calculate_next_departure(
+                                to_stop, predicted_time
+                            )
+                        else:
+                            # Can't compute duration — lose the chain
+                            predicted_time = self._get_scheduled_time(
+                                to_stop, "departure"
+                            )
                     continue
 
                 if predicted_time is None:
@@ -218,7 +232,10 @@ class DirectArrivalForecaster:
         """
         cutoff_time = now_et() - timedelta(hours=self.LOOKBACK_HOURS)
 
-        # Single query that gets segment data and filters on arrival time
+        # Single query that gets segment data and filters on arrival time.
+        # Only includes trains that have actually arrived at the to-station
+        # (actual_arrival IS NOT NULL) to avoid contaminating samples with
+        # schedule-based data from trains still en route.
         stmt = (
             select(
                 JourneyStop.journey_id,
@@ -253,10 +270,7 @@ class DirectArrivalForecaster:
                     case(
                         (
                             JourneyStop.station_code == to_station,
-                            coalesce(
-                                JourneyStop.actual_arrival,
-                                JourneyStop.scheduled_arrival,
-                            ),
+                            JourneyStop.actual_arrival,
                         )
                     )
                 ).label("arrival_time"),
@@ -289,15 +303,22 @@ class DirectArrivalForecaster:
                             )
                         )
                     ),
-                    # Key change: Filter on actual segment completion time
+                    # Only include trains that actually arrived (not NULL)
                     func.max(
                         case(
                             (
                                 JourneyStop.station_code == to_station,
-                                coalesce(
-                                    JourneyStop.actual_arrival,
-                                    JourneyStop.scheduled_arrival,
-                                ),
+                                JourneyStop.actual_arrival,
+                            )
+                        )
+                    )
+                    .isnot(None),
+                    # Filter on recency: actual arrival within lookback window
+                    func.max(
+                        case(
+                            (
+                                JourneyStop.station_code == to_station,
+                                JourneyStop.actual_arrival,
                             )
                         )
                     )
@@ -424,6 +445,21 @@ class DirectArrivalForecaster:
                 return ensure_timezone_aware(time_value)
         return None
 
+    def _get_scheduled_segment_duration(
+        self, from_stop: Any, to_stop: Any
+    ) -> timedelta | None:
+        """
+        Get the scheduled transit duration between two consecutive stops.
+
+        Uses scheduled departure from from_stop and scheduled arrival at to_stop.
+        Returns None if either time is unavailable.
+        """
+        from_time = self._get_scheduled_time(from_stop, "departure")
+        to_time = self._get_scheduled_time(to_stop, "arrival")
+        if from_time and to_time and to_time > from_time:
+            return to_time - from_time
+        return None
+
     def _validate_prediction_time(self, predicted_time: Any, stop: Any) -> Any | None:
         """
         Validate that a prediction time is reasonable.
@@ -441,13 +477,15 @@ class DirectArrivalForecaster:
             delay_minutes = (current_time - predicted_time).total_seconds() / 60.0
 
             if delay_minutes > self.STALE_PREDICTION_MINUTES:
-                # Too stale - reset to scheduled time if available
+                # Too stale - prediction is clearly wrong for this stop.
+                # Use current time as baseline for next segment (preserves
+                # implicit delay rather than resetting to schedule).
                 logger.debug(
                     f"Prediction for {_get_station_code(stop)} is {delay_minutes:.0f}min stale, skipping"
                 )
                 stop.predicted_arrival = None
                 stop.predicted_arrival_samples = 0
-                return self._get_scheduled_time(stop, "departure")
+                return current_time
             else:
                 # Slightly stale - use current time
                 logger.debug(

--- a/backend_v2/tests/unit/test_direct_forecaster.py
+++ b/backend_v2/tests/unit/test_direct_forecaster.py
@@ -207,10 +207,10 @@ class TestDirectArrivalForecaster:
             validated = forecaster._validate_prediction_time(stale_time, stop)
             assert validated == now  # Should use current time
 
-            # Test very stale time (reset to scheduled)
+            # Test very stale time (uses current time to preserve delay)
             very_stale = now - timedelta(minutes=15)
             validated = forecaster._validate_prediction_time(very_stale, stop)
-            assert validated == stop.scheduled_departure
+            assert validated == now  # Should use current time, not reset to schedule
 
     def test_calculate_next_departure(self, forecaster):
         """Test calculating next departure time."""
@@ -401,3 +401,140 @@ class TestDirectArrivalForecaster:
 
         # Should return None as the single sample exceeds MAX_SEGMENT_MINUTES
         assert result is None
+
+    def test_get_scheduled_segment_duration(self, forecaster, sample_stops):
+        """Test scheduled segment duration calculation between two stops."""
+        # sample_stops[1] (NP) has scheduled_departure, sample_stops[2] (TR) has scheduled_arrival
+        duration = forecaster._get_scheduled_segment_duration(
+            sample_stops[1], sample_stops[2]
+        )
+        assert duration is not None
+        assert duration.total_seconds() > 0
+
+    def test_get_scheduled_segment_duration_missing_times(self, forecaster):
+        """Test scheduled segment duration when times are missing."""
+        from_stop = StopDetails(
+            station=SimpleStationInfo(code="A", name="Station A"),
+            stop_sequence=0,
+            has_departed_station=False,
+            raw_status=RawStopStatus(),
+        )
+        to_stop = StopDetails(
+            station=SimpleStationInfo(code="B", name="Station B"),
+            stop_sequence=1,
+            has_departed_station=False,
+            raw_status=RawStopStatus(),
+        )
+        duration = forecaster._get_scheduled_segment_duration(from_stop, to_stop)
+        assert duration is None
+
+    @pytest.mark.asyncio
+    async def test_chain_preserves_delay_through_missing_segment(
+        self, forecaster, mock_journey
+    ):
+        """Test that accumulated delay is preserved when a segment lacks transit data.
+
+        When empirical data is missing for one segment, the chain should use the
+        scheduled segment duration to carry forward the delay, rather than resetting
+        to scheduled departure (which would lose the accumulated delay).
+
+        Scenario: Train departs NY 15 min late. NY→NP has no empirical data.
+        NP→TR has empirical data matching scheduled duration (~38 min).
+        The 15 min delay should propagate through the gap to TR.
+
+        Schedule:
+          NY depart: base-30  |  NP arrive: base-10, depart: base-8
+          TR arrive: base+30  |  PH arrive: base+60
+        Actual: NY depart: base-15 (15 min late)
+        """
+        base_time = now_et()
+
+        stops = [
+            StopDetails(
+                station=SimpleStationInfo(code="NY", name="New York"),
+                stop_sequence=0,
+                scheduled_departure=base_time - timedelta(minutes=30),
+                has_departed_station=True,
+                actual_departure=base_time - timedelta(minutes=15),  # 15 min late
+                raw_status=RawStopStatus(),
+            ),
+            StopDetails(
+                station=SimpleStationInfo(code="NP", name="Newark"),
+                stop_sequence=1,
+                scheduled_arrival=base_time - timedelta(minutes=10),
+                scheduled_departure=base_time - timedelta(minutes=8),
+                has_departed_station=False,
+                raw_status=RawStopStatus(),
+            ),
+            StopDetails(
+                station=SimpleStationInfo(code="TR", name="Trenton"),
+                stop_sequence=2,
+                scheduled_arrival=base_time + timedelta(minutes=30),
+                scheduled_departure=base_time + timedelta(minutes=32),
+                has_departed_station=False,
+                raw_status=RawStopStatus(),
+            ),
+            StopDetails(
+                station=SimpleStationInfo(code="PH", name="Philadelphia"),
+                stop_sequence=3,
+                scheduled_arrival=base_time + timedelta(minutes=60),
+                has_departed_station=False,
+                raw_status=RawStopStatus(),
+            ),
+        ]
+
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        # Segment NY→NP: NO data (returns empty)
+        # Segment NP→TR: HAS data with ~38 min transit (matches scheduled duration)
+        # Segment TR→PH: HAS data with ~28 min transit (matches scheduled duration)
+        call_count = [0]
+        def mock_execute(stmt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return []  # NY→NP: no data
+            elif call_count[0] == 2:
+                # NP→TR: 38 min transit (matches scheduled NP dep→TR arr)
+                return [
+                    MagicMock(departure_time=base_time - timedelta(hours=1, minutes=8), arrival_time=base_time - timedelta(minutes=30), from_sequence=1, to_sequence=2, journey_id=1),
+                    MagicMock(departure_time=base_time - timedelta(hours=2, minutes=8), arrival_time=base_time - timedelta(hours=1, minutes=30), from_sequence=1, to_sequence=2, journey_id=2),
+                    MagicMock(departure_time=base_time - timedelta(hours=3, minutes=8), arrival_time=base_time - timedelta(hours=2, minutes=30), from_sequence=1, to_sequence=2, journey_id=3),
+                ]
+            else:
+                # TR→PH: 28 min transit (matches scheduled TR dep→PH arr)
+                return [
+                    MagicMock(departure_time=base_time - timedelta(hours=1, minutes=32), arrival_time=base_time - timedelta(hours=1, minutes=4), from_sequence=2, to_sequence=3, journey_id=4),
+                    MagicMock(departure_time=base_time - timedelta(hours=2, minutes=32), arrival_time=base_time - timedelta(hours=2, minutes=4), from_sequence=2, to_sequence=3, journey_id=5),
+                    MagicMock(departure_time=base_time - timedelta(hours=3, minutes=32), arrival_time=base_time - timedelta(hours=3, minutes=4), from_sequence=2, to_sequence=3, journey_id=6),
+                ]
+
+        mock_db.execute = AsyncMock(side_effect=mock_execute)
+
+        await forecaster.add_predictions_to_stops(
+            mock_db, mock_journey, stops, user_origin="NY"
+        )
+
+        # NP has no empirical data, so no prediction shown for it
+        assert stops[1].predicted_arrival is None
+
+        # TR should have a prediction reflecting the propagated delay.
+        # Chain: actual_dep(NY)=base-15, gap NY→NP uses scheduled 20min → base+5,
+        # _calculate_next_departure at NP: max(sched_dep=base-8, base+5) = base+5,
+        # empirical NP→TR = 38min → predicted_arr(TR) = base+43
+        # scheduled_arr(TR) = base+30 → delay = 13min
+        assert stops[2].predicted_arrival is not None, "TR should have a prediction"
+        scheduled_arrival_tr = base_time + timedelta(minutes=30)
+        predicted_delay_tr = (stops[2].predicted_arrival - scheduled_arrival_tr).total_seconds() / 60
+        assert predicted_delay_tr > 10, (
+            f"Expected ~13 min delay at TR (from 15min late departure) but got "
+            f"{predicted_delay_tr:.1f}min. Chain may have reset to schedule."
+        )
+
+        # PH should also have a prediction with similar delay
+        assert stops[3].predicted_arrival is not None, "PH should have a prediction"
+        scheduled_arrival_ph = base_time + timedelta(minutes=60)
+        predicted_delay_ph = (stops[3].predicted_arrival - scheduled_arrival_ph).total_seconds() / 60
+        assert predicted_delay_ph > 10, (
+            f"Expected ~13 min delay at PH but got {predicted_delay_ph:.1f}min. "
+            f"Delay not propagated through chain."
+        )

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -256,27 +256,19 @@ struct CombinedDetailsCard: View {
         return formatter.string(from: train.departureTime)
     }
         
-    // Check if predictions should be shown for the entire journey
+    // Check if predictions should be shown for the entire journey.
+    // Shows predictions when any stop in the journey has a meaningful predicted delay.
     private var shouldShowJourneyPredictions: Bool {
-        // Find the user's destination stop by CODE (reliable matching)
-        guard let destinationCode = selectedDestinationCode,
-              let destinationStop = displayableTrainStops.first(where: { stop in
-                  stop.stationCode.uppercased() == destinationCode.uppercased()
-              }) else {
-            return false
+        return displayableTrainStops.contains { stop in
+            guard let predictedArrival = stop.predictedArrival,
+                  let scheduledArrival = stop.scheduledArrival,
+                  let samples = stop.predictedArrivalSamples,
+                  samples > 0,
+                  !stop.hasDepartedStation else {
+                return false
+            }
+            return predictedArrival.timeIntervalSince(scheduledArrival) > 240
         }
-        
-        // Check if destination has significant predicted delay (≥4 minutes)
-        guard let predictedArrival = destinationStop.predictedArrival,
-              let scheduledArrival = destinationStop.scheduledArrival,
-              let samples = destinationStop.predictedArrivalSamples,
-              samples > 0,
-              !destinationStop.hasDepartedStation else {
-            return false
-        }
-        
-        let delaySeconds = predictedArrival.timeIntervalSince(scheduledArrival)
-        return delaySeconds > 240  // ≥4 minutes
     }
     
     // Helper functions for status display


### PR DESCRIPTION
## Summary
This PR improves delay propagation in the direct forecaster by preserving accumulated train delays when empirical transit data is unavailable for a segment, rather than resetting to scheduled times. It also refines the transit data query to only use actual arrival times (excluding schedule-based fallbacks) for more accurate predictions.

## Key Changes

**Backend - Delay Chain Preservation:**
- Modified `add_predictions_to_stops()` to use scheduled segment duration when empirical data is missing, allowing delays to propagate through gaps instead of being lost
- Added `_get_scheduled_segment_duration()` helper method to calculate transit time between consecutive stops using scheduled times
- Updated stale prediction handling to use current time as baseline (preserving implicit delay) instead of resetting to scheduled departure

**Backend - Transit Data Query Accuracy:**
- Changed `_get_segment_transit_time()` to only include trains with actual arrivals (`actual_arrival IS NOT NULL`), excluding schedule-based data from trains still en route
- Removed `coalesce()` fallback to `scheduled_arrival` in segment queries to prevent contamination of empirical samples
- Added explicit filter ensuring only completed segments (with non-NULL actual arrival) are included in calculations

**Frontend - Prediction Display Logic:**
- Simplified `shouldShowJourneyPredictions` in TrainDetailsView to check any stop in the journey (not just destination) for meaningful predicted delay
- Improved readability with clearer logic flow using `contains` instead of nested guard statements

## Testing
- Added comprehensive test `test_chain_preserves_delay_through_missing_segment()` validating that a 15-minute departure delay propagates through a segment with missing data and emerges at downstream stops
- Updated existing test expectations to reflect new behavior (current time vs. scheduled time for stale predictions)
- Added tests for the new `_get_scheduled_segment_duration()` method with both valid and missing time scenarios

## Impact
Trains with accumulated delays will now maintain those delays through segments lacking empirical data, providing more accurate predictions for the entire journey rather than resetting at data gaps.

https://claude.ai/code/session_01AmgBm8afzjZcTo21LrQzDy