### PR TITLE
Update CLAUDE.md and README.md for LIRR/Metro-North integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ npm run build                        # TypeScript compile + build check
 - Handles both discovery and journey updates in one pass
 - Infers train origin from route when seen mid-journey
 
+**Backend Data Collection (LIRR / Metro-North - Unified GTFS-RT):**
+- Single unified collector per system runs every 4 minutes
+- Uses MTA's official GTFS-RT feeds directly (not Transiter)
+- Shared logic in `mta_common.py` (stop merging, departure inference, completion detection)
+- GTFS static schedules backfill stops that GTFS-RT omits (e.g., origin terminals)
+
 **Backend Data Collection (PATCO - Schedule-only):**
 - Uses GTFS static schedules from SEPTA feed
 - No real-time API available; times are scheduled only
@@ -202,6 +208,8 @@ terraform apply -var="environment=production"
 - Backend services: `backend_v2/src/trackrat/services/`
 - Backend API endpoints: `backend_v2/src/trackrat/api/`
 - Backend models: `backend_v2/src/trackrat/models/`
+- Backend collectors: `backend_v2/src/trackrat/collectors/` (njt, amtrak, path, lirr, mnr)
+- Backend config: `backend_v2/src/trackrat/config/` (stations, route_topology, station_configs)
 - Backend tests: `backend_v2/tests/`
 - iOS views: `ios/TrackRat/Views/Screens/`, `ios/TrackRat/Views/Components/`
 - iOS services: `ios/TrackRat/Services/`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Built primarily through AI-assisted development ("vibe coding").
 - **Live Activities**: Real-time iOS Lock Screen and Dynamic Island updates
 - **Congestion Maps**: Live network congestion monitoring
 - **Trip Statistics**: Commute history with on-time percentage and time saved metrics
-- **250+ Stations** across the Northeast Corridor
+- **1,000+ Stations** across the Northeast Corridor
 
 ## Architecture
 
@@ -45,7 +45,7 @@ Each transit system uses an architecture suited to its data source:
 - **NJ Transit / Amtrak**: Multi-phase pipeline — Schedule Generation (daily) → Discovery (30min) → Collection (15min) → JIT Updates (on-demand) → Validation (hourly)
 - **PATH**: Single unified collector every 4 minutes via native RidePATH API, discovers trains at all 13 stations
 - **PATCO**: GTFS static schedules (no real-time API available)
-- **LIRR / Metro-North**: Via Transiter API integration
+- **LIRR / Metro-North**: Unified collector every 4 minutes via MTA GTFS-RT feeds, with static schedule backfill
 
 ### Adding a New Transit System
 
@@ -122,8 +122,10 @@ TrackRat/
 ├── backend_v2/          # Python FastAPI backend
 │   ├── src/trackrat/
 │   │   ├── api/         # API endpoints (FastAPI routers)
+│   │   ├── collectors/  # Transit data collectors (njt, amtrak, path, lirr, mnr)
+│   │   ├── config/      # Station configs, route topology
 │   │   ├── models/      # SQLAlchemy + Pydantic models
-│   │   ├── services/    # Business logic, collectors, ML predictions
+│   │   ├── services/    # Business logic, ML predictions, scheduling
 │   │   └── main.py      # App entrypoint
 │   └── tests/           # pytest tests
 ├── ios/                 # Swift/SwiftUI iOS app
@@ -205,7 +207,7 @@ We welcome contributions. Here's how to get started:
 4. Run linting and tests (`make lint && make test`)
 5. Submit a pull request
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines (coming soon).
+See open issues for good starting points.
 
 ### Areas Where Help Is Wanted
 


### PR DESCRIPTION
- Add LIRR/MNR GTFS-RT data collection pattern to CLAUDE.md
- Add backend collectors and config to key file locations in CLAUDE.md
- Fix README: LIRR/MNR use GTFS-RT feeds, not Transiter API
- Fix README: station count from 250+ to 1,000+ (now includes LIRR/MNR)
- Fix README: project structure to show collectors/ and config/ directories
- Remove dead CONTRIBUTING.md reference from README

https://claude.ai/code/session_017BWHBVSNeQzJ4LpY9DnMFq