### PR TITLE
Hide close button and simplify Route Alerts label in Settings

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -338,13 +338,15 @@ struct SettingsView: View {
                     }
                 }
                 .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image(systemName: "xmark")
-                                .font(TrackRatTheme.IconSize.xsmall)
-                                .foregroundColor(.white)
+                    if destination != .routeAlerts {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button {
+                                dismiss()
+                            } label: {
+                                Image(systemName: "xmark")
+                                    .font(TrackRatTheme.IconSize.xsmall)
+                                    .foregroundColor(.white)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Updated the SettingsView to conditionally hide the close button when navigating to Route Alerts and simplified the Route Alerts section label to include a beta indicator.

## Key Changes
- Added conditional logic to hide the top-right close button (xmark) when `destination == .routeAlerts`
- Simplified the Route Alerts section from a multi-line VStack layout to a single Text element
- Updated the Route Alerts label from "Route Alerts" with a subtitle to "Route Alerts (beta)"
- Removed the descriptive subtitle "Delay & cancellation notifications"

## Implementation Details
The close button is now only displayed for non-Route Alerts destinations, likely because the Route Alerts screen has its own navigation handling. The Route Alerts section label was consolidated into a single line with a beta indicator, reducing visual complexity while maintaining the beta status information.

https://claude.ai/code/session_014B7V7yjBhE2SDkDsFzPKsm