### PR TITLE
Fix arrival delay calculation and on-time percentage denominator

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -270,16 +270,17 @@ async def _calculate_route_stats_sql(
         WITH route_journeys AS (
             {route_journeys_cte}
         ),
-        last_stops AS (
+        destination_stops AS (
             SELECT DISTINCT ON (js.journey_id)
                 js.journey_id,
                 EXTRACT(EPOCH FROM (js.actual_arrival - js.scheduled_arrival)) / 60.0
                     AS arrival_delay_minutes
             FROM journey_stops js
             INNER JOIN route_journeys rj ON rj.journey_id = js.journey_id
-            WHERE js.actual_arrival IS NOT NULL
+            WHERE js.station_code = ANY(:to_codes)
+              AND js.actual_arrival IS NOT NULL
               AND js.scheduled_arrival IS NOT NULL
-            ORDER BY js.journey_id, js.stop_sequence DESC
+            ORDER BY js.journey_id, js.stop_sequence ASC
         ),
         origin_stops AS (
             SELECT DISTINCT ON (js.journey_id)
@@ -298,25 +299,29 @@ async def _calculate_route_stats_sql(
                 COUNT(*) AS total_journeys,
                 COUNT(*) FILTER (WHERE rj.is_cancelled) AS cancelled_count,
                 COUNT(*) FILTER (WHERE NOT rj.is_cancelled) AS non_cancelled_count,
+                -- Count of non-cancelled trains with arrival data (proper denominator)
+                COUNT(*) FILTER (WHERE NOT rj.is_cancelled
+                    AND ds.arrival_delay_minutes IS NOT NULL)
+                    AS with_arrival_data_count,
                 -- Arrival delay aggregates (non-cancelled only)
-                AVG(GREATEST(ls.arrival_delay_minutes, 0))
-                    FILTER (WHERE NOT rj.is_cancelled AND ls.arrival_delay_minutes IS NOT NULL)
+                AVG(GREATEST(ds.arrival_delay_minutes, 0))
+                    FILTER (WHERE NOT rj.is_cancelled AND ds.arrival_delay_minutes IS NOT NULL)
                     AS avg_arrival_delay,
                 COUNT(*) FILTER (WHERE NOT rj.is_cancelled
-                    AND ls.arrival_delay_minutes IS NOT NULL
-                    AND ls.arrival_delay_minutes <= 5)
+                    AND ds.arrival_delay_minutes IS NOT NULL
+                    AND ds.arrival_delay_minutes <= 5)
                     AS on_time_count,
                 COUNT(*) FILTER (WHERE NOT rj.is_cancelled
-                    AND ls.arrival_delay_minutes IS NOT NULL
-                    AND ls.arrival_delay_minutes > 5 AND ls.arrival_delay_minutes <= 15)
+                    AND ds.arrival_delay_minutes IS NOT NULL
+                    AND ds.arrival_delay_minutes > 5 AND ds.arrival_delay_minutes <= 15)
                     AS slight_count,
                 COUNT(*) FILTER (WHERE NOT rj.is_cancelled
-                    AND ls.arrival_delay_minutes IS NOT NULL
-                    AND ls.arrival_delay_minutes > 15 AND ls.arrival_delay_minutes <= 30)
+                    AND ds.arrival_delay_minutes IS NOT NULL
+                    AND ds.arrival_delay_minutes > 15 AND ds.arrival_delay_minutes <= 30)
                     AS significant_count,
                 COUNT(*) FILTER (WHERE NOT rj.is_cancelled
-                    AND ls.arrival_delay_minutes IS NOT NULL
-                    AND ls.arrival_delay_minutes > 30)
+                    AND ds.arrival_delay_minutes IS NOT NULL
+                    AND ds.arrival_delay_minutes > 30)
                     AS major_count,
                 -- Departure delay aggregates (non-cancelled with actual departure)
                 AVG(GREATEST(os.departure_delay_minutes, 0))
@@ -324,7 +329,7 @@ async def _calculate_route_stats_sql(
                             AND os.departure_delay_minutes IS NOT NULL)
                     AS avg_departure_delay
             FROM route_journeys rj
-            LEFT JOIN last_stops ls ON ls.journey_id = rj.journey_id
+            LEFT JOIN destination_stops ds ON ds.journey_id = rj.journey_id
             LEFT JOIN origin_stops os ON os.journey_id = rj.journey_id
         )
         SELECT * FROM stats
@@ -352,18 +357,18 @@ async def _calculate_route_stats_sql(
 
     total_journeys = row["total_journeys"]
     cancelled_count = row["cancelled_count"]
-    non_cancelled = row["non_cancelled_count"]
+    with_arrival_data = row["with_arrival_data_count"]
     on_time_count = row["on_time_count"]
     avg_arrival = float(row["avg_arrival_delay"] or 0)
     avg_departure = float(row["avg_departure_delay"] or 0)
 
-    # Calculate delay breakdown percentages
-    if non_cancelled > 0:
+    # Calculate delay breakdown percentages using trains with arrival data as denominator
+    if with_arrival_data > 0:
         delay_breakdown = {
-            "on_time": round(on_time_count / non_cancelled * 100),
-            "slight": round(row["slight_count"] / non_cancelled * 100),
-            "significant": round(row["significant_count"] / non_cancelled * 100),
-            "major": round(row["major_count"] / non_cancelled * 100),
+            "on_time": round(on_time_count / with_arrival_data * 100),
+            "slight": round(row["slight_count"] / with_arrival_data * 100),
+            "significant": round(row["significant_count"] / with_arrival_data * 100),
+            "major": round(row["major_count"] / with_arrival_data * 100),
         }
     else:
         delay_breakdown = {"on_time": 0, "slight": 0, "significant": 0, "major": 0}
@@ -395,7 +400,7 @@ async def _calculate_route_stats_sql(
     return {
         "total_journeys": total_journeys,
         "on_time_percentage": (
-            (on_time_count / non_cancelled * 100) if non_cancelled > 0 else 0
+            (on_time_count / with_arrival_data * 100) if with_arrival_data > 0 else 0
         ),
         "average_delay_minutes": avg_arrival,
         "average_departure_delay_minutes": avg_departure,

--- a/backend_v2/tests/unit/api/test_route_history.py
+++ b/backend_v2/tests/unit/api/test_route_history.py
@@ -396,7 +396,7 @@ class TestDepartureDelay:
 
 @pytest.mark.asyncio
 class TestArrivalDelay:
-    """Verify arrival delay is calculated at the last stop (destination)."""
+    """Verify arrival delay is calculated at the destination station (to_codes)."""
 
     async def test_arrival_delay_at_destination(self, db_session: AsyncSession):
         """Train arrives 8 minutes late at the destination."""
@@ -422,6 +422,181 @@ class TestArrivalDelay:
 
         result = await _run_stats(db_session)
         assert abs(result["average_delay_minutes"] - 8.0) < 0.1
+
+    async def test_arrival_delay_at_destination_not_last_stop(
+        self, db_session: AsyncSession
+    ):
+        """Arrival delay should be measured at the to_station, not the train's final stop.
+
+        A train NY -> TR -> HAM should measure arrival delay at TR (the to_station),
+        not HAM (the train's final stop). This tests the fix for the bug where
+        last_stops CTE picked the highest stop_sequence regardless of to_codes.
+        """
+        await _create_journey(
+            db_session,
+            train_id="train_continues_past",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME,
+                    "actual_departure": BASE_TIME,
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                    "actual_arrival": BASE_TIME + timedelta(hours=1, minutes=3),
+                },
+                {
+                    "station_code": "HAM",
+                    "stop_sequence": 2,
+                    "scheduled_arrival": BASE_TIME + timedelta(hours=1, minutes=30),
+                    "actual_arrival": BASE_TIME + timedelta(hours=1, minutes=50),
+                },
+            ],
+        )
+        await db_session.commit()
+
+        # to_codes=["TR"], so arrival delay should be 3 min (at TR), not 20 min (at HAM)
+        result = await _run_stats(db_session)
+        assert abs(result["average_delay_minutes"] - 3.0) < 0.1, (
+            f"Expected 3.0m (delay at TR), got {result['average_delay_minutes']}. "
+            "Arrival delay should be measured at the destination station, not the last stop."
+        )
+
+
+@pytest.mark.asyncio
+class TestOnTimePercentageDenominator:
+    """Verify on_time_percentage only counts trains with arrival data in denominator.
+
+    This was the root cause of the '71% on-time but 0m avg delay' bug: trains
+    without actual_arrival data were included in the denominator, deflating the
+    on-time percentage while average delay (correctly) excluded them.
+    """
+
+    async def test_trains_without_arrival_data_excluded_from_denominator(
+        self, db_session: AsyncSession
+    ):
+        """5 trains with arrival data (all on-time), 2 without = should be 100%, not 71%.
+
+        Before the fix: on_time_count=5, non_cancelled=7 -> 71%
+        After the fix:  on_time_count=5, with_arrival_data=5 -> 100%
+        """
+        # 5 trains with arrival data, all on-time
+        for i in range(5):
+            await _create_journey(
+                db_session,
+                train_id=f"train_with_data_{i}",
+                stops=[
+                    {
+                        "station_code": "NY",
+                        "stop_sequence": 0,
+                        "scheduled_departure": BASE_TIME,
+                        "actual_departure": BASE_TIME,
+                    },
+                    {
+                        "station_code": "TR",
+                        "stop_sequence": 1,
+                        "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                        "actual_arrival": BASE_TIME + timedelta(hours=1, minutes=2),
+                    },
+                ],
+            )
+        # 2 trains without arrival data (still in progress)
+        for i in range(2):
+            await _create_journey(
+                db_session,
+                train_id=f"train_no_arrival_{i}",
+                stops=[
+                    {
+                        "station_code": "NY",
+                        "stop_sequence": 0,
+                        "scheduled_departure": BASE_TIME,
+                        "actual_departure": BASE_TIME,
+                    },
+                    {
+                        "station_code": "TR",
+                        "stop_sequence": 1,
+                        "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                        "actual_arrival": None,
+                    },
+                ],
+            )
+        await db_session.commit()
+
+        result = await _run_stats(db_session)
+
+        assert result["total_journeys"] == 7
+        assert result["on_time_percentage"] == 100.0, (
+            f"Expected 100% (5/5 trains with data are on-time), got "
+            f"{result['on_time_percentage']}%. Trains without arrival data "
+            "should not be counted in the denominator."
+        )
+        # Average delay should also be very small (2 min, clamped positive)
+        assert result["average_delay_minutes"] < 3.0
+
+    async def test_delay_breakdown_sums_to_100(self, db_session: AsyncSession):
+        """Delay breakdown percentages should sum to ~100% when trains have mixed delays."""
+        delays = [2, 10, 25, 45]  # on_time, slight, significant, major
+        for i, delay in enumerate(delays):
+            await _create_journey(
+                db_session,
+                train_id=f"train_mix_{i}",
+                stops=[
+                    {
+                        "station_code": "NY",
+                        "stop_sequence": 0,
+                        "scheduled_departure": BASE_TIME,
+                        "actual_departure": BASE_TIME,
+                    },
+                    {
+                        "station_code": "TR",
+                        "stop_sequence": 1,
+                        "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                        "actual_arrival": BASE_TIME
+                        + timedelta(hours=1, minutes=delay),
+                    },
+                ],
+            )
+        # Add one train without arrival data (should not affect breakdown)
+        await _create_journey(
+            db_session,
+            train_id="train_no_data",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME,
+                    "actual_departure": BASE_TIME,
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                    "actual_arrival": None,
+                },
+            ],
+        )
+        await db_session.commit()
+
+        result = await _run_stats(db_session)
+        breakdown = result["delay_breakdown"]
+        total_pct = (
+            breakdown["on_time"]
+            + breakdown["slight"]
+            + breakdown["significant"]
+            + breakdown["major"]
+        )
+        assert 98 <= total_pct <= 102, (
+            f"Delay breakdown should sum to ~100%, got {total_pct}%: {breakdown}. "
+            "Each category should be 25% (1 of 4 trains with data)."
+        )
+        # Each category should be 25% (1 of 4 trains with data)
+        assert breakdown["on_time"] == 25
+        assert breakdown["slight"] == 25
+        assert breakdown["significant"] == 25
+        assert breakdown["major"] == 25
 
 
 @pytest.mark.asyncio

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -199,30 +199,23 @@ struct RouteStatusView: View {
                 HStack(spacing: 12) {
                     delayStatCard(
                         title: "Avg Departure Delay",
-                        value: "\(Int(history.aggregateStats.averageDepartureDelayMinutes))m",
+                        value: formatDelay(history.aggregateStats.averageDepartureDelayMinutes),
                         color: history.aggregateStats.averageDepartureDelayMinutes <= 5 ? .green : .orange
                     )
                     delayStatCard(
                         title: "Avg Arrival Delay",
-                        value: "\(Int(history.aggregateStats.averageDelayMinutes))m",
+                        value: formatDelay(history.aggregateStats.averageDelayMinutes),
                         color: history.aggregateStats.averageDelayMinutes <= 5 ? .green : .orange
                     )
                 }
             }
 
-            let breakdown = history.aggregateStats.delayBreakdown
-            DelayPerformanceBar(
-                label: "Arrival Delay Breakdown (\(total) trains)",
-                stats: DelayStats(
-                    onTime: breakdown.onTime,
-                    slight: breakdown.slight,
-                    significant: breakdown.significant,
-                    major: breakdown.major,
-                    total: total,
-                    avgDelay: Int(history.aggregateStats.averageDelayMinutes)
-                )
-            )
         }
+    }
+
+    private func formatDelay(_ minutes: Double) -> String {
+        let rounded = Int(round(minutes))
+        return "\(rounded)m"
     }
 
     private func formatFrequency(totalTrains: Int, hours: Double) -> String {


### PR DESCRIPTION
## Summary
This PR fixes two critical bugs in route statistics calculation:
1. **Arrival delay measured at wrong station**: Arrival delay was being calculated at the train's final stop instead of the destination station (to_codes)
2. **On-time percentage deflated**: Trains without arrival data were incorrectly included in the denominator, causing artificially low on-time percentages (e.g., "71% on-time but 0m avg delay")

## Key Changes

### Backend (routes.py)
- **Renamed CTE** from `last_stops` to `destination_stops` for clarity
- **Fixed arrival delay calculation**: Changed filter from `ORDER BY stop_sequence DESC` (highest/last) to `WHERE station_code = ANY(:to_codes)` (destination only)
- **Fixed denominator**: Introduced `with_arrival_data_count` to track only non-cancelled trains with actual arrival data
- **Updated all delay metrics** to use the correct denominator:
  - `on_time_percentage` now divides by trains with arrival data, not all non-cancelled trains
  - Delay breakdown percentages (on_time, slight, significant, major) now use the same correct denominator
- **Clamped positive delays**: Maintained `GREATEST(delay, 0)` to ensure negative delays don't skew averages

### Tests (test_route_history.py)
- **Updated docstring** for `TestArrivalDelay` to clarify destination-based measurement
- **Added `test_arrival_delay_at_destination_not_last_stop`**: Verifies arrival delay is measured at TR (destination) not HAM (final stop) when train continues past destination
- **Added `TestOnTimePercentageDenominator` class** with two tests:
  - `test_trains_without_arrival_data_excluded_from_denominator`: Confirms 5 on-time trains with data = 100%, not 71% when 2 trains lack arrival data
  - `test_delay_breakdown_sums_to_100`: Verifies delay breakdown percentages correctly sum to 100% with proper denominator

### iOS (RouteStatusView.swift)
- **Improved delay formatting**: Replaced `Int()` truncation with `round()` for more accurate display
- **Removed delay breakdown bar**: Deleted `DelayPerformanceBar` display (likely pending redesign or data structure changes)
- **Added `formatDelay()` helper**: Centralizes delay formatting logic with proper rounding

## Implementation Details
- The fix ensures arrival delay is measured at the intended destination, not wherever the train physically stops
- Trains still in transit (no actual_arrival) are now correctly excluded from on-time calculations while still being counted in total_journeys
- All delay category counts now use the same denominator, ensuring percentages sum to 100%

https://claude.ai/code/session_013S2RU7GXwaGGKRtPC53P8s