### PR TITLE
Consolidate Amtrak toggle into tri-state: Off → NEC Only → All

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -632,6 +632,13 @@ final class AppState: ObservableObject {
         }
     }
 
+    // Amtrak coverage mode: NEC Only vs All Routes (persisted via UserDefaults)
+    @Published var amtrakMode: AmtrakMode = .all {
+        didSet {
+            UserDefaults.standard.set(amtrakMode.rawValue, forKey: "amtrakMode")
+        }
+    }
+
     // Map display settings (persisted via UserDefaults)
     @Published var mapHighlightMode: SegmentHighlightMode = .delays {
         didSet {
@@ -757,14 +764,29 @@ final class AppState: ObservableObject {
 
     // MARK: - Train Systems
 
-    /// Load selected systems from UserDefaults
+    /// Load selected systems from UserDefaults (with migration from legacy AMTRAK_NEC)
     private func loadSelectedSystems() {
         if let stored = UserDefaults.standard.string(forKey: "selectedTrainSystems"), !stored.isEmpty {
+            // Migration: convert legacy "AMTRAK_NEC" to "AMTRAK" + necOnly mode
+            if stored.contains("AMTRAK_NEC") {
+                let migrated = stored
+                    .replacingOccurrences(of: "AMTRAK_NEC", with: "AMTRAK")
+                let loaded = Set<TrainSystem>.from(commaSeparated: migrated)
+                selectedSystems = loaded.isEmpty ? .defaultEnabled : loaded
+                amtrakMode = .necOnly
+                return
+            }
+
             let loaded = Set<TrainSystem>.from(commaSeparated: stored)
             selectedSystems = loaded.isEmpty ? .defaultEnabled : loaded
         } else {
-            // Default to NJT and Amtrak
             selectedSystems = .defaultEnabled
+        }
+
+        // Load persisted amtrak mode
+        if let storedMode = UserDefaults.standard.string(forKey: "amtrakMode"),
+           let mode = AmtrakMode(rawValue: storedMode) {
+            amtrakMode = mode
         }
     }
 
@@ -774,26 +796,34 @@ final class AppState: ObservableObject {
     }
 
     /// Toggle a system's selection state (ensures at least one remains selected)
+    /// For Amtrak: cycles Off → NEC Only → All → Off
     func toggleSystem(_ system: TrainSystem) {
-        if selectedSystems.contains(system) {
-            // Don't allow deselecting the last system
-            guard selectedSystems.count > 1 else { return }
-            selectedSystems.remove(system)
+        if system == .amtrak {
+            if !selectedSystems.contains(.amtrak) {
+                // Off → NEC Only
+                selectedSystems.insert(.amtrak)
+                amtrakMode = .necOnly
+            } else if amtrakMode == .necOnly {
+                // NEC Only → All
+                amtrakMode = .all
+            } else {
+                // All → Off (unless it's the last system)
+                guard selectedSystems.count > 1 else { return }
+                selectedSystems.remove(.amtrak)
+            }
         } else {
-            selectedSystems.insert(system)
-            // Mutual exclusivity: full Amtrak and NEC-only can't coexist
-            switch system {
-            case .amtrak:    selectedSystems.remove(.amtrakNEC)
-            case .amtrakNEC: selectedSystems.remove(.amtrak)
-            default: break
+            if selectedSystems.contains(system) {
+                guard selectedSystems.count > 1 else { return }
+                selectedSystems.remove(system)
+            } else {
+                selectedSystems.insert(system)
             }
         }
     }
 
     /// Select all systems
     func selectAllSystems() {
-        // Exclude .amtrakNEC since .amtrak is its superset
-        selectedSystems = Set(TrainSystem.allCases.filter { $0 != .amtrakNEC })
+        selectedSystems = Set(TrainSystem.allCases)
     }
 
     // MARK: - Map Settings

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -1,10 +1,31 @@
 import Foundation
 
+/// Amtrak coverage mode: NEC-only or all routes
+enum AmtrakMode: String, CaseIterable {
+    case necOnly = "NEC_ONLY"
+    case all = "ALL"
+
+    /// Label shown as subtitle on Amtrak toggle buttons
+    var label: String {
+        switch self {
+        case .necOnly: return "NEC Only"
+        case .all: return "All Routes"
+        }
+    }
+
+    /// Cycle to next mode
+    var next: AmtrakMode {
+        switch self {
+        case .necOnly: return .all
+        case .all: return .necOnly
+        }
+    }
+}
+
 /// Represents the different train systems supported by TrackRat
 enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     case njt = "NJT"
     case amtrak = "AMTRAK"
-    case amtrakNEC = "AMTRAK_NEC"
     case path = "PATH"
     case patco = "PATCO"
     case lirr = "LIRR"
@@ -13,28 +34,14 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
 
     var id: String { rawValue }
 
-    /// Backend data source string (e.g. .amtrakNEC shares "AMTRAK")
-    var dataSource: String {
-        switch self {
-        case .amtrakNEC: return "AMTRAK"
-        default: return rawValue
-        }
-    }
-
-    /// Route IDs this system is restricted to, or nil for no restriction
-    var routeIds: [String]? {
-        switch self {
-        case .amtrakNEC: return ["amtrak-nec", "amtrak-keystone"]
-        default: return nil
-        }
-    }
+    /// Backend data source string
+    var dataSource: String { rawValue }
 
     /// Human-readable display name
     var displayName: String {
         switch self {
         case .njt: return "NJ Transit"
         case .amtrak: return "Amtrak"
-        case .amtrakNEC: return "Amtrak (NEC Only)"
         case .path: return "PATH"
         case .patco: return "PATCO"
         case .lirr: return "LIRR"
@@ -48,7 +55,6 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .njt: return "New Jersey commuter rail"
         case .amtrak: return "National passenger rail"
-        case .amtrakNEC: return "Northeast Corridor & Keystone"
         case .path: return "NY-NJ rapid transit"
         case .patco: return "Philly-South Jersey"
         case .lirr: return "Long Island commuter rail"
@@ -61,7 +67,7 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     var icon: String {
         switch self {
         case .njt: return "tram.fill"
-        case .amtrak, .amtrakNEC: return "train.side.front.car"
+        case .amtrak: return "train.side.front.car"
         case .path: return "tram"
         case .patco: return "lightrail.fill"
         case .lirr: return "train.side.rear.car"
@@ -74,7 +80,7 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     var color: String {
         switch self {
         case .njt: return "#004D6E"   // NJ Transit blue
-        case .amtrak, .amtrakNEC: return "#004B87" // Amtrak blue
+        case .amtrak: return "#004B87" // Amtrak blue
         case .path: return "#FF5722"  // PATH orange
         case .patco: return "#0072CE" // PATCO blue
         case .lirr: return "#0039A6"  // MTA LIRR blue
@@ -119,37 +125,28 @@ extension Set where Element == TrainSystem {
         []
     }
 
-    /// Deduplicated data source strings for API calls (e.g. both .amtrak and .amtrakNEC → "AMTRAK")
+    /// Deduplicated data source strings for API calls
     var apiDataSources: String {
-        Set<String>(self.map(\.dataSource)).sorted().joined(separator: ",")
+        Set<String>(self.map(\.rawValue)).sorted().joined(separator: ",")
     }
 
     /// Converts to raw data source string set for use with Stations/route filtering
     var asRawStrings: Set<String> {
-        var result = Set<String>()
-        for system in self {
-            result.insert(system.dataSource)
-        }
-        return result
+        Set<String>(self.map(\.rawValue))
     }
 }
 
 // MARK: - Stations Extensions (TrainSystem-aware wrappers)
 
 extension Stations {
-    /// Cached mapping of route-filtered system rawValues to their allowed station codes.
-    /// For systems like .amtrakNEC that restrict to specific routes.
-    static let routeFilteredStations: [String: Set<String>] = {
-        var result: [String: Set<String>] = [:]
-        for system in TrainSystem.allCases {
-            guard let routeIds = system.routeIds else { continue }
-            var codes = Set<String>()
-            for route in RouteTopology.allRoutes where routeIds.contains(route.id) {
-                codes.formUnion(route.stationCodes)
-            }
-            result[system.rawValue] = codes
+    /// Station codes on the Amtrak NEC + Keystone routes (used for NEC-only filtering)
+    static let amtrakNECStations: Set<String> = {
+        let necRouteIds: Set<String> = ["amtrak-nec", "amtrak-keystone"]
+        var codes = Set<String>()
+        for route in RouteTopology.allRoutes where necRouteIds.contains(route.id) {
+            codes.formUnion(route.stationCodes)
         }
-        return result
+        return codes
     }()
 
     /// Returns the train systems that serve a given station
@@ -159,15 +156,16 @@ extension Stations {
         return Set(rawSystems.compactMap { TrainSystem(rawValue: $0) })
     }
 
-    /// Check if a station should be visible based on selected systems
+    /// Check if a station should be visible based on selected systems and Amtrak mode
     /// A station is visible if ANY of the selected systems serve it
-    static func isStationVisible(_ code: String, withSystems selectedSystems: Set<TrainSystem>) -> Bool {
+    static func isStationVisible(_ code: String, withSystems selectedSystems: Set<TrainSystem>, amtrakMode: AmtrakMode = .all) -> Bool {
         for system in selectedSystems {
-            if let allowedStations = routeFilteredStations[system.rawValue] {
-                if allowedStations.contains(code) { return true }
+            if system == .amtrak && amtrakMode == .necOnly {
+                // NEC-only: restrict to NEC + Keystone stations
+                if amtrakNECStations.contains(code) { return true }
             } else {
                 let stationSystems = systemStringsForStation(code)
-                if stationSystems.contains(system.dataSource) { return true }
+                if stationSystems.contains(system.rawValue) { return true }
             }
         }
         return false

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -152,7 +152,10 @@ struct CongestionMapView: View {
             await viewModel.fetchCongestionData()
         }
         .onChange(of: appState.selectedSystems) { _, newSystems in
-            viewModel.setSelectedSystems(newSystems)
+            viewModel.setSelectedSystems(newSystems, amtrakMode: appState.amtrakMode)
+        }
+        .onChange(of: appState.amtrakMode) { _, newMode in
+            viewModel.setSelectedSystems(appState.selectedSystems, amtrakMode: newMode)
         }
         .onChange(of: appState.mapHighlightMode) { _, newMode in
             viewModel.highlightMode = newMode
@@ -162,7 +165,7 @@ struct CongestionMapView: View {
         }
         .onAppear {
             // Sync AppState settings to ViewModel on appear
-            viewModel.setSelectedSystems(appState.selectedSystems)
+            viewModel.setSelectedSystems(appState.selectedSystems, amtrakMode: appState.amtrakMode)
             viewModel.highlightMode = appState.mapHighlightMode
             viewModel.showStations = appState.showMapStations
         }
@@ -264,6 +267,7 @@ struct CongestionMapView: View {
                 SystemToggleButton(
                     system: system,
                     isSelected: appState.isSystemSelected(system),
+                    subtitle: system == .amtrak ? appState.amtrakMode.label : nil,
                     action: {
                         appState.toggleSystem(system)
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -382,6 +386,7 @@ private struct LayerToggleButton: View {
 private struct SystemToggleButton: View {
     let system: TrainSystem
     let isSelected: Bool
+    var subtitle: String? = nil
     let action: () -> Void
 
     var body: some View {
@@ -392,9 +397,17 @@ private struct SystemToggleButton: View {
                     .foregroundColor(isSelected ? .orange : .secondary)
                     .frame(width: 20)
 
-                Text(system.displayName)
-                    .font(.subheadline)
-                    .foregroundColor(.primary)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(system.displayName)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+
+                    if let subtitle, isSelected {
+                        Text(subtitle)
+                            .font(.caption2)
+                            .foregroundColor(.orange)
+                    }
+                }
 
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .font(.body)
@@ -490,6 +503,7 @@ class CongestionMapViewModel: ObservableObject {
 
     // System filter
     private var selectedSystems: Set<TrainSystem> = .all
+    private var amtrakMode: AmtrakMode = .all
 
     // Live Activity observation
     private var liveActivityCancellables = Set<AnyCancellable>()
@@ -515,20 +529,22 @@ class CongestionMapViewModel: ObservableObject {
         }
         // Apply system filter to get visible stations
         routeStations = allRouteStations.filter { station in
-            Stations.isStationVisible(station.code, withSystems: selectedSystems)
+            Stations.isStationVisible(station.code, withSystems: selectedSystems, amtrakMode: amtrakMode)
         }
         print("🗺️ Loaded \(allRouteStations.count) route topology stations, \(routeStations.count) visible with current systems")
     }
 
     /// Updates the selected systems filter and reapplies all filtering
-    func setSelectedSystems(_ systems: Set<TrainSystem>) {
-        guard systems != selectedSystems else { return }
+    func setSelectedSystems(_ systems: Set<TrainSystem>, amtrakMode: AmtrakMode = .all) {
+        let changed = systems != selectedSystems || amtrakMode != self.amtrakMode
         selectedSystems = systems
+        self.amtrakMode = amtrakMode
+        guard changed else { return }
         print("🚦 Selected systems updated: \(systems.map(\.rawValue).sorted().joined(separator: ", "))")
 
         // Refilter route stations
         routeStations = allRouteStations.filter { station in
-            Stations.isStationVisible(station.code, withSystems: selectedSystems)
+            Stations.isStationVisible(station.code, withSystems: selectedSystems, amtrakMode: amtrakMode)
         }
 
         // Reapply all filters
@@ -745,11 +761,11 @@ class CongestionMapViewModel: ObservableObject {
         // First filter by effective systems
         let systemFilteredAggregated = allAggregatedSegments.filter { effectiveSystemStrings.contains($0.dataSource) }
         let systemFilteredIndividual = allIndividualSegments.filter { effectiveSystemStrings.contains($0.dataSource) }
-        let systemFilteredStations = allStations.filter { Stations.isStationVisible($0.code, withSystems: effectiveSystems) }
+        let systemFilteredStations = allStations.filter { Stations.isStationVisible($0.code, withSystems: effectiveSystems, amtrakMode: amtrakMode) }
 
         // Update route station visibility to match effective systems
         routeStations = allRouteStations.filter { station in
-            Stations.isStationVisible(station.code, withSystems: effectiveSystems)
+            Stations.isStationVisible(station.code, withSystems: effectiveSystems, amtrakMode: amtrakMode)
         }
 
         // Then apply route filter if we have one
@@ -908,8 +924,8 @@ struct FilterSheet: View {
                 Section("Data Source") {
                     Picker("Source", selection: $selectedDataSource) {
                         Text("All").tag("All")
-                        ForEach(TrainSystem.allCases.filter { $0 != .amtrakNEC }) { system in
-                            Text(system.displayName).tag(system.dataSource)
+                        ForEach(TrainSystem.allCases) { system in
+                            Text(system.displayName).tag(system.rawValue)
                         }
                     }
                 }

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -71,7 +71,7 @@ struct DeparturePickerView: View {
         // Always search stations, filtered by selected systems
         let stationResults = Stations.search(query).filter { stationName in
             guard let code = Stations.getStationCode(stationName) else { return false }
-            return Stations.isStationVisible(code, withSystems: appState.selectedSystems)
+            return Stations.isStationVisible(code, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
         }
         
         // Check if input also looks like a train number

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -14,7 +14,7 @@ struct DestinationPickerView: View {
         return results.filter { stationName in
             guard stationName != appState.selectedDeparture else { return false }
             guard let code = Stations.getStationCode(stationName) else { return false }
-            return Stations.isStationVisible(code, withSystems: appState.selectedSystems)
+            return Stations.isStationVisible(code, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
         }
     }
 
@@ -22,7 +22,7 @@ struct DestinationPickerView: View {
     private var favoriteStations: [FavoriteStation] {
         return appState.favoriteStations.filter { station in
             station.id != appState.departureStationCode &&
-            Stations.isStationVisible(station.id, withSystems: appState.selectedSystems)
+            Stations.isStationVisible(station.id, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
         }
     }
     

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -413,7 +413,8 @@ struct SettingsSection: View {
                     TrainSystemRow(
                         system: system,
                         isSelected: appState.isSystemSelected(system),
-                        isLast: system == sortedSystems.last
+                        isLast: system == sortedSystems.last,
+                        subtitle: system == .amtrak ? appState.amtrakMode.label : nil
                     ) {
                         appState.toggleSystem(system)
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -914,6 +915,7 @@ private struct TrainSystemRow: View {
     let system: TrainSystem
     let isSelected: Bool
     let isLast: Bool
+    var subtitle: String? = nil
     let action: () -> Void
 
     var body: some View {
@@ -925,10 +927,18 @@ private struct TrainSystemRow: View {
                         .foregroundColor(isSelected ? .orange : .white.opacity(0.5))
                         .frame(width: 24, height: 24)
 
-                    Text(system.displayName + (system.isBeta ? " (beta)" : ""))
-                        .font(.headline)
-                        .fontWeight(.medium)
-                        .foregroundColor(.white)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(system.displayName + (system.isBeta ? " (beta)" : ""))
+                            .font(.headline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.white)
+
+                        if let subtitle, isSelected {
+                            Text(subtitle)
+                                .font(.caption)
+                                .foregroundColor(.orange)
+                        }
+                    }
 
                     Spacer()
 

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -93,6 +93,7 @@ struct OnboardingView: View {
                 selectedStation: binding(for: stationBeingEdited),
                 disabledStation: disabledStation(for: stationBeingEdited),
                 selectedSystems: appState.selectedSystems,
+                amtrakMode: appState.amtrakMode,
                 onStationSelected: { station in
                     // Explicitly handle station assignment with proper state update
                     DispatchQueue.main.async {
@@ -134,6 +135,7 @@ struct OnboardingView: View {
                     SystemSelectionCard(
                         system: system,
                         isSelected: appState.isSystemSelected(system),
+                        subtitle: system == .amtrak ? appState.amtrakMode.label : nil,
                         onTap: {
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 appState.toggleSystem(system)
@@ -552,6 +554,7 @@ struct StationSelectionCard: View {
 struct SystemSelectionCard: View {
     let system: TrainSystem
     let isSelected: Bool
+    var subtitle: String? = nil
     let onTap: () -> Void
 
     var body: some View {
@@ -569,6 +572,17 @@ struct SystemSelectionCard: View {
                         Text(system.displayName)
                             .font(.headline)
                             .foregroundColor(.white)
+                        if let subtitle, isSelected {
+                            Text(subtitle)
+                                .font(.caption2)
+                                .fontWeight(.semibold)
+                                .foregroundColor(.orange)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule().fill(.orange.opacity(0.2))
+                                )
+                        }
                         if system.isBeta {
                             Text("beta")
                                 .font(.caption2)
@@ -672,6 +686,7 @@ struct StationPickerSheet: View {
     @Binding var selectedStation: Station?
     let disabledStation: Station?  // Station that should be shown as disabled
     var selectedSystems: Set<TrainSystem>? = nil  // Optional: filter stations by selected systems
+    var amtrakMode: AmtrakMode = .all
     let onStationSelected: (Station) -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -686,7 +701,7 @@ struct StationPickerSheet: View {
 
         if let systems = selectedSystems {
             allStations = allStations.filter { station in
-                Stations.isStationVisible(station.code, withSystems: systems)
+                Stations.isStationVisible(station.code, withSystems: systems, amtrakMode: amtrakMode)
             }
         }
 

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -25,8 +25,8 @@ struct TripSelectionView: View {
     // Whether the RatSense suggestion button should be visible
     private var isRatSenseSuggestionVisible: Bool {
         guard let suggestion = ratSenseService.suggestedJourney,
-              Stations.isStationVisible(suggestion.fromStation, withSystems: appState.selectedSystems),
-              Stations.isStationVisible(suggestion.toStation, withSystems: appState.selectedSystems),
+              Stations.isStationVisible(suggestion.fromStation, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode),
+              Stations.isStationVisible(suggestion.toStation, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode),
               !liveActivityService.isActivityActive,
               !isSearching,
               !showingProfile else {
@@ -38,7 +38,7 @@ struct TripSelectionView: View {
     // Get favorite stations filtered by selected systems
     private var favoriteStations: [FavoriteStation] {
         return appState.favoriteStations.filter { station in
-            Stations.isStationVisible(station.id, withSystems: appState.selectedSystems)
+            Stations.isStationVisible(station.id, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
         }
     }
     
@@ -49,7 +49,7 @@ struct TripSelectionView: View {
         let allStationResults = Stations.search(query)
         let stationResults = allStationResults.filter { stationName in
             guard let code = Stations.getStationCode(stationName) else { return false }
-            return Stations.isStationVisible(code, withSystems: appState.selectedSystems)
+            return Stations.isStationVisible(code, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
         }
 
         // Generate potential train numbers for dual search


### PR DESCRIPTION
Replace the two separate Amtrak/.amtrakNEC enum cases with a single
.amtrak case + AmtrakMode enum (necOnly/all). The Amtrak button now
cycles through Off → NEC Only → All Routes → Off on each tap.

- Remove TrainSystem.amtrakNEC case and all mutual exclusivity logic
- Add AmtrakMode enum with label/cycling support
- Add amtrakMode property to AppState (persisted to UserDefaults)
- Migration: legacy "AMTRAK_NEC" in UserDefaults → amtrakMode = .necOnly
- Replace routeFilteredStations dict with static amtrakNECStations set
- Add amtrakMode parameter to isStationVisible (default .all)
- Show mode subtitle ("NEC Only"/"All Routes") on Amtrak toggle in
  map layers, onboarding, and profile settings
- Pass amtrakMode through all station visibility call sites

https://claude.ai/code/session_01HhbRaDQXQp9aKaqiVRnNZd