### PR TITLE
Fix NJT discovery deadlock and validation service greenlet error

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -60,19 +60,18 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
         return discovered_ids
 
     async def run(self) -> dict[str, Any]:
-        """Run the collector with a database session.
+        """Run the collector.
 
         Returns:
             Collection results
         """
-        async with get_session() as session:
-            return await self.collect(session)
+        return await self.collect()
 
-    async def collect(self, session: AsyncSession) -> dict[str, Any]:
+    async def collect(self) -> dict[str, Any]:
         """Run discovery for all configured stations.
 
-        Args:
-            session: Database session
+        Uses a separate database session per station to minimize lock hold time
+        and prevent deadlocks with concurrent journey collection.
 
         Returns:
             Discovery results summary
@@ -84,7 +83,8 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
         station_results = {}
 
         for station_code in DISCOVERY_STATIONS:
-            result = await self.discover_station_trains(session, station_code)
+            async with get_session() as session:
+                result = await self.discover_station_trains(session, station_code)
             station_results[station_code] = result
             total_discovered += result["trains_discovered"]
             total_new += result["new_trains"]

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2786,21 +2786,24 @@ class SchedulerService:
                     self._running_tasks[task_id] = task
 
                 # Import and run validation
+                # Create session here (before HTTP I/O) to avoid greenlet issues
+                # when _save_validation_result needs DB access deep in the call chain
                 from trackrat.services.validation import TrainValidationService
 
-                async with TrainValidationService(self.settings) as validator:
-                    results = await validator.run_validation()
+                async with get_session() as validation_db:
+                    async with TrainValidationService(self.settings) as validator:
+                        results = await validator.run_validation(db=validation_db)
 
-                    # Summary metrics
-                    total_missing = sum(len(r.missing_trains) for r in results)
-                    routes_with_issues = sum(1 for r in results if r.missing_trains)
+                        # Summary metrics
+                        total_missing = sum(len(r.missing_trains) for r in results)
+                        routes_with_issues = sum(1 for r in results if r.missing_trains)
 
-                    logger.info(
-                        "train_validation_completed",
-                        total_routes_checked=len(results),
-                        routes_with_issues=routes_with_issues,
-                        total_missing_trains=total_missing,
-                    )
+                        logger.info(
+                            "train_validation_completed",
+                            total_routes_checked=len(results),
+                            routes_with_issues=routes_with_issues,
+                            total_missing_trains=total_missing,
+                        )
 
             except Exception as e:
                 logger.error(

--- a/backend_v2/src/trackrat/services/validation.py
+++ b/backend_v2/src/trackrat/services/validation.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from trackrat.collectors.amtrak.client import AmtrakClient
@@ -326,7 +327,11 @@ class TrainValidationService:
             }
 
     async def validate_route(
-        self, from_station: str, to_station: str, sources: list[str]
+        self,
+        from_station: str,
+        to_station: str,
+        sources: list[str],
+        db: AsyncSession | None = None,
     ) -> list[ValidationResult]:
         """Validate a single route for all specified sources."""
         results = []
@@ -433,42 +438,53 @@ class TrainValidationService:
             results.append(result)
 
             # Save to database for persistence
-            await self._save_validation_result(result, missing_details)
+            await self._save_validation_result(result, missing_details, db=db)
 
         return results
 
     async def _save_validation_result(
-        self, result: ValidationResult, missing_details: dict[str, Any] | None = None
+        self,
+        result: ValidationResult,
+        missing_details: dict[str, Any] | None = None,
+        db: AsyncSession | None = None,
     ) -> None:
-        """Save validation result to database for persistence and monitoring."""
-        try:
-            async with get_session() as db:
-                db_result: ValidationResultDB = ValidationResultDB(
-                    route=result.route,
-                    source=result.source,
-                    transit_train_count=len(result.transit_trains),
-                    api_train_count=len(result.api_trains),
-                    coverage_percent=float(result.coverage_percent),  # type: ignore[arg-type]
-                    missing_trains=(
-                        list(result.missing_trains) if result.missing_trains else []
-                    ),
-                    extra_trains=(
-                        list(result.extra_trains) if result.extra_trains else []
-                    ),
-                    details={
-                        "missing_train_details": missing_details or {},
-                        "timestamp": result.timestamp.isoformat(),
-                    },
-                )
-                db.add(db_result)
-                await db.commit()
+        """Save validation result to database for persistence and monitoring.
 
-                logger.debug(
-                    "validation_result_saved",
-                    route=result.route,
-                    source=result.source,
-                    coverage=result.coverage_percent,
-                )
+        Args:
+            result: Validation result to save
+            missing_details: Optional details about missing trains
+            db: Optional pre-created session (avoids greenlet issues in scheduler context)
+        """
+        try:
+            db_result: ValidationResultDB = ValidationResultDB(
+                route=result.route,
+                source=result.source,
+                transit_train_count=len(result.transit_trains),
+                api_train_count=len(result.api_trains),
+                coverage_percent=float(result.coverage_percent),  # type: ignore[arg-type]
+                missing_trains=(
+                    list(result.missing_trains) if result.missing_trains else []
+                ),
+                extra_trains=(list(result.extra_trains) if result.extra_trains else []),
+                details={
+                    "missing_train_details": missing_details or {},
+                    "timestamp": result.timestamp.isoformat(),
+                },
+            )
+
+            if db:
+                db.add(db_result)
+                await db.flush()
+            else:
+                async with get_session() as session:
+                    session.add(db_result)
+
+            logger.debug(
+                "validation_result_saved",
+                route=result.route,
+                source=result.source,
+                coverage=result.coverage_percent,
+            )
         except Exception as e:
             logger.error(
                 "failed_to_save_validation_result",
@@ -477,8 +493,14 @@ class TrainValidationService:
                 error=str(e),
             )
 
-    async def run_validation(self) -> list[ValidationResult]:
-        """Run validation for all monitored routes."""
+    async def run_validation(
+        self, db: AsyncSession | None = None
+    ) -> list[ValidationResult]:
+        """Run validation for all monitored routes.
+
+        Args:
+            db: Optional pre-created session (avoids greenlet issues in scheduler context)
+        """
         logger.info("starting_train_validation", routes=self.MONITORED_ROUTES)
 
         all_results = []
@@ -486,7 +508,7 @@ class TrainValidationService:
 
         for from_st, to_st, sources in self.MONITORED_ROUTES:
             try:
-                results = await self.validate_route(from_st, to_st, sources)
+                results = await self.validate_route(from_st, to_st, sources, db=db)
                 all_results.extend(results)
             except Exception as e:
                 validation_status = "failure"

--- a/backend_v2/tests/unit/collectors/njt/test_discovery.py
+++ b/backend_v2/tests/unit/collectors/njt/test_discovery.py
@@ -308,15 +308,22 @@ class TestTrainDiscoveryCollector:
 
         mock_session = AsyncMock()
 
-        with patch.object(
-            discovery_collector, "discover_station_trains"
-        ) as mock_discover:
+        @asynccontextmanager
+        async def mock_get_session():
+            yield mock_session
+
+        with (
+            patch("trackrat.collectors.njt.discovery.get_session", mock_get_session),
+            patch.object(
+                discovery_collector, "discover_station_trains"
+            ) as mock_discover,
+        ):
             # Return different results for each station
             mock_discover.side_effect = lambda session, station: station_results[
                 station
             ]
 
-            result = await discovery_collector.collect(mock_session)
+            result = await discovery_collector.collect()
 
         # Verify aggregation
         assert result["stations_processed"] == 17  # Updated discovery stations count


### PR DESCRIPTION
1. NJT discovery deadlock: The discovery collector used a single long-lived session across all 17 stations, accumulating row locks for minutes and creating deadlocks with concurrent journey collection. Fixed by moving get_session() from run() into per-station scope in collect(), so each station's transactions commit and release locks independently.

2. Validation greenlet error: _save_validation_result created a new async session deep in the call chain after extensive HTTP I/O, which lost the greenlet context required by SQLAlchemy's async engine. This caused 6 errors per hour (one per monitored route) and prevented validation results from being persisted. Fixed by creating the session at the top of do_validation_work (before HTTP I/O) and passing it through to run_validation -> validate_route -> _save_validation_result.

https://claude.ai/code/session_011H7yt8ejaNNHr1hQeyXJLM