### PR TITLE
Fix Amtrak delay propagation: parse depCmnt/arrCmnt into updated_departure/updated_arrival

### DIFF
--- a/backend_v2/src/trackrat/collectors/amtrak/journey.py
+++ b/backend_v2/src/trackrat/collectors/amtrak/journey.py
@@ -4,7 +4,8 @@ Amtrak journey collection for TrackRat V2.
 Collects complete journey details for Amtrak trains.
 """
 
-from datetime import datetime
+import re
+from datetime import datetime, timedelta
 from typing import Any, cast
 
 from sqlalchemy import and_, delete, select
@@ -319,8 +320,8 @@ class AmtrakJourneyCollector(BaseJourneyCollector):
                     "stop_sequence": stop_sequence,
                     "scheduled_arrival": sched_arr,
                     "scheduled_departure": sched_dep,
-                    "updated_arrival": sched_arr,  # For Amtrak, use scheduled since no estimates
-                    "updated_departure": sched_dep,
+                    "updated_arrival": self._compute_estimated_time(sched_arr, amtrak_stop.arrCmnt),
+                    "updated_departure": self._compute_estimated_time(sched_dep, amtrak_stop.depCmnt),
                     "actual_arrival": actual_arr,
                     "actual_departure": actual_dep,
                     "raw_amtrak_status": amtrak_stop.status,
@@ -429,6 +430,31 @@ class AmtrakJourneyCollector(BaseJourneyCollector):
         except Exception as e:
             logger.warning("amtrak_time_parse_failed", time_str=time_str, error=str(e))
             return None
+
+    @staticmethod
+    def _compute_estimated_time(
+        scheduled: datetime | None, comment: str
+    ) -> datetime | None:
+        """Compute estimated time from scheduled time and Amtrak delay comment.
+
+        The Amtrak API provides delay info in depCmnt/arrCmnt fields as strings
+        like "5 Min Late", "64 Min Late", "On Time", "Cancelled", or "".
+
+        Returns scheduled + delay if a delay is parsed, otherwise returns scheduled.
+        """
+        if not scheduled or not comment:
+            return scheduled
+
+        match = re.match(r"(\d+)\s*min\s*late", comment, re.IGNORECASE)
+        if match:
+            return scheduled + timedelta(minutes=int(match.group(1)))
+
+        match = re.match(r"(\d+)\s*min\s*early", comment, re.IGNORECASE)
+        if match:
+            return scheduled - timedelta(minutes=int(match.group(1)))
+
+        # "On Time", "Cancelled", or unrecognized — return scheduled as-is
+        return scheduled
 
     async def collect_journey_details(
         self, session: AsyncSession, journey: TrainJourney
@@ -571,8 +597,8 @@ class AmtrakJourneyCollector(BaseJourneyCollector):
                 "stop_sequence": stop_sequence,
                 "scheduled_arrival": scheduled_arrival,
                 "scheduled_departure": scheduled_departure,
-                "updated_arrival": scheduled_arrival,  # For Amtrak, use scheduled since no estimates
-                "updated_departure": scheduled_departure,
+                "updated_arrival": self._compute_estimated_time(scheduled_arrival, amtrak_stop.arrCmnt),
+                "updated_departure": self._compute_estimated_time(scheduled_departure, amtrak_stop.depCmnt),
                 "actual_arrival": actual_arrival,
                 "actual_departure": actual_departure,
                 "raw_amtrak_status": amtrak_stop.status,

--- a/backend_v2/tests/factories/amtrak.py
+++ b/backend_v2/tests/factories/amtrak.py
@@ -23,6 +23,8 @@ def create_amtrak_station_data(
     actual_arr: str | None = None,
     status: str = "Enroute",
     platform: str = "",
+    dep_cmnt: str = "",
+    arr_cmnt: str = "",
 ) -> AmtrakStationData:
     """Factory for creating AmtrakStationData objects."""
     return AmtrakStationData(
@@ -34,8 +36,8 @@ def create_amtrak_station_data(
         schArr=sch_arr,
         dep=actual_dep,
         arr=actual_arr,
-        arrCmnt="",
-        depCmnt="",
+        arrCmnt=arr_cmnt,
+        depCmnt=dep_cmnt,
         status=status,
         stopIconColor="",
         platform=platform,

--- a/backend_v2/tests/unit/collectors/amtrak/test_journey.py
+++ b/backend_v2/tests/unit/collectors/amtrak/test_journey.py
@@ -475,3 +475,67 @@ class TestAmtrakJourneyCollector:
         """Test train state mapping with various inputs."""
         result = journey_collector.TRAIN_STATE_MAP.get(train_state, "UNKNOWN")
         assert result == expected
+
+
+class TestComputeEstimatedTime:
+    """Tests for _compute_estimated_time delay comment parsing."""
+
+    SCHEDULED = ET.localize(datetime(2025, 7, 5, 14, 0, 0))
+
+    @pytest.mark.parametrize(
+        "comment,expected_offset_min,description",
+        [
+            ("5 Min Late", 5, "standard delay format"),
+            ("64 Min Late", 64, "large delay"),
+            ("1 min late", 1, "lowercase format"),
+            ("120 MIN LATE", 120, "uppercase format"),
+            ("5  min  late", 5, "extra whitespace"),
+            ("10 Min Early", -10, "early arrival"),
+            ("3 min early", -3, "lowercase early"),
+        ],
+    )
+    def test_delay_comments(self, comment, expected_offset_min, description):
+        """Test that delay/early comments correctly shift the scheduled time.
+
+        Validates: {description}
+        """
+        from datetime import timedelta
+
+        result = AmtrakJourneyCollector._compute_estimated_time(
+            self.SCHEDULED, comment
+        )
+        expected = self.SCHEDULED + timedelta(minutes=expected_offset_min)
+        assert result == expected, (
+            f"comment={comment!r}: expected {expected}, got {result}"
+        )
+
+    @pytest.mark.parametrize(
+        "comment,description",
+        [
+            ("On Time", "on-time returns scheduled"),
+            ("Cancelled", "cancelled returns scheduled"),
+            ("", "empty string returns scheduled"),
+            ("Next Stop", "unrecognized comment returns scheduled"),
+        ],
+    )
+    def test_no_shift_comments(self, comment, description):
+        """Test that non-delay comments return scheduled time unchanged.
+
+        Validates: {description}
+        """
+        result = AmtrakJourneyCollector._compute_estimated_time(
+            self.SCHEDULED, comment
+        )
+        assert result == self.SCHEDULED, (
+            f"comment={comment!r}: expected scheduled time unchanged, got {result}"
+        )
+
+    def test_none_scheduled_returns_none(self):
+        """Test that None scheduled time returns None regardless of comment."""
+        result = AmtrakJourneyCollector._compute_estimated_time(None, "5 Min Late")
+        assert result is None
+
+    def test_none_scheduled_empty_comment_returns_none(self):
+        """Test that None scheduled with empty comment returns None."""
+        result = AmtrakJourneyCollector._compute_estimated_time(None, "")
+        assert result is None


### PR DESCRIPTION
The Amtrak API provides delay info in depCmnt/arrCmnt fields (e.g., "64 Min Late")
but these were never read — updated_departure was hardcoded to scheduled_departure.
This caused ground truth validation failures for delayed trains (64 min, 25 min, 11 min off).

https://claude.ai/code/session_01Vs96JXzWBtdsZmUKYvgZoC