### PR TITLE
Remove showingSettings condition from trip selection visibility check

### DIFF
--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -28,8 +28,7 @@ struct TripSelectionView: View {
               Stations.isStationVisible(suggestion.fromStation, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode),
               Stations.isStationVisible(suggestion.toStation, withSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode),
               !liveActivityService.isActivityActive,
-              !isSearching,
-              !showingSettings else {
+              !isSearching else {
             return false
         }
         return true


### PR DESCRIPTION
## Summary
Removed the `!showingSettings` condition from the trip selection visibility logic in TripSelectionView, allowing trip suggestions to remain visible even when the settings panel is open.

## Key Changes
- Removed `!showingSettings` from the visibility guard clause in TripSelectionView
- Trip suggestions will now display regardless of settings panel state
- Simplified the conditional logic by removing one less-than-necessary condition

## Implementation Details
The visibility check now only validates:
- Station visibility based on selected systems and Amtrak mode
- Live activity service state
- Search state

This change allows users to view trip suggestions while the settings panel is displayed, improving the user experience by not hiding relevant information when settings are accessed.

https://claude.ai/code/session_01C6fdBZYga7X8yftbRaYq9o