### PR TITLE
Filter shuttle routes that are subsets of longer routes in PATH origin inference

### DIFF
--- a/backend_v2/src/trackrat/collectors/path/collector.py
+++ b/backend_v2/src/trackrat/collectors/path/collector.py
@@ -248,6 +248,26 @@ def _infer_origin_station(
         # No matching route - use current station as origin
         return current_station
 
+    # Filter out shuttle routes whose raw PATH_ROUTE_STOPS definition is a
+    # contiguous prefix of a longer matching route.  e.g., NWK-HAR shuttle
+    # [PNK, PHR] is a prefix of NWK-WTC [PNK, PHR, PJS, PGR, PEX, PWC].
+    # Without this filter, the shuttle wins on position index despite giving
+    # a less informative 2-stop journey instead of the full 6-stop route.
+    if len(matching_routes) > 1:
+        raw = {r[0]: PATH_ROUTE_STOPS[r[0]] for r in matching_routes}
+        filtered = [
+            r
+            for r in matching_routes
+            if not any(
+                raw[r[0]] == raw[o[0]][: len(raw[r[0]])]
+                and len(raw[r[0]]) < len(raw[o[0]])
+                for o in matching_routes
+                if o[0] != r[0]
+            )
+        ]
+        if filtered:
+            matching_routes = filtered
+
     if len(matching_routes) == 1:
         # Unambiguous - return first stop of this route
         return matching_routes[0][1][0]

--- a/backend_v2/tests/unit/collectors/path/test_collector.py
+++ b/backend_v2/tests/unit/collectors/path/test_collector.py
@@ -310,6 +310,27 @@ class TestInferOriginStation:
         result = _infer_origin_station("PHO", "PHO")
         assert result == "PHO"
 
+    def test_harrison_to_newark_prefers_full_route_over_shuttle(self):
+        """Test that NWK-WTC route is preferred over NWK-HAR shuttle for Harrison→Newark.
+
+        NWK-WTC reversed: [PWC, PEX, PGR, PJS, PHR, PNK] - PHR at idx 4
+        NWK-HAR reversed: [PHR, PNK] - PHR at idx 0
+
+        The shuttle [PNK, PHR] is a strict subset of the NWK-WTC route
+        [PNK, PHR, PJS, PGR, PEX, PWC]. The subset filter should eliminate the
+        shuttle so the full NWK-WTC route is selected, giving origin=PWC (World
+        Trade Center) and a complete 6-stop journey.
+        """
+        result = _infer_origin_station("PHR", "PNK")
+        assert result == "PWC"
+
+    def test_harrison_to_wtc_uses_nwk_wtc_route(self):
+        """Test that Harrison going to WTC correctly infers Newark as origin."""
+        # NWK-WTC route: PNK → PHR → PJS → PGR → PEX → PWC
+        # Harrison (PHR) at index 1, forward direction → origin is PNK
+        result = _infer_origin_station("PHR", "PWC")
+        assert result == "PNK"
+
 
 # =============================================================================
 # PATH COLLECTOR TESTS


### PR DESCRIPTION
## Summary
Improved the PATH station origin inference logic to prefer complete routes over shuttle routes when a shuttle's stops are a contiguous subset of a longer route. This ensures more informative journey information is provided to users.

## Key Changes
- Added filtering logic in `_infer_origin_station()` to eliminate shuttle routes whose stop sequence is a prefix of a longer matching route
- The filter specifically handles cases like the NWK-HAR shuttle `[PNK, PHR]` which is a subset of the full NWK-WTC route `[PNK, PHR, PJS, PGR, PEX, PWC]`
- When multiple routes match, the algorithm now prefers the longer route to provide complete journey information
- Added two test cases to verify the behavior:
  - `test_harrison_to_newark_prefers_full_route_over_shuttle`: Validates that Harrison→Newark uses the full 6-stop NWK-WTC route instead of the 2-stop shuttle
  - `test_harrison_to_wtc_uses_nwk_wtc_route`: Validates correct origin inference when traveling from Harrison to World Trade Center

## Implementation Details
The filtering logic checks if any route's raw stop definition is a strict prefix of another matching route's definition. Routes that are prefixes of longer routes are excluded from consideration, ensuring the most complete route information is used for origin inference.

https://claude.ai/code/session_01YCviqThS61P4P5vZwDsWK5