### PR TITLE
Add directional filtering for line-based alert subscriptions

### DIFF
--- a/backend_v2/src/trackrat/api/alerts.py
+++ b/backend_v2/src/trackrat/api/alerts.py
@@ -42,6 +42,7 @@ class SubscriptionItem(BaseModel):
     from_station_code: str | None = None
     to_station_code: str | None = None
     train_id: str | None = None
+    direction: str | None = None
     weekdays_only: bool = False
 
     @model_validator(mode="after")
@@ -73,6 +74,7 @@ class SubscriptionResponse(BaseModel):
     from_station_code: str | None = None
     to_station_code: str | None = None
     train_id: str | None = None
+    direction: str | None = None
     weekdays_only: bool = False
 
 
@@ -144,6 +146,7 @@ async def sync_subscriptions(
             from_station_code=item.from_station_code,
             to_station_code=item.to_station_code,
             train_id=item.train_id,
+            direction=item.direction,
             weekdays_only=item.weekdays_only,
         )
         db.add(sub)
@@ -186,6 +189,7 @@ async def get_subscriptions(
                 from_station_code=sub.from_station_code,
                 to_station_code=sub.to_station_code,
                 train_id=sub.train_id,
+                direction=sub.direction,
                 weekdays_only=sub.weekdays_only,
             )
             for sub in device.subscriptions

--- a/backend_v2/src/trackrat/db/migrations/versions/20260301_1600-f4a5b6c7d8e9_add_direction_to_alert_subscriptions.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260301_1600-f4a5b6c7d8e9_add_direction_to_alert_subscriptions.py
@@ -1,0 +1,29 @@
+"""add_direction_to_alert_subscriptions
+
+Revision ID: f4a5b6c7d8e9
+Revises: e5f6a7b8c9d0
+Create Date: 2026-03-01 16:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f4a5b6c7d8e9"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add direction column for directional line subscriptions."""
+    op.add_column(
+        "route_alert_subscriptions",
+        sa.Column("direction", sa.String(10), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove direction column."""
+    op.drop_column("route_alert_subscriptions", "direction")

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -325,6 +325,7 @@ class RouteAlertSubscription(Base):
     from_station_code = Column(String(10), nullable=True)
     to_station_code = Column(String(10), nullable=True)
     train_id = Column(String(30), nullable=True)
+    direction = Column(String(10), nullable=True)
     weekdays_only = Column(
         Boolean, default=False, nullable=False, server_default="false"
     )

--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -15,7 +15,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
-from trackrat.config.route_topology import ALL_ROUTES
+from trackrat.config.route_topology import ALL_ROUTES, Route
+from trackrat.config.stations import get_station_name
 from trackrat.models.database import (
     DeviceToken,
     JourneyStop,
@@ -126,6 +127,9 @@ async def evaluate_route_alerts(
                 if sub.data_source in REALTIME_SOURCES:
                     active_count = total_count - cancelled_count
                     baseline = await _query_baseline_train_count(db, sub, now)
+                    # Halve baseline for directional subs since baseline covers both directions
+                    if baseline is not None and sub.direction:
+                        baseline *= 0.5
                     if baseline is not None and baseline > 0:
                         frequency_factor = active_count / baseline
                         if frequency_factor < FREQ_THRESHOLD_REDUCED:
@@ -170,6 +174,7 @@ async def evaluate_route_alerts(
                 "route_alert": {
                     "data_source": sub.data_source,
                     "line_id": sub.line_id,
+                    "direction": sub.direction,
                     "from_station_code": sub.from_station_code,
                     "to_station_code": sub.to_station_code,
                     "train_id": sub.train_id,
@@ -189,6 +194,7 @@ async def evaluate_route_alerts(
                     device_id=device.device_id,
                     data_source=sub.data_source,
                     line_id=sub.line_id,
+                    direction=sub.direction,
                     from_station=sub.from_station_code,
                     to_station=sub.to_station_code,
                     train_id=sub.train_id,
@@ -332,7 +338,13 @@ async def _query_journeys_for_subscription(
         base_conditions.append(TrainJourney.line_code.in_(line_codes))
 
         result = await db.execute(select(TrainJourney).where(and_(*base_conditions)))
-        return list(result.scalars().all())
+        journeys = list(result.scalars().all())
+
+        # Filter by direction if specified
+        if sub.direction:
+            journeys = _filter_by_direction(journeys, route, sub.direction)
+
+        return journeys
 
     else:
         # Station-pair mode: match origin/destination or journey stops
@@ -495,6 +507,43 @@ async def _query_baseline_train_count(
     return float(avg_count)
 
 
+def _filter_by_direction(
+    journeys: list[TrainJourney],
+    route: Route,
+    direction: str,
+) -> list[TrainJourney]:
+    """Keep only journeys traveling toward the given terminus station.
+
+    Direction is determined by comparing station indices in the route's
+    ordered stations tuple.  If direction equals the last station,
+    keep trains where terminal_idx > origin_idx (forward).  If it
+    equals the first station, keep trains where terminal_idx < origin_idx
+    (reverse).
+    """
+    station_list = route.stations
+    station_set = route._station_set
+
+    if direction not in station_set:
+        return journeys  # unknown direction — return unfiltered
+
+    toward_end = direction == station_list[-1]
+
+    filtered = []
+    for j in journeys:
+        if (
+            j.origin_station_code not in station_set
+            or j.terminal_station_code not in station_set
+        ):
+            continue
+        o_idx = station_list.index(j.origin_station_code)
+        t_idx = station_list.index(j.terminal_station_code)
+        if toward_end and t_idx > o_idx:
+            filtered.append(j)
+        elif not toward_end and t_idx < o_idx:
+            filtered.append(j)
+    return filtered
+
+
 def _is_significantly_delayed(
     journey: TrainJourney,
     to_station_code: str | None = None,
@@ -561,6 +610,9 @@ def _build_alert_message(
     if sub.line_id:
         route = _ROUTES_BY_ID.get(sub.line_id)
         route_name = route.name if route else sub.line_id
+        if sub.direction:
+            direction_name = get_station_name(sub.direction)
+            route_name = f"{route_name} toward {direction_name}"
     else:
         route_name = f"{sub.from_station_code} → {sub.to_station_code}"
 

--- a/backend_v2/tests/unit/api/test_alerts.py
+++ b/backend_v2/tests/unit/api/test_alerts.py
@@ -362,3 +362,91 @@ class TestGetSubscriptions:
         """Getting subscriptions for an unregistered device returns 404."""
         resp = e2e_client.get("/api/v2/alerts/subscriptions/no-such-device")
         assert resp.status_code == 404
+
+
+class TestDirectionSubscriptions:
+    """Tests for the direction field on line subscriptions."""
+
+    def test_line_with_direction_roundtrips(self, e2e_client: TestClient):
+        """A line subscription with direction is stored and returned correctly."""
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "dev-dir-1", "apns_token": "tok-dir1"},
+        )
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": "dev-dir-1",
+                "subscriptions": [
+                    {"data_source": "NJT", "line_id": "njt-nec", "direction": "TR"},
+                    {"data_source": "NJT", "line_id": "njt-nec", "direction": "NY"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 2
+
+        get_resp = e2e_client.get("/api/v2/alerts/subscriptions/dev-dir-1")
+        subs = get_resp.json()["subscriptions"]
+        assert len(subs) == 2
+        directions = {s["direction"] for s in subs}
+        assert directions == {"TR", "NY"}
+        for s in subs:
+            assert s["line_id"] == "njt-nec"
+            assert s["data_source"] == "NJT"
+        print(f"  Direction roundtrip: {directions}")
+
+    def test_direction_null_by_default(self, e2e_client: TestClient):
+        """A line subscription without direction has direction=null."""
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "dev-dir-2", "apns_token": "tok-dir2"},
+        )
+        e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": "dev-dir-2",
+                "subscriptions": [
+                    {"data_source": "NJT", "line_id": "njt-nec"},
+                ],
+            },
+        )
+
+        get_resp = e2e_client.get("/api/v2/alerts/subscriptions/dev-dir-2")
+        subs = get_resp.json()["subscriptions"]
+        assert len(subs) == 1
+        assert subs[0]["direction"] is None
+        print(f"  Direction default null: {subs[0]}")
+
+    def test_mixed_direction_subscriptions(self, e2e_client: TestClient):
+        """A sync with all subscription types including direction is accepted."""
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "dev-dir-4", "apns_token": "tok-dir4"},
+        )
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": "dev-dir-4",
+                "subscriptions": [
+                    {"data_source": "NJT", "line_id": "njt-nec", "direction": "TR"},
+                    {"data_source": "NJT", "line_id": "njt-nec", "direction": "NY"},
+                    {
+                        "data_source": "NJT",
+                        "from_station_code": "NY",
+                        "to_station_code": "TR",
+                    },
+                    {"data_source": "NJT", "train_id": "3254", "weekdays_only": True},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 4
+
+        get_resp = e2e_client.get("/api/v2/alerts/subscriptions/dev-dir-4")
+        subs = get_resp.json()["subscriptions"]
+        assert len(subs) == 4
+        line_subs = [s for s in subs if s["line_id"]]
+        assert len(line_subs) == 2
+        assert {s["direction"] for s in line_subs} == {"TR", "NY"}
+        print(f"  Mixed subs with direction: {len(subs)} total")

--- a/backend_v2/tests/unit/services/test_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_alert_evaluator.py
@@ -17,6 +17,7 @@ from trackrat.models.database import (
     RouteAlertSubscription,
     TrainJourney,
 )
+from trackrat.config.route_topology import Route
 from trackrat.services.alert_evaluator import (
     COOLDOWN_MINUTES,
     DELAY_THRESHOLD_MINUTES,
@@ -26,6 +27,7 @@ from trackrat.services.alert_evaluator import (
     _build_train_alert_message,
     _compute_alert_hash,
     _compute_train_alert_hash,
+    _filter_by_direction,
     _is_significantly_delayed,
     evaluate_route_alerts,
 )
@@ -84,6 +86,7 @@ def _make_device_and_sub(
     from_station: str | None = None,
     to_station: str | None = None,
     train_id: str | None = None,
+    direction: str | None = None,
     weekdays_only: bool = False,
 ) -> tuple[DeviceToken, RouteAlertSubscription]:
     """Create a DeviceToken + RouteAlertSubscription pair."""
@@ -97,6 +100,7 @@ def _make_device_and_sub(
         from_station_code=from_station,
         to_station_code=to_station,
         train_id=train_id,
+        direction=direction,
         weekdays_only=weekdays_only,
     )
     db.add(sub)
@@ -1372,3 +1376,274 @@ class TestTrainSubscriptionAlerts:
         assert route_alert["line_id"] is None
         assert route_alert["from_station_code"] is None
         print(f"  Custom data: {route_alert}")
+
+
+# ---------------------------------------------------------------------------
+# Direction filtering
+# ---------------------------------------------------------------------------
+
+# Build a small test route for direction tests
+_TEST_ROUTE = Route(
+    id="test-route",
+    name="Test Route",
+    data_source="TEST",
+    line_codes=frozenset({"TE"}),
+    stations=("A", "B", "C", "D", "E"),
+)
+
+
+class TestFilterByDirection:
+    """Unit tests for _filter_by_direction()."""
+
+    def _journey(self, origin: str, terminal: str) -> TrainJourney:
+        """Create a minimal TrainJourney with just origin/terminal."""
+        now = now_et()
+        return TrainJourney(
+            train_id="T1",
+            journey_date=now.date(),
+            line_code="TE",
+            line_name="Test Route",
+            destination=terminal,
+            origin_station_code=origin,
+            terminal_station_code=terminal,
+            data_source="TEST",
+            scheduled_departure=now,
+            has_complete_journey=True,
+        )
+
+    def test_forward_direction_keeps_forward_trains(self):
+        """Direction = last station should keep only forward-traveling trains."""
+        forward = self._journey("A", "E")
+        reverse = self._journey("E", "A")
+        mid_forward = self._journey("B", "D")
+
+        result = _filter_by_direction([forward, reverse, mid_forward], _TEST_ROUTE, "E")
+        origins = [(j.origin_station_code, j.terminal_station_code) for j in result]
+        assert ("A", "E") in origins
+        assert ("B", "D") in origins
+        assert ("E", "A") not in origins
+        print(f"  Forward filter kept {len(result)} of 3 journeys: {origins}")
+
+    def test_reverse_direction_keeps_reverse_trains(self):
+        """Direction = first station should keep only reverse-traveling trains."""
+        forward = self._journey("A", "E")
+        reverse = self._journey("E", "A")
+        mid_reverse = self._journey("D", "B")
+
+        result = _filter_by_direction([forward, reverse, mid_reverse], _TEST_ROUTE, "A")
+        origins = [(j.origin_station_code, j.terminal_station_code) for j in result]
+        assert ("E", "A") in origins
+        assert ("D", "B") in origins
+        assert ("A", "E") not in origins
+        print(f"  Reverse filter kept {len(result)} of 3 journeys: {origins}")
+
+    def test_short_turn_trains_included(self):
+        """A train that doesn't go to the terminus but travels the right direction is kept."""
+        short_forward = self._journey("A", "C")  # doesn't reach E but heads toward it
+        result = _filter_by_direction([short_forward], _TEST_ROUTE, "E")
+        assert len(result) == 1
+        print(f"  Short-turn train A->C kept for direction E")
+
+    def test_unknown_direction_returns_all(self):
+        """If direction station is not in the route, return all journeys unfiltered."""
+        j = self._journey("A", "E")
+        result = _filter_by_direction([j], _TEST_ROUTE, "Z")
+        assert len(result) == 1
+        print(f"  Unknown direction 'Z' returned all journeys")
+
+    def test_off_route_trains_excluded(self):
+        """Trains with stations not on the route are excluded."""
+        off_route = self._journey("X", "Y")
+        on_route = self._journey("A", "E")
+        result = _filter_by_direction([off_route, on_route], _TEST_ROUTE, "E")
+        assert len(result) == 1
+        assert result[0].origin_station_code == "A"
+        print(f"  Off-route train excluded, on-route kept")
+
+    def test_empty_input_returns_empty(self):
+        """Empty journey list returns empty."""
+        result = _filter_by_direction([], _TEST_ROUTE, "E")
+        assert result == []
+
+
+@pytest.mark.asyncio
+class TestDirectionalAlertEvaluation:
+    """Integration tests for directional line subscriptions."""
+
+    async def test_direction_filters_line_alert_to_one_direction(
+        self, db_session: AsyncSession
+    ):
+        """A line sub with direction=TR should only alert on NY->TR trains, not TR->NY."""
+        apns = _make_apns()
+        _make_device_and_sub(
+            db_session,
+            data_source="NJT",
+            line_id="njt-nec",
+            direction="TR",  # toward Trenton
+        )
+        # 2 delayed southbound trains (NY->TR direction)
+        for i in range(2):
+            _make_journey(
+                db_session,
+                train_id=f"south-{i}",
+                origin="NY",
+                terminal="TR",
+                delay_minutes=DELAY_THRESHOLD_MINUTES + 5,
+                minutes_ago=30 + i * 5,
+            )
+        # 2 on-time northbound trains (TR->NY direction — should be filtered out)
+        for i in range(2):
+            _make_journey(
+                db_session,
+                train_id=f"north-{i}",
+                origin="TR",
+                terminal="NY",
+                delay_minutes=0,
+                minutes_ago=30 + i * 5,
+            )
+        await db_session.flush()
+
+        count = await evaluate_route_alerts(db_session, apns)
+        assert count == 1, "Should alert: 2/2 southbound trains delayed (100% >= 50%)"
+        apns.send_alert_notification.assert_called_once()
+
+        call_args = apns.send_alert_notification.call_args
+        title = call_args.args[1]
+        assert "toward" in title.lower(), f"Title should mention direction: {title}"
+        print(f"  Title: {title}")
+
+    async def test_no_direction_includes_both_directions(
+        self, db_session: AsyncSession
+    ):
+        """A line sub with direction=None evaluates trains in both directions."""
+        apns = _make_apns()
+        _make_device_and_sub(
+            db_session,
+            device_id="dev-no-dir",
+            data_source="NJT",
+            line_id="njt-nec",
+            direction=None,  # both directions
+        )
+        # 2 delayed southbound + 2 on-time northbound = 50% delayed overall
+        for i in range(2):
+            _make_journey(
+                db_session,
+                train_id=f"south-d-{i}",
+                origin="NY",
+                terminal="TR",
+                delay_minutes=DELAY_THRESHOLD_MINUTES + 5,
+                minutes_ago=30 + i * 5,
+            )
+        for i in range(2):
+            _make_journey(
+                db_session,
+                train_id=f"north-d-{i}",
+                origin="TR",
+                terminal="NY",
+                delay_minutes=0,
+                minutes_ago=30 + i * 5,
+            )
+        await db_session.flush()
+
+        count = await evaluate_route_alerts(db_session, apns)
+        assert count == 1, "Should alert: 2/4 = 50% delayed (meets threshold)"
+
+    async def test_direction_filters_prevent_false_alert(
+        self, db_session: AsyncSession
+    ):
+        """Direction filtering should prevent alert when opposite direction is fine."""
+        apns = _make_apns()
+        _make_device_and_sub(
+            db_session,
+            device_id="dev-no-alert",
+            data_source="NJT",
+            line_id="njt-nec",
+            direction="NY",  # toward NY Penn — northbound
+        )
+        # Southbound trains are delayed (wrong direction for this sub)
+        for i in range(4):
+            _make_journey(
+                db_session,
+                train_id=f"south-e-{i}",
+                origin="NY",
+                terminal="TR",
+                delay_minutes=DELAY_THRESHOLD_MINUTES + 5,
+                minutes_ago=30 + i * 5,
+            )
+        # Northbound trains are on time (the direction we're watching)
+        for i in range(4):
+            _make_journey(
+                db_session,
+                train_id=f"north-e-{i}",
+                origin="TR",
+                terminal="NY",
+                delay_minutes=0,
+                minutes_ago=30 + i * 5,
+            )
+        await db_session.flush()
+
+        count = await evaluate_route_alerts(db_session, apns)
+        assert count == 0, "Should NOT alert: northbound trains are all on time"
+        apns.send_alert_notification.assert_not_called()
+        print("  Verified: direction filter prevented false alert")
+
+    async def test_direction_included_in_custom_data(self, db_session: AsyncSession):
+        """APNS custom data should include the direction field."""
+        apns = _make_apns()
+        _make_device_and_sub(
+            db_session,
+            device_id="dev-custom",
+            data_source="NJT",
+            line_id="njt-nec",
+            direction="TR",
+        )
+        # Enough delayed trains to trigger
+        for i in range(3):
+            _make_journey(
+                db_session,
+                train_id=f"south-c-{i}",
+                origin="NY",
+                terminal="TR",
+                delay_minutes=DELAY_THRESHOLD_MINUTES + 5,
+                minutes_ago=30 + i * 5,
+            )
+        await db_session.flush()
+
+        count = await evaluate_route_alerts(db_session, apns)
+        assert count == 1
+
+        call_kwargs = apns.send_alert_notification.call_args.kwargs
+        route_alert = call_kwargs["custom_data"]["route_alert"]
+        assert route_alert["direction"] == "TR"
+        assert route_alert["line_id"] == "njt-nec"
+        print(f"  Custom data includes direction: {route_alert}")
+
+
+class TestDirectionalAlertMessage:
+    """Tests for direction in alert message formatting."""
+
+    def test_build_alert_message_with_direction(self):
+        """Alert message should include 'toward <station name>' when direction is set."""
+        sub = RouteAlertSubscription(
+            device_id="test",
+            data_source="NJT",
+            line_id="njt-nec",
+            direction="TR",
+        )
+        title, body = _build_alert_message(sub, "delay", 0, 3, 4)
+        assert "toward" in title.lower()
+        assert "Trenton" in title or "TR" in title
+        print(f"  Title with direction: {title}")
+        print(f"  Body: {body}")
+
+    def test_build_alert_message_without_direction(self):
+        """Alert message without direction should just show route name."""
+        sub = RouteAlertSubscription(
+            device_id="test",
+            data_source="NJT",
+            line_id="njt-nec",
+        )
+        title, body = _build_alert_message(sub, "delay", 0, 3, 4)
+        assert "toward" not in title.lower()
+        assert "Northeast Corridor" in title
+        print(f"  Title without direction: {title}")

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -1342,6 +1342,7 @@ extension APIService {
             let from_station_code: String?
             let to_station_code: String?
             let train_id: String?
+            let direction: String?
             let weekdays_only: Bool
         }
 
@@ -1357,6 +1358,7 @@ extension APIService {
                 from_station_code: sub.fromStationCode,
                 to_station_code: sub.toStationCode,
                 train_id: sub.trainId,
+                direction: sub.direction,
                 weekdays_only: sub.weekdaysOnly
             )
         }

--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -25,28 +25,47 @@ final class AlertSubscriptionService: ObservableObject {
 
     // MARK: - Mutation
 
-    func addLineSubscription(dataSource: String, lineId: String, lineName: String) {
+    /// Add two line subscriptions (one per direction) for the given route.
+    func addLineSubscriptions(dataSource: String, lineId: String, lineName: String, route: RouteLine) {
+        guard let first = route.stationCodes.first,
+              let last = route.stationCodes.last else { return }
+        addSingleLineSubscription(dataSource: dataSource, lineId: lineId, lineName: lineName, direction: first)
+        addSingleLineSubscription(dataSource: dataSource, lineId: lineId, lineName: lineName, direction: last)
+    }
+
+    /// Add a single directional line subscription (deduped on lineId + dataSource + direction).
+    func addSingleLineSubscription(dataSource: String, lineId: String, lineName: String, direction: String?) {
+        guard !subscriptions.contains(where: {
+            $0.lineId == lineId && $0.dataSource == dataSource && $0.direction == direction
+        }) else { return }
         let sub = RouteAlertSubscription(
             dataSource: dataSource,
             lineId: lineId,
-            lineName: lineName
+            lineName: lineName,
+            direction: direction
         )
-        guard !subscriptions.contains(where: { $0.lineId == lineId && $0.dataSource == dataSource }) else { return }
         subscriptions.append(sub)
         saveToDefaults()
     }
 
-    func addStationPairSubscription(dataSource: String, fromStationCode: String, toStationCode: String) {
-        let sub = RouteAlertSubscription(
-            dataSource: dataSource,
-            fromStationCode: fromStationCode,
-            toStationCode: toStationCode
-        )
+    /// Add station-pair subscriptions for both directions.
+    func addStationPairSubscriptions(dataSource: String, fromStationCode: String, toStationCode: String) {
+        addSingleStationPairSubscription(dataSource: dataSource, fromStationCode: fromStationCode, toStationCode: toStationCode)
+        addSingleStationPairSubscription(dataSource: dataSource, fromStationCode: toStationCode, toStationCode: fromStationCode)
+    }
+
+    /// Add a single station-pair subscription (deduped on from + to + dataSource).
+    func addSingleStationPairSubscription(dataSource: String, fromStationCode: String, toStationCode: String) {
         guard !subscriptions.contains(where: {
             $0.fromStationCode == fromStationCode &&
             $0.toStationCode == toStationCode &&
             $0.dataSource == dataSource
         }) else { return }
+        let sub = RouteAlertSubscription(
+            dataSource: dataSource,
+            fromStationCode: fromStationCode,
+            toStationCode: toStationCode
+        )
         subscriptions.append(sub)
         saveToDefaults()
     }
@@ -108,10 +127,11 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
     let toStationCode: String?
     let trainId: String?
     let trainName: String?
+    let direction: String?
     let weekdaysOnly: Bool
 
-    /// Line-based subscription.
-    init(dataSource: String, lineId: String, lineName: String) {
+    /// Line-based subscription with direction (terminus station code).
+    init(dataSource: String, lineId: String, lineName: String, direction: String?) {
         self.id = UUID()
         self.dataSource = dataSource
         self.lineId = lineId
@@ -120,6 +140,7 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
         self.toStationCode = nil
         self.trainId = nil
         self.trainName = nil
+        self.direction = direction
         self.weekdaysOnly = false
     }
 
@@ -133,6 +154,7 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
         self.toStationCode = toStationCode
         self.trainId = nil
         self.trainName = nil
+        self.direction = nil
         self.weekdaysOnly = false
     }
 
@@ -146,6 +168,7 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
         self.toStationCode = nil
         self.trainId = trainId
         self.trainName = trainName
+        self.direction = nil
         self.weekdaysOnly = weekdaysOnly
     }
 
@@ -160,6 +183,7 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
         toStationCode = try container.decodeIfPresent(String.self, forKey: .toStationCode)
         trainId = try container.decodeIfPresent(String.self, forKey: .trainId)
         trainName = try container.decodeIfPresent(String.self, forKey: .trainName)
+        direction = try container.decodeIfPresent(String.self, forKey: .direction)
         weekdaysOnly = try container.decodeIfPresent(Bool.self, forKey: .weekdaysOnly) ?? false
     }
 }

--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -31,12 +31,16 @@ struct AddRouteAlertView: View {
     @State private var isLoadingDepartures = false
     @State private var weekdaysOnly = true
 
-    /// Routes filtered to the user's selected train systems, excluding already-subscribed lines.
+    /// Routes filtered to the user's selected train systems, excluding fully-subscribed lines.
+    /// A route is fully subscribed when both directions have subscriptions.
     private var filteredRoutes: [RouteLine] {
         let dataSources = appState.selectedSystems.asRawStrings
         return RouteTopology.allRoutes.filter { route in
-            dataSources.contains(route.dataSource) &&
-            !alertService.subscriptions.contains(where: { $0.lineId == route.id && $0.dataSource == route.dataSource })
+            guard dataSources.contains(route.dataSource) else { return false }
+            let lineSubs = alertService.subscriptions.filter { $0.lineId == route.id && $0.dataSource == route.dataSource }
+            let subscribedDirections = Set(lineSubs.compactMap(\.direction))
+            let bothTermini = Set([route.stationCodes.first, route.stationCodes.last].compactMap { $0 })
+            return !bothTermini.isSubset(of: subscribedDirections)
         }
     }
 
@@ -99,10 +103,11 @@ struct AddRouteAlertView: View {
                     ForEach(filteredRoutes) { route in
                         Button {
                             withAnimation {
-                                alertService.addLineSubscription(
+                                alertService.addLineSubscriptions(
                                     dataSource: route.dataSource,
                                     lineId: route.id,
-                                    lineName: route.name
+                                    lineName: route.name,
+                                    route: route
                                 )
                             }
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -186,23 +191,27 @@ struct AddRouteAlertView: View {
                     let common = fromSystems.intersection(toSystems).intersection(selectedStrings)
                     let dataSource = common.first ?? fromSystems.intersection(toSystems).first ?? "NJT"
 
-                    let alreadyExists = alertService.subscriptions.contains(where: {
+                    let bothExist = alertService.subscriptions.contains(where: {
                         $0.fromStationCode == fromCode &&
                         $0.toStationCode == toCode &&
                         $0.dataSource == dataSource
+                    }) && alertService.subscriptions.contains(where: {
+                        $0.fromStationCode == toCode &&
+                        $0.toStationCode == fromCode &&
+                        $0.dataSource == dataSource
                     })
 
-                    if alreadyExists {
+                    if bothExist {
                         UINotificationFeedbackGenerator().notificationOccurred(.warning)
                         showConfirmation("Already subscribed")
                     } else {
-                        alertService.addStationPairSubscription(
+                        alertService.addStationPairSubscriptions(
                             dataSource: dataSource,
                             fromStationCode: fromCode,
                             toStationCode: toCode
                         )
                         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                        showConfirmation("Alert added")
+                        showConfirmation("Alerts added for both directions")
                     }
 
                     withAnimation {
@@ -222,8 +231,8 @@ struct AddRouteAlertView: View {
 
             if let message = confirmationMessage {
                 HStack(spacing: 6) {
-                    Image(systemName: message == "Alert added" ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
-                        .foregroundColor(message == "Alert added" ? .green : .yellow)
+                    Image(systemName: message.hasPrefix("Alert") ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                        .foregroundColor(message.hasPrefix("Alert") ? .green : .yellow)
                     Text(message)
                         .foregroundColor(.white)
                 }

--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -88,12 +88,7 @@ struct EditRouteAlertsView: View {
                             if sub.trainId != nil {
                                 selectedTrainAlert = sub
                             } else {
-                                selectedRouteStatus = RouteStatusContext(
-                                    dataSource: sub.dataSource,
-                                    lineId: sub.lineId,
-                                    fromStationCode: sub.fromStationCode,
-                                    toStationCode: sub.toStationCode
-                                )
+                                selectedRouteStatus = routeStatusContext(for: sub)
                             }
                         } label: {
                             HStack {
@@ -107,7 +102,7 @@ struct EditRouteAlertsView: View {
                                         }
                                     }
                                 } else if let lineName = sub.lineName {
-                                    Label(lineName, systemImage: "tram.fill")
+                                    Label(lineDisplayName(sub: sub, lineName: lineName), systemImage: "tram.fill")
                                 } else if let from = sub.fromStationCode, let to = sub.toStationCode {
                                     Label(
                                         "\(Stations.displayName(for: from)) → \(Stations.displayName(for: to))",
@@ -167,15 +162,10 @@ struct EditRouteAlertsView: View {
         let common = homeSystems.intersection(workSystems).intersection(selectedStrings)
         guard let dataSource = common.first ?? homeSystems.intersection(workSystems).first else { return }
 
-        alertService.addStationPairSubscription(
+        alertService.addStationPairSubscriptions(
             dataSource: dataSource,
             fromStationCode: home,
             toStationCode: work
-        )
-        alertService.addStationPairSubscription(
-            dataSource: dataSource,
-            fromStationCode: work,
-            toStationCode: home
         )
     }
 
@@ -184,5 +174,40 @@ struct EditRouteAlertsView: View {
             guard let token = AppDelegate.deviceToken else { return }
             await alertService.syncWithBackend(apnsToken: token)
         }
+    }
+
+    /// Build display name for a line subscription, appending direction if present.
+    private func lineDisplayName(sub: RouteAlertSubscription, lineName: String) -> String {
+        guard let direction = sub.direction else { return lineName }
+        return "\(lineName) → \(Stations.displayName(for: direction))"
+    }
+
+    /// Build a RouteStatusContext for a subscription, using direction to set from/to.
+    private func routeStatusContext(for sub: RouteAlertSubscription) -> RouteStatusContext {
+        if let lineId = sub.lineId, let direction = sub.direction,
+           let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
+            let stations = route.stationCodes
+            if direction == stations.last {
+                return RouteStatusContext(
+                    dataSource: sub.dataSource,
+                    lineId: lineId,
+                    fromStationCode: stations.first,
+                    toStationCode: stations.last
+                )
+            } else {
+                return RouteStatusContext(
+                    dataSource: sub.dataSource,
+                    lineId: lineId,
+                    fromStationCode: stations.last,
+                    toStationCode: stations.first
+                )
+            }
+        }
+        return RouteStatusContext(
+            dataSource: sub.dataSource,
+            lineId: sub.lineId,
+            fromStationCode: sub.fromStationCode,
+            toStationCode: sub.toStationCode
+        )
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for directional line subscriptions, allowing users to receive alerts for a specific direction (terminus) of a transit line rather than both directions. For example, a user can subscribe to alerts for the NEC line "toward Trenton" without also getting alerts for "toward NY Penn".

## Key Changes

**Backend (Python/SQLAlchemy)**
- Added `direction` column to `RouteAlertSubscription` model to store the terminus station code
- Implemented `_filter_by_direction()` function to filter train journeys based on their travel direction relative to the route's ordered stations
- Updated `_query_journeys_for_subscription()` to apply directional filtering when a subscription has a direction set
- Modified baseline train count calculation to halve the baseline for directional subscriptions (since baseline covers both directions)
- Updated `_build_alert_message()` to include "toward <station name>" in alert titles for directional subscriptions
- Added database migration to add the `direction` column
- Updated API models and endpoints to accept/return the `direction` field

**iOS Client (Swift)**
- Modified `AlertSubscriptionService` to add directional subscriptions:
  - `addLineSubscriptions()` now creates two subscriptions (one per direction) when adding a line
  - `addSingleLineSubscription()` handles individual directional subscriptions with deduplication
  - `addStationPairSubscriptions()` creates bidirectional station-pair subscriptions
- Updated `RouteAlertSubscription` model to include `direction` field
- Modified `AddRouteAlertView` to filter out fully-subscribed routes (both directions already subscribed)
- Updated `EditRouteAlertsView` to display direction in line names and build proper route status context based on direction

**Tests**
- Added comprehensive unit tests for `_filter_by_direction()` covering forward/reverse directions, short-turn trains, and edge cases
- Added integration tests for directional alert evaluation verifying filtering prevents false alerts
- Added API tests for direction field roundtripping and mixed subscription types

## Implementation Details

- Direction is determined by comparing station indices in the route's ordered stations tuple
- If direction equals the last station, forward-traveling trains are kept (terminal_idx > origin_idx)
- If direction equals the first station, reverse-traveling trains are kept (terminal_idx < origin_idx)
- Trains with stations not on the route are excluded from filtering
- Unknown directions return all journeys unfiltered
- The baseline frequency calculation is adjusted for directional subscriptions to account for the fact that the baseline covers both directions

https://claude.ai/code/session_01WTF7fkkxSM4ySwLZ7w1zYy