### PR TITLE
Optimize data fetching with batch queries and prefetching

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -760,7 +760,7 @@ async def get_operations_summary(
     - body: Detailed summary (2-4 sentences) for expanded view
     - metrics: Raw statistics for optional UI display
     """
-    from trackrat.services.summary import SummaryService
+    from trackrat.services.summary import summary_service
 
     logger.info(
         "get_operations_summary_request",
@@ -784,8 +784,6 @@ async def get_operations_summary(
                 status_code=400,
                 detail="train_id is required for train scope",
             )
-
-    summary_service = SummaryService()
 
     if scope == "network":
         summary = await summary_service.get_network_summary(db, data_source)

--- a/backend_v2/src/trackrat/services/direct_forecaster.py
+++ b/backend_v2/src/trackrat/services/direct_forecaster.py
@@ -7,10 +7,11 @@ It queries journey_stops directly to find how long recent trains took.
 """
 
 import statistics
+from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any
 
-from sqlalchemy import and_, case, distinct, func, select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.functions import coalesce
 from structlog import get_logger
@@ -108,6 +109,29 @@ class DirectArrivalForecaster:
             predictions_made = 0
             segments_processed = 0
 
+            # Collect station codes for batch query
+            route_station_codes = []
+            for s in stops[start_index:]:
+                try:
+                    route_station_codes.append(_get_station_code(s))
+                except AttributeError as e:
+                    logger.error(f"Failed to get station code: {e}")
+                    break
+
+            # Batch-fetch all segment transit times in one query
+            try:
+                all_transit_data = await self._get_all_segment_transit_times(
+                    db,
+                    route_station_codes,
+                    journey.data_source or "NJT",
+                    journey.line_code,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to batch-fetch transit data: {e}", exc_info=True
+                )
+                all_transit_data = {}
+
             # Process each segment from the starting point
             for i in range(start_index, len(stops) - 1):
                 segments_processed += 1
@@ -131,18 +155,8 @@ class DirectArrivalForecaster:
                     logger.debug(f"Skipping {to_code} - already departed")
                     continue
 
-                # Get transit time for this segment
-                try:
-                    transit_data = await self._get_segment_transit_time(
-                        db,
-                        from_code,
-                        to_code,
-                        journey.data_source or "NJT",
-                        journey.line_code,
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to get transit data: {e}", exc_info=True)
-                    transit_data = None
+                # Look up pre-fetched transit data for this segment
+                transit_data = all_transit_data.get((from_code, to_code))
 
                 if transit_data is None:
                     logger.debug(
@@ -199,6 +213,151 @@ class DirectArrivalForecaster:
                 train_id=journey.train_id if journey else None,
             )
 
+    async def _get_all_segment_transit_times(
+        self,
+        db: AsyncSession,
+        station_codes: list[str],
+        data_source: str,
+        line_code: str | None = None,
+    ) -> dict[tuple[str, str], dict[str, float]]:
+        """
+        Batch-fetch transit times for all consecutive station pairs in one query.
+
+        Instead of N-1 individual queries (one per segment), this fetches all
+        relevant stops in a single query and computes segment times in Python.
+
+        Args:
+            db: Database session
+            station_codes: Ordered list of station codes along the route
+            data_source: Train data source (NJT, AMTRAK, etc.)
+            line_code: Optional line code filter
+
+        Returns:
+            Dict mapping (from_station, to_station) to {"avg": float, "samples": int}.
+            Missing pairs (insufficient data) are omitted from the result.
+        """
+        if len(station_codes) < 2:
+            return {}
+
+        cutoff_time = now_et() - timedelta(hours=self.LOOKBACK_HOURS)
+        unique_codes = list(dict.fromkeys(station_codes))  # dedupe preserving order
+
+        # Single query: fetch all recent stops at relevant stations
+        stmt = (
+            select(
+                JourneyStop.journey_id,
+                JourneyStop.station_code,
+                JourneyStop.stop_sequence,
+                coalesce(
+                    JourneyStop.actual_departure, JourneyStop.scheduled_departure
+                ).label("departure_time"),
+                coalesce(
+                    JourneyStop.actual_arrival, JourneyStop.scheduled_arrival
+                ).label("arrival_time"),
+            )
+            .join(TrainJourney, JourneyStop.journey_id == TrainJourney.id)
+            .where(
+                and_(
+                    TrainJourney.data_source == data_source,
+                    JourneyStop.station_code.in_(unique_codes),
+                    # Narrow scan to recent journeys only
+                    TrainJourney.journey_date
+                    >= (now_et() - timedelta(days=1)).date(),
+                )
+            )
+        )
+
+        if line_code:
+            stmt = stmt.where(TrainJourney.line_code == line_code)
+
+        result = await db.execute(stmt)
+
+        # Group stops by journey_id
+        journeys_stops: dict[int, list] = defaultdict(list)
+        for row in result:
+            journeys_stops[row.journey_id].append(row)
+
+        # For each historical journey, compute transit times for each segment pair
+        segment_times: dict[tuple[str, str], list[float]] = defaultdict(list)
+
+        for journey_id, j_stops in journeys_stops.items():
+            # Build lookup: station_code -> (first stop for departure, last stop for arrival)
+            # This matches the original MIN/MAX semantics for handling duplicate stations
+            first_at: dict[str, Any] = {}  # earliest stop_sequence per station
+            last_at: dict[str, Any] = {}  # latest stop_sequence per station
+
+            for stop in j_stops:
+                code = stop.station_code
+                if code not in first_at or stop.stop_sequence < first_at[code].stop_sequence:
+                    first_at[code] = stop
+                if code not in last_at or stop.stop_sequence > last_at[code].stop_sequence:
+                    last_at[code] = stop
+
+            # Check each consecutive pair in the route
+            for i in range(len(station_codes) - 1):
+                from_code = station_codes[i]
+                to_code = station_codes[i + 1]
+
+                from_stop = first_at.get(from_code)
+                to_stop = last_at.get(to_code)
+
+                if not from_stop or not to_stop:
+                    continue
+
+                # Ensure from comes before to (same as original HAVING clause)
+                if from_stop.stop_sequence >= to_stop.stop_sequence:
+                    continue
+
+                # Check arrival recency (same as original cutoff filter)
+                if not to_stop.arrival_time:
+                    continue
+                arr_time = ensure_timezone_aware(to_stop.arrival_time)
+                if arr_time < cutoff_time:
+                    continue
+
+                # Compute transit time
+                if not from_stop.departure_time:
+                    continue
+                dep_time = ensure_timezone_aware(from_stop.departure_time)
+                minutes = (arr_time - dep_time).total_seconds() / 60.0
+
+                if 0 < minutes <= self.MAX_SEGMENT_MINUTES:
+                    segment_times[(from_code, to_code)].append(minutes)
+                    logger.debug(
+                        f"Found recent segment: {from_code}→{to_code} = {minutes:.1f}min "
+                        f"(arrived {to_stop.arrival_time})"
+                    )
+                else:
+                    logger.debug(
+                        f"Skipped unreasonable time: {minutes:.1f}min for {from_code}→{to_code}"
+                    )
+
+        # Convert to result format, only including pairs with sufficient samples
+        result_dict: dict[tuple[str, str], dict[str, float]] = {}
+        for i in range(len(station_codes) - 1):
+            pair = (station_codes[i], station_codes[i + 1])
+            times = segment_times.get(pair, [])
+            if len(times) >= self.MIN_SAMPLES:
+                result_dict[pair] = {
+                    "avg": statistics.median(times),
+                    "samples": len(times),
+                }
+            else:
+                logger.debug(
+                    f"Insufficient recent segments for {pair[0]}→{pair[1]}: "
+                    f"found {len(times)}, need {self.MIN_SAMPLES}"
+                )
+
+        logger.info(
+            "Batch segment query complete",
+            station_count=len(unique_codes),
+            segment_pairs=len(station_codes) - 1,
+            segments_with_data=len(result_dict),
+            total_journeys_scanned=len(journeys_stops),
+        )
+
+        return result_dict
+
     async def _get_segment_transit_time(
         self,
         db: AsyncSession,
@@ -208,142 +367,17 @@ class DirectArrivalForecaster:
         line_code: str | None = None,
     ) -> dict[str, float] | None:
         """
-        Calculate transit time from segments that completed recently.
+        Calculate transit time for a single segment.
 
-        A segment is considered "recent" if the arrival at the destination
-        station occurred within LOOKBACK_HOURS.
+        Delegates to the batch method for a single pair.
 
         Returns:
             Dict with 'avg' and 'samples' keys, or None if insufficient data
         """
-        cutoff_time = now_et() - timedelta(hours=self.LOOKBACK_HOURS)
-
-        # Single query that gets segment data and filters on arrival time
-        stmt = (
-            select(
-                JourneyStop.journey_id,
-                func.min(
-                    case(
-                        (
-                            JourneyStop.station_code == from_station,
-                            JourneyStop.stop_sequence,
-                        )
-                    )
-                ).label("from_sequence"),
-                func.max(
-                    case(
-                        (
-                            JourneyStop.station_code == from_station,
-                            coalesce(
-                                JourneyStop.actual_departure,
-                                JourneyStop.scheduled_departure,
-                            ),
-                        )
-                    )
-                ).label("departure_time"),
-                func.max(
-                    case(
-                        (
-                            JourneyStop.station_code == to_station,
-                            JourneyStop.stop_sequence,
-                        )
-                    )
-                ).label("to_sequence"),
-                func.max(
-                    case(
-                        (
-                            JourneyStop.station_code == to_station,
-                            coalesce(
-                                JourneyStop.actual_arrival,
-                                JourneyStop.scheduled_arrival,
-                            ),
-                        )
-                    )
-                ).label("arrival_time"),
-            )
-            .join(TrainJourney, JourneyStop.journey_id == TrainJourney.id)
-            .where(
-                and_(
-                    TrainJourney.data_source == data_source,
-                    JourneyStop.station_code.in_([from_station, to_station]),
-                )
-            )
-            .group_by(JourneyStop.journey_id)
-            .having(
-                and_(
-                    func.count(distinct(JourneyStop.station_code)) == 2,
-                    # Ensure from comes before to
-                    func.min(
-                        case(
-                            (
-                                JourneyStop.station_code == from_station,
-                                JourneyStop.stop_sequence,
-                            )
-                        )
-                    )
-                    < func.max(
-                        case(
-                            (
-                                JourneyStop.station_code == to_station,
-                                JourneyStop.stop_sequence,
-                            )
-                        )
-                    ),
-                    # Key change: Filter on actual segment completion time
-                    func.max(
-                        case(
-                            (
-                                JourneyStop.station_code == to_station,
-                                coalesce(
-                                    JourneyStop.actual_arrival,
-                                    JourneyStop.scheduled_arrival,
-                                ),
-                            )
-                        )
-                    )
-                    >= cutoff_time,
-                )
-            )
+        results = await self._get_all_segment_transit_times(
+            db, [from_station, to_station], data_source, line_code
         )
-
-        # Add line filter if provided
-        if line_code:
-            stmt = stmt.where(TrainJourney.line_code == line_code)
-
-        result = await db.execute(stmt)
-        transit_times = []
-
-        for row in result:
-            if row.departure_time and row.arrival_time:
-                delta = ensure_timezone_aware(row.arrival_time) - ensure_timezone_aware(
-                    row.departure_time
-                )
-                minutes = delta.total_seconds() / 60.0
-
-                # Validate the time is reasonable (positive and not too long)
-                if 0 < minutes <= self.MAX_SEGMENT_MINUTES:
-                    transit_times.append(minutes)
-                    logger.debug(
-                        f"Found recent segment: {from_station}→{to_station} = {minutes:.1f}min "
-                        f"(arrived {row.arrival_time})"
-                    )
-                else:
-                    logger.debug(
-                        f"Skipped unreasonable time: {minutes:.1f}min for {from_station}→{to_station}"
-                    )
-
-        # Check if we have enough samples
-        if len(transit_times) >= self.MIN_SAMPLES:
-            return {
-                "avg": statistics.median(transit_times),
-                "samples": len(transit_times),
-            }
-
-        logger.debug(
-            f"Insufficient recent segments for {from_station}→{to_station}: "
-            f"found {len(transit_times)}, need {self.MIN_SAMPLES}"
-        )
-        return None
+        return results.get((from_station, to_station))
 
     def _determine_starting_point(
         self, stops: list[Any], user_origin: str | None

--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1396,3 +1396,6 @@ class SummaryService:
             body_parts.append(hist_text)
 
         return headline, " ".join(body_parts)
+
+
+summary_service = SummaryService()

--- a/backend_v2/tests/unit/test_direct_forecaster.py
+++ b/backend_v2/tests/unit/test_direct_forecaster.py
@@ -79,42 +79,67 @@ def sample_stops():
 
 @pytest.fixture
 def mock_db_with_segments():
-    """Create a mock database session with segment data."""
+    """Create a mock database session with per-stop row data.
+
+    The batch query in _get_all_segment_transit_times fetches raw per-stop rows
+    (journey_id, station_code, stop_sequence, departure_time, arrival_time)
+    and computes segment transit times in Python.
+    """
     mock_db = AsyncMock(spec=AsyncSession)
 
-    # Create properly structured mock rows for the database query
-    # These represent the aggregated results from the SQL query in _get_segment_transit_time
     base_time = now_et()
 
-    # The query returns aggregated data per journey with departure_time and arrival_time
+    # Raw per-stop rows: each journey has a departure from NP and arrival at TR.
+    # Arrival times must be within LOOKBACK_HOURS (1h) since the batch method
+    # applies the cutoff check in Python rather than SQL.
     mock_rows = [
-        # Journey 1: NP->TR segment (45 minutes)
+        # Journey 1: NP departure, then TR arrival (45 min transit)
         MagicMock(
-            departure_time=base_time - timedelta(hours=2, minutes=18),
-            arrival_time=base_time - timedelta(hours=1, minutes=33),
-            from_sequence=1,
-            to_sequence=2,
             journey_id=1,
+            station_code="NP",
+            stop_sequence=1,
+            departure_time=base_time - timedelta(minutes=55),
+            arrival_time=base_time - timedelta(minutes=57),
         ),
-        # Journey 2: NP->TR segment (46 minutes)
         MagicMock(
-            departure_time=base_time - timedelta(hours=3, minutes=18),
-            arrival_time=base_time - timedelta(hours=2, minutes=32),
-            from_sequence=1,
-            to_sequence=2,
+            journey_id=1,
+            station_code="TR",
+            stop_sequence=2,
+            departure_time=base_time - timedelta(minutes=8),
+            arrival_time=base_time - timedelta(minutes=10),
+        ),
+        # Journey 2: NP departure, then TR arrival (46 min transit)
+        MagicMock(
             journey_id=2,
+            station_code="NP",
+            stop_sequence=1,
+            departure_time=base_time - timedelta(minutes=56),
+            arrival_time=base_time - timedelta(minutes=58),
         ),
-        # Journey 3: NP->TR segment (45 minutes)
         MagicMock(
-            departure_time=base_time - timedelta(hours=4, minutes=20),
-            arrival_time=base_time - timedelta(hours=3, minutes=35),
-            from_sequence=1,
-            to_sequence=2,
+            journey_id=2,
+            station_code="TR",
+            stop_sequence=2,
+            departure_time=base_time - timedelta(minutes=8),
+            arrival_time=base_time - timedelta(minutes=10),
+        ),
+        # Journey 3: NP departure, then TR arrival (45 min transit)
+        MagicMock(
             journey_id=3,
+            station_code="NP",
+            stop_sequence=1,
+            departure_time=base_time - timedelta(minutes=55),
+            arrival_time=base_time - timedelta(minutes=57),
+        ),
+        MagicMock(
+            journey_id=3,
+            station_code="TR",
+            stop_sequence=2,
+            departure_time=base_time - timedelta(minutes=8),
+            arrival_time=base_time - timedelta(minutes=10),
         ),
     ]
 
-    # The result of `execute` is an iterable.
     mock_db.execute.return_value = mock_rows
     return mock_db
 
@@ -329,39 +354,38 @@ class TestDirectArrivalForecaster:
 
     @pytest.mark.asyncio
     async def test_coalesce_logic(self, forecaster):
-        """Test COALESCE logic (actual times preferred over scheduled)."""
+        """Test COALESCE logic (actual times preferred over scheduled).
+
+        The batch query uses COALESCE(actual, scheduled) at the SQL level.
+        Mock rows represent the coalesced values as raw per-stop data.
+        """
         mock_db = AsyncMock(spec=AsyncSession)
         base_time = now_et()
 
-        # Create aggregated results as returned by the SQL query
-        # The query COALESCEs actual times preferred over scheduled times
+        # Per-stop rows with coalesced departure/arrival times (30 min transit each).
+        # Arrival times within LOOKBACK_HOURS (1h) for the cutoff check.
         mock_rows = [
-            # Journey 1: Uses actual times (30 minutes)
-            MagicMock(
-                departure_time=base_time - timedelta(hours=1),  # actual departure
-                arrival_time=base_time - timedelta(minutes=30),  # actual arrival
-                from_sequence=1,
-                to_sequence=2,
-                journey_id=1,
-            ),
-            # Journey 2: Uses scheduled times (30 minutes)
-            MagicMock(
-                departure_time=base_time - timedelta(hours=2),  # scheduled departure
-                arrival_time=base_time
-                - timedelta(hours=1, minutes=30),  # scheduled arrival
-                from_sequence=1,
-                to_sequence=2,
-                journey_id=2,
-            ),
-            # Journey 3: Mixed times (30 minutes) - need 3 samples for MIN_SAMPLES
-            MagicMock(
-                departure_time=base_time - timedelta(hours=3),  # scheduled departure
-                arrival_time=base_time
-                - timedelta(hours=2, minutes=30),  # scheduled arrival
-                from_sequence=1,
-                to_sequence=2,
-                journey_id=3,
-            ),
+            # Journey 1: A departure, B arrival (30 min)
+            MagicMock(journey_id=1, station_code="A", stop_sequence=0,
+                      departure_time=base_time - timedelta(minutes=40),
+                      arrival_time=None),
+            MagicMock(journey_id=1, station_code="B", stop_sequence=1,
+                      departure_time=None,
+                      arrival_time=base_time - timedelta(minutes=10)),
+            # Journey 2: A departure, B arrival (30 min)
+            MagicMock(journey_id=2, station_code="A", stop_sequence=0,
+                      departure_time=base_time - timedelta(minutes=50),
+                      arrival_time=None),
+            MagicMock(journey_id=2, station_code="B", stop_sequence=1,
+                      departure_time=None,
+                      arrival_time=base_time - timedelta(minutes=20)),
+            # Journey 3: A departure, B arrival (30 min)
+            MagicMock(journey_id=3, station_code="A", stop_sequence=0,
+                      departure_time=base_time - timedelta(minutes=55),
+                      arrival_time=None),
+            MagicMock(journey_id=3, station_code="B", stop_sequence=1,
+                      departure_time=None,
+                      arrival_time=base_time - timedelta(minutes=25)),
         ]
 
         mock_db.execute.return_value = mock_rows
@@ -372,8 +396,7 @@ class TestDirectArrivalForecaster:
 
         assert result is not None
         assert result["samples"] == 3
-        # All three journeys should contribute (COALESCE uses actual when available)
-        assert result["avg"] == pytest.approx(30.0)  # Median of 30, 30, and 30 minutes
+        assert result["avg"] == pytest.approx(30.0)
 
     @pytest.mark.asyncio
     async def test_max_segment_minutes_filtering(self, forecaster):
@@ -381,16 +404,16 @@ class TestDirectArrivalForecaster:
         mock_db = AsyncMock(spec=AsyncSession)
         base_time = now_et()
 
-        # Create aggregated result with unreasonable transit time (2 hours = 120 minutes)
+        # Per-stop rows with unreasonable transit time (2 hours = 120 minutes)
         # This exceeds MAX_SEGMENT_MINUTES (60 minutes)
+        # B arrival within lookback window so it passes the cutoff check
         mock_rows = [
-            MagicMock(
-                departure_time=base_time - timedelta(hours=3),
-                arrival_time=base_time - timedelta(hours=1),  # 2 hours transit time!
-                from_sequence=1,
-                to_sequence=2,
-                journey_id=1,
-            ),
+            MagicMock(journey_id=1, station_code="A", stop_sequence=0,
+                      departure_time=base_time - timedelta(minutes=150),
+                      arrival_time=None),
+            MagicMock(journey_id=1, station_code="B", stop_sequence=1,
+                      departure_time=None,
+                      arrival_time=base_time - timedelta(minutes=30)),  # 120 min transit!
         ]
 
         mock_db.execute.return_value = mock_rows

--- a/ios/TrackRat/Views/Components/TrainStatsSummaryView.swift
+++ b/ios/TrackRat/Views/Components/TrainStatsSummaryView.swift
@@ -14,6 +14,8 @@ struct TrainStatsSummaryView: View {
     let journeyDate: Date?
     let showDepartureOdds: Bool
     let onTrainTap: ((String) -> Void)?
+    let prefetchedSummary: OperationsSummaryResponse?
+    let prefetchedForecast: DelayForecastResponse?
 
     @State private var summary: OperationsSummaryResponse?
     @State private var delayForecast: DelayForecastResponse?
@@ -22,13 +24,15 @@ struct TrainStatsSummaryView: View {
     @State private var hasError = false
     @Environment(\.scenePhase) private var scenePhase
 
-    init(trainId: String, fromStation: String?, toStation: String?, journeyDate: Date? = nil, showDepartureOdds: Bool = true, onTrainTap: ((String) -> Void)? = nil) {
+    init(trainId: String, fromStation: String?, toStation: String?, journeyDate: Date? = nil, showDepartureOdds: Bool = true, onTrainTap: ((String) -> Void)? = nil, prefetchedSummary: OperationsSummaryResponse? = nil, prefetchedForecast: DelayForecastResponse? = nil) {
         self.trainId = trainId
         self.fromStation = fromStation
         self.toStation = toStation
         self.journeyDate = journeyDate
         self.showDepartureOdds = showDepartureOdds
         self.onTrainTap = onTrainTap
+        self.prefetchedSummary = prefetchedSummary
+        self.prefetchedForecast = prefetchedForecast
     }
 
     var body: some View {
@@ -48,7 +52,13 @@ struct TrainStatsSummaryView: View {
             }
         }
         .task {
-            await fetchSummary()
+            if let prefetched = prefetchedSummary {
+                summary = prefetched
+                delayForecast = prefetchedForecast
+                isLoading = false
+            } else {
+                await fetchSummary()
+            }
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -109,7 +109,9 @@ struct TrainDetailsView: View {
                                                 dataSource: nil
                                             )
                                         )
-                                    }
+                                    },
+                                    prefetchedSummary: viewModel.prefetchedSummary,
+                                    prefetchedForecast: viewModel.prefetchedDelayForecast
                                 )
                             }
 
@@ -123,7 +125,8 @@ struct TrainDetailsView: View {
                                 journeyProgressPercentage: viewModel.journeyProgressPercentage,
                                 journeyStopsCompleted: viewModel.journeyStopsCompleted,
                                 journeyTotalStops: viewModel.journeyTotalStops,
-                                isLoadingStops: viewModel.isLoadingStops
+                                isLoadingStops: viewModel.isLoadingStops,
+                                prefetchedTrackPrediction: viewModel.prefetchedTrackPrediction
                             )
                         }
                         .padding()
@@ -239,6 +242,7 @@ struct CombinedDetailsCard: View {
     let journeyStopsCompleted: Int
     let journeyTotalStops: Int
     let isLoadingStops: Bool
+    let prefetchedTrackPrediction: PredictionData?
 
     private var departureTime: String {
         let formatter = DateFormatter()
@@ -401,7 +405,8 @@ struct CombinedDetailsCard: View {
                     if subscriptionService.isPro {
                         SegmentedTrackPredictionView(
                             train: train,
-                            isDepartingFromNYPenn: appState.departureStationCode == "NY"
+                            isDepartingFromNYPenn: appState.departureStationCode == "NY",
+                            prefetchedPredictions: prefetchedTrackPrediction
                         )
                         .allowsHitTesting(true)  // Ensure predictions card is interactive
                     } else {
@@ -794,7 +799,12 @@ class TrainDetailsViewModel: ObservableObject {
     @Published var error: String?
     @Published var triggerBoardingHaptic = false
     @Published var triggerTrackAssignedHaptic = false
-    
+
+    // Prefetched secondary data (loaded in parallel with main train fetch)
+    @Published var prefetchedSummary: OperationsSummaryResponse?
+    @Published var prefetchedDelayForecast: DelayForecastResponse?
+    @Published var prefetchedTrackPrediction: PredictionData?
+
     // Flexible initialization parameters
     private let databaseId: Int?
     let trainNumber: String?  // Made public for transaction tracking
@@ -976,6 +986,16 @@ class TrainDetailsViewModel: ObservableObject {
         print("🌐 No cache available - fetching from network")
         isLoading = true
 
+        // Start secondary data fetch in parallel (summary, delay forecast, track prediction)
+        let secondaryTask = Task {
+            await self.prefetchSecondaryData(
+                trainId: trainNumber ?? "",
+                fromStation: fromStationCode,
+                toStation: toStationCode,
+                journeyDate: journeyDate
+            )
+        }
+
         do {
             // Use the flexible API method with dataSource for disambiguation
             let fetchedTrain = try await apiService.fetchTrainDetailsFlexible(
@@ -996,7 +1016,11 @@ class TrainDetailsViewModel: ObservableObject {
             // Update all computed properties after setting train
             updateComputedProperties()
 
+            // Wait for secondary data before clearing loading state
+            await secondaryTask.value
+
         } catch {
+            secondaryTask.cancel()
             // Handle APIError.noData specifically
             if let apiError = error as? APIError {
                 switch apiError {
@@ -1117,6 +1141,50 @@ class TrainDetailsViewModel: ObservableObject {
             print("❌ Full error details: \(String(describing: error))")
         }
     }
+
+    /// Prefetch secondary data (summary, delay forecast, track prediction) in parallel.
+    /// Called concurrently with the main train fetch to eliminate the loading waterfall.
+    private func prefetchSecondaryData(trainId: String, fromStation: String?, toStation: String?, journeyDate: Date?) async {
+        guard !trainId.isEmpty else { return }
+
+        async let summaryResult: OperationsSummaryResponse? = {
+            try? await apiService.fetchOperationsSummary(
+                scope: .train,
+                fromStation: fromStation,
+                toStation: toStation,
+                trainId: trainId
+            )
+        }()
+
+        async let forecastResult: DelayForecastResponse? = {
+            guard let stationCode = fromStation, let date = journeyDate else { return nil }
+            return try? await apiService.getDelayForecast(
+                trainId: trainId,
+                stationCode: stationCode,
+                journeyDate: date
+            )
+        }()
+
+        async let trackResult: PredictionData? = {
+            guard let stationCode = fromStation,
+                  StaticTrackDistributionService.supportedStations.contains(stationCode),
+                  let date = journeyDate else { return nil }
+            do {
+                let prediction = try await apiService.getPlatformPrediction(
+                    stationCode: stationCode,
+                    trainId: trainId,
+                    journeyDate: date
+                )
+                return PredictionData(trackProbabilities: prediction.convertToTrackProbabilities())
+            } catch {
+                return nil
+            }
+        }()
+
+        prefetchedSummary = await summaryResult
+        prefetchedDelayForecast = await forecastResult
+        prefetchedTrackPrediction = await trackResult
+    }
 }
 
 // MARK: - Train Progress Indicator
@@ -1179,6 +1247,7 @@ struct TrainProgressIndicator: View {
 struct SegmentedTrackPredictionView: View {
     let train: TrainV2
     let isDepartingFromNYPenn: Bool
+    let prefetchedPredictions: PredictionData?
     @State private var adjustedPredictions: PredictionData?
     @State private var isLoadingPredictions = true
     @State private var showWaitingLink = false
@@ -1274,11 +1343,21 @@ struct SegmentedTrackPredictionView: View {
                     .stroke(Color.orange.opacity(0.3), lineWidth: 1)
             )
             .task {
-                await loadAdjustedPredictions()
+                if let prefetched = prefetchedPredictions, train.track == nil {
+                    adjustedPredictions = prefetched
+                    isLoadingPredictions = false
+                    if isDepartingFromNYPenn {
+                        withAnimation(.easeInOut(duration: 0.3).delay(0.2)) {
+                            showWaitingLink = true
+                        }
+                    }
+                } else {
+                    await loadAdjustedPredictions()
+                }
             }
         }
     }
-    
+
     private func loadAdjustedPredictions() async {
         print("🔄 [TrainDetailsView] Loading predictions for train \(train.trainId)")
         print("   - Origin: \(train.originStationCode ?? "nil" as String)")


### PR DESCRIPTION
## Summary
This PR improves application performance by implementing batch database queries and parallel data prefetching, eliminating N+1 query patterns and reducing loading waterfalls.

## Key Changes

### Backend Optimizations
- **Batch segment transit time queries**: Refactored `_get_segment_transit_time()` into `_get_all_segment_transit_times()` that fetches all consecutive station pairs in a single database query instead of N-1 individual queries. The method now:
  - Fetches raw per-stop rows for all relevant stations in one query
  - Computes segment transit times in Python using `defaultdict` for grouping
  - Maintains original SQL semantics (MIN/MAX for duplicate stations, cutoff filtering, validation)
  - Reduces database round-trips significantly for routes with many stops

- **Singleton SummaryService**: Changed `SummaryService` instantiation from per-request to a module-level singleton (`summary_service`) in `routes.py`, eliminating unnecessary object creation overhead

### iOS Client Optimizations
- **Parallel secondary data prefetching**: Added `prefetchSecondaryData()` method in `TrainDetailsViewModel` that concurrently fetches summary, delay forecast, and track prediction data alongside the main train fetch using `async let`
  - Eliminates sequential loading waterfall where secondary data was fetched after main train loaded
  - Passes prefetched data to child views via new optional parameters

- **Prefetch parameter propagation**: Updated view components to accept and use prefetched data:
  - `TrainStatsSummaryView`: Added `prefetchedSummary` and `prefetchedForecast` parameters
  - `SegmentedTrackPredictionView`: Added `prefetchedPredictions` parameter
  - `CombinedDetailsCard`: Added `prefetchedTrackPrediction` parameter
  - Views skip network requests when prefetched data is available

### Testing Updates
- Updated `test_direct_forecaster.py` mock fixtures to reflect the new batch query structure with per-stop rows instead of aggregated results
- Tests now properly simulate the Python-side grouping and computation logic

## Implementation Details
- The batch query maintains backward compatibility by keeping the single-segment `_get_segment_transit_time()` method as a thin wrapper around the batch method
- Prefetching uses `Task` to allow cancellation if the main fetch fails
- All prefetched data is optional, gracefully falling back to on-demand fetching if needed
- Database query optimization reduces from O(n) queries to O(1) for a route with n stops

https://claude.ai/code/session_01GTiXxGiVfTAYZ13JRx9FpS