### PR TITLE
Add PM execution tracker and first standup notes

### DIFF
--- a/PM.md
+++ b/PM.md
@@ -1,0 +1,116 @@
+# PM.md — TrackRat Execution Tracker
+
+> Last updated: 2026-02-08
+
+## Role
+
+The PM (Claude) translates the CEO's strategic plan into daily executable work. This document tracks sprint-level execution against the phases approved by the board on 2026-02-06. See `CEO.md` for strategic context and `board-meetings/` for governance decisions.
+
+Daily standup notes are recorded in `standup-notes/`.
+
+---
+
+## Current Phase: Phase 1 — Fix the Funnel, Open-Source Prep & Launch
+
+**Board target:** Week of Feb 9, 2026
+**Status:** In progress — backend stabilization complete, prep work remains
+
+### Phase 1 Execution Checklist
+
+#### 1.1 Landing Page Overhaul (#408)
+
+| Task | Owner | Status |
+|------|-------|--------|
+| Take 6-8 iPhone screenshots | Andy | Not started |
+| Record 30-second screen recording | Andy | Not started |
+| Gather 2-3 user testimonials | Andy | Not started |
+| Redesign trackrat.net (hero, App Store badge, GitHub link, FAQ, SEO) | Claude | Not started |
+| Add structured data (JSON-LD) | Claude | Not started |
+| Add App Store smart banner meta tag | Claude | Not started |
+
+#### 1.2 App Store Optimization (#409)
+
+| Task | Owner | Status |
+|------|-------|--------|
+| Update keywords | Andy | Not started |
+| Update subtitle | Andy | Not started |
+| Upload screenshots with text overlays | Andy | Not started |
+| Write keyword-rich description | Andy | Not started |
+| Add 30-second App Preview video | Andy | Not started |
+
+#### 1.3 Open-Source Prep (#339)
+
+| Task | Owner | Status |
+|------|-------|--------|
+| Merge PR #368 (LIRR + Metro-North) | Claude | Done |
+| Stabilize LIRR/MNR collectors (bug fixes) | Claude | Done |
+| Move Android to separate private repo (#410) | Andy/Claude | Not started |
+| Complete #339 (secrets audit, CORS, env docs) | Claude | Not started |
+| License: Apache 2.0 | Joint | Done (resolved 2026-02-06) |
+| Write README.md | Claude | Not started |
+| Write CONTRIBUTING.md | Claude | Not started |
+| Clean up repo (dead code, TODOs) | Claude | Not started |
+| Build sharing deep links (#411) | Claude | Not started |
+| Resolve Dependabot alerts (3 alerts) | Claude | Not started |
+
+#### 1.4 Open-Source Launch & Growth (#412)
+
+| Task | Owner | Status |
+|------|-------|--------|
+| Landing page live with open-source framing | Claude | Blocked (1.1) |
+| Sharing deep links functional | Claude | Blocked (1.3) |
+| Web app footer link to GitHub | Claude | Not started |
+| Make repo public | Andy | Blocked (1.3) |
+| Reddit posts (r/NJTransit, r/nycrail, etc.) | Andy | Blocked (launch) |
+| Show HN post | Andy | Blocked (launch) |
+| Press outreach | Andy | Blocked (launch) |
+
+---
+
+## What's Been Done
+
+Recent work (last 7 days) has focused on backend stability for LIRR/Metro-North:
+
+- Merged PR #368 (LIRR + Metro-North support)
+- Fixed MNR direction inference for inbound trains stuck as SCHEDULED
+- Fixed unique_journey_stop constraint violations in MNR/LIRR collectors
+- Fixed MNR train ID prefix mismatch
+- Fixed LIRR route topology errors on 4 branches
+- Fixed GTFS backfill edge cases (all-unmapped stops, missing origin stop)
+- Fixed MNR/LIRR collector MissingGreenlet crash and congestion data gaps
+- Fixed NULL station_code crash and session poisoning
+- Added GCP log query helper script
+
+---
+
+## Blockers
+
+1. **Andy's content tasks** — Screenshots, videos, testimonials needed before landing page can ship. These are blocking 1.1 and by extension 1.4.
+2. **Android repo move** — Needs to happen before repo goes public. Requires Andy's GitHub access or joint coordination.
+3. **Secrets audit (#339)** — Must verify no API keys, credentials, or sensitive config leak when repo goes public.
+
+---
+
+## Standup Format
+
+Daily standups are recorded in `standup-notes/YYYY-MM-DD.md`. Format:
+
+```
+# Standup — YYYY-MM-DD
+
+## Yesterday
+- What got done
+
+## Today
+- What we'll work on
+
+## Blockers
+- What's in the way
+
+## Decisions Needed
+- Questions for Andy
+```
+
+---
+
+*This is a living document maintained by the PM (Claude). Updated at each standup.*

--- a/standup-notes/2026-02-08.md
+++ b/standup-notes/2026-02-08.md
@@ -1,0 +1,56 @@
+# Standup — 2026-02-08 (Sunday)
+
+**Phase:** 1 — Open-Source Prep & Launch
+**Target:** Week of Feb 9 (tomorrow)
+
+## Yesterday
+
+- Stabilized LIRR/MNR backend collectors (direction inference, constraint violations, route topology, GTFS backfill edge cases)
+- All LIRR/MNR bug fix branches merged to main
+- PR #368 work complete — 6 transit systems now operational
+
+## Today — Proposed Plan
+
+The open-source launch target is tomorrow's week. Here's what Claude can tackle today, ordered by launch-criticality:
+
+### Critical Path (blocks going public)
+
+1. **Secrets audit (#339)** — Scan the entire repo for hardcoded API keys, credentials, connection strings, or sensitive config. This is the #1 blocker for making the repo public.
+
+2. **README.md** — Write a proper open-source README: what TrackRat is, architecture overview, getting started, supported transit systems, screenshots/demo, contributing link, license.
+
+3. **CONTRIBUTING.md** — Contributor guide: how to set up dev environment, how to add a transit system, PR process, code style, testing requirements.
+
+4. **Dependabot alerts** — Resolve the 3 alerts (2 high, 1 moderate) before the repo goes public.
+
+5. **Repo cleanup** — Scan for dead code, embarrassing TODOs, debug prints, commented-out code blocks.
+
+### Important but Not Blocking
+
+6. **Web app GitHub footer link** — Add a link to the GitHub repo in the web app footer. Quick win.
+
+7. **Sharing deep links (#411)** — Enable users to share specific train/route links. Helps with launch virality.
+
+### Needs Andy
+
+8. **Android repo move (#410)** — Need Andy to create the private repo or grant access.
+
+9. **Landing page content** — Screenshots, video, testimonials are Andy's tasks. Can't ship 1.1 without them.
+
+10. **App Store Optimization** — Entirely Andy's domain (keywords, subtitle, description, preview video).
+
+## Blockers
+
+- **Andy's availability** — Multiple tasks require Andy's input or action (screenshots, Android move, ASO). Need to confirm what Andy can deliver today/this week.
+- **Landing page design** — Can scaffold the code, but hero content (video, screenshots, testimonials) comes from Andy.
+
+## Decisions Needed from Andy
+
+1. **Priority call:** Should Claude start with secrets audit + README + CONTRIBUTING today? That would clear the critical path for going public.
+2. **Android move:** Can you create the private repo today, or should we just remove the Android directory from this repo for now?
+3. **Landing page:** Do you have any screenshots/video ready, or should we ship a text-only version first and add media later?
+4. **Launch day:** Is Monday Feb 9 still the target, or are we looking at mid-week?
+
+---
+
+*First standup. Going forward these will be shorter as we establish a rhythm.*


### PR DESCRIPTION
## Summary

Introduce project management documentation to track Phase 1 execution against the board-approved strategic plan. This establishes a living PM document and daily standup cadence to coordinate work across the open-source launch initiative.

## Changes

- **PM.md** — New project management document that:
  - Translates the CEO's strategic plan into executable Phase 1 work
  - Tracks 4 major workstreams (landing page, App Store optimization, open-source prep, launch & growth)
  - Documents task ownership, status, and blockers
  - Summarizes recent backend stabilization work (LIRR/Metro-North)
  - Establishes standup format and cadence

- **standup-notes/2026-02-08.md** — First daily standup that:
  - Recaps completed backend work (PR #368 merged, 6 transit systems operational)
  - Proposes a prioritized plan for the critical path to going public (secrets audit, README, CONTRIBUTING, Dependabot)
  - Identifies blockers (Andy's content tasks, Android repo move, secrets audit)
  - Surfaces key decisions needed from Andy (priority, Android move timing, landing page content readiness, launch date confirmation)

## Implementation Details

- PM.md references `CEO.md` for strategic context and `board-meetings/` for governance decisions, establishing a clear document hierarchy
- Execution checklist uses GitHub issue numbers (#408, #409, etc.) for traceability
- Standup format is intentionally lightweight to encourage daily updates without friction
- Critical path clearly separates blocking work (secrets audit, README, CONTRIBUTING) from important-but-not-blocking work (deep links, footer link)

This establishes the operational cadence for Phase 1 execution targeting the week of Feb 9, 2026.

https://claude.ai/code/session_01HMRxMMwFE2rdgQWo35Gapo