### PR TITLE
Fix database query ordering and probability calculation edge cases

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -308,11 +308,17 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                 # concurrent journey collection. Explicit flush() still works.
                 async with session.begin_nested():
                     with session.no_autoflush:
-                        # Check if journey already exists
-                        stmt = select(TrainJourney).where(
-                            TrainJourney.train_id == train_id,
-                            TrainJourney.journey_date == journey_date,
-                            TrainJourney.data_source == "NJT",
+                        # Check if journey already exists.
+                        # ORDER BY id ensures consistent lock ordering to
+                        # reduce deadlocks with concurrent collection.
+                        stmt = (
+                            select(TrainJourney)
+                            .where(
+                                TrainJourney.train_id == train_id,
+                                TrainJourney.journey_date == journey_date,
+                                TrainJourney.data_source == "NJT",
+                            )
+                            .order_by(TrainJourney.id)
                         )
                         existing = await session.scalar(stmt)
 

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -523,17 +523,24 @@ class AmtrakPatternScheduler:
 
         async with get_session() as session:
             for pattern in patterns:
-                # Check if journey already exists for this train today
-                stmt = select(TrainJourney).where(
-                    and_(
-                        # Use LIKE to match any train_id starting with the train number
-                        TrainJourney.train_id.like(f"{pattern['train_number']}%"),
-                        TrainJourney.journey_date == target_date,
-                        TrainJourney.data_source == "AMTRAK",
+                # Check if journey already exists for this train today.
+                # LIKE can match multiple rows (e.g. "69%" matches "69", "690"),
+                # so use .first() with OBSERVED sorted first to detect real data.
+                stmt = (
+                    select(TrainJourney)
+                    .where(
+                        and_(
+                            TrainJourney.train_id.like(
+                                f"{pattern['train_number']}%"
+                            ),
+                            TrainJourney.journey_date == target_date,
+                            TrainJourney.data_source == "AMTRAK",
+                        )
                     )
+                    .order_by(TrainJourney.observation_type)
                 )
                 result = await session.execute(stmt)
-                existing = result.scalar_one_or_none()
+                existing = result.scalars().first()
 
                 if existing and existing.observation_type == "OBSERVED":
                     # Skip - we already have real data

--- a/backend_v2/src/trackrat/services/delay_forecaster.py
+++ b/backend_v2/src/trackrat/services/delay_forecaster.py
@@ -688,6 +688,13 @@ class DelayForecaster:
             slight_prob /= delay_total
             significant_prob /= delay_total
             major_prob /= delay_total
+        else:
+            # Records exist but none have actual departure times yet;
+            # use the same conservative defaults as the non_cancelled == 0 case
+            on_time_prob = 0.8
+            slight_prob = 0.15
+            significant_prob = 0.04
+            major_prob = 0.01
 
         # Expected delay (average of non-cancelled journeys)
         if non_cancelled > 0:
@@ -739,6 +746,8 @@ class DelayForecaster:
 
         # Normalize
         total = new_on_time + new_slight + new_significant + new_major
+        if total <= 0:
+            return forecast
         new_on_time /= total
         new_slight /= total
         new_significant /= total

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -237,7 +237,7 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         # First execute call: check for existing journey (returns None)
         # Second execute call: fetch recent journey with stops
         mock_no_existing = MagicMock()
-        mock_no_existing.scalar_one_or_none.return_value = None
+        mock_no_existing.scalars.return_value.first.return_value = None
 
         mock_recent_result = MagicMock()
         mock_recent_result.scalar_one_or_none.return_value = recent_journey
@@ -320,7 +320,7 @@ async def test_create_scheduled_journeys_fallback_no_recent(pattern_scheduler):
     ) as mock_session:
         # First: no existing journey; Second: no recent journey found
         mock_no_existing = MagicMock()
-        mock_no_existing.scalar_one_or_none.return_value = None
+        mock_no_existing.scalars.return_value.first.return_value = None
 
         mock_no_recent = MagicMock()
         mock_no_recent.scalar_one_or_none.return_value = None
@@ -369,8 +369,10 @@ async def test_skip_already_observed_trains(pattern_scheduler):
         existing_journey = MagicMock()
         existing_journey.observation_type = "OBSERVED"
 
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = existing_journey
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = existing_journey
+        mock_result.scalars.return_value = mock_scalars
         mock_execute = AsyncMock(return_value=mock_result)
 
         mock_session.return_value.__aenter__.return_value.execute = mock_execute


### PR DESCRIPTION
## Summary
This PR addresses three distinct issues in the codebase: database query ordering for consistency and deadlock prevention, proper handling of edge cases in delay probability calculations, and updates to corresponding unit tests.

## Key Changes

- **Amtrak Pattern Scheduler**: Modified the existing journey check query to use `.order_by(TrainJourney.observation_type)` and `.scalars().first()` instead of `.scalar_one_or_none()`. This ensures that when a LIKE pattern matches multiple rows (e.g., "69%" matching both "69" and "690"), the OBSERVED data is prioritized. Added clarifying comments explaining the LIKE matching behavior.

- **NJT Discovery**: Added `.order_by(TrainJourney.id)` to the existing journey check query to ensure consistent lock ordering during concurrent collection, reducing the risk of deadlocks when multiple processes query the same data simultaneously.

- **Delay Forecaster**: 
  - Added an `else` clause in `_calculate_probabilities()` to handle the edge case where records exist but none have actual departure times yet, applying conservative default probabilities (0.8, 0.15, 0.04, 0.01).
  - Added a zero-check in `_apply_adjustment()` before normalizing probabilities to prevent division by zero when the total is zero or negative.

- **Unit Tests**: Updated test mocks in `test_amtrak_pattern_scheduler.py` to reflect the new query pattern using `.scalars().return_value.first()` instead of `.scalar_one_or_none()`.

## Implementation Details

The changes maintain backward compatibility while improving robustness:
- Query ordering is deterministic and doesn't change the logical behavior, only ensures consistent results
- Probability calculation edge cases now have explicit handling instead of potentially causing errors
- All changes are defensive and handle previously unhandled scenarios gracefully

https://claude.ai/code/session_01H8p65aRqc4jvLsng7VG9eQ