### PR TITLE
Rebrand "My Profile" to "Settings" with gear icon

### DIFF
--- a/ios/DESIGN.md
+++ b/ios/DESIGN.md
@@ -102,7 +102,7 @@ This document contains detailed design specifications, screen documentation, and
 - Cache clearing utilities
 - Backend health check testing
 
-### 13. **MyProfileView**
+### 13. **SettingsView**
 - **Trip Statistics**: Total trips, on-time percentage, minutes saved vs scheduled
 - **Trip History Access**: Link to full TripHistoryView
 - User preferences and settings
@@ -234,9 +234,9 @@ This document contains detailed design specifications, screen documentation, and
   - `.trainDetails(trainId: Int)` - Legacy train details by ID
   - `.trainDetailsFlexible(trainNumber: String, fromStation: String?, journeyDate: Date?)` - Flexible train lookup
   - `.advancedConfiguration` - Developer settings
-  - `.myProfile` - User profile
+  - `.settings` - Settings
   - `.congestionMap` - Network congestion view
-  - `.favoriteStations` - Favorite stations (managed inline in MyProfileView)
+  - `.favoriteStations` - Favorite stations (managed inline in SettingsView)
 
 ### API Response Types
 - **OriginStation**: Train origin information
@@ -644,7 +644,7 @@ ML-powered delay predictions shown in train details:
 Comprehensive trip tracking with statistics:
 - **TripRecordingService**: Records completed trips from Live Activities with start/end times, delays, train info
 - **CompletedTrip Model**: Stores journey data including origin/destination, duration, delay minutes, data source
-- **MyProfileView**: Shows trip statistics (total trips, on-time %, minutes saved vs scheduled)
+- **SettingsView**: Shows trip statistics (total trips, on-time %, minutes saved vs scheduled)
 - **TripHistoryView**: Full trip history with filtering and detailed journey information
 - **StorageService**: Enhanced to persist trip data across sessions
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -115,7 +115,7 @@ TrackRat/
 │   │   ├── PennStationGuideView.swift   # Navigation assistance
 │   │   ├── CongestionMapView.swift      # Network congestion
 │   │   ├── HistoricalDataView.swift     # Performance analytics
-│   │   ├── MyProfileView.swift          # User settings
+│   │   ├── SettingsView.swift            # User settings
 │   │   ├── MapContainerView.swift       # Primary map interface
 │   │   ├── OnboardingView.swift         # User onboarding
 │   │   └── AdvancedConfigurationView.swift # Developer settings

--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		A17B1E712E7F05B00026D42E /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		A17B9F3B2E17FD0A00B370A6 /* StationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17B9F372E17FD0A00B370A6 /* StationButton.swift */; };
 		A183B7E12E6352E80024FADC /* LegacySheetAwareScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A183B7E02E6352E80024FADC /* LegacySheetAwareScrollView.swift */; };
-		A1875C7F2E400F4F00FCC7FC /* MyProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1875C7E2E400F4F00FCC7FC /* MyProfileView.swift */; };
+		A1875C7F2E400F4F00FCC7FC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1875C7E2E400F4F00FCC7FC /* SettingsView.swift */; };
 		A18D98D72F1D2F3700F5D22F /* DateSelectorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A18D98D62F1D2F3700F5D22F /* DateSelectorSheet.swift */; };
 		A18D98D82F1D2F3700F5D22F /* DateSelectorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A18D98D62F1D2F3700F5D22F /* DateSelectorSheet.swift */; };
 		A18E543A2DEB88E500AB2B74 /* LiveActivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A18E54392DEB88E500AB2B74 /* LiveActivityService.swift */; };
@@ -215,7 +215,7 @@
 		A17A63E02EE60FD2003BD685 /* TrainStatsSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TrainStatsSummaryView.swift; path = TrackRat/Views/Components/TrainStatsSummaryView.swift; sourceTree = "<group>"; };
 		A17B9F372E17FD0A00B370A6 /* StationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StationButton.swift; path = Views/Components/StationButton.swift; sourceTree = "<group>"; };
 		A183B7E02E6352E80024FADC /* LegacySheetAwareScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LegacySheetAwareScrollView.swift; path = Views/Components/LegacySheetAwareScrollView.swift; sourceTree = "<group>"; };
-		A1875C7E2E400F4F00FCC7FC /* MyProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MyProfileView.swift; path = Views/Screens/MyProfileView.swift; sourceTree = "<group>"; };
+		A1875C7E2E400F4F00FCC7FC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SettingsView.swift; path = Views/Screens/SettingsView.swift; sourceTree = "<group>"; };
 		A18D98D62F1D2F3700F5D22F /* DateSelectorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DateSelectorSheet.swift; path = TrackRat/Views/Components/DateSelectorSheet.swift; sourceTree = "<group>"; };
 		A18E54392DEB88E500AB2B74 /* LiveActivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LiveActivityService.swift; path = Services/LiveActivityService.swift; sourceTree = "<group>"; };
 		A18E54412DEB893100AB2B74 /* LiveActivityControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LiveActivityControls.swift; path = Views/Components/LiveActivityControls.swift; sourceTree = "<group>"; };
@@ -381,7 +381,7 @@
 				A11A2C322E27C1A400B74BB5 /* StaticTrackDistributionService.swift */,
 				A19E912C2E3F8E4A0011F777 /* LegacyBottomSheetView.swift */,
 				A18E54452DEB8B0000AB2B74 /* ActiveTripsSection.swift */,
-				A1875C7E2E400F4F00FCC7FC /* MyProfileView.swift */,
+				A1875C7E2E400F4F00FCC7FC /* SettingsView.swift */,
 				A11A0DBC2F4B840B00C96DA1 /* AddRouteAlertView.swift */,
 				A11A0DBD2F4B840B00C96DA1 /* EditRouteAlertsView.swift */,
 				A1ROUTE0012F5000000000001 /* RouteStatusView.swift */,
@@ -714,7 +714,7 @@
 				A11A0DBB2F4B83CF00C96DA1 /* APIService.swift in Sources */,
 				A1AD0D0D2E106D32003DA39F /* LiveActivityModels.swift in Sources */,
 				A17A63DE2EE60474003BD685 /* OperationsSummaryView.swift in Sources */,
-				A1875C7F2E400F4F00FCC7FC /* MyProfileView.swift in Sources */,
+				A1875C7F2E400F4F00FCC7FC /* SettingsView.swift in Sources */,
 				A1CB28302E3D6189004A49E6 /* AdvancedConfigurationView.swift in Sources */,
 				A1D92A752F0AF01E0098897F /* CompletedTrip.swift in Sources */,
 				A1CB28312E3D6189004A49E6 /* CongestionMapView.swift in Sources */,

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-// MARK: - Profile Navigation
-enum ProfileDestination: Hashable {
+// MARK: - Settings Navigation
+enum SettingsDestination: Hashable {
     case tripHistory
     case favoriteStations
     case routeAlerts
     case advancedConfiguration
 }
 
-struct MyProfileView: View {
+struct SettingsView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var themeManager: ThemeManager
     @Environment(\.openURL) private var openURL
@@ -33,7 +33,7 @@ struct MyProfileView: View {
 
                 // Center title with Pro badge
                 HStack(spacing: 8) {
-                    Text("My Profile")
+                    Text("Settings")
                         .font(.headline)
                         .foregroundColor(.white)
 
@@ -173,7 +173,7 @@ struct MyProfileView: View {
                         // My Trips
                         Button {
                             if subscriptionService.isPro {
-                                navigationPath.append(ProfileDestination.tripHistory)
+                                navigationPath.append(SettingsDestination.tripHistory)
                             } else {
                                 showingPaywall = true
                             }
@@ -313,7 +313,7 @@ struct MyProfileView: View {
                         .buttonStyle(.plain)
                         .sheet(isPresented: $showingFeedbackSheet) {
                             FeedbackSheet(
-                                screen: "my_profile",
+                                screen: "settings",
                                 trainId: nil,
                                 originCode: nil,
                                 destinationCode: nil
@@ -324,7 +324,7 @@ struct MyProfileView: View {
                 .padding()
                 .padding(.bottom, 40)
             }
-            .navigationDestination(for: ProfileDestination.self) { destination in
+            .navigationDestination(for: SettingsDestination.self) { destination in
                 Group {
                     switch destination {
                     case .tripHistory:
@@ -410,7 +410,7 @@ struct SettingsSection: View {
 
             // Favorite Stations
             Button {
-                navigationPath.append(ProfileDestination.favoriteStations)
+                navigationPath.append(SettingsDestination.favoriteStations)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
             } label: {
                 HStack(spacing: 16) {
@@ -444,7 +444,7 @@ struct SettingsSection: View {
 
             // Route Alerts
             Button {
-                navigationPath.append(ProfileDestination.routeAlerts)
+                navigationPath.append(SettingsDestination.routeAlerts)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
             } label: {
                 HStack(spacing: 16) {
@@ -485,7 +485,7 @@ struct SettingsSection: View {
             if showDebugSections {
             // Advanced Configuration
             Button {
-                navigationPath.append(ProfileDestination.advancedConfiguration)
+                navigationPath.append(SettingsDestination.advancedConfiguration)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
             } label: {
                 HStack(spacing: 16) {
@@ -890,7 +890,7 @@ private struct TrainSystemRow: View {
 
 #Preview {
     NavigationStack {
-        MyProfileView()
+        SettingsView()
             .environmentObject(AppState())
             .environmentObject(ThemeManager.shared)
     }

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -12,7 +12,7 @@ struct TripSelectionView: View {
     @Environment(\.openURL) private var openURL
     @State private var searchText = ""
     @State private var isSearching = false
-    @State private var showingProfile = false
+    @State private var showingSettings = false
     @FocusState private var searchFieldFocused: Bool
     @StateObject private var liveActivityService = LiveActivityService.shared
     @StateObject private var ratSenseService = RatSenseService.shared
@@ -29,7 +29,7 @@ struct TripSelectionView: View {
               Stations.isStationVisible(suggestion.toStation, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode),
               !liveActivityService.isActivityActive,
               !isSearching,
-              !showingProfile else {
+              !showingSettings else {
             return false
         }
         return true
@@ -210,11 +210,11 @@ struct TripSelectionView: View {
                                 }
                             }
                         
-                        // Profile icon - presented as dismissable sheet
+                        // Settings icon - presented as dismissable sheet
                         Button {
-                            showingProfile = true
+                            showingSettings = true
                         } label: {
-                            Image(systemName: "person.circle.fill")
+                            Image(systemName: "gearshape.fill")
                                 .font(TrackRatTheme.IconSize.large)
                                 .foregroundColor(.white.opacity(0.8))
                         }
@@ -323,8 +323,8 @@ struct TripSelectionView: View {
             appState.loadRecentTrips()
             appState.loadFavoriteStations()
         }
-        .sheet(isPresented: $showingProfile) {
-            MyProfileView()
+        .sheet(isPresented: $showingSettings) {
+            SettingsView()
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }


### PR DESCRIPTION
- Rename MyProfileView → SettingsView (file, struct, enum, references)
- Change button icon from person.circle.fill to gearshape.fill
- Rename ProfileDestination → SettingsDestination
- Rename showingProfile → showingSettings state var
- Update feedback screen identifier from "my_profile" to "settings"
- Update Xcode project file and documentation

https://claude.ai/code/session_01HZyrhXkTrbCHFW8JpxvkSh