### PR TITLE
Fix race conditions in journey stop updates and train expiration logic

### DIFF
--- a/backend_v2/src/trackrat/collectors/path/collector.py
+++ b/backend_v2/src/trackrat/collectors/path/collector.py
@@ -765,16 +765,24 @@ class PathCollector:
                     # Train is still visible in API - reset error count
                     journey.api_error_count = 0
                 else:
-                    # No arrivals matched - train may have disappeared from API
-                    # Increment error count to track consecutive misses
-                    journey.api_error_count = (journey.api_error_count or 0) + 1
-                    if journey.api_error_count >= 3:
-                        journey.is_expired = True
-                        logger.info(
-                            "path_journey_expired_no_arrivals",
-                            train_id=journey.train_id,
-                            error_count=journey.api_error_count,
-                        )
+                    # No arrivals matched - but don't penalize trains that
+                    # haven't departed yet. Trains with long ETAs (e.g. HOB-33
+                    # at 8-18 min) can't match intermediate station arrivals
+                    # until they actually start moving.
+                    now = now_et()
+                    origin_departed = (
+                        journey.scheduled_departure
+                        and journey.scheduled_departure <= now
+                    )
+                    if origin_departed:
+                        journey.api_error_count = (journey.api_error_count or 0) + 1
+                        if journey.api_error_count >= 3:
+                            journey.is_expired = True
+                            logger.info(
+                                "path_journey_expired_no_arrivals",
+                                train_id=journey.train_id,
+                                error_count=journey.api_error_count,
+                            )
 
                 if journey.is_completed:
                     completed += 1

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import and_, case, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from structlog import get_logger
@@ -661,7 +662,7 @@ class DepartureService:
                         stops_data = train_data.get("STOPS", [])
                         if stops_data:
                             await self._update_stops_from_embedded_data(
-                                journey, stops_data
+                                db, journey, stops_data
                             )
                             journey.has_complete_journey = True
                             journey.stops_count = len(stops_data)
@@ -804,29 +805,49 @@ class DepartureService:
             await njt_client.close()
 
     async def _update_stops_from_embedded_data(
-        self, journey: TrainJourney, stops_data: list[dict[str, Any]]
+        self,
+        session: AsyncSession,
+        journey: TrainJourney,
+        stops_data: list[dict[str, Any]],
     ) -> None:
-        """Update journey stops from embedded STOPS data in getTrainSchedule response."""
+        """Update journey stops from embedded STOPS data in getTrainSchedule response.
 
-        # Create a map of existing stops by station code
-        existing_stops = {stop.station_code: stop for stop in journey.stops}
+        Uses PostgreSQL ON CONFLICT to safely handle concurrent updates from
+        multiple sessions (e.g., cache precomputation vs user request).
+        """
 
-        # Update or create stops from embedded data
         for i, stop_data in enumerate(stops_data):
             station_code = stop_data.get("STATION_2CHAR")
             if not station_code:
                 continue
 
-            # Get existing stop or create new one
-            stop = existing_stops.get(station_code)
-            if not stop:
-                stop = JourneyStop(
+            # Upsert: insert or fetch existing stop (race-safe)
+            stmt = (
+                pg_insert(JourneyStop)
+                .values(
                     journey_id=journey.id,
                     station_code=station_code,
                     station_name=stop_data.get("STATIONNAME", ""),
                     stop_sequence=i,
                 )
-                journey.stops.append(stop)
+                .on_conflict_do_nothing(constraint="unique_journey_stop")
+                .returning(JourneyStop.id)
+            )
+            result = await session.execute(stmt)
+            inserted_id = result.scalar_one_or_none()
+
+            if inserted_id:
+                # New row inserted — fetch the ORM object
+                stop = await session.get(JourneyStop, inserted_id)
+            else:
+                # Already existed — fetch by unique key
+                existing = await session.execute(
+                    select(JourneyStop).where(
+                        JourneyStop.journey_id == journey.id,
+                        JourneyStop.station_code == station_code,
+                    )
+                )
+                stop = existing.scalar_one()
 
             # Update stop data from schedule
             if arrival_time_str := stop_data.get("TIME"):

--- a/backend_v2/tests/unit/test_departure_flag_validation.py
+++ b/backend_v2/tests/unit/test_departure_flag_validation.py
@@ -57,7 +57,7 @@ class TestDepartureFlagValidation:
 
         journey = MagicMock(spec=TrainJourney)
         journey.train_id = "3201"
-        journey.stops = []
+        journey.id = 1
 
         # Past train with DEPARTED=YES
         stops_data = [
@@ -71,14 +71,30 @@ class TestDepartureFlagValidation:
             }
         ]
 
+        # Mock session: simulate successful insert, then return a real JourneyStop
+        stop = JourneyStop(
+            journey_id=1,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+        )
+        stop.actual_departure = None
+        insert_result = MagicMock()
+        insert_result.scalar_one_or_none.return_value = 1
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=insert_result)
+        mock_session.get = AsyncMock(return_value=stop)
+
         with patch("trackrat.services.departure.parse_njt_time") as mock_parse:
             mock_parse.return_value = self.past_time
 
             import asyncio
 
-            asyncio.run(service._update_stops_from_embedded_data(journey, stops_data))
-
-        stop = journey.stops[0]
+            asyncio.run(
+                service._update_stops_from_embedded_data(
+                    mock_session, journey, stops_data
+                )
+            )
 
         # Past train should be marked as departed
         assert stop.has_departed_station == True
@@ -97,7 +113,7 @@ class TestDepartureFlagValidation:
 
         journey = MagicMock(spec=TrainJourney)
         journey.train_id = "7845"
-        journey.stops = []
+        journey.id = 2
 
         # Train with DEPARTED=YES and no existing actual_departure
         stops_data = [
@@ -111,14 +127,30 @@ class TestDepartureFlagValidation:
             }
         ]
 
+        # Mock session: simulate successful insert, then return a real JourneyStop
+        stop = JourneyStop(
+            journey_id=2,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+        )
+        stop.actual_departure = None
+        insert_result = MagicMock()
+        insert_result.scalar_one_or_none.return_value = 1
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=insert_result)
+        mock_session.get = AsyncMock(return_value=stop)
+
         with patch("trackrat.services.departure.parse_njt_time") as mock_parse:
             mock_parse.return_value = self.past_time
 
             import asyncio
 
-            asyncio.run(service._update_stops_from_embedded_data(journey, stops_data))
-
-        stop = journey.stops[0]
+            asyncio.run(
+                service._update_stops_from_embedded_data(
+                    mock_session, journey, stops_data
+                )
+            )
 
         # Both fields must be set together for data consistency
         assert stop.has_departed_station == True
@@ -135,14 +167,19 @@ class TestDepartureFlagValidation:
 
         journey = MagicMock(spec=TrainJourney)
         journey.train_id = "7845"
+        journey.id = 3
 
         # Create an existing stop with actual_departure already set
         existing_actual = self.past_time - timedelta(minutes=5)
-        existing_stop = MagicMock(spec=JourneyStop)
-        existing_stop.station_code = "NY"
+        existing_stop = JourneyStop(
+            journey_id=3,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+        )
         existing_stop.actual_departure = existing_actual
-        existing_stop.stop_sequence = None
-        journey.stops = [existing_stop]
+        existing_stop.track = None
+        existing_stop.track_assigned_at = None
 
         stops_data = [
             {
@@ -155,12 +192,24 @@ class TestDepartureFlagValidation:
             }
         ]
 
+        # Mock session: simulate conflict (stop already exists), return existing_stop
+        insert_result = MagicMock()
+        insert_result.scalar_one_or_none.return_value = None
+        select_result = MagicMock()
+        select_result.scalar_one.return_value = existing_stop
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=[insert_result, select_result])
+
         with patch("trackrat.services.departure.parse_njt_time") as mock_parse:
             mock_parse.return_value = self.past_time
 
             import asyncio
 
-            asyncio.run(service._update_stops_from_embedded_data(journey, stops_data))
+            asyncio.run(
+                service._update_stops_from_embedded_data(
+                    mock_session, journey, stops_data
+                )
+            )
 
         # actual_departure should NOT be overwritten
         assert existing_stop.actual_departure == existing_actual


### PR DESCRIPTION
## Summary
This PR addresses two critical issues in the journey tracking system:
1. **Race condition in stop updates**: Multiple concurrent sessions could create duplicate journey stops
2. **Premature train expiration**: Trains with long ETAs were incorrectly marked as expired before departure

## Key Changes

### PATH Collector - Train Expiration Logic
- Modified `_update_journeys()` to only increment error count for trains that have already departed
- Added check for `scheduled_departure <= now` before penalizing trains with no matched arrivals
- Prevents false expiration of trains with long ETAs (e.g., HOB-33 at 8-18 min) that haven't started moving yet

### Departure Service - Concurrent Stop Updates
- Refactored `_update_stops_from_embedded_data()` to use PostgreSQL `ON CONFLICT DO NOTHING` for race-safe upserts
- Added `session` parameter to enable proper database operations
- Replaces manual stop creation/lookup with atomic insert-or-fetch pattern
- Prevents duplicate stops when multiple sessions update the same journey concurrently (e.g., cache precomputation vs user request)

### Test Updates
- Updated unit tests to mock the new `session` parameter
- Fixed test setup to use real `JourneyStop` objects instead of mocks for proper behavior validation
- Added proper mock session behavior for both insert-success and conflict scenarios

## Implementation Details
- Uses PostgreSQL's `insert().on_conflict_do_nothing()` with constraint-based conflict detection
- Maintains data consistency by fetching the ORM object after upsert (either newly inserted or existing)
- Preserves existing stop data when conflicts occur, preventing overwrites of fields like `actual_departure`

https://claude.ai/code/session_011H7yt8ejaNNHr1hQeyXJLM