### PR TITLE
Fix departure service greenlet errors and NJT discovery deadlocks

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -6,7 +6,7 @@ Discovers active trains by polling station departure boards.
 
 from typing import Any
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, exists, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -309,8 +309,10 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                 async with session.begin_nested():
                     with session.no_autoflush:
                         # Check if journey already exists.
-                        # ORDER BY id ensures consistent lock ordering to
-                        # reduce deadlocks with concurrent collection.
+                        # FOR UPDATE SKIP LOCKED prevents deadlocks with
+                        # concurrent journey collection by skipping rows
+                        # that are locked by another process, matching the
+                        # pattern used by PATH and Amtrak collectors.
                         stmt = (
                             select(TrainJourney)
                             .where(
@@ -319,8 +321,32 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                                 TrainJourney.data_source == "NJT",
                             )
                             .order_by(TrainJourney.id)
+                            .with_for_update(skip_locked=True)
                         )
                         existing = await session.scalar(stmt)
+
+                        if existing is None:
+                            # Distinguish "row doesn't exist" from "row is
+                            # locked by another process" (skip_locked).
+                            # A non-locking existence check avoids inserting
+                            # a duplicate that would violate unique_train_journey.
+                            row_exists = await session.scalar(
+                                select(
+                                    exists().where(
+                                        TrainJourney.train_id == train_id,
+                                        TrainJourney.journey_date == journey_date,
+                                        TrainJourney.data_source == "NJT",
+                                    )
+                                )
+                            )
+                            if row_exists:
+                                # Row is locked by concurrent collection — skip
+                                logger.debug(
+                                    "discovery_skipped_locked_row",
+                                    train_id=train_id,
+                                    journey_date=journey_date,
+                                )
+                                continue
 
                         if existing:
                             # Re-activate expired trains that reappear in discovery

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -452,8 +452,11 @@ class DepartureService:
                 ),
             )
 
-        # Fallback: Calculate from stops if progress not available
-        if not journey.stops:
+        # Fallback: Calculate from stops if progress not available.
+        # Guard against lazy-load in sync context — if stops weren't eagerly
+        # loaded, return empty position rather than triggering MissingGreenlet.
+        stops_value = state.attrs.stops.loaded_value if state else NO_VALUE
+        if stops_value is NO_VALUE or not journey.stops:
             return TrainPosition()
 
         # Sort stops by sequence

--- a/backend_v2/src/trackrat/utils/train.py
+++ b/backend_v2/src/trackrat/utils/train.py
@@ -4,8 +4,25 @@ Train-related utility functions for TrackRat V2.
 
 from typing import TYPE_CHECKING
 
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm.base import NO_VALUE
+
 if TYPE_CHECKING:
     from trackrat.models.database import TrainJourney
+
+
+def _stops_loaded(journey: "TrainJourney") -> bool:
+    """Check if the stops relationship is eagerly loaded (safe to access in sync context).
+
+    Accessing a lazy-loaded relationship in a sync function within an async
+    SQLAlchemy session triggers MissingGreenlet. This helper uses SQLAlchemy's
+    instance inspection to check whether stops were eagerly loaded (via
+    selectinload/joinedload) without triggering a lazy load.
+    """
+    state = sa_inspect(journey, raiseerr=False)
+    if state is None:
+        return False
+    return state.attrs.stops.loaded_value is not NO_VALUE
 
 
 def get_effective_observation_type(journey: "TrainJourney") -> str:
@@ -42,8 +59,10 @@ def get_effective_observation_type(journey: "TrainJourney") -> str:
     if journey.data_source == "NJT":
         return "SCHEDULED"
 
-    # For schedule-only systems (PATCO): promote if departure time has passed
-    if not journey.stops:
+    # For schedule-only systems (PATCO): promote if departure time has passed.
+    # Guard against lazy-load in sync context — if stops weren't eagerly loaded,
+    # fall back to SCHEDULED rather than triggering MissingGreenlet.
+    if not _stops_loaded(journey) or not journey.stops:
         return "SCHEDULED"
 
     sorted_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)


### PR DESCRIPTION
1. Prevent MissingGreenlet errors when stops aren't eagerly loaded:
   - Add _stops_loaded() guard in utils/train.py to check if stops
     relationship is loaded before accessing it in sync context
   - Apply same guard in departure.py _calculate_train_position() fallback

2. Prevent NJT discovery deadlocks with concurrent collection:
   - Add FOR UPDATE SKIP LOCKED to discovery SELECT, matching PATH/Amtrak
   - Add non-locking existence check to distinguish "not found" from
     "locked" and avoid duplicate inserts against unique constraint

https://claude.ai/code/session_01K3cbFj7Bmjm2WzA4s9oqcJ