### PR TITLE
Update GCP log viewing docs with working REST API approach

### DIFF
--- a/.claude/scripts/gcp-logs.py
+++ b/.claude/scripts/gcp-logs.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Query GCP logs for TrackRat backend instances.
+
+Usage:
+    PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py [OPTIONS]
+
+Options:
+    --env staging|production   Environment to query (default: staging)
+    --filter FILTER            Additional log filter expression
+    --errors                   Show only severity>=ERROR
+    --warnings                 Show only severity>=WARNING
+    --search PATTERN           Search log messages for pattern
+    --limit N                  Max entries to return (default: 100)
+    --output FILE              Write output to file (for file-analyzer)
+    --raw                      Include Docker events (default: app logs only)
+
+Examples:
+    # Recent staging app logs
+    python3 .claude/scripts/gcp-logs.py
+
+    # Production errors
+    python3 .claude/scripts/gcp-logs.py --env production --errors
+
+    # Search for a pattern
+    python3 .claude/scripts/gcp-logs.py --search "departure_cache"
+
+    # Save output for file-analyzer
+    python3 .claude/scripts/gcp-logs.py --output /tmp/logs.txt
+
+    # Include raw Docker events too
+    python3 .claude/scripts/gcp-logs.py --raw
+"""
+
+import argparse
+import json
+import sys
+
+SA_KEY_PATH = "/root/.config/gcloud/service-account.json"
+PROJECT = "trackrat-v2"
+# Stable prefix — GCP MIG appends random suffixes (e.g. trackrat-staging-s565)
+HOSTNAME_PREFIX = {
+    "staging": "trackrat-staging-",
+    "production": "trackrat-production-",
+}
+
+
+def get_credentials():
+    from google.oauth2 import service_account
+    from google.auth.transport.requests import Request
+    import requests
+
+    with open(SA_KEY_PATH, "r") as f:
+        sa_info = json.loads(f.read(), strict=False)
+
+    credentials = service_account.Credentials.from_service_account_info(
+        sa_info, scopes=["https://www.googleapis.com/auth/logging.read"]
+    )
+    credentials.refresh(Request(session=requests.Session()))
+    return credentials.token
+
+
+def discover_instance_id(token, env):
+    """Find the GCE instance_id for an environment via hostname prefix match."""
+    import requests
+
+    prefix = HOSTNAME_PREFIX[env]
+    url = "https://logging.googleapis.com/v2/entries:list"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    body = {
+        "resourceNames": [f"projects/{PROJECT}"],
+        "filter": f'jsonPayload._HOSTNAME=~"^{prefix}"',
+        "orderBy": "timestamp desc",
+        "pageSize": 1,
+    }
+    resp = requests.post(url, json=body, headers=headers)
+    entries = resp.json().get("entries", [])
+    if entries:
+        e = entries[0]
+        hostname = e.get("jsonPayload", {}).get("_HOSTNAME", "")
+        instance_id = e.get("resource", {}).get("labels", {}).get("instance_id", "")
+        if hostname and instance_id:
+            return instance_id, hostname
+    return None, None
+
+
+def query_logs(token, log_filter, limit):
+    import requests
+
+    url = "https://logging.googleapis.com/v2/entries:list"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    body = {
+        "resourceNames": [f"projects/{PROJECT}"],
+        "filter": log_filter,
+        "orderBy": "timestamp desc",
+        "pageSize": limit,
+    }
+    resp = requests.post(url, json=body, headers=headers)
+    data = resp.json()
+    if "error" in data:
+        print(f"API error: {data['error'].get('message', data['error'])}", file=sys.stderr)
+        sys.exit(1)
+    return data.get("entries", [])
+
+
+def format_app_entry(entry):
+    """Format a cos_containers structured app log entry."""
+    ts = entry.get("timestamp", "?")[:19]
+    jp = entry.get("jsonPayload", {})
+    level = jp.get("level", "info").upper()
+    event = jp.get("event", "")
+    logger = jp.get("logger", "").replace("trackrat.", "")
+    message = jp.get("message", "")
+
+    # Build a readable summary from structured fields
+    detail_parts = []
+    if message:
+        detail_parts.append(message)
+    elif event:
+        detail_parts.append(event)
+
+    # Include key structured data if present
+    for key in ("task", "duration_ms", "route", "train_id", "error", "params"):
+        if key in jp and key != "event":
+            val = jp[key]
+            if isinstance(val, dict):
+                val = json.dumps(val, default=str)
+            detail_parts.append(f"{key}={val}")
+
+    detail = " | ".join(detail_parts)
+    prefix = f"[{ts}] {level}"
+    if logger:
+        prefix += f" [{logger}]"
+    return f"{prefix}: {detail[:400]}"
+
+
+def format_raw_entry(entry):
+    """Format a docker-events / system log entry."""
+    ts = entry.get("timestamp", "?")[:19]
+    severity = entry.get("severity", "DEFAULT")
+    text = entry.get("textPayload", "")
+    if not text:
+        jp = entry.get("jsonPayload", {})
+        text = jp.get("MESSAGE", jp.get("message", ""))
+        if not text and jp:
+            text = json.dumps(jp, default=str)[:500]
+    return f"[{ts}] {severity}: {text[:400]}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Query TrackRat GCP logs")
+    parser.add_argument("--env", choices=["staging", "production"], default="staging")
+    parser.add_argument("--filter", dest="extra_filter", default="")
+    parser.add_argument("--errors", action="store_true")
+    parser.add_argument("--warnings", action="store_true")
+    parser.add_argument("--search", default="")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument("--output", default="")
+    parser.add_argument("--raw", action="store_true", help="Include Docker events (noisy)")
+    args = parser.parse_args()
+
+    token = get_credentials()
+
+    # Discover instance
+    instance_id, hostname = discover_instance_id(token, args.env)
+    if not instance_id:
+        print(f"Could not find a running {args.env} instance.", file=sys.stderr)
+        sys.exit(1)
+    print(f"Instance: {hostname} ({instance_id})", file=sys.stderr)
+
+    # Build filter
+    parts = [f'resource.labels.instance_id="{instance_id}"']
+
+    if not args.raw:
+        # App logs only: cos_containers log with trackrat-api container
+        parts.append(f'logName="projects/{PROJECT}/logs/cos_containers"')
+
+    if args.errors:
+        if args.raw:
+            parts.append("severity>=ERROR")
+        else:
+            parts.append('jsonPayload.level="error"')
+    elif args.warnings:
+        if args.raw:
+            parts.append("severity>=WARNING")
+        else:
+            parts.append('(jsonPayload.level="error" OR jsonPayload.level="warning")')
+
+    if args.search:
+        # Search across event and message fields
+        parts.append(
+            f'(jsonPayload.event=~"{args.search}" OR jsonPayload.message=~"{args.search}"'
+            f' OR jsonPayload.MESSAGE=~"{args.search}")'
+        )
+
+    if args.extra_filter:
+        parts.append(args.extra_filter)
+
+    log_filter = " AND ".join(parts)
+    entries = query_logs(token, log_filter, args.limit)
+
+    formatter = format_raw_entry if args.raw else format_app_entry
+    lines = [formatter(e) for e in entries]
+
+    if args.output:
+        with open(args.output, "w") as f:
+            for line in lines:
+                f.write(line + "\n")
+        print(f"Wrote {len(entries)} entries to {args.output}", file=sys.stderr)
+    else:
+        print(f"--- {len(entries)} entries ---")
+        for line in lines:
+            print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,90 +205,76 @@ terraform apply -var="environment=production"
 
 ## GCP Log Viewing (Cloud Environment)
 
-The cloud environment has a read-only GCP service account (`roles/logging.viewer` on `trackrat-v2`). The SessionStart hook in `.claude/settings.json` writes the key to `/root/.config/gcloud/service-account.json` when `GCP_SA_KEY_JSON` is set (no-op locally).
-
-**Important:** The `gcloud` CLI cannot be installed in this environment (curl to `sdk.cloud.google.com` is blocked). Use the **Python REST API approach** below instead.
+The cloud environment has a read-only GCP service account (`roles/logging.viewer` on `trackrat-v2`). The SessionStart hook in `.claude/settings.json` writes `GCP_SA_KEY_JSON` to `/root/.config/gcloud/service-account.json`. This hook is required for authentication.
 
 ### Setup (once per session)
 
 ```bash
-# Install Python dependencies (cffi must go to /tmp to avoid conflict with system cryptography)
 pip install google-cloud-logging 2>&1 | tail -3
 pip install cffi cryptography --force-reinstall --target=/tmp/pylibs 2>&1 | tail -3
 ```
 
 ### Architecture
 
-- **Staging**: GCE instance `trackrat-staging-s565` running Docker Compose (not Cloud Run)
-- **Production**: GCE instance `trackrat-production-wwk7` running Docker Compose
-- **Resource type**: `gce_instance` (NOT `cloud_run_revision` for the main backend)
+- **Staging & Production**: GCE instances via Managed Instance Groups (Docker Compose, not Cloud Run)
+- **Hostnames**: `trackrat-staging-XXXX` / `trackrat-production-XXXX` (suffix is random, changes on instance recreation)
+- **Resource type**: `gce_instance` (NOT `cloud_run_revision`)
 - **Cloud Run services**: `feedback-notifier`, `train-follow-notifier` (auxiliary only)
-- **Containers on each GCE instance**: `trackrat-api` (FastAPI), PostgreSQL
-- **Log forwarding**: `docker-events-collector-fluent-bit` systemd service
+- **Containers**: `trackrat-api` (FastAPI), PostgreSQL
 
-### Query Logs (Python REST API)
+### Log Structure
 
-The service account JSON has literal newlines in the private key field — use `json.loads(content, strict=False)` to parse it.
+There are two log sources per GCE instance. **Always use `cos_containers` for app logs:**
 
-```python
-# Run with: PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 << 'PYEOF'
-import json, requests
-from google.oauth2 import service_account
-from google.auth.transport.requests import Request
+| Source | Log name | Key fields | Content |
+|--------|----------|------------|---------|
+| **App logs** | `cos_containers` | `jsonPayload.event`, `.level`, `.logger`, `.message` | Structured application logs from trackrat-api |
+| **Docker events** | (default/systemd) | `jsonPayload._HOSTNAME`, `.MESSAGE` | Container lifecycle noise (exec_create/die) — rarely useful |
 
-# Authenticate
-with open('/root/.config/gcloud/service-account.json', 'r') as f:
-    sa_info = json.loads(f.read(), strict=False)  # strict=False needed for literal \n in key
-credentials = service_account.Credentials.from_service_account_info(
-    sa_info, scopes=['https://www.googleapis.com/auth/logging.read']
-)
-credentials.refresh(Request(session=requests.Session()))
+### Query Logs (Helper Script)
 
-# Query
-url = "https://logging.googleapis.com/v2/entries:list"
-headers = {"Authorization": f"Bearer {credentials.token}", "Content-Type": "application/json"}
-body = {
-    "resourceNames": ["projects/trackrat-v2"],
-    "filter": '<FILTER_HERE>',
-    "orderBy": "timestamp desc",
-    "pageSize": 100,
-}
-resp = requests.post(url, json=body, headers=headers)
-entries = resp.json().get("entries", [])
+Use `.claude/scripts/gcp-logs.py` — handles auth, hostname discovery, and structured log formatting:
 
-for entry in entries:
-    ts = entry.get("timestamp", "?")[:19]
-    severity = entry.get("severity", "DEFAULT")
-    text = entry.get("textPayload", "")
-    if not text:
-        jp = entry.get("jsonPayload", {})
-        text = jp.get("message", json.dumps(jp, default=str)[:500]) if jp else ""
-    print(f"[{ts}] {severity}: {text[:400]}")
-# PYEOF
-```
+```bash
+# Recent staging app logs (default)
+PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py
 
-### Common Filters
-
-```python
-# Staging backend logs
-'resource.type="gce_instance" AND resource.labels.instance_id="1367060876182092510"'
-# Or by hostname in log content:
-'jsonPayload._HOSTNAME="trackrat-staging-s565"'
-
-# Production backend logs
-'jsonPayload._HOSTNAME="trackrat-production-wwk7"'
+# Production app logs
+PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --env production
 
 # Errors only
-'severity>=ERROR'
+PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --errors
 
-# Application logs (not Docker events)
-'jsonPayload.message=~".*" AND jsonPayload._HOSTNAME="trackrat-staging-s565"'
+# Search for a pattern (searches event + message fields)
+PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --search "departure_cache"
+
+# Save to file for file-analyzer sub-agent
+PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --output /tmp/logs.txt --limit 500
+
+# Include raw Docker events (noisy, rarely needed)
+PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
+```
+
+### Common Filters (for manual queries or --filter flag)
+
+```python
+# App logs (always use cos_containers for application-level logs)
+'logName="projects/trackrat-v2/logs/cos_containers"'
+
+# Discover instance by hostname prefix (prefixes are stable, suffixes change)
+'jsonPayload._HOSTNAME=~"^trackrat-staging-"'
+'jsonPayload._HOSTNAME=~"^trackrat-production-"'
+
+# App-level errors/warnings (structured field, not severity)
+'jsonPayload.level="error"'
+'jsonPayload.level="warning"'
+
+# Search app events or messages
+'jsonPayload.event=~"departure_cache"'
+'jsonPayload.message=~"some pattern"'
 
 # Time range
 'timestamp>="2025-01-01T00:00:00Z" AND timestamp<="2025-01-02T00:00:00Z"'
-
-# Text search
-'jsonPayload.message=~"some pattern"'
 
 # Cloud Run auxiliary services
 'resource.type="cloud_run_revision" AND resource.labels.service_name="train-follow-notifier"'
@@ -296,10 +282,11 @@ for entry in entries:
 
 ### Tips
 
-- **Always use the file-analyzer sub-agent** to process raw log output — GCE Docker logs are very verbose with system-level noise.
-- The grpc transport fails in this environment (SSL cert issues). Always use the REST approach above.
-- Logs from staging and production are in the same project — always filter by hostname.
-- Save query output to a file and pass to file-analyzer to keep the main context clean.
+- **Use the helper script first** — it handles hostname discovery and formats structured logs cleanly.
+- **Use file-analyzer sub-agent** for large result sets — save with `--output` then pass to file-analyzer.
+- `gcloud` CLI cannot be installed (blocked). grpc transport fails (SSL cert issues). Always use REST API.
+- Staging and production logs share the same GCP project — always filter by instance.
+- Service account JSON has literal `\n` in private_key — use `json.loads(content, strict=False)`.
 
 ## Key File Locations
 


### PR DESCRIPTION
The gcloud CLI and grpc transport don't work in the cloud
environment. Replace with Python REST API instructions, correct
resource types (gce_instance not cloud_run_revision), hostnames
for staging/production, and common filter examples.

https://claude.ai/code/session_01ECHL2rKgbs8uDRZWnWGGr8