### PR TITLE
Fix route alert notifications delivered quietly due to .provisional auth

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -107,7 +107,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     private func requestNotificationPermissions() async {
         do {
             let granted = try await UNUserNotificationCenter.current().requestAuthorization(
-                options: [.alert, .sound, .badge, .provisional]
+                options: [.alert, .sound, .badge]
             )
             print("🔔 Notification permission granted: \(granted)")
             


### PR DESCRIPTION
The .provisional option in UNUserNotificationCenter.requestAuthorization()
causes iOS to auto-grant notification permission without prompting the user.
Under provisional authorization, all push notifications are delivered silently
to Notification Center only — no banner, no sound, no Lock Screen.

This went unnoticed because Live Activity updates bypass the notification
system entirely (they use apns-push-type: liveactivity). Route alerts are
the first feature using standard APNS alert notifications.

https://claude.ai/code/session_01SkKATMQ7bLjmxbzHrYvzN7