### PR TITLE
Fix LIRR Long Beach/Hempstead 0 OBSERVED: GTFS static backfill for date-suffix trip_ids

### DIFF
--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -296,6 +296,23 @@ class LIRRCollector:
                 if inferred_origin:
                     origin_code = inferred_origin
 
+            # Skip trips with fewer than 2 usable stops when no static
+            # backfill is available.  LIRR GTFS-RT includes future trains
+            # where only the origin terminal has a departure time; creating
+            # a 1-stop journey with origin == destination is nonsensical.
+            effective_stop_count = (
+                len(merged_stops)
+                if merged_stops
+                else len(arrivals) + (1 if inferred_origin else 0)
+            )
+            if effective_stop_count < 2:
+                logger.debug(
+                    "Skipping LIRR trip %s: only %d usable stop(s)",
+                    trip_id,
+                    effective_stop_count,
+                )
+                return None
+
             # Compute scheduled times
             if merged_stops:
                 sched_departure = merged_stops[0]["scheduled_departure"]

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -288,6 +288,22 @@ class MNRCollector:
                 if inferred_origin:
                     origin_code = inferred_origin
 
+            # Skip trips with fewer than 2 usable stops when no static
+            # backfill is available.  A 1-stop journey with origin == destination
+            # is nonsensical (train sitting at terminal with no predictions yet).
+            effective_stop_count = (
+                len(merged_stops)
+                if merged_stops
+                else len(arrivals) + (1 if inferred_origin else 0)
+            )
+            if effective_stop_count < 2:
+                logger.debug(
+                    "Skipping MNR trip %s: only %d usable stop(s)",
+                    trip_id,
+                    effective_stop_count,
+                )
+                return None
+
             # Compute scheduled times
             if merged_stops:
                 sched_departure = merged_stops[0]["scheduled_departure"]

--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -183,6 +183,26 @@ def _strip_source_prefix(train_id: str, source: str) -> str:
     return train_id
 
 
+def _extract_lirr_train_number(gtfs_trip_id: str) -> str | None:
+    """Extract LIRR train number from a date-suffix GTFS-RT trip_id.
+
+    LIRR GTFS-RT uses trip_ids like "6817_2026-02-24" for trains not matching
+    the current GTFS static schedule's trip_ids (which use "GO103_25_6817").
+    The train number (first segment) matches trip_short_name in GTFS static.
+
+    Args:
+        gtfs_trip_id: GTFS-RT trip_id string.
+
+    Returns:
+        Train number string (e.g., "6817") if date-suffix format detected,
+        None otherwise.
+    """
+    parts = gtfs_trip_id.split("_")
+    if len(parts) == 2 and "-" in parts[1] and parts[0].isdigit():
+        return parts[0]
+    return None
+
+
 class GTFSService:
     """Service for managing GTFS static schedule data."""
 
@@ -1915,14 +1935,23 @@ class GTFSService:
             db, gtfs_trip_id, data_source, service_ids, "trip_id"
         )
         if not trip_row:
-            logger.debug(
-                "gtfs_static_trip_not_found",
-                data_source=data_source,
-                trip_id=gtfs_trip_id,
-                target_date=str(target_date),
-                service_id_count=len(service_ids),
-            )
-            return None
+            # LIRR GTFS-RT uses date-suffix trip_ids (e.g., "6817_2026-02-24")
+            # that don't exist in GTFS static. Extract the train number and
+            # try matching by train_id (trip_short_name in GTFS static).
+            train_number = _extract_lirr_train_number(gtfs_trip_id)
+            if train_number:
+                trip_row = await self._find_trip_in_source(
+                    db, train_number, data_source, service_ids, "train_id"
+                )
+            if not trip_row:
+                logger.debug(
+                    "gtfs_static_trip_not_found",
+                    data_source=data_source,
+                    trip_id=gtfs_trip_id,
+                    target_date=str(target_date),
+                    service_id_count=len(service_ids),
+                )
+                return None
 
         db_trip_id = trip_row.id
 

--- a/backend_v2/tests/unit/services/test_gtfs.py
+++ b/backend_v2/tests/unit/services/test_gtfs.py
@@ -10,6 +10,7 @@ from trackrat.services.gtfs import (
     GTFSService,
     GTFS_DOWNLOAD_INTERVAL_HOURS,
     NJT_LINE_CODE_MAPPING,
+    _extract_lirr_train_number,
     _lirr_train_id_from_gtfs,
     _mnr_train_id_from_gtfs,
     _strip_source_prefix,
@@ -1066,3 +1067,223 @@ class TestMnrTrainIdFromGtfs:
     def test_single_digit_in_suffix(self):
         """Even a single digit in last 6 chars is extracted."""
         assert _mnr_train_id_from_gtfs("ABCDE1FG") == "M1"
+
+
+class TestExtractLirrTrainNumber:
+    """Tests for _extract_lirr_train_number helper.
+
+    LIRR GTFS-RT uses date-suffix trip_ids (e.g., '6817_2026-02-24') for
+    trains that don't match the current GTFS static trip_ids.  The helper
+    extracts the bare train number so we can fall back to a train_id lookup
+    in the static schedule.
+    """
+
+    def test_date_suffix_format_returns_train_number(self):
+        """Standard date-suffix format: '6817_2026-02-24' -> '6817'."""
+        assert _extract_lirr_train_number("6817_2026-02-24") == "6817"
+
+    def test_four_digit_train_number(self):
+        """Four-digit train number with date suffix."""
+        assert _extract_lirr_train_number("6853_2026-02-24") == "6853"
+
+    def test_five_digit_train_number(self):
+        """Five-digit train number with date suffix."""
+        assert _extract_lirr_train_number("12345_2025-12-31") == "12345"
+
+    def test_go_prefix_format_returns_none(self):
+        """GO-prefix trip_ids are NOT date-suffix format."""
+        assert _extract_lirr_train_number("GO103_25_6127") is None
+
+    def test_go_event_format_returns_none(self):
+        """GO-event trip_ids (with METS suffix) are NOT date-suffix format."""
+        assert _extract_lirr_train_number("GO103_25_367_2891_METS") is None
+
+    def test_plain_number_returns_none(self):
+        """Plain numeric trip_id (MNR style) returns None."""
+        assert _extract_lirr_train_number("3009440") is None
+
+    def test_non_numeric_first_segment_returns_none(self):
+        """Non-numeric first segment before date separator returns None."""
+        assert _extract_lirr_train_number("ABC_2026-01-01") is None
+
+    def test_no_hyphen_in_second_segment_returns_none(self):
+        """Two segments but second doesn't contain a hyphen returns None."""
+        assert _extract_lirr_train_number("6817_20260224") is None
+
+    def test_empty_string_returns_none(self):
+        """Empty string returns None."""
+        assert _extract_lirr_train_number("") is None
+
+    def test_single_segment_returns_none(self):
+        """Single segment with no underscore returns None."""
+        assert _extract_lirr_train_number("6817") is None
+
+
+class TestGetStaticStopTimesLirrFallback:
+    """Tests for get_static_stop_times fallback to train_id for LIRR date-suffix trips.
+
+    When the GTFS-RT trip_id (e.g., '6817_2026-02-24') doesn't match any
+    static trip_id, the service should extract the train number ('6817')
+    and retry with a train_id lookup.
+    """
+
+    def setup_method(self):
+        self.service = GTFSService()
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_train_id_on_date_suffix_trip(self):
+        """Date-suffix trip_id triggers train_id fallback when trip_id lookup fails."""
+        mock_db = AsyncMock()
+        target_date = date(2026, 2, 24)
+
+        mock_trip_row = MagicMock()
+        mock_trip_row.id = 42
+
+        find_calls = []
+
+        async def mock_find(db, search_id, source, sids, match_field):
+            find_calls.append((search_id, match_field))
+            if match_field == "trip_id":
+                return None  # trip_id "6817_2026-02-24" not found
+            elif match_field == "train_id" and search_id == "6817":
+                return mock_trip_row  # train_id "6817" found
+            return None
+
+        # Mock stop_times query result
+        mock_stops_result = MagicMock()
+        mock_stops_result.all.return_value = [
+            MagicMock(
+                station_code="NY",
+                stop_sequence=1,
+                arrival_time="11:54:00",
+                departure_time="11:54:00",
+            ),
+            MagicMock(
+                station_code="JAM",
+                stop_sequence=2,
+                arrival_time="12:15:00",
+                departure_time="12:15:00",
+            ),
+            MagicMock(
+                station_code="LBH",
+                stop_sequence=3,
+                arrival_time="12:45:00",
+                departure_time="12:45:00",
+            ),
+        ]
+        mock_db.execute = AsyncMock(return_value=mock_stops_result)
+
+        with (
+            patch.object(
+                self.service,
+                "get_active_service_ids",
+                return_value={"SVC_WEEKDAY"},
+            ),
+            patch.object(
+                self.service,
+                "_find_trip_in_source",
+                side_effect=mock_find,
+            ),
+        ):
+            stops = await self.service.get_static_stop_times(
+                mock_db, "LIRR", "6817_2026-02-24", target_date
+            )
+
+        # Should have found stops via train_id fallback
+        assert stops is not None, "Expected stops from train_id fallback"
+        assert len(stops) == 3
+        assert stops[0]["station_code"] == "NY"
+        assert stops[2]["station_code"] == "LBH"
+        # Verify trip_id lookup failed, then train_id lookup succeeded
+        assert len(find_calls) == 2
+        assert find_calls[0] == ("6817_2026-02-24", "trip_id")
+        assert find_calls[1] == ("6817", "train_id")
+
+    @pytest.mark.asyncio
+    async def test_go_prefix_uses_direct_trip_id_lookup(self):
+        """GO-prefix trip_ids succeed on first lookup without fallback."""
+        mock_db = AsyncMock()
+        target_date = date(2026, 2, 24)
+
+        mock_trip_row = MagicMock()
+        mock_trip_row.id = 42
+
+        find_calls = []
+
+        async def mock_find(db, search_id, source, sids, match_field):
+            find_calls.append((search_id, match_field))
+            if match_field == "trip_id" and search_id == "GO103_25_6127":
+                return mock_trip_row
+            return None
+
+        mock_stops_result = MagicMock()
+        mock_stops_result.all.return_value = [
+            MagicMock(
+                station_code="NY",
+                stop_sequence=1,
+                arrival_time="11:00:00",
+                departure_time="11:00:00",
+            ),
+            MagicMock(
+                station_code="BTA",
+                stop_sequence=2,
+                arrival_time="12:00:00",
+                departure_time="12:00:00",
+            ),
+        ]
+        mock_db.execute = AsyncMock(return_value=mock_stops_result)
+
+        with (
+            patch.object(
+                self.service,
+                "get_active_service_ids",
+                return_value={"SVC_WEEKDAY"},
+            ),
+            patch.object(
+                self.service,
+                "_find_trip_in_source",
+                side_effect=mock_find,
+            ),
+        ):
+            stops = await self.service.get_static_stop_times(
+                mock_db, "LIRR", "GO103_25_6127", target_date
+            )
+
+        assert stops is not None
+        # Only 1 find call: trip_id succeeded, no train_id fallback
+        assert len(find_calls) == 1
+        assert find_calls[0] == ("GO103_25_6127", "trip_id")
+
+    @pytest.mark.asyncio
+    async def test_date_suffix_both_lookups_fail_returns_none(self):
+        """When both trip_id and train_id lookups fail, returns None."""
+        mock_db = AsyncMock()
+        target_date = date(2026, 2, 24)
+
+        find_calls = []
+
+        async def mock_find(db, search_id, source, sids, match_field):
+            find_calls.append((search_id, match_field))
+            return None  # All lookups fail
+
+        with (
+            patch.object(
+                self.service,
+                "get_active_service_ids",
+                return_value={"SVC_WEEKDAY"},
+            ),
+            patch.object(
+                self.service,
+                "_find_trip_in_source",
+                side_effect=mock_find,
+            ),
+        ):
+            stops = await self.service.get_static_stop_times(
+                mock_db, "LIRR", "9999_2026-02-24", target_date
+            )
+
+        assert stops is None
+        # 2 find calls: trip_id (fail) + train_id (fail)
+        assert len(find_calls) == 2
+        assert find_calls[0] == ("9999_2026-02-24", "trip_id")
+        assert find_calls[1] == ("9999", "train_id")


### PR DESCRIPTION
LIRR GTFS-RT uses date-suffix trip_ids (e.g., "6817_2026-02-24") for some
branches (Long Beach, Hempstead) that don't match GTFS static trip_ids.
This caused static backfill to fail, producing broken 1-stop journeys
where origin == destination.

Changes:
- Add _extract_lirr_train_number() to extract train number from date-suffix
  trip_ids and fall back to train_id lookup in GTFS static
- Add minimum stop guard (<2 stops) in LIRR and MNR collectors to skip
  nonsensical 1-stop journeys from trains with no real-time predictions yet
- Add 13 tests covering the new helper and fallback logic

https://claude.ai/code/session_01Er8fqW88qQVKNKGufBQpRK