### PR TITLE
Fix SQLAlchemy greenlet bridge initialization in scheduler cache task

### DIFF
--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2479,9 +2479,15 @@ class SchedulerService:
 
                 from trackrat.services.api_cache import ApiCacheService
 
-                async with get_session() as session:
-                    cache_service = ApiCacheService()
-                    await cache_service.precompute_departure_responses(session)
+                # Wrap in create_task to ensure fresh greenlet context
+                # APScheduler's AsyncIOExecutor doesn't reliably initialize
+                # SQLAlchemy's greenlet bridge (see also line 1734)
+                async def _inner() -> None:
+                    async with get_session() as session:
+                        cache_service = ApiCacheService()
+                        await cache_service.precompute_departure_responses(session)
+
+                await asyncio.create_task(_inner())
 
                 logger.info("departure_cache_precomputation_completed")
 


### PR DESCRIPTION
## Summary
Wraps the cache precomputation task in `asyncio.create_task()` to ensure a fresh greenlet context is created, fixing potential SQLAlchemy greenlet bridge initialization issues when running under APScheduler's AsyncIOExecutor.

## Changes
- Extracted the cache precomputation logic into an inner async function `_inner()`
- Wrapped the inner function call with `asyncio.create_task()` to create a new task context
- Added explanatory comments referencing the known APScheduler/SQLAlchemy greenlet bridge compatibility issue

## Implementation Details
APScheduler's AsyncIOExecutor doesn't reliably initialize SQLAlchemy's greenlet bridge in all contexts. By explicitly creating a new asyncio task, we ensure that the greenlet context is properly initialized before the database session is created and used. This approach is consistent with similar fixes elsewhere in the codebase (see line 1734).

https://claude.ai/code/session_013knLaDAQcZJHhKbUTXKjcY