### PR TITLE
Track train data source and expand skip-stop station gaps

### DIFF
--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -10,6 +10,7 @@ class LiveActivityService: ObservableObject {
     @Published var currentActivity: Activity<TrainActivityAttributes>?
     @Published var isActivityActive: Bool = false
     @Published var journeyStationCodes: [String] = []
+    @Published var journeyDataSource: String = ""
 
     private var updateTimer: Timer?
     private var pushTokenTask: Task<Void, Never>?
@@ -58,6 +59,11 @@ class LiveActivityService: ObservableObject {
         let estimatedDepartureTime = train.getEstimatedDepartureTime(fromStationCode: originCode)
         let estimatedArrivalTime = train.getEstimatedArrivalTime(toStationCode: destinationCode)
         let scheduledArrivalTime = train.getScheduledArrivalTime(toStationCode: destinationCode)
+
+        // Store data source for system filtering
+        await MainActor.run {
+            self.journeyDataSource = train.dataSource
+        }
 
         // Extract journey station codes from origin to destination using existing stops
         if let stops = train.stops {
@@ -207,6 +213,7 @@ class LiveActivityService: ObservableObject {
             self?.isActivityActive = false
             self?.currentPushToken = nil
             self?.journeyStationCodes = []
+            self?.journeyDataSource = ""
             self?.hasDepartedOrigin = false
         }
 

--- a/ios/TrackRat/Shared/RouteTopology.swift
+++ b/ios/TrackRat/Shared/RouteTopology.swift
@@ -346,6 +346,45 @@ struct RouteTopology {
         )
     ]
 
+    // MARK: - Station Expansion
+
+    /// Returns all station codes (inclusive) between two stations on a matching route.
+    /// Handles both forward and reverse direction. Returns nil if no route contains both stations.
+    static func getIntermediateStations(from: String, to: String, dataSource: String) -> [String]? {
+        for route in allRoutes where route.dataSource == dataSource {
+            guard let fromIndex = route.stationCodes.firstIndex(of: from),
+                  let toIndex = route.stationCodes.firstIndex(of: to) else {
+                continue
+            }
+            if fromIndex <= toIndex {
+                return Array(route.stationCodes[fromIndex...toIndex])
+            } else {
+                return Array(route.stationCodes[toIndex...fromIndex].reversed())
+            }
+        }
+        return nil
+    }
+
+    /// Expands a list of station codes to include all intermediate stations from route topology.
+    /// For each consecutive pair in the input, fills in any skipped stations.
+    static func expandStationCodes(_ stopCodes: [String], dataSource: String) -> [String] {
+        guard stopCodes.count >= 2 else { return stopCodes }
+
+        var expanded: [String] = []
+        for i in 0..<(stopCodes.count - 1) {
+            let intermediates = getIntermediateStations(
+                from: stopCodes[i], to: stopCodes[i + 1], dataSource: dataSource
+            ) ?? [stopCodes[i], stopCodes[i + 1]]
+
+            if expanded.isEmpty {
+                expanded.append(contentsOf: intermediates)
+            } else {
+                expanded.append(contentsOf: intermediates.dropFirst())
+            }
+        }
+        return expanded
+    }
+
     // MARK: - Unique Stations
 
     /// Returns all unique station codes across all routes (for station annotation rendering)

--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -123,24 +123,20 @@ class JourneyCongestionViewModel: ObservableObject {
             // Fetch congestion data
             let congestionData = try await APIService.shared.fetchCongestionData(timeWindowHours: 1)
             
-            // Determine expected data source based on train type
-            let expectedDataSource: String
-            if train.trainClass == "Amtrak" {
-                expectedDataSource = "AMTRAK"
-            } else {
-                expectedDataSource = "NJT"
-            }
-            
+            // Use train's actual data source for filtering
+            let expectedDataSource = train.dataSource
+
             // Filter segments to any valid forward path in the user's journey
-            let journeyStationCodes = getJourneyStationCodes()
-            print("🚦 Journey station codes: \(journeyStationCodes)")
+            // Expand skip-stop gaps using route topology so intermediate canonical segments match
+            let rawStationCodes = getJourneyStationCodes()
+            let journeyStationCodes = RouteTopology.expandStationCodes(rawStationCodes, dataSource: expectedDataSource)
+            print("🚦 Journey station codes: \(rawStationCodes) → expanded: \(journeyStationCodes)")
             print("🚦 Expected data source: \(expectedDataSource)")
             print("🚦 Total segments to filter: \(congestionData.aggregatedSegments.count)")
             
             filteredSegments = congestionData.aggregatedSegments.filter { segment in
-                // First check if data source matches train type
-                guard segment.dataSource.uppercased() == expectedDataSource else {
-                    print("🚦 ❌ Data source mismatch: \(segment.dataSource) != \(expectedDataSource)")
+                // First check if data source matches train's system
+                guard segment.dataSource == expectedDataSource else {
                     return false
                 }
                 
@@ -865,19 +861,17 @@ class EmbeddedCongestionViewModel: ObservableObject {
             // Fetch congestion data using existing API
             let congestionData = try await APIService.shared.fetchCongestionData(timeWindowHours: 1)
             
-            // Determine expected data source based on train type
-            let expectedDataSource: String
-            if train.trainClass == "Amtrak" {
-                expectedDataSource = "AMTRAK"
-            } else {
-                expectedDataSource = "NJT"
-            }
-            
+            // Use train's actual data source for filtering
+            let expectedDataSource = train.dataSource
+
             // Filter segments to user's journey path only
-            let journeyStationCodes = getJourneyStationCodes()
+            // Expand skip-stop gaps using route topology so intermediate canonical segments match
+            let rawStationCodes = getJourneyStationCodes()
+            let journeyStationCodes = RouteTopology.expandStationCodes(rawStationCodes, dataSource: expectedDataSource)
+
             let filteredSegments = congestionData.aggregatedSegments.filter { segment in
-                // Check if data source matches train type
-                guard segment.dataSource.uppercased() == expectedDataSource else {
+                // Check if data source matches train's system
+                guard segment.dataSource == expectedDataSource else {
                     return false
                 }
                 

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -502,6 +502,7 @@ class CongestionMapViewModel: ObservableObject {
     // Current journey filter
     private var selectedRoute: TripPair?
     private var journeyStations: [String] = []
+    private var journeyDataSource: String = ""
 
     // System filter
     private var selectedSystems: Set<TrainSystem> = .all
@@ -567,17 +568,20 @@ class CongestionMapViewModel: ObservableObject {
 
     private func handleLiveActivityStateChange(isActive: Bool, stationCodes: [String]) {
         if isActive && !stationCodes.isEmpty {
-            // Live Activity is active - apply route filter
+            // Live Activity is active - apply route filter with system lock
             if let activity = LiveActivityService.shared.currentActivity {
                 let attributes = activity.attributes
+                let dataSource = LiveActivityService.shared.journeyDataSource
                 let route = TripPair(
                     departureCode: attributes.originStationCode,
                     departureName: attributes.origin,
                     destinationCode: attributes.destinationStationCode,
                     destinationName: attributes.destination
                 )
-                setRouteFilter(route, journeyStations: stationCodes)
-                print("🗺️ Applied route filter for Live Activity: \(attributes.originStationCode) → \(attributes.destinationStationCode)")
+                // Expand skip-stop gaps so intermediate canonical segments match
+                let expandedCodes = RouteTopology.expandStationCodes(stationCodes, dataSource: dataSource)
+                setRouteFilter(route, journeyStations: expandedCodes, dataSource: dataSource)
+                print("🗺️ Applied route filter for Live Activity: \(attributes.originStationCode) → \(attributes.destinationStationCode) [\(dataSource)] (\(stationCodes.count) stops → \(expandedCodes.count) expanded)")
             }
         } else {
             // No active Live Activity - clear filter to show all segments
@@ -743,13 +747,26 @@ class CongestionMapViewModel: ObservableObject {
     }
 
     private func applyDisplayModeFilter() {
-        // Get raw values of selected systems for filtering
-        let selectedSystemStrings = selectedSystems.asRawStrings
+        // When route filter is active (Live Activity), lock to the journey's train system.
+        // Otherwise use the user's selected systems.
+        let effectiveSystems: Set<TrainSystem>
+        if selectedRoute != nil, !journeyDataSource.isEmpty,
+           let system = TrainSystem(rawValue: journeyDataSource) {
+            effectiveSystems = Set([system])
+        } else {
+            effectiveSystems = selectedSystems
+        }
+        let effectiveSystemStrings = effectiveSystems.asRawStrings
 
-        // First filter by selected systems
-        let systemFilteredAggregated = allAggregatedSegments.filter { selectedSystemStrings.contains($0.dataSource) }
-        let systemFilteredIndividual = allIndividualSegments.filter { selectedSystemStrings.contains($0.dataSource) }
-        let systemFilteredStations = allStations.filter { Stations.isStationVisible($0.code, withSystems: selectedSystems) }
+        // First filter by effective systems
+        let systemFilteredAggregated = allAggregatedSegments.filter { effectiveSystemStrings.contains($0.dataSource) }
+        let systemFilteredIndividual = allIndividualSegments.filter { effectiveSystemStrings.contains($0.dataSource) }
+        let systemFilteredStations = allStations.filter { Stations.isStationVisible($0.code, withSystems: effectiveSystems) }
+
+        // Update route station visibility to match effective systems
+        routeStations = allRouteStations.filter { station in
+            Stations.isStationVisible(station.code, withSystems: effectiveSystems)
+        }
 
         // Then apply route filter if we have one
         let filteredAggregated = selectedRoute != nil ? filterSegmentsForRoute(systemFilteredAggregated) : systemFilteredAggregated
@@ -782,12 +799,13 @@ class CongestionMapViewModel: ObservableObject {
         }
     }
     
-    func setRouteFilter(_ route: TripPair?, journeyStations: [String] = []) {
-        print("🚦 Setting route filter: \(route?.departureCode ?? "none") → \(route?.destinationCode ?? "none")")
+    func setRouteFilter(_ route: TripPair?, journeyStations: [String] = [], dataSource: String = "") {
+        print("🚦 Setting route filter: \(route?.departureCode ?? "none") → \(route?.destinationCode ?? "none") [\(dataSource)]")
         print("🚦 Journey stations: \(journeyStations)")
 
         self.selectedRoute = route
         self.journeyStations = journeyStations
+        self.journeyDataSource = dataSource
 
         // Re-apply filters with the new route
         applyDisplayModeFilter()


### PR DESCRIPTION
## Summary
This PR improves journey tracking and congestion map filtering by explicitly tracking each train's data source (AMTRAK or NJT) and expanding skip-stop station gaps to include intermediate canonical segments from the route topology.

## Key Changes

- **LiveActivityService**: Added `journeyDataSource` property to track and persist the active train's data source throughout the journey lifecycle
- **RouteTopology**: Introduced two new static methods:
  - `getIntermediateStations()`: Returns all stations (inclusive) between two points on a matching route
  - `expandStationCodes()`: Expands a list of station codes to include all intermediate stations, filling gaps from skip-stop service patterns
- **CongestionMapViewModel**: 
  - Now locks the system filter to the journey's train system when a Live Activity route filter is active
  - Expands skip-stop gaps before filtering segments so intermediate canonical segments match the journey
  - Updated `setRouteFilter()` to accept and store the data source parameter
- **JourneyCongestionMapView**: 
  - Uses train's actual `dataSource` property instead of inferring from train class
  - Expands station codes before filtering to match intermediate segments
  - Removed `.uppercased()` call for consistent data source comparison

## Implementation Details

The skip-stop expansion is critical for accurate congestion filtering: when a train skips intermediate stations, the congestion API still returns canonical segments for those stations. By expanding the journey's station list using route topology, we ensure these intermediate segments are properly included in the filtered results, providing users with complete congestion information for their actual journey path.

The data source is now explicitly tracked and passed through the filtering pipeline rather than inferred from train class, improving reliability and maintainability.

https://claude.ai/code/session_01UTQDiBTJxkn4kZLXCkXmx2