### PR TITLE
Remove congestion legend and adjust frequency baseline color

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -65,7 +65,7 @@ struct RouteStatusView: View {
                 .frame(height: 200)
                 .cornerRadius(12)
 
-                CompactCongestionLegend(highlightMode: preferredMode)
+                // Legend intentionally omitted — map colors are self-explanatory
             } else if viewModel.mapError != nil {
                 ContentUnavailableView("Map Unavailable", systemImage: "map", description: Text("Could not load congestion data"))
                     .frame(height: 200)
@@ -217,7 +217,7 @@ struct RouteStatusView: View {
     /// Color for frequency based on comparison to historical baseline.
     /// Uses the same thresholds as CongestionSegment.frequencyDisplayColor.
     private func frequencyColor(totalTrains: Int, baseline: Double?) -> Color {
-        guard let baseline = baseline, baseline > 0 else { return .blue }
+        guard let baseline = baseline, baseline > 0 else { return .white }
         let factor = Double(totalTrains) / baseline
         if factor >= 0.9 { return .green }
         if factor >= 0.7 { return .yellow }


### PR DESCRIPTION
## Summary
This PR makes two UI adjustments to the RouteStatusView: removing the congestion legend component and changing the default frequency indicator color when baseline data is unavailable.

## Key Changes
- **Removed CompactCongestionLegend**: Replaced the legend component with a comment indicating that map colors are self-explanatory, simplifying the UI and reducing visual clutter
- **Updated frequency baseline color**: Changed the default color from blue to white when no baseline data is available for frequency comparison, improving visual consistency

## Implementation Details
- The legend removal assumes the congestion map's color scheme is intuitive enough for users without explicit labeling
- The frequency color change from blue to white likely improves contrast or visual hierarchy in the frequency display when baseline data is missing

https://claude.ai/code/session_01LwENZvnKhn15NK3ciaxyex