### PR TITLE
Remove Pro subscription requirement from route operations summary

### DIFF
--- a/ios/TrackRat/Views/Components/OperationsSummaryView.swift
+++ b/ios/TrackRat/Views/Components/OperationsSummaryView.swift
@@ -40,11 +40,8 @@ struct OperationsSummaryView: View {
         self.ratSenseRoute = ratSenseRoute
     }
 
-    /// Combined display text: network summary or route summary (Pro only)
+    /// Combined display text: network summary or route summary
     private var combinedBodyText: String? {
-        // Congestion summary overlay is a Pro feature
-        guard SubscriptionService.shared.isPro else { return nil }
-
         guard let summary = summary, !summary.body.isEmpty else { return nil }
 
         // Show route-specific summary if available
@@ -107,12 +104,6 @@ struct OperationsSummaryView: View {
     }
 
     private func fetchSummaries() async {
-        // Skip API calls for non-Pro users - view won't display anyway
-        guard SubscriptionService.shared.isPro else {
-            isLoading = false
-            return
-        }
-
         isLoading = true
         hasError = false
 

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -137,35 +137,25 @@ struct TrainListView: View {
                         if !isFutureDate,
                            !departureStationCode.isEmpty,
                            let destinationCode = Stations.getStationCode(destination) {
-                            if subscriptionService.isPro {
-                                OperationsSummaryView(
-                                    scope: .route,
-                                    fromStation: departureStationCode,
-                                    toStation: destinationCode,
-                                    isExpandable: true,
-                                    onTrainTap: { selectedTrainId in
-                                        // Navigate to the selected train's detail view
-                                        // Note: dataSource not available from this callback, backend uses two-phase search
-                                        appState.navigationPath.append(
-                                            NavigationDestination.trainDetailsFlexible(
-                                                trainNumber: selectedTrainId,
-                                                fromStation: departureStationCode,
-                                                journeyDate: nil,
-                                                dataSource: nil
-                                            )
+                            OperationsSummaryView(
+                                scope: .route,
+                                fromStation: departureStationCode,
+                                toStation: destinationCode,
+                                isExpandable: true,
+                                onTrainTap: { selectedTrainId in
+                                    // Navigate to the selected train's detail view
+                                    // Note: dataSource not available from this callback, backend uses two-phase search
+                                    appState.navigationPath.append(
+                                        NavigationDestination.trainDetailsFlexible(
+                                            trainNumber: selectedTrainId,
+                                            fromStation: departureStationCode,
+                                            journeyDate: nil,
+                                            dataSource: nil
                                         )
-                                    }
-                                )
-                                .padding(.bottom, 4)
-                            } else {
-                                // Locked route summary for free users
-                                ProFeatureLockView(
-                                    feature: .historicalData,
-                                    context: .historicalData,
-                                    showingPaywall: $showingPaywall
-                                )
-                                .padding(.bottom, 4)
-                            }
+                                    )
+                                }
+                            )
+                            .padding(.bottom, 4)
                         }
 
                         ForEach(viewModel.trains) { train in


### PR DESCRIPTION
## Summary
This PR removes the Pro subscription paywall from the route operations summary feature, making it available to all users regardless of subscription tier.

## Key Changes
- **TrainListView.swift**: Removed the `subscriptionService.isPro` conditional check that previously gated the `OperationsSummaryView` behind a Pro subscription. Free users now see the route summary instead of the `ProFeatureLockView`.
- **OperationsSummaryView.swift**: 
  - Removed the Pro-only guard clause from the `combinedBodyText` computed property
  - Removed the Pro subscription check from the `fetchSummaries()` method that was skipping API calls for non-Pro users

## Implementation Details
The route operations summary view now displays for all users without subscription restrictions. The API calls to fetch summary data are no longer conditionally skipped based on subscription status, allowing the feature to function fully for both Pro and free tier users.

https://claude.ai/code/session_01KL4AWXhbEjgrKc5reimtvD