### PR TITLE
Fix JIT refresh matching wrong train on non-branching subway lines

### DIFF
--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -516,32 +516,41 @@ class LIRRCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Find the best matching trip: most overlapping stations, then
-        # closest departure time as tiebreaker.
+        # Exact match: regenerate train_id from each candidate trip_id
+        # and compare against the stored train_id. This avoids the fuzzy
+        # matching bug where trains on the same branch with identical
+        # station sets and close departure times get swapped.
         best_trip: list[LirrArrival] | None = None
-        best_overlap = 0
-        best_time_diff = float("inf")
-
-        for trip_arrivals in matching_trips.values():
-            trip_stations = {a.station_code for a in trip_arrivals}
-            overlap = len(trip_stations & journey_station_codes)
-
-            # Time-based tiebreaker against journey's scheduled departure
-            time_diff = float("inf")
-            if journey.scheduled_departure:
-                first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                time_diff = abs(
-                    (
-                        first_arr.arrival_time - journey.scheduled_departure
-                    ).total_seconds()
-                )
-
-            if overlap > best_overlap or (
-                overlap == best_overlap and time_diff < best_time_diff
-            ):
-                best_overlap = overlap
-                best_time_diff = time_diff
+        for trip_id_candidate, trip_arrivals in matching_trips.items():
+            if _generate_train_id(trip_id_candidate) == journey.train_id:
                 best_trip = trip_arrivals
+                break
+
+        # Fuzzy fallback: if the trip_id changed (rare), fall back to
+        # station overlap + time proximity.
+        if best_trip is None:
+            best_overlap = 0
+            best_time_diff = float("inf")
+
+            for trip_arrivals in matching_trips.values():
+                trip_stations = {a.station_code for a in trip_arrivals}
+                overlap = len(trip_stations & journey_station_codes)
+
+                time_diff = float("inf")
+                if journey.scheduled_departure:
+                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
+                    time_diff = abs(
+                        (
+                            first_arr.arrival_time - journey.scheduled_departure
+                        ).total_seconds()
+                    )
+
+                if overlap > best_overlap or (
+                    overlap == best_overlap and time_diff < best_time_diff
+                ):
+                    best_overlap = overlap
+                    best_time_diff = time_diff
+                    best_trip = trip_arrivals
 
         if not best_trip:
             logger.debug(f"No matching LIRR trip found for journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -506,32 +506,41 @@ class MNRCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Find the best matching trip: most overlapping stations, then
-        # closest departure time as tiebreaker.
+        # Exact match: regenerate train_id from each candidate trip_id
+        # and compare against the stored train_id. This avoids the fuzzy
+        # matching bug where trains on the same line with identical
+        # station sets and close departure times get swapped.
         best_trip: list[MnrArrival] | None = None
-        best_overlap = 0
-        best_time_diff = float("inf")
-
-        for trip_arrivals in matching_trips.values():
-            trip_stations = {a.station_code for a in trip_arrivals}
-            overlap = len(trip_stations & journey_station_codes)
-
-            # Time-based tiebreaker against journey's scheduled departure
-            time_diff = float("inf")
-            if journey.scheduled_departure:
-                first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                time_diff = abs(
-                    (
-                        first_arr.arrival_time - journey.scheduled_departure
-                    ).total_seconds()
-                )
-
-            if overlap > best_overlap or (
-                overlap == best_overlap and time_diff < best_time_diff
-            ):
-                best_overlap = overlap
-                best_time_diff = time_diff
+        for trip_id_candidate, trip_arrivals in matching_trips.items():
+            if _generate_train_id(trip_id_candidate) == journey.train_id:
                 best_trip = trip_arrivals
+                break
+
+        # Fuzzy fallback: if the trip_id changed (rare), fall back to
+        # station overlap + time proximity.
+        if best_trip is None:
+            best_overlap = 0
+            best_time_diff = float("inf")
+
+            for trip_arrivals in matching_trips.values():
+                trip_stations = {a.station_code for a in trip_arrivals}
+                overlap = len(trip_stations & journey_station_codes)
+
+                time_diff = float("inf")
+                if journey.scheduled_departure:
+                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
+                    time_diff = abs(
+                        (
+                            first_arr.arrival_time - journey.scheduled_departure
+                        ).total_seconds()
+                    )
+
+                if overlap > best_overlap or (
+                    overlap == best_overlap and time_diff < best_time_diff
+                ):
+                    best_overlap = overlap
+                    best_time_diff = time_diff
+                    best_trip = trip_arrivals
 
         if not best_trip:
             logger.debug(f"No matching MNR trip found for journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -446,29 +446,42 @@ class SubwayCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
+        # Exact match: re-hash each candidate trip_id and compare against
+        # the stored train_id. This avoids the fuzzy matching bug where
+        # non-branching lines (e.g., L) have identical station sets for
+        # every trip, causing the fuzzy matcher to pick the wrong train.
         best_trip: list[SubwayArrival] | None = None
-        best_overlap = 0
-        best_time_diff = float("inf")
-
-        for trip_arrivals in matching_trips.values():
-            trip_stations = {a.station_code for a in trip_arrivals}
-            overlap = len(trip_stations & journey_station_codes)
-
-            time_diff = float("inf")
-            if journey.scheduled_departure:
-                first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                time_diff = abs(
-                    (
-                        first_arr.arrival_time - journey.scheduled_departure
-                    ).total_seconds()
-                )
-
-            if overlap > best_overlap or (
-                overlap == best_overlap and time_diff < best_time_diff
-            ):
-                best_overlap = overlap
-                best_time_diff = time_diff
+        route_id = journey.line_code or ""
+        for trip_id_candidate, trip_arrivals in matching_trips.items():
+            if _generate_train_id(trip_id_candidate, route_id) == journey.train_id:
                 best_trip = trip_arrivals
+                break
+
+        # Fuzzy fallback: if the trip_id changed (rare), fall back to
+        # station overlap + time proximity.
+        if best_trip is None:
+            best_overlap = 0
+            best_time_diff = float("inf")
+
+            for trip_arrivals in matching_trips.values():
+                trip_stations = {a.station_code for a in trip_arrivals}
+                overlap = len(trip_stations & journey_station_codes)
+
+                time_diff = float("inf")
+                if journey.scheduled_departure:
+                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
+                    time_diff = abs(
+                        (
+                            first_arr.arrival_time - journey.scheduled_departure
+                        ).total_seconds()
+                    )
+
+                if overlap > best_overlap or (
+                    overlap == best_overlap and time_diff < best_time_diff
+                ):
+                    best_overlap = overlap
+                    best_time_diff = time_diff
+                    best_trip = trip_arrivals
 
         if not best_trip:
             logger.debug(

--- a/backend_v2/tests/unit/collectors/lirr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/lirr/test_collector.py
@@ -496,6 +496,183 @@ class TestLIRRCollectorJourneyDetails:
         # Should complete without error
         mock_client.get_all_arrivals.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_exact_match_picks_correct_trip_over_closer_time(
+        self, collector, mock_client, mock_session
+    ):
+        """Regression test: when two trips share the same stations (same branch),
+        the JIT must use exact train_id matching (regenerating from trip_id) instead
+        of fuzzy time proximity.
+
+        Scenario: journey was created from GO103_25_181 (train L181). The feed has
+        two trips on the same branch. trip_wrong has a closer departure time, but
+        trip_correct is the actual train. The exact match must win.
+        """
+        now = datetime.now(timezone.utc)
+        trip_correct = "GO103_25_181"  # -> L181
+        trip_wrong = "GO103_25_183"  # -> L183
+
+        correct_train_id = _generate_train_id(trip_correct)
+        assert correct_train_id == "L181"
+
+        journey = MagicMock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = correct_train_id
+        journey.data_source = "LIRR"
+        journey.scheduled_departure = now - timedelta(minutes=5)
+        journey.is_completed = False
+        journey.update_count = 0
+
+        stop1 = MagicMock(spec=JourneyStop)
+        stop1.station_code = "JAM"
+        stop1.stop_sequence = 1
+        stop1.actual_departure = now - timedelta(minutes=5)
+        stop1.actual_arrival = now - timedelta(minutes=5)
+        stop1.scheduled_arrival = now - timedelta(minutes=5)
+        stop1.has_departed_station = True
+        stop1.departure_source = None
+
+        stop2 = MagicMock(spec=JourneyStop)
+        stop2.station_code = "NY"
+        stop2.stop_sequence = 2
+        stop2.actual_departure = None
+        stop2.actual_arrival = None
+        stop2.scheduled_arrival = now + timedelta(minutes=25)
+        stop2.has_departed_station = False
+        stop2.departure_source = None
+
+        journey.stops = [stop1, stop2]
+
+        correct_time = now + timedelta(minutes=2)
+        wrong_time = now - timedelta(minutes=4)
+
+        arrivals = [
+            # trip_wrong: closer departure time to scheduled_departure
+            LirrArrival(
+                station_code="JAM",
+                gtfs_stop_id="102",
+                trip_id=trip_wrong,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=wrong_time,
+                departure_time=wrong_time + timedelta(minutes=1),
+                delay_seconds=0,
+                track="3",
+            ),
+            LirrArrival(
+                station_code="NY",
+                gtfs_stop_id="237",
+                trip_id=trip_wrong,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=wrong_time + timedelta(minutes=30),
+                departure_time=None,
+                delay_seconds=0,
+                track="18",
+            ),
+            # trip_correct: the actual train
+            LirrArrival(
+                station_code="JAM",
+                gtfs_stop_id="102",
+                trip_id=trip_correct,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=correct_time,
+                departure_time=correct_time + timedelta(minutes=1),
+                delay_seconds=0,
+                track="5",
+            ),
+            LirrArrival(
+                station_code="NY",
+                gtfs_stop_id="237",
+                trip_id=trip_correct,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=correct_time + timedelta(minutes=30),
+                departure_time=None,
+                delay_seconds=0,
+                track="17",
+            ),
+        ]
+        mock_client.get_all_arrivals.return_value = arrivals
+
+        mock_stop_result = MagicMock()
+        mock_stop_result.scalar_one_or_none.side_effect = [stop1, stop2]
+        mock_stops_list = MagicMock()
+        mock_stops_list.scalars.return_value.all.return_value = [stop1, stop2]
+        mock_session.execute.side_effect = [
+            mock_stop_result,
+            mock_stop_result,
+            mock_stops_list,
+        ]
+
+        await collector.collect_journey_details(mock_session, journey)
+
+        # Must use trip_correct times, NOT trip_wrong
+        assert journey.actual_departure == correct_time
+        assert journey.actual_arrival == correct_time + timedelta(minutes=30)
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_fallback_when_trip_id_changed(
+        self, collector, mock_client, mock_session
+    ):
+        """When the original trip_id is no longer in the feed, the JIT falls
+        back to fuzzy matching by station overlap and time proximity."""
+        now = datetime.now(timezone.utc)
+
+        journey = MagicMock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = "L999"  # No trip in feed will generate this
+        journey.data_source = "LIRR"
+        journey.scheduled_departure = now
+        journey.is_completed = False
+        journey.update_count = 0
+
+        stop1 = MagicMock(spec=JourneyStop)
+        stop1.station_code = "JAM"
+        stop1.stop_sequence = 1
+        stop1.actual_departure = now
+        stop1.actual_arrival = now
+        stop1.scheduled_arrival = now
+        stop1.has_departed_station = False
+        stop1.departure_source = None
+
+        journey.stops = [stop1]
+
+        arrivals = [
+            LirrArrival(
+                station_code="JAM",
+                gtfs_stop_id="102",
+                trip_id="new_trip_reassigned",
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=now + timedelta(seconds=30),
+                departure_time=now + timedelta(seconds=60),
+                delay_seconds=0,
+                track="5",
+            ),
+        ]
+        mock_client.get_all_arrivals.return_value = arrivals
+
+        mock_stop_result = MagicMock()
+        mock_stop_result.scalar_one_or_none.return_value = stop1
+        mock_stops_list = MagicMock()
+        mock_stops_list.scalars.return_value.all.return_value = [stop1]
+        mock_session.execute.side_effect = [
+            mock_stop_result,
+            mock_stops_list,
+        ]
+
+        await collector.collect_journey_details(mock_session, journey)
+
+        # Fuzzy fallback should still update the journey
+        assert journey.actual_departure == now + timedelta(seconds=30)
+
 
 class TestLIRRCollectorRun:
     """Tests for the run() entry point method."""

--- a/backend_v2/tests/unit/collectors/mnr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/mnr/test_collector.py
@@ -483,6 +483,183 @@ class TestMNRCollectorJourneyDetails:
         # Should complete without error
         mock_client.get_all_arrivals.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_exact_match_picks_correct_trip_over_closer_time(
+        self, collector, mock_client, mock_session
+    ):
+        """Regression test: when two trips share the same stations (same line),
+        the JIT must use exact train_id matching (regenerating from trip_id) instead
+        of fuzzy time proximity.
+
+        Scenario: journey was created from a trip whose last 6 digits are "631700"
+        (train M631700). The feed has two trips on the same line. trip_wrong has a
+        closer departure time, but trip_correct is the actual train.
+        """
+        now = datetime.now(timezone.utc)
+        trip_correct = "MNR_trip_631700"  # -> M631700
+        trip_wrong = "MNR_trip_631800"  # -> M631800
+
+        correct_train_id = _generate_train_id(trip_correct)
+        assert correct_train_id == "M631700"
+
+        journey = MagicMock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = correct_train_id
+        journey.data_source = "MNR"
+        journey.scheduled_departure = now - timedelta(minutes=5)
+        journey.is_completed = False
+        journey.update_count = 0
+
+        stop1 = MagicMock(spec=JourneyStop)
+        stop1.station_code = "GCT"
+        stop1.stop_sequence = 1
+        stop1.actual_departure = now - timedelta(minutes=5)
+        stop1.actual_arrival = now - timedelta(minutes=5)
+        stop1.scheduled_arrival = now - timedelta(minutes=5)
+        stop1.has_departed_station = True
+        stop1.departure_source = None
+
+        stop2 = MagicMock(spec=JourneyStop)
+        stop2.station_code = "M125"
+        stop2.stop_sequence = 2
+        stop2.actual_departure = None
+        stop2.actual_arrival = None
+        stop2.scheduled_arrival = now + timedelta(minutes=25)
+        stop2.has_departed_station = False
+        stop2.departure_source = None
+
+        journey.stops = [stop1, stop2]
+
+        correct_time = now + timedelta(minutes=2)
+        wrong_time = now - timedelta(minutes=4)
+
+        arrivals = [
+            # trip_wrong: closer departure time to scheduled_departure
+            MnrArrival(
+                station_code="GCT",
+                gtfs_stop_id="1",
+                trip_id=trip_wrong,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=wrong_time,
+                departure_time=wrong_time + timedelta(minutes=1),
+                delay_seconds=0,
+                track="23",
+            ),
+            MnrArrival(
+                station_code="M125",
+                gtfs_stop_id="4",
+                trip_id=trip_wrong,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=wrong_time + timedelta(minutes=30),
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+            ),
+            # trip_correct: the actual train
+            MnrArrival(
+                station_code="GCT",
+                gtfs_stop_id="1",
+                trip_id=trip_correct,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=correct_time,
+                departure_time=correct_time + timedelta(minutes=1),
+                delay_seconds=0,
+                track="21",
+            ),
+            MnrArrival(
+                station_code="M125",
+                gtfs_stop_id="4",
+                trip_id=trip_correct,
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=correct_time + timedelta(minutes=30),
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+            ),
+        ]
+        mock_client.get_all_arrivals.return_value = arrivals
+
+        mock_stop_result = MagicMock()
+        mock_stop_result.scalar_one_or_none.side_effect = [stop1, stop2]
+        mock_stops_list = MagicMock()
+        mock_stops_list.scalars.return_value.all.return_value = [stop1, stop2]
+        mock_session.execute.side_effect = [
+            mock_stop_result,
+            mock_stop_result,
+            mock_stops_list,
+        ]
+
+        await collector.collect_journey_details(mock_session, journey)
+
+        # Must use trip_correct times, NOT trip_wrong
+        assert journey.actual_departure == correct_time
+        assert journey.actual_arrival == correct_time + timedelta(minutes=30)
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_fallback_when_trip_id_changed(
+        self, collector, mock_client, mock_session
+    ):
+        """When the original trip_id is no longer in the feed, the JIT falls
+        back to fuzzy matching by station overlap and time proximity."""
+        now = datetime.now(timezone.utc)
+
+        journey = MagicMock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = "M999999"  # No trip in feed will generate this
+        journey.data_source = "MNR"
+        journey.scheduled_departure = now
+        journey.is_completed = False
+        journey.update_count = 0
+
+        stop1 = MagicMock(spec=JourneyStop)
+        stop1.station_code = "GCT"
+        stop1.stop_sequence = 1
+        stop1.actual_departure = now
+        stop1.actual_arrival = now
+        stop1.scheduled_arrival = now
+        stop1.has_departed_station = False
+        stop1.departure_source = None
+
+        journey.stops = [stop1]
+
+        arrivals = [
+            MnrArrival(
+                station_code="GCT",
+                gtfs_stop_id="1",
+                trip_id="new_trip_reassigned",
+                route_id="1",
+                direction_id=0,
+                headsign=None,
+                arrival_time=now + timedelta(seconds=30),
+                departure_time=now + timedelta(seconds=60),
+                delay_seconds=0,
+                track="21",
+            ),
+        ]
+        mock_client.get_all_arrivals.return_value = arrivals
+
+        mock_stop_result = MagicMock()
+        mock_stop_result.scalar_one_or_none.return_value = stop1
+        mock_stops_list = MagicMock()
+        mock_stops_list.scalars.return_value.all.return_value = [stop1]
+        mock_session.execute.side_effect = [
+            mock_stop_result,
+            mock_stops_list,
+        ]
+
+        await collector.collect_journey_details(mock_session, journey)
+
+        # Fuzzy fallback should still update the journey
+        assert journey.actual_departure == now + timedelta(seconds=30)
+
 
 class TestMNRCollectorRun:
     """Tests for the run() entry point method."""

--- a/backend_v2/tests/unit/collectors/subway/test_collector.py
+++ b/backend_v2/tests/unit/collectors/subway/test_collector.py
@@ -609,6 +609,205 @@ class TestSubwayCollectorJourneyDetails:
         assert journey.actual_departure == now
         assert journey.actual_arrival == now + timedelta(minutes=10)
 
+    @pytest.mark.asyncio
+    async def test_exact_match_picks_correct_trip_on_non_branching_line(
+        self, collector, mock_client, mock_session
+    ):
+        """Regression test: on non-branching lines like the L, all trips share
+        identical station sets. The fuzzy matcher would pick the wrong train
+        based on time proximity. The exact match (re-hashing candidate trip_ids)
+        must pick the correct one regardless of timing.
+
+        Scenario: Journey was created from trip_correct. The feed has two L trips
+        with identical stations. trip_wrong has a closer departure time (simulating
+        a newer train closer to origin), but trip_correct is the actual train.
+        The JIT must pick trip_correct via exact hash match.
+        """
+        now = datetime.now(timezone.utc)
+        trip_correct = "074850_L..S"
+        trip_wrong = "075200_L..S"
+
+        # Build the train_id the same way the collector would
+        correct_train_id = _generate_train_id(trip_correct, "L")
+
+        journey = MagicMock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = correct_train_id
+        journey.data_source = "SUBWAY"
+        journey.line_code = "L"
+        # Scheduled departure is 10 minutes ago (train is mid-route)
+        journey.scheduled_departure = now - timedelta(minutes=10)
+        journey.is_completed = False
+        journey.update_count = 0
+
+        # Both trips visit the same stations (L line has no branches)
+        stop1 = MagicMock(spec=JourneyStop)
+        stop1.station_code = "SL01"
+        stop1.stop_sequence = 1
+        stop1.actual_departure = now - timedelta(minutes=10)
+        stop1.actual_arrival = now - timedelta(minutes=10)
+        stop1.scheduled_arrival = now - timedelta(minutes=10)
+        stop1.scheduled_departure = now - timedelta(minutes=10)
+        stop1.has_departed_station = True
+        stop1.departure_source = None
+
+        stop2 = MagicMock(spec=JourneyStop)
+        stop2.station_code = "SL02"
+        stop2.stop_sequence = 2
+        stop2.actual_departure = None
+        stop2.actual_arrival = None
+        stop2.scheduled_arrival = now + timedelta(minutes=5)
+        stop2.scheduled_departure = now + timedelta(minutes=5)
+        stop2.has_departed_station = False
+        stop2.departure_source = None
+
+        journey.stops = [stop1, stop2]
+
+        correct_time = now + timedelta(minutes=3)
+        wrong_time = now - timedelta(minutes=8)
+
+        arrivals = [
+            # trip_wrong: closer to scheduled_departure (fuzzy would pick this)
+            SubwayArrival(
+                station_code="SL01",
+                gtfs_stop_id="L01S",
+                trip_id=trip_wrong,
+                route_id="L",
+                direction_id=1,
+                headsign=None,
+                arrival_time=wrong_time,
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+                nyct_train_id=None,
+                is_assigned=True,
+            ),
+            SubwayArrival(
+                station_code="SL02",
+                gtfs_stop_id="L02S",
+                trip_id=trip_wrong,
+                route_id="L",
+                direction_id=1,
+                headsign=None,
+                arrival_time=wrong_time + timedelta(minutes=10),
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+                nyct_train_id=None,
+                is_assigned=True,
+            ),
+            # trip_correct: further from scheduled_departure but the actual train
+            SubwayArrival(
+                station_code="SL01",
+                gtfs_stop_id="L01S",
+                trip_id=trip_correct,
+                route_id="L",
+                direction_id=1,
+                headsign=None,
+                arrival_time=correct_time,
+                departure_time=None,
+                delay_seconds=0,
+                track="2",
+                nyct_train_id=None,
+                is_assigned=True,
+            ),
+            SubwayArrival(
+                station_code="SL02",
+                gtfs_stop_id="L02S",
+                trip_id=trip_correct,
+                route_id="L",
+                direction_id=1,
+                headsign=None,
+                arrival_time=correct_time + timedelta(minutes=10),
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+                nyct_train_id=None,
+                is_assigned=True,
+            ),
+        ]
+        mock_client.get_feed_arrivals.return_value = arrivals
+
+        mock_stop_result = MagicMock()
+        mock_stop_result.scalar_one_or_none.side_effect = [stop1, stop2]
+        mock_stops_list = MagicMock()
+        mock_stops_list.scalars.return_value.all.return_value = [stop1, stop2]
+        mock_session.execute.side_effect = [
+            mock_stop_result,  # SL01 stop lookup
+            mock_stop_result,  # SL02 stop lookup
+            mock_stops_list,  # Get all stops for update
+        ]
+
+        await collector.collect_journey_details(mock_session, journey)
+
+        # Must use trip_correct (track "2" at SL01), NOT trip_wrong
+        assert journey.actual_departure == correct_time
+        assert journey.actual_arrival == correct_time + timedelta(minutes=10)
+
+    @pytest.mark.asyncio
+    async def test_fuzzy_fallback_when_trip_id_changed(
+        self, collector, mock_client, mock_session
+    ):
+        """When the original trip_id is no longer in the feed (rare: MTA
+        reassignment), the JIT falls back to fuzzy matching by station overlap
+        and time proximity."""
+        now = datetime.now(timezone.utc)
+
+        # Journey has a hash from a trip_id that's no longer in the feed
+        journey = MagicMock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = _generate_train_id("old_trip_gone", "L")
+        journey.data_source = "SUBWAY"
+        journey.line_code = "L"
+        journey.scheduled_departure = now
+        journey.is_completed = False
+        journey.update_count = 0
+
+        stop1 = MagicMock(spec=JourneyStop)
+        stop1.station_code = "SL01"
+        stop1.stop_sequence = 1
+        stop1.actual_departure = now
+        stop1.actual_arrival = now
+        stop1.scheduled_arrival = now
+        stop1.scheduled_departure = now
+        stop1.has_departed_station = False
+        stop1.departure_source = None
+
+        journey.stops = [stop1]
+
+        # Feed only has a new trip_id (no hash match possible)
+        arrivals = [
+            SubwayArrival(
+                station_code="SL01",
+                gtfs_stop_id="L01S",
+                trip_id="new_trip_reassigned",
+                route_id="L",
+                direction_id=1,
+                headsign=None,
+                arrival_time=now + timedelta(seconds=30),
+                departure_time=None,
+                delay_seconds=0,
+                track="1",
+                nyct_train_id=None,
+                is_assigned=True,
+            ),
+        ]
+        mock_client.get_feed_arrivals.return_value = arrivals
+
+        mock_stop_result = MagicMock()
+        mock_stop_result.scalar_one_or_none.return_value = stop1
+        mock_stops_list = MagicMock()
+        mock_stops_list.scalars.return_value.all.return_value = [stop1]
+        mock_session.execute.side_effect = [
+            mock_stop_result,  # SL01 stop lookup
+            mock_stops_list,  # Get all stops for update
+        ]
+
+        await collector.collect_journey_details(mock_session, journey)
+
+        # Fuzzy fallback should still update the journey
+        assert journey.actual_departure == now + timedelta(seconds=30)
+
 
 # =============================================================================
 # RUN ENTRY POINT TESTS


### PR DESCRIPTION
The subway/LIRR/MNR JIT (Just-In-Time) refresh in collect_journey_details
used fuzzy matching (station overlap + time proximity) to find the
corresponding trip in the live GTFS-RT feed. On non-branching lines like
the L train, all trips share identical station sets, so station overlap
provided zero discrimination. The time proximity tiebreaker would then
pick the wrong train — typically a newer train closer to the origin.

Fix: before fuzzy matching, regenerate the train_id from each candidate
trip_id in the feed and compare against the stored journey.train_id.
This is an exact match using the same deterministic function that created
the ID during collection. Fuzzy matching is preserved as a fallback for
the rare case where a trip_id changes mid-service.

Affected collectors: subway, LIRR, MNR. PATH was already safe (uses
headsign-based matching with distinct routes).

https://claude.ai/code/session_017qMRJMoAwAQdiJJUNcAuqL