### PR TITLE
Use repr() instead of str() for exception error logging

### DIFF
--- a/backend_v2/src/trackrat/services/validation.py
+++ b/backend_v2/src/trackrat/services/validation.py
@@ -137,7 +137,7 @@ class TrainValidationService:
                 "njt_route_scan_failed",
                 from_station=from_station,
                 to_station=to_station,
-                error=str(e),
+                error=repr(e),
             )
             return set()
 
@@ -236,7 +236,7 @@ class TrainValidationService:
                 "amtrak_route_scan_failed",
                 from_station=from_station,
                 to_station=to_station,
-                error=str(e),
+                error=repr(e),
             )
             return set()
 
@@ -287,7 +287,7 @@ class TrainValidationService:
                 "api_scan_failed",
                 from_station=from_station,
                 to_station=to_station,
-                error=str(e),
+                error=repr(e),
             )
             return set()
 
@@ -323,7 +323,7 @@ class TrainValidationService:
         except Exception as e:
             return {
                 "accessible": False,
-                "error": str(e),
+                "error": repr(e),
             }
 
     async def validate_route(
@@ -490,7 +490,7 @@ class TrainValidationService:
                 "failed_to_save_validation_result",
                 route=result.route,
                 source=result.source,
-                error=str(e),
+                error=repr(e),
             )
 
     async def run_validation(
@@ -517,7 +517,7 @@ class TrainValidationService:
                     from_station=from_st,
                     to_station=to_st,
                     sources=sources,
-                    error=str(e),
+                    error=repr(e),
                 )
 
         # Record overall validation run metric


### PR DESCRIPTION
## Summary
Updated exception error logging throughout the validation service to use `repr()` instead of `str()` for more detailed error representation.

## Key Changes
- Changed 6 instances of `str(e)` to `repr(e)` in exception handlers across the validation service
- Affected functions:
  - `get_njt_trains_for_route()`
  - `get_amtrak_trains_for_route()`
  - `get_trains_from_our_api()`
  - `verify_train_details_accessible()`
  - `_save_validation_result()`
  - `run_validation()`

## Implementation Details
Using `repr()` instead of `str()` for exception objects provides more detailed error information including the exception type and traceback details, which improves debugging and error tracking capabilities. This is particularly useful for monitoring and logging systems that need to distinguish between different exception types and their specific details.

https://claude.ai/code/session_01H28v4VDZDhkg3qaPq2PEQ2