### PR TITLE
Fix NJT API null ITEMS/STOPS causing station_refresh_failed

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/client.py
+++ b/backend_v2/src/trackrat/collectors/njt/client.py
@@ -197,7 +197,7 @@ class NJTransitClient:
             and "STOPS" in response["ITEMS"][0]
         ):
             sample_train = response["ITEMS"][0]
-            stops_count = len(sample_train.get("STOPS", []))
+            stops_count = len(sample_train.get("STOPS") or [])
             logger.debug(
                 "train_schedule_stops_sample",
                 station_code=station_code,

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -595,7 +595,7 @@ class DepartureService:
         try:
             schedule_data = await njt_client.get_train_schedule_with_stops(station_code)
 
-            train_items = schedule_data.get("ITEMS", [])
+            train_items = schedule_data.get("ITEMS") or []
             logger.info(
                 "station_refresh_retrieved",
                 station_code=station_code,
@@ -679,7 +679,7 @@ class DepartureService:
                         journey.update_count = (journey.update_count or 0) + 1
 
                         # Update stops from embedded STOPS data
-                        stops_data = train_data.get("STOPS", [])
+                        stops_data = train_data.get("STOPS") or []
                         if stops_data:
                             await self._update_stops_from_embedded_data(
                                 db, journey, stops_data

--- a/backend_v2/src/trackrat/services/validation.py
+++ b/backend_v2/src/trackrat/services/validation.py
@@ -111,7 +111,7 @@ class TrainValidationService:
         try:
             # Get departure board for origin station
             response = await self.njt_client.get_train_schedule_with_stops(from_station)
-            trains_data = response.get("ITEMS", [])
+            trains_data = response.get("ITEMS") or []
 
             # Filter for trains going to destination
             relevant_trains = set()
@@ -121,7 +121,7 @@ class TrainValidationService:
                     continue
 
                 # Check if train goes to destination
-                stops = train.get("STOPS", [])
+                stops = train.get("STOPS") or []
                 if any(stop.get("STATION_2CHAR") == to_station for stop in stops):
                     relevant_trains.add(train_id)
 


### PR DESCRIPTION
NJT API can return {"ITEMS": null} (key present with None value).
dict.get("ITEMS", []) only uses the default when the key is missing,
not when it exists with value None. Changed to .get("ITEMS") or []
pattern used everywhere else in the NJT codebase.

Fixes station_refresh_failed: object of type 'NoneType' has no len()
Also fixes same pattern in validation.py and client.py.

https://claude.ai/code/session_019qqy4BcLxxVrnQ24fS2eyD