### PR TITLE
Replace arrow symbols with "to" text in route display labels

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -553,12 +553,12 @@ struct RouteStatusContext: Identifiable, Equatable {
 
     /// Human-readable title for the route
     var title: String {
+        if let from = fromStationCode, let to = toStationCode {
+            return "\(Stations.displayName(for: from)) to \(Stations.displayName(for: to))"
+        }
         if let lineId = lineId,
            let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
             return route.name
-        }
-        if let from = fromStationCode, let to = toStationCode {
-            return "\(Stations.displayName(for: from)) → \(Stations.displayName(for: to))"
         }
         return dataSource
     }

--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -139,17 +139,14 @@ struct AddRouteAlertView: View {
 
     private var stationPairPicker: some View {
         VStack(spacing: 16) {
-            // From station
+            // First station
             Button {
                 showFromPicker = true
             } label: {
                 HStack {
-                    Text("From")
-                        .font(.subheadline)
-                        .foregroundColor(.white.opacity(0.6))
-                    Spacer()
                     Text(fromStation.map { $0.name } ?? "Select station")
                         .foregroundColor(fromStation != nil ? .white : .white.opacity(0.4))
+                    Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption)
                         .foregroundColor(.white.opacity(0.3))
@@ -159,17 +156,14 @@ struct AddRouteAlertView: View {
             }
             .buttonStyle(.plain)
 
-            // To station
+            // Second station
             Button {
                 showToPicker = true
             } label: {
                 HStack {
-                    Text("To")
-                        .font(.subheadline)
-                        .foregroundColor(.white.opacity(0.6))
-                    Spacer()
                     Text(toStation.map { $0.name } ?? "Select station")
                         .foregroundColor(toStation != nil ? .white : .white.opacity(0.4))
+                    Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption)
                         .foregroundColor(.white.opacity(0.3))

--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -105,7 +105,7 @@ struct EditRouteAlertsView: View {
                                     Label(lineDisplayName(sub: sub, lineName: lineName), systemImage: "tram.fill")
                                 } else if let from = sub.fromStationCode, let to = sub.toStationCode {
                                     Label(
-                                        "\(Stations.displayName(for: from)) → \(Stations.displayName(for: to))",
+                                        "\(Stations.displayName(for: from)) to \(Stations.displayName(for: to))",
                                         systemImage: "arrow.right"
                                     )
                                 }
@@ -176,10 +176,20 @@ struct EditRouteAlertsView: View {
         }
     }
 
-    /// Build display name for a line subscription, appending direction if present.
+    /// Build display name for a line subscription, showing "{from} to {destination}".
     private func lineDisplayName(sub: RouteAlertSubscription, lineName: String) -> String {
         guard let direction = sub.direction else { return lineName }
-        return "\(lineName) → \(Stations.displayName(for: direction))"
+        let directionName = Stations.displayName(for: direction)
+        // Use route station codes to find the "from" terminus
+        if let lineId = sub.lineId,
+           let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
+            let stations = route.stationCodes
+            let fromCode = direction == stations.last ? stations.first : stations.last
+            if let fromCode = fromCode {
+                return "\(Stations.displayName(for: fromCode)) to \(directionName)"
+            }
+        }
+        return "\(lineName) to \(directionName)"
     }
 
     /// Build a RouteStatusContext for a subscription, using direction to set from/to.


### PR DESCRIPTION
## Summary
This PR updates route alert displays to use the word "to" instead of arrow symbols (→) for better clarity and consistency across the app.

## Key Changes
- **EditRouteAlertsView.swift**: 
  - Changed station pair separator from "→" to "to" in the subscription label
  - Enhanced `lineDisplayName()` to intelligently determine the "from" terminus by checking route topology, displaying "{from station} to {destination}" format
  - Falls back to "{line name} to {direction}" if route data is unavailable

- **AddRouteAlertView.swift**:
  - Simplified station picker UI by removing "From" and "To" labels
  - Reordered button content to show station name first, followed by chevron icon
  - Updated comments to reflect "First station" and "Second station" terminology

- **TrackRatApp.swift** (RouteStatusContext):
  - Reordered title property logic to prioritize station pair display
  - Changed arrow separator to "to" for consistency
  - Ensures station-based titles are generated before falling back to route name

## Implementation Details
The `lineDisplayName()` function now uses `RouteTopology.allRoutes` to determine the correct "from" terminus based on whether the selected direction matches the last station in the route. This provides more contextual information to users about their alert direction.

https://claude.ai/code/session_01LXYuqRmVA3k6NbHyQuHkXo