### PR TITLE
Exclude internal routers from OpenAPI schema

### DIFF
--- a/backend_v2/src/trackrat/main.py
+++ b/backend_v2/src/trackrat/main.py
@@ -179,13 +179,13 @@ async def suppress_health_check_logs(
 
 
 # Include routers
-app.include_router(feedback.router)
-app.include_router(health.router)
-app.include_router(live_activities.router)
+app.include_router(feedback.router, include_in_schema=False)
+app.include_router(health.router, include_in_schema=False)
+app.include_router(live_activities.router, include_in_schema=False)
 app.include_router(predictions.router)
 app.include_router(routes.router)
 app.include_router(trains.router)
-app.include_router(validation.router)
+app.include_router(validation.router, include_in_schema=False)
 
 # Mount Prometheus metrics endpoint if enabled
 settings = get_settings()


### PR DESCRIPTION
## Summary
This change excludes internal utility routers from the OpenAPI/Swagger documentation schema by adding `include_in_schema=False` to their router inclusions.

## Key Changes
- Added `include_in_schema=False` to the following routers:
  - `feedback.router`
  - `health.router`
  - `live_activities.router`
  - `validation.router`

- Left the following routers included in the schema (public API):
  - `predictions.router`
  - `routes.router`
  - `trains.router`

## Details
These internal routers are utility/support endpoints that don't need to be exposed in the public API documentation. By excluding them from the OpenAPI schema, the generated API documentation will be cleaner and focused only on the primary API endpoints that external consumers should interact with.

https://claude.ai/code/session_01LAKFQihbnKWTP3icDN1Zzg