### PR TITLE
Standardize summary headlines to "Past 2h" format

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1131,7 +1131,7 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         else:
-            headline = f"Recent departures: {dep_on_time_pct:.0f}% on time"
+            headline = f"Past 2h: {dep_on_time_pct:.0f}% on time"
 
         # Status clause
         if cancellations > 0:
@@ -1182,11 +1182,9 @@ class SummaryService:
             headline = f"{cancellations} {cancel_word}"
         elif train_count > 0:
             headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
-            train_word = "train" if train_count == 1 else "trains"
-            headline = f"{train_count} {train_word} — every ~{headway:.0f} min"
+            headline = f"Past 2h: every ~{headway:.0f} min"
         else:
-            headline = ""
-            return headline, ""
+            headline = "Past 2h: 0 trains"
 
         # Body
         body_parts = []
@@ -1199,12 +1197,16 @@ class SummaryService:
                 body_parts.append(
                     f"{remaining} others departed, averaging every {headway:.0f} minutes."
                 )
-        else:
+        elif train_count > 0:
             headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
             train_word = "train" if train_count == 1 else "trains"
             body_parts.append(
                 f"{train_count} {train_word} departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
                 f"averaging every {headway:.0f} minutes."
+            )
+        else:
+            body_parts.append(
+                f"No trains departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours."
             )
 
         return headline, " ".join(body_parts)
@@ -1428,11 +1430,9 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         elif dep_stats.has_data:
-            headline = f"Recent departures: {dep_stats.on_time_percentage:.0f}% on time"
+            headline = f"Past 2h: {dep_stats.on_time_percentage:.0f}% on time"
         elif train_stats.has_data:
-            headline = (
-                f"Recent departures: {train_stats.on_time_percentage:.0f}% on time"
-            )
+            headline = f"Past 2h: {train_stats.on_time_percentage:.0f}% on time"
         else:
             return "", ""  # No data
 
@@ -1502,10 +1502,7 @@ class SummaryService:
             headline = f"{cancellations} {cancel_word}"
         elif similar_total > 0:
             headway = SUMMARY_TIME_WINDOW_MINUTES / similar_total
-            train_word = "train" if similar_total == 1 else "trains"
-            headline = (
-                f"{similar_total} similar {train_word} — every ~{headway:.0f} min"
-            )
+            headline = f"Past 2h: every ~{headway:.0f} min"
         elif train_stats.has_data:
             headline = f"Historically ~{train_stats.total_count} trains per month"
         else:

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -280,7 +280,7 @@ class TestSummaryService:
         summary = summary_service._generate_route_summary(route_journeys, "NY", "NP")
 
         assert summary.scope == "route"
-        assert "Recent departures:" in summary.headline
+        assert "Past 2h:" in summary.headline
         assert "% on time" in summary.headline
         assert summary.metrics is not None
         assert summary.metrics.train_count == 2
@@ -1248,8 +1248,8 @@ class TestFormatFrequencyRouteHeadlineBody:
         """Create a SummaryService instance for testing."""
         return SummaryService()
 
-    def test_normal_service_shows_count_and_headway(self, summary_service):
-        """12 trains over 120min → headline shows count + ~10 min headway."""
+    def test_normal_service_shows_headway(self, summary_service):
+        """12 trains over 120min → headline shows Past 2h + ~10 min headway."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=12, cancellations=0
         )
@@ -1257,21 +1257,18 @@ class TestFormatFrequencyRouteHeadlineBody:
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
         print(f"expected_headway: {expected_headway}")
-        assert "12 trains" in headline
-        assert "~10 min" in headline
+        assert headline == "Past 2h: every ~10 min"
         assert "12 trains departed" in body
         assert "every 10 minutes" in body
 
     def test_single_train_headway(self, summary_service):
-        """1 train over 120min → large headway, singular grammar."""
+        """1 train over 120min → large headway."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=1, cancellations=0
         )
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
-        assert "1 train" in headline
-        assert "1 trains" not in headline  # Verify singular form
-        assert "~120 min" in headline
+        assert headline == "Past 2h: every ~120 min"
 
     def test_high_frequency_headway(self, summary_service):
         """30 trains over 120min → 4 min headway."""
@@ -1280,8 +1277,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         )
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
-        assert "30 trains" in headline
-        assert "~4 min" in headline
+        assert headline == "Past 2h: every ~4 min"
 
     def test_cancellations_lead_headline(self, summary_service):
         """Cancellations should lead the headline, with remaining train headway in body."""
@@ -1304,15 +1300,15 @@ class TestFormatFrequencyRouteHeadlineBody:
         assert headline == "1 cancellation"
         assert "1 train was cancelled" in body
 
-    def test_zero_trains_returns_empty(self, summary_service):
-        """No trains and no cancellations → empty headline and body."""
+    def test_zero_trains_shows_no_service(self, summary_service):
+        """No trains and no cancellations → 'Past 2h: 0 trains'."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=0, cancellations=0
         )
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
-        assert headline == ""
-        assert body == ""
+        assert headline == "Past 2h: 0 trains"
+        assert "No trains departed" in body
 
     def test_all_cancelled_no_remaining(self, summary_service):
         """All trains cancelled, none running → no headway info in body."""
@@ -1363,8 +1359,7 @@ class TestFormatFrequencyTrainHeadlineBody:
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
         expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 8  # 15
-        assert "8 similar trains" in headline
-        assert "~15 min" in headline
+        assert headline == "Past 2h: every ~15 min"
         assert "World Trade Center" in body
         assert "on time" in body
 


### PR DESCRIPTION
## Summary
This PR standardizes the headline format across all summary types (route and train) to use a consistent "Past 2h" prefix instead of "Recent departures", and refactors frequency-based headlines to always show headway information in a uniform format.

## Key Changes
- **Headline standardization**: Replaced "Recent departures:" with "Past 2h:" across route and train summaries for consistency
- **Frequency headline format**: Changed from `"{count} {trains} — every ~{headway} min"` to `"Past 2h: every ~{headway} min"` to simplify and standardize the format
- **Zero trains handling**: Updated the zero-train case to show `"Past 2h: 0 trains"` with a descriptive body message instead of returning empty strings
- **Test updates**: Updated all corresponding test assertions to match the new headline formats and verify the standardized output

## Implementation Details
- The changes apply to both route-level and train-level summaries
- Frequency-based summaries now consistently lead with "Past 2h:" regardless of train count
- The body text still provides detailed information about train counts and headway averages where applicable
- No functional changes to the underlying calculation logic; this is purely a presentation/formatting update

https://claude.ai/code/session_01KTQJWobzbkh7sRihTmwVyr