### PR TITLE
Fix phantom stop tests: add missing ORDER BY to stop queries

### DIFF
--- a/backend_v2/tests/unit/collectors/njt/test_journey_stop_sequences.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_stop_sequences.py
@@ -95,7 +95,11 @@ class TestPhantomStopDeletion:
         await db_session.flush()
 
         # Verify phantom stop was deleted
-        stmt = select(JourneyStop).where(JourneyStop.journey_id == journey.id)
+        stmt = (
+            select(JourneyStop)
+            .where(JourneyStop.journey_id == journey.id)
+            .order_by(JourneyStop.stop_sequence)
+        )
         all_stops = (await db_session.scalars(stmt)).all()
 
         station_codes = [stop.station_code for stop in all_stops]
@@ -238,7 +242,11 @@ class TestPhantomStopDeletion:
         await db_session.flush()
 
         # Verify both phantom stops were deleted
-        stmt = select(JourneyStop).where(JourneyStop.journey_id == journey.id)
+        stmt = (
+            select(JourneyStop)
+            .where(JourneyStop.journey_id == journey.id)
+            .order_by(JourneyStop.stop_sequence)
+        )
         all_stops = (await db_session.scalars(stmt)).all()
 
         station_codes = [stop.station_code for stop in all_stops]
@@ -386,7 +394,11 @@ class TestStopSequenceReordering:
         await db_session.flush()
 
         # Verify no duplicates
-        stmt = select(JourneyStop).where(JourneyStop.journey_id == journey.id)
+        stmt = (
+            select(JourneyStop)
+            .where(JourneyStop.journey_id == journey.id)
+            .order_by(JourneyStop.stop_sequence)
+        )
         stops = (await db_session.scalars(stmt)).all()
 
         sequences = [stop.stop_sequence for stop in stops]


### PR DESCRIPTION
Three tests queried JourneyStop rows without .order_by(stop_sequence),
causing assertions to fail due to undefined row ordering from PostgreSQL.
Other tests in the same file already use the correct pattern.

https://claude.ai/code/session_01U6tD2VFYkrFQVDfRcJf8Nw