### PR TITLE
Replace App Store badge image with SVG icon on landing page

### DIFF
--- a/webpage_v2/src/pages/LandingPage.tsx
+++ b/webpage_v2/src/pages/LandingPage.tsx
@@ -108,16 +108,18 @@ export function LandingPage() {
         <p className="text-lg md:text-xl text-text-secondary mb-8 max-w-xl mx-auto">
           Open source, real-time train tracking for NJ Transit, Amtrak, PATH, PATCO, LIRR, and Metro-North
         </p>
-        <div className="flex items-center justify-center mb-6">
-          <a href={APP_STORE_URL} target="_blank" rel="noopener noreferrer">
-            <img
-              src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
-              alt="Download on the App Store"
-              className="h-12"
-            />
-          </a>
-        </div>
         <div className="flex items-center justify-center gap-4">
+          <a
+            href={APP_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-text-muted hover:text-accent transition-colors"
+            aria-label="Download on the App Store"
+          >
+            <svg className="w-7 h-7" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+            </svg>
+          </a>
           <a
             href={YOUTUBE_URL}
             target="_blank"


### PR DESCRIPTION
## Summary
Replaced the App Store badge image with an inline SVG icon on the landing page, improving performance and maintainability while maintaining the same functionality.

## Key Changes
- Removed the external App Store badge image (`download-on-the-app-store.svg` from Apple's CDN)
- Replaced with an inline Apple logo SVG icon that scales responsively
- Reorganized the button layout to display the App Store and YouTube links horizontally with consistent spacing
- Enhanced accessibility by adding `aria-label` attribute to the App Store link
- Added hover state styling with `hover:text-accent transition-colors` for better UX

## Implementation Details
- The new SVG uses `currentColor` to inherit text color, allowing the hover state to work seamlessly
- Icon dimensions set to `w-7 h-7` for appropriate sizing
- Maintains the same link functionality and target behavior (`target="_blank"` and `rel="noopener noreferrer"`)
- Simplified DOM structure by removing the wrapper div that previously contained only the App Store badge

https://claude.ai/code/session_01LbqZfc6cwRg6UuHQmonXFr