### PR TITLE
Add frequency baseline coloring to Route Alerts view

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -165,12 +165,18 @@ async def get_route_history(
                 track_usage_at_origin=highlighted_stats["track_usage"],
             )
 
+    # Calculate baseline train count for frequency comparison
+    baseline_train_count = await _calculate_baseline_train_count(
+        db, data_source, from_codes, to_codes, hours, now
+    )
+
     response = RouteHistoryResponse(
         route=HistoricalRouteInfo(
             from_station=from_station,
             to_station=to_station,
             total_trains=aggregate_stats["total_journeys"],
             data_source=data_source,
+            baseline_train_count=baseline_train_count,
         ),
         aggregate_stats=AggregateStats(
             on_time_percentage=aggregate_stats["on_time_percentage"],
@@ -405,6 +411,92 @@ async def _calculate_route_stats_sql(
         "delay_breakdown": delay_breakdown,
         "track_usage": track_usage,
     }
+
+
+async def _calculate_baseline_train_count(
+    db: AsyncSession,
+    data_source: str,
+    from_codes: list[str],
+    to_codes: list[str],
+    hours: int | None,
+    now: datetime,
+) -> float | None:
+    """Calculate expected train count for frequency baseline comparison.
+
+    Uses segment_transit_times from the past 30 days to estimate how many
+    trains typically run on this route during an equivalent time window.
+
+    Matching strategy (mirrors congestion service):
+    - hours=1: same hour-of-day + weekday/weekend pattern
+    - hours=24: weekday/weekend pattern only (all hours)
+    - hours=None (days-based) or hours>=168: no time/day filter (weekly average)
+
+    Returns None if no historical data exists.
+    """
+    from trackrat.utils.time import normalize_to_et
+
+    now_eastern = normalize_to_et(now)
+    current_hour = now_eastern.hour
+    is_weekend = now_eastern.weekday() >= 5  # Saturday=5, Sunday=6
+
+    # Build filters based on time window
+    hour_filter = ""
+    day_filter = ""
+
+    if hours is not None and hours <= 1:
+        # 1-hour window: match same hour-of-day and weekday/weekend
+        hour_filter = "AND stt.hour_of_day = :current_hour"
+        day_filter = """AND (
+            (:is_weekend AND stt.day_of_week IN (0, 6))
+            OR (NOT :is_weekend AND stt.day_of_week NOT IN (0, 6))
+        )"""
+        divisor = 30.0
+    elif hours is not None and hours <= 24:
+        # 24-hour window: match weekday/weekend only
+        day_filter = """AND (
+            (:is_weekend AND stt.day_of_week IN (0, 6))
+            OR (NOT :is_weekend AND stt.day_of_week NOT IN (0, 6))
+        )"""
+        divisor = 30.0
+    else:
+        # 7+ day window: no time/day filter, scale to weekly average
+        divisor = 30.0 / 7.0
+
+    sql = text(f"""
+        SELECT COUNT(DISTINCT stt.journey_id) AS baseline_count
+        FROM segment_transit_times stt
+        WHERE stt.departure_time >= :baseline_start
+          AND stt.from_station_code = ANY(:from_codes)
+          AND stt.data_source = :data_source
+          {hour_filter}
+          {day_filter}
+          AND EXISTS (
+              SELECT 1 FROM segment_transit_times stt2
+              WHERE stt2.journey_id = stt.journey_id
+                AND stt2.to_station_code = ANY(:to_codes)
+          )
+    """)
+
+    params: dict[str, Any] = {
+        "baseline_start": now - timedelta(days=30),
+        "from_codes": from_codes,
+        "to_codes": to_codes,
+        "data_source": data_source,
+        "current_hour": current_hour,
+        "is_weekend": is_weekend,
+    }
+
+    try:
+        result = await db.execute(sql, params)
+        row = result.mappings().first()
+        if not row or row["baseline_count"] == 0:
+            return None
+
+        baseline = float(row["baseline_count"]) / divisor
+        return round(baseline, 1) if baseline > 0 else None
+    except Exception as e:
+        logger.warning("baseline_train_count_query_failed", error=str(e))
+        return None
 
 
 @router.get("/congestion", response_model=CongestionMapResponse)

--- a/backend_v2/src/trackrat/models/api.py
+++ b/backend_v2/src/trackrat/models/api.py
@@ -470,6 +470,11 @@ class HistoricalRouteInfo(BaseModel):
     to_station: str = Field(..., min_length=1, max_length=4)
     total_trains: int = Field(..., ge=0)
     data_source: Literal["NJT", "AMTRAK", "PATH", "PATCO", "LIRR", "MNR", "SUBWAY"]
+    baseline_train_count: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Expected train count for this time window based on 30-day historical average",
+    )
 
 
 class DelayBreakdown(BaseModel):

--- a/backend_v2/tests/unit/api/test_baseline_frequency.py
+++ b/backend_v2/tests/unit/api/test_baseline_frequency.py
@@ -1,0 +1,289 @@
+"""
+Tests for the baseline train count calculation used for frequency coloring.
+
+Tests _calculate_baseline_train_count to verify:
+- Returns None when no historical segment data exists
+- Correctly counts distinct journeys for 1-hour window (same hour + day type)
+- Correctly counts distinct journeys for 24-hour window (same day type only)
+- Correctly counts distinct journeys for 7-day window (no time/day filter)
+- Only counts journeys that match both from and to stations
+- Does not count journeys from different data sources
+
+These tests require a PostgreSQL test database because the baseline calculation
+uses raw SQL against segment_transit_times.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from trackrat.api.routes import _calculate_baseline_train_count
+from trackrat.models.database import SegmentTransitTime, TrainJourney
+
+# Wednesday 8am ET = Wednesday 13:00 UTC (ET is UTC-5 in winter)
+BASE_TIME = datetime(2025, 6, 18, 12, 0, 0, tzinfo=timezone.utc)  # Wednesday 8am ET (EDT)
+BASE_DATE = date(2025, 6, 18)
+
+
+async def _create_journey_with_segments(
+    db: AsyncSession,
+    train_id: str,
+    segments: list[dict],
+    data_source: str = "NJT",
+    journey_date: date | None = None,
+) -> TrainJourney:
+    """Create a TrainJourney with SegmentTransitTime records."""
+    jdate = journey_date or BASE_DATE
+    journey = TrainJourney(
+        train_id=train_id,
+        journey_date=jdate,
+        line_code="NE",
+        line_name="Northeast Corridor",
+        destination="Trenton",
+        origin_station_code=segments[0]["from_station"],
+        terminal_station_code=segments[-1]["to_station"],
+        data_source=data_source,
+        observation_type="OBSERVED",
+        scheduled_departure=segments[0]["departure_time"],
+        is_cancelled=False,
+        has_complete_journey=True,
+        stops_count=len(segments) + 1,
+    )
+    db.add(journey)
+    await db.flush()
+
+    for seg in segments:
+        dep_time = seg["departure_time"]
+        stt = SegmentTransitTime(
+            journey_id=journey.id,
+            from_station_code=seg["from_station"],
+            to_station_code=seg["to_station"],
+            data_source=data_source,
+            line_code="NE",
+            scheduled_minutes=seg.get("scheduled_minutes", 15),
+            actual_minutes=seg.get("actual_minutes", 15),
+            delay_minutes=seg.get("delay_minutes", 0),
+            departure_time=dep_time,
+            hour_of_day=dep_time.hour,
+            day_of_week=dep_time.weekday(),
+        )
+        db.add(stt)
+
+    await db.flush()
+    return journey
+
+
+@pytest.mark.asyncio
+class TestBaselineNoData:
+    """Returns None when no segment data exists."""
+
+    async def test_returns_none_when_empty(self, db_session: AsyncSession):
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=1, now=BASE_TIME
+        )
+        assert result is None, "Expected None when no historical segment data"
+
+
+@pytest.mark.asyncio
+class TestBaselineOneHour:
+    """1-hour window: matches same hour-of-day and weekday/weekend."""
+
+    async def test_counts_matching_journeys(self, db_session: AsyncSession):
+        """30 journeys at hour 8 on weekdays over 30 days → baseline ~1.0."""
+        for i in range(30):
+            day_offset = i
+            dep_time = BASE_TIME - timedelta(days=day_offset)
+            # Skip weekends
+            if dep_time.weekday() >= 5:
+                continue
+            await _create_journey_with_segments(
+                db_session,
+                train_id=f"train_{i}",
+                segments=[
+                    {"from_station": "NY", "to_station": "NP", "departure_time": dep_time},
+                    {
+                        "from_station": "NP",
+                        "to_station": "TR",
+                        "departure_time": dep_time + timedelta(minutes=15),
+                    },
+                ],
+                journey_date=(BASE_DATE - timedelta(days=day_offset)),
+            )
+        await db_session.commit()
+
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=1, now=BASE_TIME
+        )
+        assert result is not None, "Expected a baseline value"
+        assert result > 0, f"Expected positive baseline, got {result}"
+
+    async def test_excludes_different_hour(self, db_session: AsyncSession):
+        """Journey at a different hour should not be counted for 1-hour baseline."""
+        # Create journey at hour 15 (3pm), but query at hour 8
+        dep_time = BASE_TIME - timedelta(days=7) + timedelta(hours=7)  # 3pm
+        await _create_journey_with_segments(
+            db_session,
+            train_id="train_wrong_hour",
+            segments=[
+                {"from_station": "NY", "to_station": "NP", "departure_time": dep_time},
+                {
+                    "from_station": "NP",
+                    "to_station": "TR",
+                    "departure_time": dep_time + timedelta(minutes=15),
+                },
+            ],
+            journey_date=(BASE_DATE - timedelta(days=7)),
+        )
+        await db_session.commit()
+
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=1, now=BASE_TIME
+        )
+        assert result is None, "Journey at different hour should not be counted"
+
+    async def test_excludes_weekend_when_querying_weekday(self, db_session: AsyncSession):
+        """Weekend journeys should not appear in weekday 1-hour baseline."""
+        # Create journey on a Saturday at the same hour
+        # BASE_TIME is Wednesday; Saturday is 3 days later
+        saturday = BASE_TIME + timedelta(days=3)
+        saturday_date = BASE_DATE + timedelta(days=3)
+        # But we need it within the past 30 days - use a past Saturday
+        past_saturday = BASE_TIME - timedelta(days=4)  # Previous Saturday
+        past_saturday_date = BASE_DATE - timedelta(days=4)
+
+        await _create_journey_with_segments(
+            db_session,
+            train_id="train_weekend",
+            segments=[
+                {"from_station": "NY", "to_station": "NP", "departure_time": past_saturday},
+                {
+                    "from_station": "NP",
+                    "to_station": "TR",
+                    "departure_time": past_saturday + timedelta(minutes=15),
+                },
+            ],
+            journey_date=past_saturday_date,
+        )
+        await db_session.commit()
+
+        # Query on a weekday (BASE_TIME is Wednesday)
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=1, now=BASE_TIME
+        )
+        assert result is None, "Weekend journey should not appear in weekday baseline"
+
+
+@pytest.mark.asyncio
+class TestBaselineTwentyFourHour:
+    """24-hour window: matches weekday/weekend but not specific hour."""
+
+    async def test_includes_all_hours_same_day_type(self, db_session: AsyncSession):
+        """24-hour baseline should count journeys at any hour on matching day type."""
+        # Create journeys at different hours on weekdays
+        for hour_offset in [0, 2, 4, 6]:
+            dep_time = BASE_TIME - timedelta(days=7) + timedelta(hours=hour_offset)
+            await _create_journey_with_segments(
+                db_session,
+                train_id=f"train_h{hour_offset}",
+                segments=[
+                    {"from_station": "NY", "to_station": "NP", "departure_time": dep_time},
+                    {
+                        "from_station": "NP",
+                        "to_station": "TR",
+                        "departure_time": dep_time + timedelta(minutes=15),
+                    },
+                ],
+                journey_date=(BASE_DATE - timedelta(days=7)),
+            )
+        await db_session.commit()
+
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=24, now=BASE_TIME
+        )
+        assert result is not None, "Expected a baseline for 24-hour window"
+        assert result > 0, f"Expected positive baseline, got {result}"
+
+
+@pytest.mark.asyncio
+class TestBaselineSevenDay:
+    """7-day window (hours=None): no time/day filtering."""
+
+    async def test_includes_all_days_and_hours(self, db_session: AsyncSession):
+        """7-day baseline should include all journeys regardless of hour/day."""
+        # Create weekend journey at a different hour
+        past_saturday = BASE_TIME - timedelta(days=4)
+        past_saturday_date = BASE_DATE - timedelta(days=4)
+        await _create_journey_with_segments(
+            db_session,
+            train_id="train_sat",
+            segments=[
+                {"from_station": "NY", "to_station": "NP", "departure_time": past_saturday},
+                {
+                    "from_station": "NP",
+                    "to_station": "TR",
+                    "departure_time": past_saturday + timedelta(minutes=15),
+                },
+            ],
+            journey_date=past_saturday_date,
+        )
+        await db_session.commit()
+
+        # hours=None means days-based query (7 days)
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=None, now=BASE_TIME
+        )
+        assert result is not None, "Expected a baseline for 7-day window"
+        assert result > 0, f"Expected positive baseline, got {result}"
+
+
+@pytest.mark.asyncio
+class TestBaselineRouteFiltering:
+    """Only counts journeys that match both from and to stations."""
+
+    async def test_excludes_wrong_destination(self, db_session: AsyncSession):
+        """Journey from NY to EL (not TR) should not count for NY→TR baseline."""
+        dep_time = BASE_TIME - timedelta(days=7)
+        await _create_journey_with_segments(
+            db_session,
+            train_id="train_wrong_dest",
+            segments=[
+                {"from_station": "NY", "to_station": "NP", "departure_time": dep_time},
+                {
+                    "from_station": "NP",
+                    "to_station": "EL",
+                    "departure_time": dep_time + timedelta(minutes=15),
+                },
+            ],
+            journey_date=(BASE_DATE - timedelta(days=7)),
+        )
+        await db_session.commit()
+
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=1, now=BASE_TIME
+        )
+        assert result is None, "Journey to wrong destination should not be counted"
+
+    async def test_excludes_wrong_data_source(self, db_session: AsyncSession):
+        """Journey from a different data source should not be counted."""
+        dep_time = BASE_TIME - timedelta(days=7)
+        await _create_journey_with_segments(
+            db_session,
+            train_id="train_amtrak",
+            segments=[
+                {"from_station": "NY", "to_station": "NP", "departure_time": dep_time},
+                {
+                    "from_station": "NP",
+                    "to_station": "TR",
+                    "departure_time": dep_time + timedelta(minutes=15),
+                },
+            ],
+            data_source="AMTRAK",
+            journey_date=(BASE_DATE - timedelta(days=7)),
+        )
+        await db_session.commit()
+
+        result = await _calculate_baseline_train_count(
+            db_session, "NJT", ["NY"], ["TR"], hours=1, now=BASE_TIME
+        )
+        assert result is None, "Journey from different data source should not be counted"

--- a/ios/TrackRat/Models/Train.swift
+++ b/ios/TrackRat/Models/Train.swift
@@ -1008,6 +1008,7 @@ struct RouteHistoricalData {
         let toStation: String
         let totalTrains: Int
         let dataSource: String
+        let baselineTrainCount: Double?
     }
     
     struct Stats {

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -408,12 +408,14 @@ final class APIService: ObservableObject {
                 let toStation: String
                 let totalTrains: Int
                 let dataSource: String
-                
+                let baselineTrainCount: Double?
+
                 private enum CodingKeys: String, CodingKey {
                     case fromStation = "from_station"
                     case toStation = "to_station"
                     case totalTrains = "total_trains"
                     case dataSource = "data_source"
+                    case baselineTrainCount = "baseline_train_count"
                 }
             }
             
@@ -488,7 +490,8 @@ final class APIService: ObservableObject {
                 fromStation: response.route.fromStation,
                 toStation: response.route.toStation,
                 totalTrains: response.route.totalTrains,
-                dataSource: response.route.dataSource
+                dataSource: response.route.dataSource,
+                baselineTrainCount: response.route.baselineTrainCount
             ),
             aggregateStats: RouteHistoricalData.Stats(
                 onTimePercentage: response.aggregateStats.onTimePercentage,

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -147,6 +147,7 @@ struct RouteStatusView: View {
     @ViewBuilder
     private func historyContent(_ history: RouteHistoricalData, hours: Double) -> some View {
         let total = history.route.totalTrains
+        let freqColor = frequencyColor(totalTrains: total, baseline: history.route.baselineTrainCount)
 
         if preferredMode == .health {
             // Frequency-focused stats for rapid transit (PATH, Subway, PATCO)
@@ -154,7 +155,7 @@ struct RouteStatusView: View {
                 statCard(
                     title: "Frequency",
                     value: formatFrequency(totalTrains: total, hours: hours),
-                    color: .blue
+                    color: freqColor
                 )
                 statCard(
                     title: "On Time",
@@ -188,7 +189,7 @@ struct RouteStatusView: View {
                 statCard(
                     title: "Frequency",
                     value: formatFrequency(totalTrains: total, hours: hours),
-                    color: .blue
+                    color: freqColor
                 )
             }
 
@@ -223,6 +224,17 @@ struct RouteStatusView: View {
                 )
             )
         }
+    }
+
+    /// Color for frequency based on comparison to historical baseline.
+    /// Uses the same thresholds as CongestionSegment.frequencyDisplayColor.
+    private func frequencyColor(totalTrains: Int, baseline: Double?) -> Color {
+        guard let baseline = baseline, baseline > 0 else { return .blue }
+        let factor = Double(totalTrains) / baseline
+        if factor >= 0.9 { return .green }
+        if factor >= 0.7 { return .yellow }
+        if factor >= 0.5 { return .orange }
+        return .red
     }
 
     private func formatFrequency(totalTrains: Int, hours: Double) -> String {


### PR DESCRIPTION
Compare actual train frequency against historical baselines using a
green/yellow/orange/red color scale instead of always-blue. The baseline
uses the same hour-of-day + weekday/weekend pattern from the congestion
service's segment_transit_times data over the past 30 days.

Backend: Add baseline_train_count to /routes/history response via new
_calculate_baseline_train_count() function. iOS: Compute frequencyFactor
= totalTrains / baseline and map to color using the same thresholds as
CongestionSegment.frequencyDisplayColor (0.9/0.7/0.5). Falls back to
blue when no baseline data is available.

https://claude.ai/code/session_019f942BFagiKNnnJz2GddNo