### PR TITLE
Fix PATH departure times lagging behind RidePATH app and station signs

### DIFF
--- a/backend_v2/src/trackrat/collectors/path/ridepath_client.py
+++ b/backend_v2/src/trackrat/collectors/path/ridepath_client.py
@@ -18,7 +18,7 @@ from structlog import get_logger
 
 from trackrat.config.stations import PATH_RIDEPATH_API_TO_INTERNAL_MAP
 from trackrat.utils.metrics import track_api_call
-from trackrat.utils.time import now_et
+from trackrat.utils.time import ET, now_et
 
 logger = get_logger(__name__)
 
@@ -199,8 +199,12 @@ class RidePathClient:
             if minutes is None:
                 return None
 
-            # Parse last_updated timestamp
+            # Parse last_updated timestamp and normalize to ET so all
+            # PathArrival.arrival_time values have a consistent timezone type
+            # (pytz ET), regardless of whether baseline is now or last_updated.
             last_updated = self._parse_timestamp(msg.get("lastUpdated"))
+            if last_updated is not None:
+                last_updated = last_updated.astimezone(ET)
 
             # Use lastUpdated as the baseline for computing arrival_time.
             # The API's "X min" countdown is relative to when the prediction

--- a/backend_v2/tests/unit/collectors/path/test_ridepath_client.py
+++ b/backend_v2/tests/unit/collectors/path/test_ridepath_client.py
@@ -383,6 +383,172 @@ class TestRidePathClient:
             f"Expected ~{expected}, got {arrival.arrival_time}"
         )
 
+    def test_arrival_time_timezone_consistency(self, client):
+        """Regression: arrival_time must always have pytz ET timezone.
+
+        When baseline is lastUpdated (parsed via fromisoformat with stdlib tz),
+        the result must still be normalized to pytz ET — not carry a stdlib
+        fixed-offset timezone. This prevents downstream timezone mismatches.
+        """
+        import pytz
+        from trackrat.utils.time import ET, now_et
+
+        now = now_et()
+
+        # Case 1: lastUpdated used (fresh) — result must be pytz ET
+        fresh_msg = {
+            "headSign": "World Trade Center",
+            "arrivalTimeMessage": "5 min",
+            "lastUpdated": (now - timedelta(seconds=30)).isoformat(),
+            "lineColor": "D93A30",
+        }
+        arrival_fresh = client._parse_arrival_message("PJS", "ToNY", fresh_msg, now)
+        assert arrival_fresh is not None
+        assert arrival_fresh.arrival_time.tzinfo is not None
+        # pytz timezones have a .zone attribute; stdlib fixed-offset does not
+        assert hasattr(arrival_fresh.arrival_time.tzinfo, "zone"), (
+            f"arrival_time should have pytz timezone, got {type(arrival_fresh.arrival_time.tzinfo)}"
+        )
+
+        # Case 2: no lastUpdated (fallback to now) — result must also be pytz ET
+        no_lu_msg = {
+            "headSign": "World Trade Center",
+            "arrivalTimeMessage": "5 min",
+            "lineColor": "D93A30",
+        }
+        arrival_no_lu = client._parse_arrival_message("PJS", "ToNY", no_lu_msg, now)
+        assert arrival_no_lu is not None
+        assert hasattr(arrival_no_lu.arrival_time.tzinfo, "zone"), (
+            f"arrival_time should have pytz timezone, got {type(arrival_no_lu.arrival_time.tzinfo)}"
+        )
+
+        # Both should have the same timezone type
+        assert type(arrival_fresh.arrival_time.tzinfo) == type(arrival_no_lu.arrival_time.tzinfo)
+
+    def test_arrival_time_staleness_boundary(self, client):
+        """Regression: verify behavior at the exact 300-second staleness boundary.
+
+        At exactly 300s, lastUpdated should still be used (0 <= staleness <= 300).
+        At 301s, it should fall back to now.
+        """
+        from trackrat.utils.time import now_et
+
+        now = now_et()
+
+        # Exactly 300 seconds (5 min) — should use lastUpdated
+        boundary_time = now - timedelta(seconds=300)
+        msg_at_boundary = {
+            "headSign": "World Trade Center",
+            "arrivalTimeMessage": "10 min",
+            "lastUpdated": boundary_time.isoformat(),
+            "lineColor": "D93A30",
+        }
+        arrival = client._parse_arrival_message("PJS", "ToNY", msg_at_boundary, now)
+        assert arrival is not None
+        expected = boundary_time + timedelta(minutes=10)
+        delta = abs((arrival.arrival_time - expected).total_seconds())
+        assert delta < 1, (
+            f"At exactly 300s staleness, should use lastUpdated. "
+            f"Expected ~{expected}, got {arrival.arrival_time}"
+        )
+
+        # 301 seconds — should fall back to now
+        over_boundary = now - timedelta(seconds=301)
+        msg_over = {
+            "headSign": "World Trade Center",
+            "arrivalTimeMessage": "10 min",
+            "lastUpdated": over_boundary.isoformat(),
+            "lineColor": "D93A30",
+        }
+        arrival_over = client._parse_arrival_message("PJS", "ToNY", msg_over, now)
+        assert arrival_over is not None
+        expected_now = now + timedelta(minutes=10)
+        delta_now = abs((arrival_over.arrival_time - expected_now).total_seconds())
+        assert delta_now < 1, (
+            f"At 301s staleness, should fall back to now. "
+            f"Expected ~{expected_now}, got {arrival_over.arrival_time}"
+        )
+
+    def test_parse_response_uses_last_updated_for_all_arrivals(self, client):
+        """Regression: _parse_response must use lastUpdated for every arrival.
+
+        Simulates a realistic scenario where the API data is 90 seconds old.
+        All computed arrival_times must be based on lastUpdated, not now.
+        This is the primary regression test for the PATH time delay bug.
+        """
+        from trackrat.utils.time import now_et
+
+        now = now_et()
+        last_updated = now - timedelta(seconds=90)
+        lu_str = last_updated.isoformat()
+
+        data = {
+            "results": [
+                {
+                    "consideredStation": "JSQ",
+                    "destinations": [
+                        {
+                            "label": "ToNY",
+                            "messages": [
+                                {
+                                    "headSign": "World Trade Center",
+                                    "arrivalTimeMessage": "12 min",
+                                    "lastUpdated": lu_str,
+                                    "lineColor": "D93A30",
+                                },
+                                {
+                                    "headSign": "33rd Street",
+                                    "arrivalTimeMessage": "6 min",
+                                    "lastUpdated": lu_str,
+                                    "lineColor": "4D92FB",
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "consideredStation": "HOB",
+                    "destinations": [
+                        {
+                            "label": "ToNY",
+                            "messages": [
+                                {
+                                    "headSign": "33rd Street",
+                                    "arrivalTimeMessage": "3 min",
+                                    "lastUpdated": lu_str,
+                                    "lineColor": "4D92FB",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ]
+        }
+
+        # Patch now_et so _parse_response uses our controlled `now`
+        with patch("trackrat.collectors.path.ridepath_client.now_et", return_value=now):
+            arrivals = client._parse_response(data)
+
+        assert len(arrivals) == 3, f"Expected 3 arrivals, got {len(arrivals)}"
+
+        for arrival in arrivals:
+            # Each arrival_time must be based on lastUpdated, not now.
+            # If based on now, the offset from lastUpdated would be ~90s too much.
+            implied_baseline = arrival.arrival_time - timedelta(minutes=arrival.minutes_away)
+            offset_from_lu = abs((implied_baseline - last_updated).total_seconds())
+            offset_from_now = abs((implied_baseline - now).total_seconds())
+
+            assert offset_from_lu < 2, (
+                f"arrival {arrival.headsign} at {arrival.station_code}: "
+                f"arrival_time should be based on lastUpdated (offset {offset_from_lu:.1f}s), "
+                f"but appears based on now (offset {offset_from_now:.1f}s)"
+            )
+            assert offset_from_now > 85, (
+                f"arrival {arrival.headsign} at {arrival.station_code}: "
+                f"arrival_time appears to use now as baseline (offset {offset_from_now:.1f}s). "
+                f"This is the PATH time delay bug — must use lastUpdated instead."
+            )
+
     @pytest.mark.asyncio
     async def test_close(self, client):
         """Test closing the client."""

--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -315,9 +315,9 @@ struct TrainV2: Identifiable, Codable {
             return actualDeparture < now
         }
         
-        // Fallback: Use scheduled time with buffer for delays
+        // Fallback: Use best available departure time with buffer
         if let scheduledDeparture = getDepartureTime(fromStationCode: fromStationCode) {
-            // Allow 1 minute past scheduled time for delays/late boarding
+            // Allow 1 minute past departure time for late boarding
             let departureWithBuffer = scheduledDeparture.addingTimeInterval(1 * 60)
             return departureWithBuffer < now
         }

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -335,10 +335,10 @@ struct TrainCard: View {
     }
 
     private var arrivalTime: String {
-        // For V2, we show arrival time if available
+        // For V2, we show arrival time if available (best available: actual > updated > scheduled)
         // PERFORMANCE: Use cached static formatter instead of creating new one each call
-        if let arrivalTime = train.arrival?.scheduledTime {
-            return DateFormatter.easternTimeShort.string(from: arrivalTime)
+        if let time = train.arrival?.actualTime ?? train.arrival?.updatedTime ?? train.arrival?.scheduledTime {
+            return DateFormatter.easternTimeShort.string(from: time)
         }
         return "--:--"
     }

--- a/scripts/ground-truth-validate.py
+++ b/scripts/ground-truth-validate.py
@@ -183,17 +183,24 @@ def fetch_ridepath_arrivals(client: httpx.Client) -> tuple[list[GroundTruthArriv
                     continue
 
                 line_color = msg.get("lineColor", "")
-                expected_time = now + timedelta(minutes=minutes)
 
-                # Track staleness
+                # Use lastUpdated as the baseline for computing expected_time.
+                # The API's "X min" countdown is relative to when the prediction
+                # was generated (lastUpdated), not when we fetch it.
+                baseline = now
                 last_updated_str = msg.get("lastUpdated")
                 if last_updated_str:
                     try:
                         lu = datetime.fromisoformat(last_updated_str)
+                        staleness = (now - lu).total_seconds()
+                        if 0 <= staleness <= 300:
+                            baseline = lu
                         if oldest_updated is None or lu < oldest_updated:
                             oldest_updated = lu
                     except ValueError:
                         pass
+
+                expected_time = baseline + timedelta(minutes=minutes)
 
                 arrivals.append(
                     GroundTruthArrival(

--- a/webpage_v2/src/components/TrainCard.tsx
+++ b/webpage_v2/src/components/TrainCard.tsx
@@ -13,15 +13,11 @@ interface TrainCardProps {
 }
 
 export function TrainCard({ train, onClick, from, to, departed = false }: TrainCardProps) {
-  const delayMinutes = getDelayMinutes(
-    train.departure.scheduled_time,
-    train.departure.actual_time || undefined
-  );
+  const bestDepartureTime = train.departure.actual_time || train.departure.updated_time || undefined;
+  const delayMinutes = getDelayMinutes(train.departure.scheduled_time, bestDepartureTime);
 
-  const arrivalDelayMinutes = getDelayMinutes(
-    train.arrival.scheduled_time,
-    train.arrival.actual_time || undefined
-  );
+  const bestArrivalTime = train.arrival.actual_time || train.arrival.updated_time || undefined;
+  const arrivalDelayMinutes = getDelayMinutes(train.arrival.scheduled_time, bestArrivalTime);
 
   // Detect boarding: train is at our departure station and hasn't departed yet
   const isBoarding =
@@ -98,9 +94,9 @@ export function TrainCard({ train, onClick, from, to, departed = false }: TrainC
           <div className="text-sm text-text-muted">Departure</div>
           <div className="font-medium text-text-primary">
             {formatTime(train.departure.scheduled_time)}
-            {train.departure.actual_time && delayMinutes > 0 && (
+            {bestDepartureTime && delayMinutes > 0 && (
               <span className="text-warning ml-2">
-                ({formatTime(train.departure.actual_time)})
+                ({formatTime(bestDepartureTime)})
               </span>
             )}
           </div>
@@ -110,9 +106,9 @@ export function TrainCard({ train, onClick, from, to, departed = false }: TrainC
           <div className="text-sm text-text-muted">Arrival</div>
           <div className="font-medium text-text-primary">
             {formatTime(train.arrival.scheduled_time)}
-            {train.arrival.actual_time && arrivalDelayMinutes > 0 && (
+            {bestArrivalTime && arrivalDelayMinutes > 0 && (
               <span className="text-warning ml-2">
-                ({formatTime(train.arrival.actual_time)})
+                ({formatTime(bestArrivalTime)})
               </span>
             )}
           </div>

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -28,7 +28,7 @@ export function TrainListPage() {
   // Check if train has already departed from the origin station
   const hasTrainDeparted = (train: Train): boolean => {
     const now = new Date();
-    const departureTimeStr = train.departure.actual_time || train.departure.scheduled_time;
+    const departureTimeStr = train.departure.actual_time || train.departure.updated_time || train.departure.scheduled_time;
     if (!departureTimeStr) return false;
     const departureTime = new Date(departureTimeStr);
     // 1 minute buffer (matching iOS implementation)


### PR DESCRIPTION
Two compounding issues caused PATH times to be consistently a few
minutes behind reality:

1. Backend: arrival_time was computed as now + X_min, but the API's
   countdown is relative to lastUpdated (when the prediction was
   generated), not when we fetch it. The lag between lastUpdated and
   now inflated all arrival times. Now uses lastUpdated as the baseline
   with fallback to now if missing or stale (>5 min).

2. iOS: getDepartureTime returned scheduledTime (set once at discovery)
   instead of updatedTime (refreshed with real-time averaging every
   collection cycle). Now prefers updatedTime for all providers.

https://claude.ai/code/session_01EafFcDt1pzBRwWit66frhB