### PR TITLE
Use frequency-based stats for subway/PATH/PATCO recent departures

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -23,7 +23,10 @@ from trackrat.models.database import (
     TrainJourney,
 )
 from trackrat.services.apns import SimpleAPNSService
-from trackrat.services.congestion_types import FREQ_THRESHOLD_REDUCED
+from trackrat.services.congestion_types import (
+    FREQ_THRESHOLD_REDUCED,
+    FREQUENCY_FIRST_SOURCES,
+)
 from trackrat.utils.time import now_et
 
 logger = get_logger(__name__)
@@ -40,10 +43,6 @@ REALTIME_SOURCES = {"NJT", "AMTRAK", "PATH", "LIRR", "MNR", "SUBWAY"}
 
 # Data sources where train_id is stable and represents the same daily service
 STABLE_TRAIN_ID_SOURCES = {"NJT", "AMTRAK", "LIRR", "MNR"}
-
-# Frequency-first sources: alert on reduced service, not delays
-# (mirrors iOS TrainSystem.preferredHighlightMode == .health)
-FREQUENCY_FIRST_SOURCES = {"SUBWAY", "PATH", "PATCO"}
 
 # Build route-ID lookup once at import time
 _ROUTES_BY_ID = {route.id: route for route in ALL_ROUTES}

--- a/backend_v2/src/trackrat/services/congestion_types.py
+++ b/backend_v2/src/trackrat/services/congestion_types.py
@@ -17,6 +17,10 @@ FREQ_THRESHOLD_MODERATE = 0.7  # >= 70% of baseline trains
 FREQ_THRESHOLD_REDUCED = 0.5  # >= 50% of baseline trains
 # Below 0.5 = severe
 
+# Data sources where frequency/service health is more meaningful than delay stats.
+# Mirrors iOS TrainSystem.preferredHighlightMode == .health
+FREQUENCY_FIRST_SOURCES = {"SUBWAY", "PATH", "PATCO"}
+
 
 def get_congestion_level(congestion_factor: float) -> str:
     """Determine congestion level from a congestion factor."""

--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -21,6 +21,7 @@ from structlog import get_logger
 
 from trackrat.config.stations import expand_station_codes
 from trackrat.models.database import JourneyStop, TrainJourney
+from trackrat.services.congestion_types import FREQUENCY_FIRST_SOURCES
 from trackrat.utils.time import now_et
 
 logger = get_logger(__name__)
@@ -1072,14 +1073,25 @@ class SummaryService:
                 / arr_total
             )
 
-        # Generate headline and body
-        headline, body = self._format_route_headline_body(
-            dep_on_time_pct,
-            dep_avg_delay,
-            arr_on_time_pct,
-            arr_avg_delay,
-            total_cancellations,
+        # Detect if this is a frequency-first route (subway, PATH, PATCO)
+        is_frequency_route = all(
+            ds in FREQUENCY_FIRST_SOURCES for ds in carrier_dep_stats
         )
+
+        # Generate headline and body
+        if is_frequency_route:
+            headline, body = self._format_frequency_route_headline_body(
+                total_non_cancelled,
+                total_cancellations,
+            )
+        else:
+            headline, body = self._format_route_headline_body(
+                dep_on_time_pct,
+                dep_avg_delay,
+                arr_on_time_pct,
+                arr_avg_delay,
+                total_cancellations,
+            )
 
         return OperationsSummary(
             headline=headline,
@@ -1152,6 +1164,50 @@ class SummaryService:
             body = f"{status}."
 
         return headline, body
+
+    def _format_frequency_route_headline_body(
+        self,
+        train_count: int,
+        cancellations: int,
+    ) -> tuple[str, str]:
+        """
+        Format headline and body for frequency-first route summary (subway, PATH, PATCO).
+
+        Emphasizes train count and headway rather than on-time percentage,
+        since riders of frequent-service systems care about "how often"
+        not "is the 3:42 on time."
+        """
+        if cancellations > 0:
+            cancel_word = "cancellation" if cancellations == 1 else "cancellations"
+            headline = f"{cancellations} {cancel_word}"
+        elif train_count > 0:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
+            train_word = "train" if train_count == 1 else "trains"
+            headline = f"{train_count} {train_word} — every ~{headway:.0f} min"
+        else:
+            headline = ""
+            return headline, ""
+
+        # Body
+        body_parts = []
+        if cancellations > 0:
+            remaining = train_count
+            cancel_word = "train was" if cancellations == 1 else "trains were"
+            body_parts.append(f"{cancellations} {cancel_word} cancelled.")
+            if remaining > 0:
+                headway = SUMMARY_TIME_WINDOW_MINUTES / remaining
+                body_parts.append(
+                    f"{remaining} others departed, averaging every {headway:.0f} minutes."
+                )
+        else:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
+            train_word = "train" if train_count == 1 else "trains"
+            body_parts.append(
+                f"{train_count} {train_word} departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
+                f"averaging every {headway:.0f} minutes."
+            )
+
+        return headline, " ".join(body_parts)
 
     def _calculate_historical_departure_stats(
         self,
@@ -1275,16 +1331,25 @@ class SummaryService:
         destination = train_journeys[0].destination if train_journeys else None
 
         # Generate headline and body
-        headline, body = self._format_train_headline_body(
-            similar_dep_stats,
-            similar_arr_stats,
-            train_stats,
-            train_id,
-            carrier_name,
-            total_cancellations,
-            destination=destination,
-            data_source=data_source,
-        )
+        is_frequency_system = data_source in FREQUENCY_FIRST_SOURCES
+        if is_frequency_system:
+            headline, body = self._format_frequency_train_headline_body(
+                similar_dep_stats,
+                train_stats,
+                total_cancellations,
+                destination=destination,
+            )
+        else:
+            headline, body = self._format_train_headline_body(
+                similar_dep_stats,
+                similar_arr_stats,
+                train_stats,
+                train_id,
+                carrier_name,
+                total_cancellations,
+                destination=destination,
+                data_source=data_source,
+            )
 
         if not headline:
             # No data at all
@@ -1405,6 +1470,66 @@ class SummaryService:
                 train_display = f"This {destination} train"
             else:
                 train_display = f"Train {train_id}"
+            hist_text = f"{train_display} historically departs on time {train_stats.on_time_percentage:.0f}% of the time."
+            if train_stats.cancellation_count > 0:
+                hist_text += (
+                    f" Cancelled {train_stats.cancellation_count} "
+                    f"time{'s' if train_stats.cancellation_count != 1 else ''} in past 30 days."
+                )
+            body_parts.append(hist_text)
+
+        return headline, " ".join(body_parts)
+
+    def _format_frequency_train_headline_body(
+        self,
+        dep_stats: OnTimeStats,
+        train_stats: OnTimeStats,
+        cancellations: int,
+        destination: str | None = None,
+    ) -> tuple[str, str]:
+        """
+        Format headline and body for frequency-first train summary (subway, PATH, PATCO).
+
+        Emphasizes recent train count / headway for similar trains,
+        and historical frequency for this specific train.
+        """
+        similar_count = dep_stats.total_count
+        similar_total = similar_count + dep_stats.cancellation_count
+
+        # Headline
+        if cancellations > 0:
+            cancel_word = "cancellation" if cancellations == 1 else "cancellations"
+            headline = f"{cancellations} {cancel_word}"
+        elif similar_total > 0:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / similar_total
+            train_word = "train" if similar_total == 1 else "trains"
+            headline = f"{similar_total} similar {train_word} — every ~{headway:.0f} min"
+        elif train_stats.has_data:
+            headline = f"Historically ~{train_stats.total_count} trains per month"
+        else:
+            return "", ""
+
+        # Body
+        body_parts = []
+
+        if cancellations > 0:
+            cancel_word = "train" if cancellations == 1 else "trains"
+            body_parts.append(f"{cancellations} similar {cancel_word} cancelled.")
+
+        if similar_count > 0:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / similar_count
+            body_parts.append(
+                f"{similar_count} similar trains departed in the past "
+                f"{SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
+                f"averaging every {headway:.0f} minutes."
+            )
+
+        if train_stats.has_data:
+            train_display = (
+                f"This {destination} train"
+                if destination
+                else "This train"
+            )
             hist_text = f"{train_display} historically departs on time {train_stats.on_time_percentage:.0f}% of the time."
             if train_stats.cancellation_count > 0:
                 hist_text += (

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -19,7 +19,9 @@ from trackrat.services.summary import (
     DELAY_CATEGORY_SLIGHT_DELAY,
     ON_TIME_THRESHOLD_MINUTES,
     SLIGHT_DELAY_THRESHOLD_MINUTES,
+    SUMMARY_TIME_WINDOW_MINUTES,
     LineStats,
+    OnTimeStats,
     OperationsSummary,
     SummaryMetrics,
     SummaryService,
@@ -1236,3 +1238,265 @@ class TestDuplicateTrainPrevention:
 
         # Verify each expected train is present exactly once
         assert sorted(unique_train_ids) == sorted(["7828", "7830", "7832", "7834"])
+
+
+class TestFormatFrequencyRouteHeadlineBody:
+    """Test frequency-first route headline/body formatting (subway, PATH, PATCO)."""
+
+    @pytest.fixture
+    def summary_service(self):
+        """Create a SummaryService instance for testing."""
+        return SummaryService()
+
+    def test_normal_service_shows_count_and_headway(self, summary_service):
+        """12 trains over 120min → headline shows count + ~10 min headway."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=12, cancellations=0
+        )
+        expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 12  # 10
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        print(f"expected_headway: {expected_headway}")
+        assert "12 trains" in headline
+        assert "~10 min" in headline
+        assert "12 trains departed" in body
+        assert "every 10 minutes" in body
+
+    def test_single_train_headway(self, summary_service):
+        """1 train over 120min → large headway, singular grammar."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=1, cancellations=0
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert "1 train" in headline
+        assert "1 trains" not in headline  # Verify singular form
+        assert "~120 min" in headline
+
+    def test_high_frequency_headway(self, summary_service):
+        """30 trains over 120min → 4 min headway."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=30, cancellations=0
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert "30 trains" in headline
+        assert "~4 min" in headline
+
+    def test_cancellations_lead_headline(self, summary_service):
+        """Cancellations should lead the headline, with remaining train headway in body."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=10, cancellations=2
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert headline == "2 cancellations"
+        assert "cancelled" in body.lower()
+        assert "10 others departed" in body
+
+    def test_single_cancellation(self, summary_service):
+        """Single cancellation uses singular form."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=8, cancellations=1
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert headline == "1 cancellation"
+        assert "1 train was cancelled" in body
+
+    def test_zero_trains_returns_empty(self, summary_service):
+        """No trains and no cancellations → empty headline and body."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=0, cancellations=0
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert headline == ""
+        assert body == ""
+
+    def test_all_cancelled_no_remaining(self, summary_service):
+        """All trains cancelled, none running → no headway info in body."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=0, cancellations=3
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert headline == "3 cancellations"
+        assert "cancelled" in body.lower()
+        # No "others departed" since train_count=0
+        assert "others departed" not in body
+
+    def test_body_mentions_time_window(self, summary_service):
+        """Body should reference the 2-hour time window."""
+        headline, body = summary_service._format_frequency_route_headline_body(
+            train_count=12, cancellations=0
+        )
+        print(f"body: {body!r}")
+        assert "2 hours" in body
+
+
+class TestFormatFrequencyTrainHeadlineBody:
+    """Test frequency-first train headline/body formatting (subway, PATH, PATCO)."""
+
+    @pytest.fixture
+    def summary_service(self):
+        """Create a SummaryService instance for testing."""
+        return SummaryService()
+
+    def test_similar_trains_show_count_and_headway(self, summary_service):
+        """Similar trains count and headway should appear in headline."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=90.0,
+            average_delay_minutes=2.0,
+            total_count=8,
+            cancellation_count=0,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=85.0,
+            average_delay_minutes=3.0,
+            total_count=20,
+            cancellation_count=0,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=0, destination="World Trade Center"
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 8  # 15
+        assert "8 similar trains" in headline
+        assert "~15 min" in headline
+        assert "World Trade Center" in body
+        assert "on time" in body
+
+    def test_cancellations_lead_headline(self, summary_service):
+        """Cancellations should lead the headline."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=80.0,
+            average_delay_minutes=3.0,
+            total_count=6,
+            cancellation_count=2,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=85.0,
+            average_delay_minutes=3.0,
+            total_count=20,
+            cancellation_count=0,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=2, destination="Newark"
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert headline == "2 cancellations"
+        assert "cancelled" in body.lower()
+
+    def test_no_similar_trains_falls_back_to_historical(self, summary_service):
+        """When no similar trains, use historical data for headline."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=0.0,
+            average_delay_minutes=0.0,
+            total_count=0,
+            cancellation_count=0,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=92.0,
+            average_delay_minutes=1.5,
+            total_count=25,
+            cancellation_count=1,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=0, destination="33rd Street"
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert "25 trains" in headline
+        assert "33rd Street" in body
+        assert "on time" in body
+
+    def test_no_data_returns_empty(self, summary_service):
+        """No similar or historical data → empty strings."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=0.0,
+            average_delay_minutes=0.0,
+            total_count=0,
+            cancellation_count=0,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=0.0,
+            average_delay_minutes=0.0,
+            total_count=0,
+            cancellation_count=0,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=0
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert headline == ""
+        assert body == ""
+
+    def test_destination_none_uses_generic_label(self, summary_service):
+        """When destination is None, use 'This train' instead of specific name."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=0.0,
+            average_delay_minutes=0.0,
+            total_count=0,
+            cancellation_count=0,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=88.0,
+            average_delay_minutes=2.0,
+            total_count=15,
+            cancellation_count=0,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=0, destination=None
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert "This train" in body
+        assert "on time" in body
+
+    def test_historical_cancellations_mentioned_in_body(self, summary_service):
+        """Historical cancellations should be mentioned in the body."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=90.0,
+            average_delay_minutes=1.0,
+            total_count=10,
+            cancellation_count=0,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=80.0,
+            average_delay_minutes=4.0,
+            total_count=30,
+            cancellation_count=3,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=0, destination="Hoboken"
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        assert "Cancelled 3 times" in body
+        assert "past 30 days" in body
+
+    def test_similar_trains_body_includes_headway(self, summary_service):
+        """Body should show headway calculation for similar trains."""
+        dep_stats = OnTimeStats(
+            on_time_percentage=95.0,
+            average_delay_minutes=1.0,
+            total_count=6,
+            cancellation_count=0,
+        )
+        train_stats = OnTimeStats(
+            on_time_percentage=0.0,
+            average_delay_minutes=0.0,
+            total_count=0,
+            cancellation_count=0,
+        )
+        headline, body = summary_service._format_frequency_train_headline_body(
+            dep_stats, train_stats, cancellations=0
+        )
+        print(f"headline: {headline!r}")
+        print(f"body: {body!r}")
+        expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 6  # 20
+        assert "every 20 minutes" in body


### PR DESCRIPTION
For frequency-first transit systems (subway, PATH, PATCO), the "recent
departures" summary now shows train count and headway instead of on-time
percentage. This aligns the summary text with the congestion map's
frequency-based health display for these systems.

Route headline: "12 trains — every ~10 min" (was "Recent departures: 85% on time")
Train headline: "8 similar trains — every ~15 min"

Moves FREQUENCY_FIRST_SOURCES to congestion_types.py as a shared constant.
No iOS/web changes needed — both just render headline/body from the backend.

https://claude.ai/code/session_01SwcHE9dtsiYGs4WWDaHMzQ