### PR TITLE
Fix congestion API caching with effective time window enforcement

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -293,6 +293,16 @@ async def get_route_congestion(
 ) -> CongestionMapResponse:
     """Get current congestion levels with individual journey segments."""
 
+    # Enforce minimum 2-hour window for meaningful congestion data across all systems
+    effective_time_window = max(time_window_hours, 2)
+
+    # Cache key uses effective values so precomputed entries match
+    cache_params = {
+        "time_window_hours": effective_time_window,
+        "max_per_segment": max_per_segment,
+        "data_source": data_source,
+    }
+
     # Try to serve from cache first (unless force_refresh is requested)
     if not force_refresh:
         from trackrat.services.api_cache import ApiCacheService
@@ -301,11 +311,7 @@ async def get_route_congestion(
         cached_response = await cache_service.get_cached_response(
             db=db,
             endpoint="/api/v2/routes/congestion",
-            params={
-                "time_window_hours": time_window_hours,
-                "max_per_segment": max_per_segment,
-                "data_source": data_source,
-            },
+            params=cache_params,
         )
 
         if cached_response:
@@ -316,11 +322,7 @@ async def get_route_congestion(
                 logger.warning(
                     "cache_deserialization_failed",
                     endpoint="/api/v2/routes/congestion",
-                    params={
-                        "time_window_hours": time_window_hours,
-                        "max_per_segment": max_per_segment,
-                        "data_source": data_source,
-                    },
+                    params=cache_params,
                     error=str(e),
                     error_type=type(e).__name__,
                 )
@@ -328,16 +330,8 @@ async def get_route_congestion(
                 await cache_service.invalidate_cache_entry(
                     db,
                     "/api/v2/routes/congestion",
-                    {
-                        "time_window_hours": time_window_hours,
-                        "max_per_segment": max_per_segment,
-                        "data_source": data_source,
-                    },
+                    cache_params,
                 )
-
-    # Cache miss or force refresh - compute the response
-    # Enforce minimum 2-hour window for meaningful congestion data across all systems
-    effective_time_window = max(time_window_hours, 2)
 
     analyzer = CongestionAnalyzer()
     aggregated_segments, journeys, individual_segments = (
@@ -426,7 +420,7 @@ async def get_route_congestion(
         aggregated_segments=aggregated_api_segments,
         train_positions=train_positions,
         generated_at=now_et(),
-        time_window_hours=time_window_hours,
+        time_window_hours=effective_time_window,
         max_per_segment=max_per_segment,
         metadata={
             "total_individual_segments": len(individual_segments),
@@ -473,11 +467,7 @@ async def get_route_congestion(
         await cache_service.store_cached_response(
             db=db,
             endpoint="/api/v2/routes/congestion",
-            params={
-                "time_window_hours": time_window_hours,
-                "max_per_segment": max_per_segment,
-                "data_source": data_source,
-            },
+            params=cache_params,
             response=response.model_dump(mode="json"),
             ttl_seconds=600,  # 10 minutes (longer than 15-min refresh to avoid gaps)
         )

--- a/backend_v2/src/trackrat/services/api_cache.py
+++ b/backend_v2/src/trackrat/services/api_cache.py
@@ -143,14 +143,18 @@ class ApiCacheService:
         """Pre-compute congestion responses for common parameter combinations used by iOS app."""
 
         # Parameter combinations based on iOS app usage analysis
+        # Cache keys use effective time window (minimum 2h enforced by API endpoint)
         param_sets: list[dict[str, Any]] = [
-            # Default API call: timeWindowHours=3, maxPerSegment=100, dataSource=nil
-            {"time_window_hours": 3, "max_per_segment": 100, "data_source": None},
-            # Journey view call: timeWindowHours=2, maxPerSegment=100, dataSource=nil
+            # iOS summary mode (default): timeWindowHours=1 -> effective 2, maxPerSegment=0
+            {"time_window_hours": 2, "max_per_segment": 0, "data_source": None},
+            # iOS trains mode: timeWindowHours=1 -> effective 2, maxPerSegment=100
             {"time_window_hours": 2, "max_per_segment": 100, "data_source": None},
+            # Longer window views
+            {"time_window_hours": 3, "max_per_segment": 100, "data_source": None},
+            {"time_window_hours": 3, "max_per_segment": 0, "data_source": None},
             # User filtering with NJT only
+            {"time_window_hours": 2, "max_per_segment": 0, "data_source": "NJT"},
             {"time_window_hours": 3, "max_per_segment": 100, "data_source": "NJT"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "NJT"},
         ]
 
         logger.info("precomputing_congestion_responses", param_count=len(param_sets))
@@ -200,6 +204,18 @@ class ApiCacheService:
             )
         )
 
+        # Filter out SAN station code collision (same as routes.py)
+        aggregated_segments = [
+            s
+            for s in aggregated_segments
+            if s.from_station != "SAN" and s.to_station != "SAN"
+        ]
+        individual_segments = [
+            s
+            for s in individual_segments
+            if s.from_station != "SAN" and s.to_station != "SAN"
+        ]
+
         # Extract train positions from journeys (same logic as routes.py)
         train_positions = []
         for journey in journeys:
@@ -246,6 +262,10 @@ class ApiCacheService:
                 current_average_minutes=segment.avg_transit_minutes,
                 cancellation_count=segment.cancellation_count,
                 cancellation_rate=segment.cancellation_rate,
+                train_count=segment.train_count,
+                baseline_train_count=segment.baseline_train_count,
+                frequency_factor=segment.frequency_factor,
+                frequency_level=segment.frequency_level,
             )
             aggregated_api_segments.append(segment_model)
 

--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -136,7 +136,7 @@ class CongestionAnalyzer:
 
         # Use SQL-based individual segments calculation for better performance and accuracy
         individual_segments = []
-        if max_per_segment >= 0:  # 0 means unlimited, positive means limited
+        if max_per_segment > 0:  # positive means limited; 0 or negative means skip
             individual_segments = await self.get_individual_segments_optimized(
                 db, time_window_hours, max_per_segment, data_source
             )

--- a/backend_v2/tests/unit/services/test_api_cache.py
+++ b/backend_v2/tests/unit/services/test_api_cache.py
@@ -254,17 +254,17 @@ class TestApiCacheService:
             with patch.object(cache_service, "store_cached_response") as mock_store:
                 await cache_service.precompute_congestion_responses(mock_db)
 
-                # Should compute for 4 default parameter combinations
-                assert mock_compute.call_count == 4
+                # Should compute for 6 default parameter combinations
+                assert mock_compute.call_count == 6
 
                 # Should store each computed response
-                assert mock_store.call_count == 4
+                assert mock_store.call_count == 6
 
                 # Verify the parameter combinations
                 expected_params = [
                     {
-                        "time_window_hours": 3,
-                        "max_per_segment": 100,
+                        "time_window_hours": 2,
+                        "max_per_segment": 0,
                         "data_source": None,
                     },
                     {
@@ -275,10 +275,20 @@ class TestApiCacheService:
                     {
                         "time_window_hours": 3,
                         "max_per_segment": 100,
+                        "data_source": None,
+                    },
+                    {
+                        "time_window_hours": 3,
+                        "max_per_segment": 0,
+                        "data_source": None,
+                    },
+                    {
+                        "time_window_hours": 2,
+                        "max_per_segment": 0,
                         "data_source": "NJT",
                     },
                     {
-                        "time_window_hours": 2,
+                        "time_window_hours": 3,
                         "max_per_segment": 100,
                         "data_source": "NJT",
                     },
@@ -306,16 +316,18 @@ class TestApiCacheService:
                 {"data": "response2"},
                 {"data": "response3"},
                 {"data": "response4"},
+                {"data": "response5"},
+                {"data": "response6"},
             ]
 
             with patch.object(cache_service, "store_cached_response") as mock_store:
                 await cache_service.precompute_congestion_responses(mock_db)
 
-                # Should try to compute all 4
-                assert mock_compute.call_count == 4
+                # Should try to compute all 6
+                assert mock_compute.call_count == 6
 
-                # Should only store the 3 successful ones
-                assert mock_store.call_count == 3
+                # Should only store the 5 successful ones
+                assert mock_store.call_count == 5
 
     @pytest.mark.asyncio
     async def test_compute_congestion_response(self, cache_service, mock_db):
@@ -336,6 +348,10 @@ class TestApiCacheService:
                 avg_transit_minutes=15.5,
                 cancellation_count=0,
                 cancellation_rate=0.0,
+                train_count=10,
+                baseline_train_count=12,
+                frequency_factor=0.83,
+                frequency_level="healthy",
             )
         ]
         mock_individual = []
@@ -413,6 +429,10 @@ class TestApiCacheService:
                 avg_transit_minutes=15,
                 cancellation_count=0,
                 cancellation_rate=0,
+                train_count=10,
+                baseline_train_count=12,
+                frequency_factor=0.83,
+                frequency_level="healthy",
             ),
         ]
         mock_individual = []


### PR DESCRIPTION
## Summary
This PR fixes cache key generation in the congestion API endpoint to use the effective time window (minimum 2 hours) rather than the raw request parameter. This ensures that cache entries are properly matched when the API enforces a minimum 2-hour window for meaningful congestion data.

## Key Changes

- **Cache key consistency**: Moved time window enforcement to the beginning of `get_route_congestion()` and use the effective time window for all cache operations (get, invalidate, store). This prevents cache misses when requests with `time_window_hours < 2` should match precomputed entries.

- **Precomputation parameter updates**: Updated `precompute_congestion_responses()` to cache 6 parameter combinations (up from 4) that reflect actual iOS app usage patterns:
  - Added combinations with `max_per_segment=0` (summary mode)
  - Adjusted time windows to use effective values (minimum 2 hours)
  - Reordered to prioritize common iOS app patterns

- **SAN station filtering**: Added filtering for SAN station code collision in `_compute_congestion_response()` to match the filtering logic in the main API endpoint.

- **Response field mapping**: Updated cached response construction to include new segment fields (`train_count`, `baseline_train_count`, `frequency_factor`, `frequency_level`) that were missing from the cache service implementation.

- **Individual segments logic fix**: Changed condition in `get_network_congestion_with_trains()` from `>= 0` to `> 0` to properly skip individual segments when `max_per_segment=0` (summary mode).

## Implementation Details

The core issue was that cache keys were built with raw request parameters before enforcement, causing requests like `time_window_hours=1` to not match precomputed entries with `time_window_hours=2`. By computing the effective time window first and using it consistently throughout the function, cache hits are now properly achieved for equivalent requests.

Test expectations were updated to reflect the new 6-parameter precomputation set and the additional segment fields now included in cached responses.

https://claude.ai/code/session_01RLkvGGDFAPdUEK8ZSBQJ7e