### PR TITLE
Fix subway train ID prefixing to use full trip_id for detail lookup

### DIFF
--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -158,6 +158,31 @@ def _mnr_train_id_from_gtfs(train_id_or_trip_id: str) -> str:
     return f"M{train_id_or_trip_id[:6]}"
 
 
+def _strip_source_prefix(train_id: str, source: str) -> str:
+    """Strip transit-system display prefix from train_id for GTFS lookup.
+
+    Display prefixes are added in departure listings to avoid ID collisions
+    between systems. This reverses that for GTFS database lookup.
+
+    Examples:
+        ("A112", "AMTRAK") -> "112"
+        ("L181", "LIRR") -> "181"
+        ("M631700", "MNR") -> "631700"
+        ("S1-AFA25GEN-...", "SUBWAY") -> "AFA25GEN-..."
+    """
+    if source == "AMTRAK" and train_id.startswith("A") and train_id[1:].isdigit():
+        return train_id[1:]
+    if source == "LIRR" and train_id.startswith("L") and train_id[1:].isdigit():
+        return train_id[1:]
+    if source == "MNR" and train_id.startswith("M") and train_id[1:].isdigit():
+        return train_id[1:]
+    if source == "SUBWAY" and train_id.startswith("S"):
+        dash_idx = train_id.find("-")
+        if dash_idx != -1:
+            return train_id[dash_idx + 1 :]
+    return train_id
+
+
 class GTFSService:
     """Service for managing GTFS static schedule data."""
 
@@ -1574,26 +1599,9 @@ class GTFSService:
 
         # Normalize prefixed train IDs: strip prefix for lookup since GTFS stores without it
         # (We add prefixes for display consistency with real-time data)
-        search_train_id = train_id
-        if (
-            data_source == "AMTRAK"
-            and train_id.startswith("A")
-            and train_id[1:].isdigit()
-        ):
-            search_train_id = train_id[1:]
-        if (
-            data_source == "LIRR"
-            and train_id.startswith("L")
-            and train_id[1:].isdigit()
-        ):
-            search_train_id = train_id[1:]
-        if data_source == "MNR" and train_id.startswith("M") and train_id[1:].isdigit():
-            search_train_id = train_id[1:]
-        # Strip "S{route}-" prefix for SUBWAY to recover the original GTFS trip_id
-        if data_source == "SUBWAY" and train_id.startswith("S"):
-            dash_idx = train_id.find("-")
-            if dash_idx != -1:
-                search_train_id = train_id[dash_idx + 1 :]
+        search_train_id = (
+            _strip_source_prefix(train_id, data_source) if data_source else train_id
+        )
 
         all_sources = ["NJT", "AMTRAK", "PATH", "PATCO", "LIRR", "MNR", "SUBWAY"]
         sources_to_search = [data_source] if data_source else all_sources
@@ -1625,12 +1633,8 @@ class GTFSService:
             # Two-phase search: prioritize train_id (real numbers) over trip_id (GTFS IDs)
             # Phase 1: Search all sources for train_id match
             for source, service_ids in source_service_ids.items():
-                # For prefixed sources, use prefix-stripped ID for lookup
-                lookup_id = (
-                    search_train_id
-                    if source in ("AMTRAK", "LIRR", "MNR", "SUBWAY")
-                    else train_id
-                )
+                # Strip source-specific prefix (e.g., A112->112, S1-trip->trip)
+                lookup_id = _strip_source_prefix(train_id, source)
                 trip_row = await self._find_trip_in_source(
                     db, lookup_id, source, service_ids, "train_id"
                 )
@@ -1641,11 +1645,7 @@ class GTFSService:
             # Phase 2: Fall back to trip_id match
             if not trip_row:
                 for source, service_ids in source_service_ids.items():
-                    lookup_id = (
-                        search_train_id
-                        if source in ("AMTRAK", "LIRR", "MNR", "SUBWAY")
-                        else train_id
-                    )
+                    lookup_id = _strip_source_prefix(train_id, source)
                     trip_row = await self._find_trip_in_source(
                         db, lookup_id, source, service_ids, "trip_id"
                     )

--- a/backend_v2/tests/unit/services/test_gtfs.py
+++ b/backend_v2/tests/unit/services/test_gtfs.py
@@ -12,6 +12,7 @@ from trackrat.services.gtfs import (
     NJT_LINE_CODE_MAPPING,
     _lirr_train_id_from_gtfs,
     _mnr_train_id_from_gtfs,
+    _strip_source_prefix,
 )
 from trackrat.models.database import (
     GTFSCalendar,
@@ -612,25 +613,12 @@ class TestSubwayTrainIdPrefixing:
         prefixed_id = "S1-AFA25GEN-1079-Sunday-00_000600_1..N03R"
         original_trip_id = "AFA25GEN-1079-Sunday-00_000600_1..N03R"
 
-        # Simulate the strip logic from gtfs.py get_train_details
-        search_train_id = prefixed_id
-        if prefixed_id.startswith("S"):
-            dash_idx = prefixed_id.find("-")
-            if dash_idx != -1:
-                search_train_id = prefixed_id[dash_idx + 1 :]
-
-        assert search_train_id == original_trip_id
+        assert _strip_source_prefix(prefixed_id, "SUBWAY") == original_trip_id
 
     def test_subway_prefix_strip_with_multi_char_route(self):
         """Route names can be multi-character (e.g., 'SIR' for Staten Island)."""
         prefixed_id = "SSIR-trip_abc_123"
-        search_train_id = prefixed_id
-        if prefixed_id.startswith("S"):
-            dash_idx = prefixed_id.find("-")
-            if dash_idx != -1:
-                search_train_id = prefixed_id[dash_idx + 1 :]
-
-        assert search_train_id == "trip_abc_123"
+        assert _strip_source_prefix(prefixed_id, "SUBWAY") == "trip_abc_123"
 
     def test_subway_prefix_not_applied_twice(self):
         """If effective_train_id already starts with S, skip prefixing."""
@@ -654,15 +642,113 @@ class TestSubwayTrainIdPrefixing:
             effective_train_id = f"S{route_short}-{effective_train_id}"
         assert effective_train_id == "SA-BFA30GEN-1079-Weekday-00_043200_A..N04R"
 
-        # Step 2: Strip (detail endpoint)
-        search_id = effective_train_id
-        if search_id.startswith("S"):
-            dash_idx = search_id.find("-")
-            if dash_idx != -1:
-                search_id = search_id[dash_idx + 1 :]
+        # Step 2: Strip (detail endpoint) using actual helper
+        search_id = _strip_source_prefix(effective_train_id, "SUBWAY")
 
         # Recovered trip_id matches original
         assert search_id == original_trip_id
+
+
+class TestStripSourcePrefix:
+    """Tests for _strip_source_prefix helper function.
+
+    This function strips transit-system display prefixes from train IDs
+    so they can be looked up in the GTFS database. Used both in
+    single-source mode (data_source provided) and the two-phase search
+    (data_source=None, iterating all sources).
+
+    Bug fix: Previously, prefix stripping was gated on data_source matching,
+    so the two-phase search (data_source=None) would pass still-prefixed IDs
+    to the GTFS lookup, causing lookups to fail silently.
+    """
+
+    # --- AMTRAK ---
+
+    def test_amtrak_strips_a_prefix(self):
+        """Amtrak train A112 -> 112 for GTFS lookup."""
+        assert _strip_source_prefix("A112", "AMTRAK") == "112"
+
+    def test_amtrak_preserves_non_digit_suffix(self):
+        """Only strip A prefix when rest is all digits."""
+        assert _strip_source_prefix("ABCD", "AMTRAK") == "ABCD"
+
+    def test_amtrak_no_prefix_passthrough(self):
+        """Bare number passes through unchanged."""
+        assert _strip_source_prefix("112", "AMTRAK") == "112"
+
+    # --- LIRR ---
+
+    def test_lirr_strips_l_prefix(self):
+        """LIRR train L181 -> 181 for GTFS lookup."""
+        assert _strip_source_prefix("L181", "LIRR") == "181"
+
+    def test_lirr_preserves_non_digit_suffix(self):
+        """Only strip L prefix when rest is all digits."""
+        assert _strip_source_prefix("LABC", "LIRR") == "LABC"
+
+    def test_lirr_no_prefix_passthrough(self):
+        """Bare number passes through unchanged."""
+        assert _strip_source_prefix("181", "LIRR") == "181"
+
+    # --- MNR ---
+
+    def test_mnr_strips_m_prefix(self):
+        """MNR train M631700 -> 631700 for GTFS lookup."""
+        assert _strip_source_prefix("M631700", "MNR") == "631700"
+
+    def test_mnr_preserves_non_digit_suffix(self):
+        """Only strip M prefix when rest is all digits."""
+        assert _strip_source_prefix("MXYZ", "MNR") == "MXYZ"
+
+    # --- SUBWAY ---
+
+    def test_subway_strips_route_prefix(self):
+        """Subway S1-trip_id -> trip_id for GTFS lookup."""
+        assert (
+            _strip_source_prefix(
+                "S1-AFA25GEN-1079-Sunday-00_000600_1..N03R", "SUBWAY"
+            )
+            == "AFA25GEN-1079-Sunday-00_000600_1..N03R"
+        )
+
+    def test_subway_strips_multi_char_route(self):
+        """SIR route produces SSIR- prefix."""
+        assert _strip_source_prefix("SSIR-trip_123", "SUBWAY") == "trip_123"
+
+    def test_subway_no_dash_passthrough(self):
+        """If no dash found, ID passes through unchanged (safety guard)."""
+        assert _strip_source_prefix("S6010123", "SUBWAY") == "S6010123"
+
+    def test_subway_bare_trip_id_passthrough(self):
+        """Bare trip_id (no S prefix) passes through unchanged."""
+        assert (
+            _strip_source_prefix(
+                "AFA25GEN-1079-Sunday-00_000600_1..N03R", "SUBWAY"
+            )
+            == "AFA25GEN-1079-Sunday-00_000600_1..N03R"
+        )
+
+    # --- Cross-source safety ---
+
+    def test_njt_no_stripping(self):
+        """NJT IDs are never prefixed, so nothing is stripped."""
+        assert _strip_source_prefix("2508", "NJT") == "2508"
+
+    def test_path_no_stripping(self):
+        """PATH IDs are never prefixed, so nothing is stripped."""
+        assert _strip_source_prefix("PATH-123", "PATH") == "PATH-123"
+
+    def test_wrong_source_no_stripping(self):
+        """A prefixed ID only gets stripped for its matching source.
+
+        An Amtrak-prefixed ID passed with source=NJT should NOT be stripped,
+        since the prefix logic is source-specific.
+        """
+        assert _strip_source_prefix("A112", "NJT") == "A112"
+
+    def test_subway_prefix_not_stripped_for_amtrak(self):
+        """Subway-style prefix shouldn't be stripped for non-SUBWAY source."""
+        assert _strip_source_prefix("S1-trip_123", "AMTRAK") == "S1-trip_123"
 
 
 class TestDataSourceFiltering:


### PR DESCRIPTION
## Summary
Fixed a bug where subway GTFS train IDs were being truncated to 6 characters when prefixed, preventing the detail endpoint from reverse-looking up the original trip. The prefix now uses the full GTFS trip_id, and a new `_strip_source_prefix()` helper function centralizes prefix stripping logic for all transit systems.

## Key Changes

- **Introduced `_strip_source_prefix()` helper function**: Centralizes the logic for stripping transit-system display prefixes (A, L, M, S{route}-) from train IDs so they can be looked up in the GTFS database. This function handles:
  - AMTRAK: strips "A" prefix (e.g., A112 → 112)
  - LIRR: strips "L" prefix (e.g., L181 → 181)
  - MNR: strips "M" prefix (e.g., M631700 → 631700)
  - SUBWAY: strips "S{route}-" prefix (e.g., S1-trip_id → trip_id)

- **Fixed subway prefix truncation bug**: Changed from `f"S{route_prefix}-{effective_train_id[:6]}"` to `f"S{route_prefix}-{effective_train_id}"` in both `_query_departures_for_source()` and `get_train_details()`. This ensures the full GTFS trip_id is preserved so the detail endpoint can strip the prefix and recover the original trip for database lookup.

- **Refactored prefix stripping in `get_train_details()`**: Replaced inline prefix-stripping logic with calls to `_strip_source_prefix()`, making the code more maintainable and fixing a bug in the two-phase search where prefix stripping was gated on `data_source` matching. Now the two-phase search (when `data_source=None`) correctly strips prefixes for all sources during iteration.

## Implementation Details

- The `_strip_source_prefix()` function includes safety guards (e.g., checking that characters after the prefix are digits for A/L/M, checking for dash presence for SUBWAY) to avoid over-stripping.
- Comprehensive test coverage added for both the subway prefixing logic and the `_strip_source_prefix()` helper across all transit systems.
- The fix ensures roundtrip consistency: prefixes added in departure listings can be reliably stripped in detail lookups.

https://claude.ai/code/session_01Tcm8Lzsb9wCRmcfzFdKvLM