### PR TITLE
Simplify segment highlighting to on/off toggle with automatic per-system coloring

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -844,12 +844,13 @@ final class AppState: ObservableObject {
 
     /// Load map display settings from UserDefaults
     private func loadMapSettings() {
-        // Load highlight mode (smart default based on selected systems)
+        // Load highlight mode (on/off toggle — per-segment coloring is automatic)
         if let stored = UserDefaults.standard.string(forKey: "mapHighlightMode"),
            let mode = SegmentHighlightMode(rawValue: stored) {
-            mapHighlightMode = mode
+            // Migrate: .health is no longer user-selectable, treat as "on" (.delays)
+            mapHighlightMode = mode == .health ? .delays : mode
         } else {
-            mapHighlightMode = selectedSystems.recommendedHighlightMode
+            mapHighlightMode = .delays
         }
 
         // Load stations visibility
@@ -857,11 +858,6 @@ final class AppState: ObservableObject {
 
         // Load beta features
         showDepartureOdds = UserDefaults.standard.bool(forKey: "showDepartureOdds")
-    }
-
-    /// Cycle to next highlight mode: Off → Health → Delays → Off
-    func cycleMapHighlightMode() {
-        mapHighlightMode = mapHighlightMode.next
     }
 
 }

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -106,8 +106,8 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     /// Commuter/intercity rail → Travel Time (delays are more variable and meaningful).
     var preferredHighlightMode: SegmentHighlightMode {
         switch self {
-        case .subway, .path: return .health
-        case .njt, .amtrak, .lirr, .mnr, .patco: return .delays
+        case .subway, .path, .patco: return .health
+        case .njt, .amtrak, .lirr, .mnr: return .delays
         }
     }
 }
@@ -145,13 +145,6 @@ extension Set where Element == TrainSystem {
         Set<String>(self.map(\.rawValue))
     }
 
-    /// Recommended highlight mode based on selected systems.
-    /// If all systems prefer the same mode, use that. Otherwise default to Travel Time.
-    var recommendedHighlightMode: SegmentHighlightMode {
-        guard !self.isEmpty else { return .delays }
-        let allPreferHealth = self.allSatisfy { $0.preferredHighlightMode == .health }
-        return allPreferHealth ? .health : .delays
-    }
 }
 
 // MARK: - Stations Extensions (TrainSystem-aware wrappers)

--- a/ios/TrackRat/Models/V2APIModels.swift
+++ b/ios/TrackRat/Models/V2APIModels.swift
@@ -735,6 +735,14 @@ struct CongestionSegment: Codable, Identifiable {
         }
         return "Every ~\(rounded) min"
     }
+
+    /// Preferred highlight mode based on this segment's data source.
+    /// Rapid transit (PATH, Subway, PATCO) → frequency coloring.
+    /// Commuter/intercity rail (NJT, Amtrak, LIRR, MNR) → delay coloring.
+    var preferredHighlightMode: SegmentHighlightMode {
+        guard let system = TrainSystem(rawValue: dataSource) else { return .delays }
+        return system.preferredHighlightMode
+    }
 }
 
 // MARK: - Segment Highlight Mode
@@ -761,12 +769,11 @@ enum SegmentHighlightMode: String, CaseIterable {
         }
     }
 
-    /// Cycle to next mode: Delays → Health → Off → Delays
+    /// Toggle segments on/off. Per-segment coloring is automatic based on data source.
     var next: SegmentHighlightMode {
         switch self {
-        case .delays: return .health
-        case .health: return .off
         case .off: return .delays
+        case .delays, .health: return .off
         }
     }
 }

--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -77,23 +77,11 @@ struct JourneyCongestionMapView: View {
                 }
             }
             
-            // Legend adapts to highlight mode
+            // Legend adapts to train system's preferred mode
             if !viewModel.filteredSegments.isEmpty {
-                HStack(spacing: 16) {
-                    if appState.mapHighlightMode == .health {
-                        LegendItem(color: .green, label: "Healthy")
-                        LegendItem(color: .yellow, label: "Moderate")
-                        LegendItem(color: .orange, label: "Reduced")
-                        LegendItem(color: .red, label: "Severe")
-                    } else {
-                        LegendItem(color: .green, label: "Normal")
-                        LegendItem(color: .yellow, label: "Moderate")
-                        LegendItem(color: .orange, label: "Heavy")
-                        LegendItem(color: .red, label: "Severe")
-                    }
-                }
-                .padding(.top, 8)
-                .font(.caption2)
+                let trainMode = TrainSystem(rawValue: train.dataSource)?.preferredHighlightMode ?? .delays
+                CompactCongestionLegend(highlightMode: trainMode)
+                    .padding(.top, 8)
             }
         }
         .sheet(item: $selectedSegment) { segment in
@@ -459,19 +447,19 @@ struct CongestionMapKitView: UIViewRepresentable {
         // MARK: - Public color/width helpers (used by updateUIView and rendererFor)
         func colorForSegment(_ segment: CongestionSegment) -> UIColor {
             if segment.cancellationRate > 0 { return UIColor.darkGray }
-            switch highlightMode {
-            case .off:    return UIColor.clear
+            guard highlightMode != .off else { return UIColor.clear }
+            switch segment.preferredHighlightMode {
             case .health: return getFrequencyUIColor(for: segment.frequencyFactor)
-            case .delays: return getUIColor(for: segment.congestionFactor)
+            case .delays, .off: return getUIColor(for: segment.congestionFactor)
             }
         }
 
         func lineWidthForSegment(_ segment: CongestionSegment) -> CGFloat {
             if segment.cancellationRate > 0 { return 10 }
-            switch highlightMode {
-            case .off:    return 0
+            guard highlightMode != .off else { return 0 }
+            switch segment.preferredHighlightMode {
             case .health: return getFrequencyLineWidth(segment.frequencyFactor)
-            case .delays: return getCongestionLineWidth(segment.congestionFactor)
+            case .delays, .off: return getCongestionLineWidth(segment.congestionFactor)
             }
         }
 
@@ -880,12 +868,21 @@ struct SingleSegmentMapView: View {
 // MARK: - Compact Congestion Legend
 
 struct CompactCongestionLegend: View {
+    var highlightMode: SegmentHighlightMode = .delays
+
     var body: some View {
         HStack(spacing: 12) {
-            LegendItem(color: .green, label: "Normal")
-            LegendItem(color: .yellow, label: "Moderate")
-            LegendItem(color: .orange, label: "Heavy")
-            LegendItem(color: .red, label: "Severe")
+            if highlightMode == .health {
+                LegendItem(color: .green, label: "Healthy")
+                LegendItem(color: .yellow, label: "Moderate")
+                LegendItem(color: .orange, label: "Reduced")
+                LegendItem(color: .red, label: "Severe")
+            } else {
+                LegendItem(color: .green, label: "Normal")
+                LegendItem(color: .yellow, label: "Moderate")
+                LegendItem(color: .orange, label: "Heavy")
+                LegendItem(color: .red, label: "Severe")
+            }
         }
         .font(.caption2)
         .padding(.horizontal)

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -201,12 +201,12 @@ struct CongestionMapView: View {
                 .font(.headline)
                 .fontWeight(.semibold)
 
-            // Segment highlight mode toggle (Off → Health → Delays → Off)
+            // Segment visibility toggle (on/off — per-segment coloring is automatic)
             LayerToggleButton(
                 label: "Segments",
-                icon: viewModel.highlightMode.icon,
+                icon: viewModel.highlightMode != .off ? "waveform.path.ecg" : "eye.slash",
                 isOn: viewModel.highlightMode != .off,
-                detail: viewModel.highlightMode.displayName
+                detail: viewModel.highlightMode != .off ? "On" : "Off"
             ) {
                 let wasOff = viewModel.highlightMode == .off
                 viewModel.cycleHighlightMode()
@@ -289,54 +289,51 @@ struct CongestionMapView: View {
 
     @ViewBuilder
     private var segmentLegendView: some View {
-        switch viewModel.highlightMode {
-        case .off:
-            EmptyView()
+        if viewModel.highlightMode != .off {
+            let dataSources = Set(viewModel.segments.map(\.dataSource))
+            let hasFrequencySystems = dataSources.contains { TrainSystem(rawValue: $0)?.preferredHighlightMode == .health }
+            let hasDelaySystems = dataSources.contains { TrainSystem(rawValue: $0)?.preferredHighlightMode != .health }
 
-        case .health:
-            // Health/Frequency legend (higher is better)
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Service Health")
-                    .trackRatSectionHeader()
+            VStack(alignment: .leading, spacing: 12) {
+                if hasFrequencySystems {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Service Health")
+                            .trackRatSectionHeader()
 
-                HStack(spacing: 16) {
-                    LegendItem(color: .green, label: "Healthy")
-                    LegendItem(color: .yellow, label: "Moderate")
-                    LegendItem(color: .orange, label: "Reduced")
-                    LegendItem(color: .red, label: "Severe")
+                        HStack(spacing: 16) {
+                            LegendItem(color: .green, label: "Healthy")
+                            LegendItem(color: .yellow, label: "Moderate")
+                            LegendItem(color: .orange, label: "Reduced")
+                            LegendItem(color: .red, label: "Severe")
+                        }
+
+                        if let summary = frequencySummaryText {
+                            Text(summary)
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text("Train count vs typical for this time")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
                 }
 
-                if let summary = frequencySummaryText {
-                    Text(summary)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                } else {
-                    Text("Train count vs typical for this time")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+                if hasDelaySystems {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Delay Levels")
+                            .trackRatSectionHeader()
+
+                        HStack(spacing: 16) {
+                            LegendItem(color: .green, label: "Normal")
+                            LegendItem(color: .yellow, label: "Moderate")
+                            LegendItem(color: .orange, label: "Heavy")
+                            LegendItem(color: .red, label: "Severe")
+                        }
+
+                        LegendItem(color: .red, label: "Cancellations")
+                    }
                 }
-            }
-            .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(.ultraThinMaterial)
-            )
-
-        case .delays:
-            // Congestion/Delays legend (lower is better)
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Delay Levels")
-                    .trackRatSectionHeader()
-
-                HStack(spacing: 16) {
-                    LegendItem(color: .green, label: "Normal")
-                    LegendItem(color: .yellow, label: "Moderate")
-                    LegendItem(color: .orange, label: "Heavy")
-                    LegendItem(color: .red, label: "Severe")
-                }
-
-                // Cancellation legend
-                LegendItem(color: .red, label: "Cancellations")
             }
             .padding()
             .background(
@@ -1368,14 +1365,13 @@ struct SystemCongestionMapView: UIViewRepresentable {
             }
         }
 
-        /// Get color for aggregated segment based on highlight mode
+        /// Get color for aggregated segment based on its data source's preferred mode
         private func getColorForSegment(_ segment: CongestionSegment) -> UIColor {
-            switch highlightMode {
-            case .off:
-                return UIColor.clear
+            guard highlightMode != .off else { return UIColor.clear }
+            switch segment.preferredHighlightMode {
             case .health:
                 return getFrequencyUIColor(for: segment.frequencyFactor)
-            case .delays:
+            case .delays, .off:
                 return getUIColor(for: segment.congestionFactor)
             }
         }
@@ -1387,17 +1383,9 @@ struct SystemCongestionMapView: UIViewRepresentable {
 
         /// Get color for individual segment based on highlight mode
         private func getColorForIndividualSegment(_ segment: IndividualJourneySegment) -> UIColor {
-            // Individual segments don't have frequency data, so always use congestion coloring
-            // In health mode, use a muted color since we can't show per-train frequency
-            switch highlightMode {
-            case .off:
-                return UIColor.clear
-            case .health:
-                // For individual trains in health mode, use gray since we don't have per-train frequency
-                return UIColor.systemGray
-            case .delays:
-                return getUIColor(for: segment.congestionFactor)
-            }
+            // Individual segments don't have per-train frequency data, always use congestion coloring
+            guard highlightMode != .off else { return UIColor.clear }
+            return getUIColor(for: segment.congestionFactor)
         }
 
         /// Public accessor for getColorForIndividualSegment (used by updateUIView for mode changes)
@@ -1407,9 +1395,8 @@ struct SystemCongestionMapView: UIViewRepresentable {
 
         /// Get line width for segment based on highlight mode
         private func getSegmentLineWidth(_ segment: CongestionSegment) -> CGFloat {
-            switch highlightMode {
-            case .off:
-                return 0
+            guard highlightMode != .off else { return 0 }
+            switch segment.preferredHighlightMode {
             case .health:
                 // Use frequency factor for line width (thicker = worse service)
                 guard let factor = segment.frequencyFactor else { return 5 }
@@ -1417,7 +1404,7 @@ struct SystemCongestionMapView: UIViewRepresentable {
                 else if factor >= 0.7 { return 7 }
                 else if factor >= 0.5 { return 8 }
                 else { return 9 }
-            case .delays:
+            case .delays, .off:
                 return getCongestionLineWidth(segment.congestionFactor)
             }
         }

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -149,21 +149,14 @@ struct MapContainerView: View {
 
             // Operations summary pill (network scope) - positioned at top
             // Shows network summary + route summary when RatSense has a prediction
-            // In health mode, also shows frequency summary from congestion data
             VStack {
                 if mapViewModel.highlightMode != .off {
-                    if mapViewModel.highlightMode == .health {
-                        frequencySummaryPill
-                            .padding(.horizontal, 16)
-                            .padding(.top, 30)
-                    } else {
-                        OperationsSummaryView(
-                            scope: .network,
-                            ratSenseRoute: ratSenseService.suggestedJourney.map { ($0.fromStation, $0.toStation) }
-                        )
-                        .padding(.horizontal, 16)
-                        .padding(.top, 30)
-                    }
+                    OperationsSummaryView(
+                        scope: .network,
+                        ratSenseRoute: ratSenseService.suggestedJourney.map { ($0.fromStation, $0.toStation) }
+                    )
+                    .padding(.horizontal, 16)
+                    .padding(.top, 30)
                 }
 
                 Spacer()
@@ -558,49 +551,6 @@ struct MapContainerView: View {
         return stationCodes
     }
     
-    /// Frequency summary pill shown in health mode instead of delay-focused operations summary
-    @ViewBuilder
-    private var frequencySummaryPill: some View {
-        let segmentsWithData = mapViewModel.segments.filter { $0.hasFrequencyData }
-        if !segmentsWithData.isEmpty {
-            let totalTrains = segmentsWithData.compactMap(\.trainCount).reduce(0, +)
-            let headways = segmentsWithData.compactMap { $0.currentHeadwayMinutes(timeWindowHours: mapViewModel.lastTimeWindowHours) }
-            let avgHeadway = headways.isEmpty ? nil : Int((headways.reduce(0, +) / Double(headways.count)).rounded())
-            let severeCount = segmentsWithData.filter { ($0.frequencyFactor ?? 1.0) < 0.5 }.count
-
-            let text: String = {
-                var parts: [String] = []
-                if severeCount > 0 {
-                    let segWord = severeCount == 1 ? "segment" : "segments"
-                    parts.append("\(severeCount) \(segWord) with reduced service.")
-                }
-                parts.append("\(totalTrains) trains running.")
-                if let avg = avgHeadway {
-                    parts.append("Avg every ~\(max(avg, 1)) min.")
-                }
-                return parts.joined(separator: " ")
-            }()
-
-            Text(text)
-                .font(.subheadline)
-                .foregroundColor(.white.opacity(0.7))
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-                .lineSpacing(2)
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 12)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(.ultraThinMaterial)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.white.opacity(0.15), lineWidth: 1)
-                )
-        }
-    }
-
     private func animateMapToRoute(_ route: TripPair, targetSheetDetent: PresentationDetent? = nil) {
         // Get coordinates for departure and destination
         guard let fromCoords = Stations.getCoordinates(for: route.departureCode),
@@ -800,16 +750,35 @@ struct CongestionMapControlsView: View {
             }
             .padding(.horizontal)
             
-            // Legend
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Congestion Levels")
-                    .trackRatSectionHeader()
+            // Legend — shows both scales when mixed system types are visible
+            let dataSources = Set(mapViewModel.segments.map(\.dataSource))
+            let hasFrequencySystems = dataSources.contains { TrainSystem(rawValue: $0)?.preferredHighlightMode == .health }
+            let hasDelaySystems = dataSources.contains { TrainSystem(rawValue: $0)?.preferredHighlightMode != .health }
 
-                HStack(spacing: 16) {
-                    LegendItem(color: .green, label: "Normal")
-                    LegendItem(color: .yellow, label: "Moderate")
-                    LegendItem(color: .orange, label: "Heavy")
-                    LegendItem(color: .red, label: "Severe")
+            VStack(alignment: .leading, spacing: 12) {
+                if hasFrequencySystems {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Service Health")
+                            .trackRatSectionHeader()
+                        HStack(spacing: 16) {
+                            LegendItem(color: .green, label: "Healthy")
+                            LegendItem(color: .yellow, label: "Moderate")
+                            LegendItem(color: .orange, label: "Reduced")
+                            LegendItem(color: .red, label: "Severe")
+                        }
+                    }
+                }
+                if hasDelaySystems {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Delay Levels")
+                            .trackRatSectionHeader()
+                        HStack(spacing: 16) {
+                            LegendItem(color: .green, label: "Normal")
+                            LegendItem(color: .yellow, label: "Moderate")
+                            LegendItem(color: .orange, label: "Heavy")
+                            LegendItem(color: .red, label: "Severe")
+                        }
+                    }
                 }
             }
             .padding()

--- a/ios/TrackRat/Views/Screens/MyProfileView.swift
+++ b/ios/TrackRat/Views/Screens/MyProfileView.swift
@@ -408,36 +408,6 @@ struct SettingsSection: View {
                     .fill(.ultraThinMaterial)
             )
 
-            // Health Indicator
-            VStack(spacing: 0) {
-                HStack {
-                    Text("Health Indicator")
-                        .font(.subheadline)
-                        .foregroundColor(.white.opacity(0.7))
-                    Spacer()
-                }
-                .padding()
-
-                Divider()
-                    .background(Color.white.opacity(0.1))
-
-                let orderedModes: [SegmentHighlightMode] = [.delays, .health, .off]
-                ForEach(orderedModes, id: \.self) { mode in
-                    HealthIndicatorRow(
-                        mode: mode,
-                        isSelected: appState.mapHighlightMode == mode,
-                        isLast: mode == orderedModes.last
-                    ) {
-                        appState.mapHighlightMode = mode
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    }
-                }
-            }
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(.ultraThinMaterial)
-            )
-
             // Favorite Stations
             Button {
                 navigationPath.append(ProfileDestination.favoriteStations)
@@ -906,47 +876,6 @@ private struct TrainSystemRow: View {
                 }
                 .padding()
                 .contentShape(Rectangle())
-
-                if !isLast {
-                    Divider()
-                        .background(Color.white.opacity(0.1))
-                        .padding(.leading, 56)
-                }
-            }
-        }
-        .buttonStyle(.plain)
-    }
-}
-
-struct HealthIndicatorRow: View {
-    let mode: SegmentHighlightMode
-    let isSelected: Bool
-    let isLast: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 0) {
-                HStack(spacing: 16) {
-                    Image(systemName: mode.icon)
-                        .font(.title2)
-                        .foregroundColor(isSelected ? .orange : .white.opacity(0.5))
-                        .frame(width: 24, height: 24)
-
-                    HStack(spacing: 4) {
-                        Text(mode.displayName)
-                            .font(.headline)
-                            .fontWeight(.medium)
-                            .foregroundColor(.white)
-                    }
-
-                    Spacer()
-
-                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        .font(.title3)
-                        .foregroundColor(isSelected ? .orange : .white.opacity(0.3))
-                }
-                .padding()
 
                 if !isLast {
                     Divider()

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -442,11 +442,6 @@ struct OnboardingView: View {
         // Force immediate synchronization of favorites
         appState.loadFavoriteStations()
 
-        // Set smart default health indicator based on selected systems (first onboarding only)
-        if !isRepeating {
-            appState.mapHighlightMode = appState.selectedSystems.recommendedHighlightMode
-        }
-
         // Provide haptic feedback
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
 

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -6,6 +6,11 @@ struct RouteStatusView: View {
     @StateObject private var viewModel: RouteStatusViewModel
     @Environment(\.dismiss) private var dismiss
 
+    /// Preferred highlight mode derived from this route's data source
+    private var preferredMode: SegmentHighlightMode {
+        TrainSystem(rawValue: context.dataSource)?.preferredHighlightMode ?? .delays
+    }
+
     init(context: RouteStatusContext) {
         self.context = context
         self._viewModel = StateObject(wrappedValue: RouteStatusViewModel(context: context))
@@ -54,12 +59,13 @@ struct RouteStatusView: View {
                     segments: viewModel.filteredSegments,
                     stations: [],
                     trainPositions: [],
+                    highlightMode: .delays,  // "on" — per-segment coloring is automatic
                     onSegmentTap: { _ in }
                 )
                 .frame(height: 200)
                 .cornerRadius(12)
 
-                CompactCongestionLegend()
+                CompactCongestionLegend(highlightMode: preferredMode)
             } else if viewModel.mapError != nil {
                 ContentUnavailableView("Map Unavailable", systemImage: "map", description: Text("Could not load congestion data"))
                     .frame(height: 200)
@@ -136,53 +142,78 @@ struct RouteStatusView: View {
 
     @ViewBuilder
     private func historyContent(_ history: RouteHistoricalData) -> some View {
-        // Stat cards row
-        HStack(spacing: 12) {
-            statCard(
-                title: "On Time",
-                value: "\(Int(history.aggregateStats.onTimePercentage))%",
-                color: history.aggregateStats.onTimePercentage >= 80 ? .green : .orange
-            )
-            statCard(
-                title: "Cancelled",
-                value: "\(Int(history.aggregateStats.cancellationRate))%",
-                color: history.aggregateStats.cancellationRate <= 5 ? .green : .red
-            )
-        }
+        let total = history.route.totalTrains
 
-        // Delay statistics: departure from origin + arrival at destination
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Delay Statistics")
-                .font(.subheadline.bold())
-
+        if preferredMode == .health {
+            // Frequency-focused stats for rapid transit (PATH, Subway, PATCO)
             HStack(spacing: 12) {
-                delayStatCard(
-                    title: "Avg Departure Delay",
-                    value: "\(Int(history.aggregateStats.averageDepartureDelayMinutes))m",
-                    color: history.aggregateStats.averageDepartureDelayMinutes <= 5 ? .green : .orange
+                statCard(
+                    title: "Trains",
+                    value: "\(total)",
+                    color: .blue
                 )
-                delayStatCard(
-                    title: "Avg Arrival Delay",
-                    value: "\(Int(history.aggregateStats.averageDelayMinutes))m",
-                    color: history.aggregateStats.averageDelayMinutes <= 5 ? .green : .orange
+                statCard(
+                    title: "On Time",
+                    value: "\(Int(history.aggregateStats.onTimePercentage))%",
+                    color: history.aggregateStats.onTimePercentage >= 80 ? .green : .orange
                 )
             }
-        }
 
-        // Delay breakdown bar
-        let breakdown = history.aggregateStats.delayBreakdown
-        let total = history.route.totalTrains
-        DelayPerformanceBar(
-            label: "Arrival Delay Breakdown (\(total) trains)",
-            stats: DelayStats(
-                onTime: breakdown.onTime,
-                slight: breakdown.slight,
-                significant: breakdown.significant,
-                major: breakdown.major,
-                total: total,
-                avgDelay: Int(history.aggregateStats.averageDelayMinutes)
+            if history.aggregateStats.cancellationRate > 0 {
+                HStack(spacing: 12) {
+                    statCard(
+                        title: "Cancelled",
+                        value: "\(Int(history.aggregateStats.cancellationRate))%",
+                        color: history.aggregateStats.cancellationRate <= 5 ? .green : .red
+                    )
+                }
+            }
+        } else {
+            // Delay-focused stats for commuter/intercity rail
+            HStack(spacing: 12) {
+                statCard(
+                    title: "On Time",
+                    value: "\(Int(history.aggregateStats.onTimePercentage))%",
+                    color: history.aggregateStats.onTimePercentage >= 80 ? .green : .orange
+                )
+                statCard(
+                    title: "Cancelled",
+                    value: "\(Int(history.aggregateStats.cancellationRate))%",
+                    color: history.aggregateStats.cancellationRate <= 5 ? .green : .red
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Delay Statistics")
+                    .font(.subheadline.bold())
+
+                HStack(spacing: 12) {
+                    delayStatCard(
+                        title: "Avg Departure Delay",
+                        value: "\(Int(history.aggregateStats.averageDepartureDelayMinutes))m",
+                        color: history.aggregateStats.averageDepartureDelayMinutes <= 5 ? .green : .orange
+                    )
+                    delayStatCard(
+                        title: "Avg Arrival Delay",
+                        value: "\(Int(history.aggregateStats.averageDelayMinutes))m",
+                        color: history.aggregateStats.averageDelayMinutes <= 5 ? .green : .orange
+                    )
+                }
+            }
+
+            let breakdown = history.aggregateStats.delayBreakdown
+            DelayPerformanceBar(
+                label: "Arrival Delay Breakdown (\(total) trains)",
+                stats: DelayStats(
+                    onTime: breakdown.onTime,
+                    slight: breakdown.slight,
+                    significant: breakdown.significant,
+                    major: breakdown.major,
+                    total: total,
+                    avgDelay: Int(history.aggregateStats.averageDelayMinutes)
+                )
             )
-        )
+        }
     }
 
     private func statCard(title: String, value: String, color: Color) -> some View {


### PR DESCRIPTION
## Summary
Refactors the segment highlighting system from a three-mode cycle (Delays → Health → Off) to a simple on/off toggle. Per-segment coloring is now automatically determined by each segment's data source (rapid transit systems use frequency/health coloring, commuter rail uses delay coloring), eliminating the need for user-selectable highlight modes.

## Key Changes

- **Simplified highlight mode toggle**: Changed from cycling through `.delays` → `.health` → `.off` to toggling between `.off` and `.delays` (with `.health` as an internal-only mode)
- **Automatic per-segment coloring**: Added `preferredHighlightMode` property to `CongestionSegment` and `TrainSystem` to determine coloring based on data source rather than global user selection
- **Updated UI controls**: 
  - Segment toggle button now shows "On/Off" instead of mode names
  - Icon changes based on toggle state (eye.slash when off, waveform.path.ecg when on)
- **Unified legend display**: Map legends now show both "Service Health" and "Delay Levels" sections when mixed system types are visible, rather than switching between them
- **Removed settings UI**: Deleted the "Health Indicator" settings section from MyProfileView that allowed users to select highlight modes
- **Updated legend components**: `CompactCongestionLegend` now accepts a `highlightMode` parameter to display appropriate legend items
- **Simplified color logic**: Refactored `getColorForSegment()` and `getSegmentLineWidth()` to use segment's preferred mode instead of global highlight mode
- **Removed frequency summary pill**: Deleted the health-mode-specific operations summary from MapContainerView
- **Updated route status view**: Modified `RouteStatusView` to show frequency-focused stats for rapid transit systems and delay-focused stats for commuter rail
- **Migrated stored settings**: Existing `.health` mode preference is converted to `.delays` on app load

## Implementation Details

- `TrainSystem.preferredHighlightMode` now includes PATCO as a health-mode system (rapid transit)
- Individual journey segments continue to use congestion coloring (they lack per-train frequency data)
- The toggle now represents "segments visible" rather than "which metric to display"
- Removed `cycleMapHighlightMode()` and `recommendedHighlightMode` as they're no longer needed

https://claude.ai/code/session_012UG1GS8kWZzEuUhvRi584T