### PR TITLE
Fix async lazy loading issues in TrainJourney relationships

### DIFF
--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -72,30 +72,38 @@ class TrainJourney(Base):
     discovery_track = Column(String(5))
     discovery_station_code = Column(String(10))
 
-    # Relationships
+    # Relationships — use lazy="raise_on_sql" to prevent accidental lazy loads
+    # in async context, which cause greenlet_spawn errors (sqlalche.me/e/20/xd2s).
+    # All access must use explicit eager loading (selectinload) or direct queries.
     stops: Mapped[list["JourneyStop"]] = relationship(
-        "JourneyStop", back_populates="journey", cascade="all, delete-orphan"
+        "JourneyStop", back_populates="journey", cascade="all, delete-orphan",
+        lazy="raise_on_sql",
     )
     snapshots: Mapped[list["JourneySnapshot"]] = relationship(
-        "JourneySnapshot", back_populates="journey", cascade="all, delete-orphan"
+        "JourneySnapshot", back_populates="journey", cascade="all, delete-orphan",
+        lazy="raise_on_sql",
     )
     progress: Mapped["JourneyProgress"] = relationship(
         "JourneyProgress",
         back_populates="journey",
         uselist=False,
         primaryjoin="and_(TrainJourney.id==JourneyProgress.journey_id)",
+        lazy="raise_on_sql",
     )
     segment_times: Mapped[list["SegmentTransitTime"]] = relationship(
-        "SegmentTransitTime", back_populates="journey", cascade="all, delete-orphan"
+        "SegmentTransitTime", back_populates="journey", cascade="all, delete-orphan",
+        lazy="raise_on_sql",
     )
     dwell_times: Mapped[list["StationDwellTime"]] = relationship(
-        "StationDwellTime", back_populates="journey", cascade="all, delete-orphan"
+        "StationDwellTime", back_populates="journey", cascade="all, delete-orphan",
+        lazy="raise_on_sql",
     )
     progress_snapshots: Mapped[list["JourneyProgress"]] = relationship(
         "JourneyProgress",
         back_populates="journey",
         cascade="all, delete-orphan",
         overlaps="progress",
+        lazy="raise_on_sql",
     )
 
     __table_args__ = (

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -786,13 +786,18 @@ class DepartureService:
                     journey_id = journey.id
 
                     async def refresh_journey(jid: int = journey_id) -> None:
-                        # Re-query to get fresh state after potential rollback
-                        # Default param captures journey_id at definition time
-                        fresh = await db.get(
-                            TrainJourney,
-                            jid,
-                            options=[selectinload(TrainJourney.stops)],
+                        # Re-query to get fresh state after potential rollback.
+                        # Default param captures journey_id at definition time.
+                        # Use explicit query instead of db.get() because get()
+                        # returns from identity map without applying selectinload
+                        # when the object was already loaded by the query above.
+                        result = await db.execute(
+                            select(TrainJourney)
+                            .where(TrainJourney.id == jid)
+                            .options(selectinload(TrainJourney.stops))
+                            .execution_options(populate_existing=True)
                         )
+                        fresh = result.scalar_one_or_none()
                         if fresh:
                             await njt_collector.collect_journey_details(db, fresh)
 

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2604,7 +2604,10 @@ class SchedulerService:
                                 TrainJourney.journey_date == now_et().date(),
                             )
                         )
-                        .options(selectinload(TrainJourney.stops))
+                        .options(
+                            selectinload(TrainJourney.stops),
+                            selectinload(TrainJourney.snapshots),
+                        )
                     )
 
                     journey = session.scalar(journey_stmt)


### PR DESCRIPTION
## Summary
This PR addresses async context lazy loading errors in SQLAlchemy by explicitly configuring relationships to prevent accidental lazy loads and ensuring eager loading is used throughout the codebase.

## Key Changes

- **TrainJourney model relationships**: Added `lazy="raise_on_sql"` to all relationship definitions (stops, snapshots, progress, segment_times, dwell_times, progress_snapshots) to prevent lazy loading in async contexts, which causes greenlet_spawn errors. All relationship access now requires explicit eager loading via `selectinload()`.

- **Departure service bulk refresh**: Replaced `db.get()` with explicit `select()` query using `selectinload()` and `populate_existing=True` to ensure fresh state is loaded with relationships properly eager-loaded. The `db.get()` method was returning cached objects from the identity map without applying the selectinload options.

- **Scheduler live activity work**: Added `selectinload(TrainJourney.snapshots)` to the query options alongside the existing `selectinload(TrainJourney.stops)` to ensure snapshots are eagerly loaded when needed.

## Implementation Details

The `lazy="raise_on_sql"` configuration will raise an error if any code attempts to lazy load these relationships, making async issues explicit during development rather than causing runtime greenlet errors. This enforces the pattern of using explicit eager loading (selectinload) or direct queries for all relationship access.

The changes in the departure service demonstrate the correct pattern: using `select()` with `options()` and `execution_options(populate_existing=True)` to ensure fresh data is loaded with all required relationships eagerly fetched.

https://claude.ai/code/session_011Jut8Vyv5FN9miwvG6gP9m