### PR TITLE
Remove cancellation reason display from train status UI

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -331,17 +331,10 @@ struct CombinedDetailsCard: View {
                     // Show CANCELLED banner if train is cancelled
                     let contextStatus = train.calculateStatus(fromStationCode: appState.departureStationCode ?? "")
                     if contextStatus == .cancelled {
-                        VStack(spacing: 4) {
-                            Text("CANCELLED")
-                                .font(.largeTitle)
-                                .fontWeight(.bold)
-                                .foregroundColor(.white)
-                            if let reason = train.cancellationReason {
-                                Text(reason.localizedCapitalized)
-                                    .font(.subheadline)
-                                    .foregroundColor(.white.opacity(0.9))
-                            }
-                        }
+                        Text("CANCELLED")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
                         .padding()
                         .frame(maxWidth: .infinity)
                         .background(Color.red.opacity(0.9))

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -413,17 +413,10 @@ struct TrainCard: View {
 
             // Show cancellation, departed, or scheduled-only status
             if isCancelled {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Cancelled")
-                        .font(.caption)
-                        .foregroundColor(.red.opacity(0.8))
-                        .fontWeight(.medium)
-                    if let reason = train.cancellationReason {
-                        Text(reason.localizedCapitalized)
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                }
+                Text("Cancelled")
+                    .font(.caption)
+                    .foregroundColor(.red.opacity(0.8))
+                    .fontWeight(.medium)
             } else if hasDeparted {
                 Text("Departed")
                     .font(.caption)


### PR DESCRIPTION
## Summary
Simplified the train cancellation status UI by removing the display of cancellation reasons in both the train details and train list views. The changes maintain the primary "CANCELLED"/"Cancelled" status indicator while eliminating the secondary reason text.

## Key Changes
- **TrainDetailsView**: Removed the `VStack` containing cancellation reason from the cancelled banner, keeping only the "CANCELLED" title text
- **TrainListView**: Removed the `VStack` containing cancellation reason from the train card status, keeping only the "Cancelled" caption text

## Implementation Details
- Both changes follow the same pattern: converting a multi-line `VStack` layout to a single `Text` view
- The primary status text styling (font, weight, color) is preserved in both cases
- Cancellation reason conditional logic has been completely removed
- Layout and spacing adjustments remain intact (padding, frame, background styling)

https://claude.ai/code/session_01ANnQy4SAP4atdVzYLDi9aV