### PR TITLE
Move debug section visibility logic to MyProfileView

### DIFF
--- a/ios/TrackRat/Views/Screens/AdvancedConfigurationView.swift
+++ b/ios/TrackRat/Views/Screens/AdvancedConfigurationView.swift
@@ -15,18 +15,6 @@ struct AdvancedConfigurationView: View {
     @State private var healthCheckResult: HealthCheckResult?
     @State private var isTestingConnection = false
 
-    /// Shows debug sections in DEBUG builds or TestFlight (but not App Store releases)
-    private var showDebugSections: Bool {
-        #if DEBUG
-        return true
-        #else
-        // Check if running in TestFlight by looking for sandbox receipt
-        // Note: In iOS 18+, prefer AppTransaction for receipt validation in production
-        guard let url = Bundle.main.appStoreReceiptURL else { return false }
-        return url.lastPathComponent == "sandboxReceipt"
-        #endif
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             TrackRatNavigationHeader(
@@ -37,12 +25,10 @@ struct AdvancedConfigurationView: View {
 
             ScrollView {
                 VStack(spacing: 24) {
-                    if showDebugSections {
-                        createSubscriptionDebugSection()
-                        createServerEnvironmentSection()
-                        createHealthCheckSection()
-                        createDebugToolsSection()
-                    }
+                    createSubscriptionDebugSection()
+                    createServerEnvironmentSection()
+                    createHealthCheckSection()
+                    createDebugToolsSection()
                     createDataManagementSection()
                 }
                 .padding()

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -618,7 +618,8 @@ struct SettingsSection: View {
             }
             .buttonStyle(.plain)
 
-            // Advanced Configuration
+            // Advanced Configuration (only shown in DEBUG/TestFlight builds)
+            if showDebugSections {
             Button {
                 navigationPath.append(ProfileDestination.advancedConfiguration)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -651,7 +652,18 @@ struct SettingsSection: View {
                 )
             }
             .buttonStyle(.plain)
+            }
         }
+    }
+
+    /// Shows debug sections in DEBUG builds or TestFlight (but not App Store releases)
+    private var showDebugSections: Bool {
+        #if DEBUG
+        return true
+        #else
+        guard let url = Bundle.main.appStoreReceiptURL else { return false }
+        return url.lastPathComponent == "sandboxReceipt"
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary
Refactored the debug section visibility logic by moving the `showDebugSections` computed property from `AdvancedConfigurationView` to `MyProfileView`, and updated `AdvancedConfigurationView` to always display all sections without conditional checks.

## Key Changes
- **Removed** `showDebugSections` computed property from `AdvancedConfigurationView`
- **Removed** conditional `if showDebugSections` wrapper around debug sections in `AdvancedConfigurationView`, making all sections always visible
- **Added** `showDebugSections` computed property to `SettingsSection` in `MyProfileView`
- **Added** conditional `if showDebugSections` check around the "Advanced Configuration" button in `MyProfileView` to control navigation access
- **Updated** comment in `MyProfileView` to clarify that Advanced Configuration is only shown in DEBUG/TestFlight builds

## Implementation Details
The visibility control is now enforced at the navigation level rather than within the destination view. This means:
- The Advanced Configuration screen is only accessible from MyProfileView in DEBUG/TestFlight builds
- Once accessed, the screen displays all debug sections without additional filtering
- The receipt validation logic (checking for `sandboxReceipt`) remains unchanged for TestFlight detection

https://claude.ai/code/session_01NoVhw6xRBi8j7odrjZMH3L