### PR TITLE
Fix staging 500s: graceful JIT refresh + empty line_code fallback

### DIFF
--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -336,8 +336,8 @@ async def get_train_details(
         train_id=journey.train_id,
         journey_date=journey.journey_date,
         line=LineInfo(
-            code=journey.line_code,
-            name=journey.line_name or journey.line_code,
+            code=journey.line_code or "UNK",
+            name=journey.line_name or journey.line_code or "Unknown",
             color=(journey.line_color or "#000000").strip(),
         ),
         route=RouteInfo(

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -186,9 +186,20 @@ class DepartureService:
         # up-to-date departure times. This prevents stale data from causing
         # incorrect delay calculations in the response.
         jit_start = time.perf_counter()
-        await self._ensure_fresh_station_data(
-            db, from_station, target_date, skip_individual_refresh, hide_departed
-        )
+        try:
+            await self._ensure_fresh_station_data(
+                db, from_station, target_date, skip_individual_refresh, hide_departed
+            )
+        except Exception as e:
+            logger.warning(
+                "jit_refresh_failed_serving_stale",
+                station_code=from_station,
+                error=str(e),
+            )
+            try:
+                await db.rollback()
+            except Exception:
+                pass
         jit_duration_ms = (time.perf_counter() - jit_start) * 1000
 
         query_start = time.perf_counter()
@@ -261,8 +272,8 @@ class DepartureService:
                 train_id=journey.train_id,
                 journey_date=journey.journey_date,
                 line=LineInfo(
-                    code=journey.line_code,
-                    name=journey.line_name or journey.line_code,
+                    code=journey.line_code or "UNK",
+                    name=journey.line_name or journey.line_code or "Unknown",
                     color=(journey.line_color or "#000000").strip(),
                 ),
                 destination=journey.destination,
@@ -799,7 +810,10 @@ class DepartureService:
             logger.error(
                 "station_refresh_failed", station_code=station_code, error=str(e)
             )
-            await db.rollback()
+            try:
+                await db.rollback()
+            except Exception:
+                pass
             raise
         finally:
             await njt_client.close()


### PR DESCRIPTION
Two issues from staging error logs:

1. greenlet_spawn / deadlock errors in _ensure_fresh_station_data caused
   500s on /departures. The JIT refresh is an optimization — wrap it in
   try/except so the main query always proceeds with stale data rather
   than crashing. Also make the inner rollback safe to prevent it from
   replacing the original error.

2. Empty line_code on some journeys caused Pydantic ValidationError
   (min_length=1) when constructing LineInfo. Add defensive fallback
   to "UNK"/"Unknown" at both serialization points.

https://claude.ai/code/session_01NKZ8HcVqpyJHqARrNzmnoZ