### PR TITLE
Add home station setup nudge and improve onboarding state recovery

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -14,13 +14,18 @@ struct TrackRatApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     
+    /// True if user needs onboarding: either never completed, or state is corrupt (no systems selected)
+    private var shouldShowOnboarding: Bool {
+        !hasCompletedOnboarding || appState.selectedSystems.isEmpty
+    }
+
     var body: some Scene {
         WindowGroup {
             Group {
-                if hasCompletedOnboarding {
-                    ContentView()
-                } else {
+                if shouldShowOnboarding {
                     OnboardingView()
+                } else {
+                    ContentView()
                 }
             }
             .environmentObject(appState)

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -130,7 +130,8 @@ extension Set where Element == TrainSystem {
         Set(TrainSystem.allCases)
     }
 
-    /// No systems enabled by default — user picks during onboarding
+    /// Empty by default — user picks during onboarding.
+    /// If state is corrupt (empty after onboarding), the app self-heals by re-showing onboarding.
     static var defaultEnabled: Set<TrainSystem> {
         []
     }

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -80,8 +80,9 @@ struct OnboardingView: View {
         }
         .navigationBarHidden(true)
         .onAppear {
-            // Only clear data on first onboarding, not when editing favorites
-            if !isRepeating {
+            // Only clear data on truly fresh onboarding (never completed before),
+            // not when editing favorites or re-onboarding due to corrupt state
+            if !isRepeating && !hasCompletedOnboarding {
                 clearAllPreviousData()
             }
 

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -137,7 +137,40 @@ struct TripSelectionView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal)
                 .padding(.top, isRatSenseSuggestionVisible ? 8 : 28)
-                
+
+                // Home station setup nudge — shown every launch until user sets a home station
+                if !isSearching && ratSenseService.getHomeStation() == nil {
+                    Button {
+                        appState.navigationPath.append(NavigationDestination.favoriteStations)
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "house.fill")
+                                .font(.body)
+                            Text("Set your home station for faster trip planning")
+                                .font(TrackRatTheme.Typography.bodySecondary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
+                        .foregroundColor(.white)
+                        .textProtected()
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(Color.orange.opacity(0.2))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(Color.orange.opacity(0.4), lineWidth: 1)
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal)
+                    .padding(.top, 4)
+                }
+
                 // Search results and content container
                 VStack(alignment: .leading, spacing: 16) {
                     


### PR DESCRIPTION
## Summary
This PR adds a persistent home station setup prompt to the trip selection screen and improves the app's ability to recover from corrupt onboarding state by re-showing onboarding when no transit systems are selected.

## Key Changes
- **Home Station Nudge**: Added a prominent button on TripSelectionView that appears when the user hasn't set a home station. The nudge displays on every launch until dismissed by setting a home station, improving discoverability of the feature for faster trip planning.
- **Onboarding State Recovery**: Modified TrackRatApp to detect and recover from corrupt state (when onboarding is marked complete but no transit systems are selected) by re-showing the onboarding flow.
- **Improved Onboarding Logic**: Updated OnboardingView to only clear previous data on truly fresh onboarding (first time), not when re-onboarding due to corrupt state or when editing favorites.
- **Documentation**: Added clarifying comments to TrainSystem.swift explaining the default empty state and self-healing behavior.

## Implementation Details
- The home station nudge uses an orange-themed button with house icon, matching the app's design language
- The nudge is conditionally hidden during search to avoid UI clutter
- The onboarding state recovery uses a computed property `shouldShowOnboarding` that checks both the onboarding flag and whether any transit systems are selected
- Data clearing is now guarded by both the `isRepeating` flag and `hasCompletedOnboarding` check to prevent data loss during state recovery

https://claude.ai/code/session_01EGs6U5gXzJZQ2bdCbcWcAQ