### PR TITLE
Skip stale cache when resuming from background

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -930,10 +930,13 @@ class TrainDetailsViewModel: ObservableObject {
         let effectiveDate = journeyDate ?? Date()
 
         // PRIORITY 1: Check cache first (will have full train data with stops from previous visits)
+        // Skip stale cache (>60s) to avoid showing outdated data when resuming from background
+        // (e.g., tapping Live Activity after app was suspended — polling timer doesn't fire in background)
         if !trainIdentifier.isEmpty,
-           let cached = cacheService.getCachedTrain(trainNumber: trainIdentifier, date: effectiveDate) {
+           let cached = cacheService.getCachedTrain(trainNumber: trainIdentifier, date: effectiveDate),
+           cached.ageSeconds <= 60 {
             // Load from cache immediately - NO loading indicator
-            print("📦 Loading from cache - instant display")
+            print("📦 Loading from cache (\(cached.ageSeconds)s old) - instant display")
             train = cached.train
             updateComputedProperties()
 


### PR DESCRIPTION
## Summary
Added cache staleness validation to prevent displaying outdated train data when the app resumes from background suspension. The app now skips cached data older than 60 seconds to ensure users see current information.

## Key Changes
- Added age check to cache validation: only use cached train data if it's 60 seconds old or newer
- Updated cache hit logging to display the age of the cached data for debugging purposes
- Added explanatory comments clarifying why stale cache is skipped (background suspension prevents polling timer from firing)

## Implementation Details
The fix addresses a specific scenario where:
1. User views train details and the data is cached
2. App is suspended in the background (polling timer stops)
3. User returns to the app via Live Activity or other means
4. Stale cached data would be displayed instead of fetching fresh data

By enforcing a 60-second cache TTL, the app now automatically fetches fresh data in these scenarios while still providing instant display for recently cached data during normal app usage.

https://claude.ai/code/session_01SPUb88zwZyK2MuB9M7pd9N