### PR TITLE
Fix 4 staging bugs: Amtrak tz mismatch, NJT deadlock cascade, greenlet lazy load, forecaster null check

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -255,9 +255,11 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
         """
         new_train_ids = set()
 
+        # Process each train inside a savepoint so one failure
+        # doesn't poison the session for subsequent trains.
         for train_data in trains_data:
             try:
-                # Extract key fields
+                # Extract key fields (no DB access - safe outside savepoint)
                 train_id = train_data.get("TRAIN_ID", "").strip()
                 if not train_id:
                     continue
@@ -283,91 +285,92 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                 scheduled_departure = parse_njt_time(sched_dep_str)
                 journey_date = scheduled_departure.date()
 
-                # Check if journey already exists
-                stmt = select(TrainJourney).where(
-                    TrainJourney.train_id == train_id,
-                    TrainJourney.journey_date == journey_date,
-                    TrainJourney.data_source == "NJT",
-                )
-                existing = await session.scalar(stmt)
+                async with session.begin_nested():
+                    # Check if journey already exists
+                    stmt = select(TrainJourney).where(
+                        TrainJourney.train_id == train_id,
+                        TrainJourney.journey_date == journey_date,
+                        TrainJourney.data_source == "NJT",
+                    )
+                    existing = await session.scalar(stmt)
 
-                if existing:
-                    # Re-activate expired trains that reappear in discovery
-                    if existing.is_expired:
-                        existing.is_expired = False
-                        existing.api_error_count = 0
-                        logger.info(
-                            "reactivated_expired_train",
-                            train_id=train_id,
-                            journey_date=journey_date,
-                        )
+                    if existing:
+                        # Re-activate expired trains that reappear in discovery
+                        if existing.is_expired:
+                            existing.is_expired = False
+                            existing.api_error_count = 0
+                            logger.info(
+                                "reactivated_expired_train",
+                                train_id=train_id,
+                                journey_date=journey_date,
+                            )
 
-                    # Update last seen time
-                    existing.last_updated_at = now_et()
+                        # Update last seen time
+                        existing.last_updated_at = now_et()
 
-                    # Mark as observed if it was previously scheduled
-                    if existing.observation_type == "SCHEDULED":
-                        existing.observation_type = "OBSERVED"
-                        logger.info(
-                            "upgraded_scheduled_to_observed",
-                            train_id=train_id,
-                            journey_date=journey_date,
-                        )
+                        # Mark as observed if it was previously scheduled
+                        if existing.observation_type == "SCHEDULED":
+                            existing.observation_type = "OBSERVED"
+                            logger.info(
+                                "upgraded_scheduled_to_observed",
+                                train_id=train_id,
+                                journey_date=journey_date,
+                            )
+
+                        # Update track directly in journey stop
+                        track = train_data.get("TRACK")
+                        if track and station_code:
+                            await self._update_stop_track_if_needed(
+                                session, existing, station_code, track
+                            )
+
+                        continue
+
+                    # Create new journey
+                    # NOTE: We temporarily use the discovery station as origin, but this might be
+                    # an intermediate stop. The journey collector will correct this when it fetches
+                    # the full journey details (see journey.py lines 685-694).
+                    journey = TrainJourney(
+                        train_id=train_id,
+                        journey_date=journey_date,
+                        line_code=train_data.get("LINE", "").strip()[:2],
+                        line_name=train_data.get("LINE_NAME", ""),
+                        destination=train_data.get("DESTINATION", "").strip(),
+                        origin_station_code=station_code,  # May be wrong - journey collector will fix
+                        terminal_station_code=station_code,  # Will be updated later
+                        scheduled_departure=scheduled_departure,  # May be wrong - journey collector will fix
+                        data_source="NJT",
+                        observation_type="OBSERVED",  # Real-time discovery data
+                        first_seen_at=now_et(),
+                        last_updated_at=now_et(),
+                        has_complete_journey=False,
+                        update_count=1,
+                    )
+
+                    # Extract line color if available
+                    if "BACKCOLOR" in train_data:
+                        journey.line_color = train_data["BACKCOLOR"].strip()
+
+                    session.add(journey)
+                    await session.flush()  # Ensure journey has ID before creating stops
+                    new_train_ids.add(train_id)
 
                     # Update track directly in journey stop
                     track = train_data.get("TRACK")
                     if track and station_code:
                         await self._update_stop_track_if_needed(
-                            session, existing, station_code, track
+                            session, journey, station_code, track
                         )
 
-                    continue
-
-                # Create new journey
-                # NOTE: We temporarily use the discovery station as origin, but this might be
-                # an intermediate stop. The journey collector will correct this when it fetches
-                # the full journey details (see journey.py lines 685-694).
-                journey = TrainJourney(
-                    train_id=train_id,
-                    journey_date=journey_date,
-                    line_code=train_data.get("LINE", "").strip()[:2],
-                    line_name=train_data.get("LINE_NAME", ""),
-                    destination=train_data.get("DESTINATION", "").strip(),
-                    origin_station_code=station_code,  # May be wrong - journey collector will fix
-                    terminal_station_code=station_code,  # Will be updated later
-                    scheduled_departure=scheduled_departure,  # May be wrong - journey collector will fix
-                    data_source="NJT",
-                    observation_type="OBSERVED",  # Real-time discovery data
-                    first_seen_at=now_et(),
-                    last_updated_at=now_et(),
-                    has_complete_journey=False,
-                    update_count=1,
-                )
-
-                # Extract line color if available
-                if "BACKCOLOR" in train_data:
-                    journey.line_color = train_data["BACKCOLOR"].strip()
-
-                session.add(journey)
-                await session.flush()  # Ensure journey has ID before creating stops
-                new_train_ids.add(train_id)
-
-                # Update track directly in journey stop
-                track = train_data.get("TRACK")
-                if track and station_code:
-                    await self._update_stop_track_if_needed(
-                        session, journey, station_code, track
+                    logger.debug(
+                        "new_journey_discovered",
+                        train_id=train_id,
+                        journey_date=journey_date,
+                        line=journey.line_code,
+                        destination=journey.destination,
+                        departure=scheduled_departure.isoformat(),
+                        track=track,
                     )
-
-                logger.debug(
-                    "new_journey_discovered",
-                    train_id=train_id,
-                    journey_date=journey_date,
-                    line=journey.line_code,
-                    destination=journey.destination,
-                    departure=scheduled_departure.isoformat(),
-                    track=track,
-                )
 
             except Exception as e:
                 logger.error(

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -17,7 +17,7 @@ from trackrat.config.stations import get_station_name
 from trackrat.db.engine import get_session
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.settings import get_settings
-from trackrat.utils.time import now_et
+from trackrat.utils.time import ET, now_et
 
 logger = get_logger(__name__)
 
@@ -545,8 +545,8 @@ class AmtrakPatternScheduler:
                     continue
 
                 # Combine date and time for scheduled departure
-                scheduled_departure = datetime.combine(
-                    target_date, pattern["median_departure"]
+                scheduled_departure = ET.localize(
+                    datetime.combine(target_date, pattern["median_departure"])
                 )
 
                 # Create scheduled journey

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -757,7 +757,11 @@ class DepartureService:
                     async def refresh_journey(jid: int = journey_id) -> None:
                         # Re-query to get fresh state after potential rollback
                         # Default param captures journey_id at definition time
-                        fresh = await db.get(TrainJourney, jid)
+                        fresh = await db.get(
+                            TrainJourney,
+                            jid,
+                            options=[selectinload(TrainJourney.stops)],
+                        )
                         if fresh:
                             await njt_collector.collect_journey_details(db, fresh)
 

--- a/backend_v2/src/trackrat/services/direct_forecaster.py
+++ b/backend_v2/src/trackrat/services/direct_forecaster.py
@@ -274,6 +274,7 @@ class DirectArrivalForecaster:
                     JourneyStop.station_code.in_(unique_codes),
                     # Narrow scan to recent journeys only
                     TrainJourney.journey_date >= (now_et() - timedelta(days=1)).date(),
+                    JourneyStop.stop_sequence.isnot(None),
                 )
             )
         )

--- a/backend_v2/tests/unit/collectors/njt/test_discovery.py
+++ b/backend_v2/tests/unit/collectors/njt/test_discovery.py
@@ -5,12 +5,27 @@ Tests the TrainDiscoveryCollector class with focus on the new batch collection f
 """
 
 import pytest
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 from datetime import datetime, date
 
 from trackrat.collectors.njt.discovery import TrainDiscoveryCollector
 from trackrat.models.database import TrainJourney, DiscoveryRun
 from trackrat.utils.time import now_et
+
+
+@asynccontextmanager
+async def _mock_savepoint():
+    """Mock async context manager for session.begin_nested()."""
+    yield
+
+
+def _make_session_mock():
+    """Create an AsyncMock session that supports begin_nested() as async CM."""
+    mock_session = AsyncMock()
+    mock_session.add = Mock()
+    mock_session.begin_nested = lambda: _mock_savepoint()
+    return mock_session
 
 
 @pytest.fixture
@@ -320,10 +335,7 @@ class TestTrainDiscoveryCollector:
         self, discovery_collector, sample_train_data
     ):
         """Test that process_discovered_trains creates journey records correctly."""
-        mock_session = AsyncMock()
-
-        # Mock synchronous database operations
-        mock_session.add = Mock()
+        mock_session = _make_session_mock()
 
         # Mock database query to return no existing journeys (all are new)
         mock_session.scalar = AsyncMock(return_value=None)
@@ -356,10 +368,7 @@ class TestTrainDiscoveryCollector:
         self, discovery_collector
     ):
         """Test that Amtrak trains are skipped during NJT discovery."""
-        mock_session = AsyncMock()
-
-        # Mock synchronous database operations
-        mock_session.add = Mock()
+        mock_session = _make_session_mock()
 
         mock_session.scalar = AsyncMock(return_value=None)  # No existing journey
 
@@ -419,10 +428,7 @@ class TestTrainDiscoveryCollector:
     @pytest.mark.asyncio
     async def test_amtrak_train_id_patterns(self, discovery_collector):
         """Test that various Amtrak train ID patterns are correctly identified."""
-        mock_session = AsyncMock()
-
-        # Mock synchronous database operations
-        mock_session.add = Mock()
+        mock_session = _make_session_mock()
 
         mock_session.scalar = AsyncMock(return_value=None)
 

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.services.amtrak_pattern_scheduler import AmtrakPatternScheduler
-from trackrat.utils.time import now_et
+from trackrat.utils.time import ET, now_et
 
 
 @pytest.fixture
@@ -198,36 +198,36 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
             station_code="NYP",
             station_name="New York Penn Station",
             stop_sequence=0,
-            scheduled_departure=datetime(2024, 1, 22, 15, 3),
-            scheduled_arrival=datetime(2024, 1, 22, 15, 3),
+            scheduled_departure=ET.localize(datetime(2024, 1, 22, 15, 3)),
+            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 15, 3)),
         ),
         MagicMock(
             station_code="NWK",
             station_name="Newark Penn Station",
             stop_sequence=1,
-            scheduled_departure=datetime(2024, 1, 22, 15, 22),
-            scheduled_arrival=datetime(2024, 1, 22, 15, 20),
+            scheduled_departure=ET.localize(datetime(2024, 1, 22, 15, 22)),
+            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 15, 20)),
         ),
         MagicMock(
             station_code="TRE",
             station_name="Trenton",
             stop_sequence=2,
-            scheduled_departure=datetime(2024, 1, 22, 15, 55),
-            scheduled_arrival=datetime(2024, 1, 22, 15, 53),
+            scheduled_departure=ET.localize(datetime(2024, 1, 22, 15, 55)),
+            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 15, 53)),
         ),
         MagicMock(
             station_code="PH",
             station_name="Philadelphia 30th Street",
             stop_sequence=3,
-            scheduled_departure=datetime(2024, 1, 22, 16, 25),
-            scheduled_arrival=datetime(2024, 1, 22, 16, 22),
+            scheduled_departure=ET.localize(datetime(2024, 1, 22, 16, 25)),
+            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 16, 22)),
         ),
         MagicMock(
             station_code="WS",
             station_name="Washington Union Station",
             stop_sequence=4,
             scheduled_departure=None,
-            scheduled_arrival=datetime(2024, 1, 22, 18, 30),
+            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 18, 30)),
         ),
     ]
 
@@ -264,7 +264,9 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         assert journey.terminal_station_code == "WAS"
         assert journey.destination == "Washington Union Station"
         assert journey.line_name == "Northeast Regional"
-        assert journey.scheduled_departure == datetime.combine(target_date, time(15, 5))
+        assert journey.scheduled_departure == ET.localize(
+            datetime.combine(target_date, time(15, 5))
+        )
 
         # Should have all 5 stops from the recent journey, not just origin
         assert len(stops) == 5
@@ -277,15 +279,15 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         # Verify time offset was applied correctly
         # Recent origin departed at 15:03, pattern median is 15:05 -> offset = +2 min
         # (plus 3-day date shift from Jan 22 to Jan 25)
-        assert stops[0].scheduled_departure == datetime(2024, 1, 25, 15, 5)
-        assert stops[1].scheduled_departure == datetime(2024, 1, 25, 15, 24)
-        assert stops[2].scheduled_departure == datetime(2024, 1, 25, 15, 57)
-        assert stops[3].scheduled_departure == datetime(2024, 1, 25, 16, 27)
+        assert stops[0].scheduled_departure == ET.localize(datetime(2024, 1, 25, 15, 5))
+        assert stops[1].scheduled_departure == ET.localize(datetime(2024, 1, 25, 15, 24))
+        assert stops[2].scheduled_departure == ET.localize(datetime(2024, 1, 25, 15, 57))
+        assert stops[3].scheduled_departure == ET.localize(datetime(2024, 1, 25, 16, 27))
         assert stops[4].scheduled_departure is None  # Terminal has no departure
 
         # Verify arrivals also shifted
-        assert stops[0].scheduled_arrival == datetime(2024, 1, 25, 15, 5)
-        assert stops[4].scheduled_arrival == datetime(2024, 1, 25, 18, 32)
+        assert stops[0].scheduled_arrival == ET.localize(datetime(2024, 1, 25, 15, 5))
+        assert stops[4].scheduled_arrival == ET.localize(datetime(2024, 1, 25, 18, 32))
 
 
 @pytest.mark.asyncio
@@ -330,8 +332,8 @@ async def test_create_scheduled_journeys_fallback_no_recent(pattern_scheduler):
         # Falls back to single origin stop
         assert len(stops) == 1
         assert stops[0].station_code == "NYP"
-        assert stops[0].scheduled_departure == datetime.combine(
-            target_date, time(10, 0)
+        assert stops[0].scheduled_departure == ET.localize(
+            datetime.combine(target_date, time(10, 0))
         )
 
 


### PR DESCRIPTION
- amtrak_pattern_scheduler: Localize datetime.combine() output with ET to
  fix "can't subtract offset-naive and offset-aware datetimes" crash that
  blocked daily Amtrak schedule generation
- njt/discovery: Wrap per-train processing in session.begin_nested()
  savepoint so a single deadlock doesn't poison the session for all
  subsequent trains (matches existing LIRR/MNR pattern)
- departure: Add selectinload(TrainJourney.stops) to db.get() in the
  individual refresh path to prevent MissingGreenlet error when
  collect_journey_details accesses the lazy-loaded stops relationship
- direct_forecaster: Filter out NULL stop_sequence rows in batch query
  to prevent TypeError on comparison operators

Update tests to match new timezone-aware behavior and mock begin_nested().

https://claude.ai/code/session_01BtHgVkRwBmjfaVkUW8Hvw9