### PR TITLE
Support sheet presentation mode in TrainDetailsView

### DIFF
--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -147,7 +147,8 @@ struct EditRouteAlertsView: View {
             NavigationStack {
                 TrainDetailsView(
                     trainNumber: sub.trainId ?? "",
-                    dataSource: sub.dataSource
+                    dataSource: sub.dataSource,
+                    isSheet: true
                 )
             }
             .presentationDetents([.large])

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -3,6 +3,7 @@ import ActivityKit
 
 struct TrainDetailsView: View {
     @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: TrainDetailsViewModel
     @ObservedObject private var subscriptionService = SubscriptionService.shared
     // PERFORMANCE: Track visibility to prevent polling when view is not visible
@@ -11,17 +12,20 @@ struct TrainDetailsView: View {
     @State private var paywallContext: PaywallContext = .generic
 
     let trainId: Int  // Keep for backwards compatibility
+    let isSheet: Bool
 
     // Legacy initializer for database ID
-    init(trainId: Int) {
+    init(trainId: Int, isSheet: Bool = false) {
         self.trainId = trainId
+        self.isSheet = isSheet
         let VModel = TrainDetailsViewModel(trainId: trainId)
         self._viewModel = StateObject(wrappedValue: VModel)
     }
 
     // New initializer for train number
-    init(trainNumber: String, fromStation: String? = nil, journeyDate: Date? = nil, dataSource: String? = nil) {
+    init(trainNumber: String, fromStation: String? = nil, journeyDate: Date? = nil, dataSource: String? = nil, isSheet: Bool = false) {
         self.trainId = 0  // Not used for train number based initialization
+        self.isSheet = isSheet
         let VModel = TrainDetailsViewModel(
             databaseId: nil,
             trainNumber: trainNumber,
@@ -43,6 +47,7 @@ struct TrainDetailsView: View {
             TrackRatNavigationHeader(
                 // PATH and PATCO trains display destination instead of synthetic train ID
                 title: trainNavigationTitle,
+                showBackButton: !isSheet,
                 showCloseButton: false,
                 trailingContent: {
                     HStack(alignment: .center, spacing: 12) {
@@ -57,7 +62,11 @@ struct TrainDetailsView: View {
                         }
 
                         Button("Close") {
-                            appState.navigationPath = NavigationPath()
+                            if isSheet {
+                                dismiss()
+                            } else {
+                                appState.navigationPath = NavigationPath()
+                            }
                         }
                         .font(.body)
                         .fontWeight(.medium)


### PR DESCRIPTION
## Summary
Updated `TrainDetailsView` to properly handle both navigation stack and sheet presentation contexts, ensuring appropriate UI behavior and navigation handling for each mode.

## Key Changes
- Added `isSheet` parameter to both `TrainDetailsView` initializers to distinguish between navigation stack and sheet presentations
- Added `@Environment(\.dismiss)` to enable sheet dismissal
- Updated `TrackRatNavigationHeader` to conditionally show back button only in navigation stack mode (not in sheets)
- Modified close button behavior to use `dismiss()` when presented as a sheet, or clear navigation path when in a stack
- Updated `EditRouteAlertsView` to pass `isSheet: true` when presenting `TrainDetailsView` in a sheet

## Implementation Details
The view now intelligently adapts its navigation UI based on presentation context:
- In navigation stack mode: displays back button and clears navigation path on close
- In sheet mode: hides back button and uses environment dismiss action to close the sheet

This ensures consistent UX regardless of how the view is presented to the user.

https://claude.ai/code/session_01NjmGqBtA2RgnVfbpNsmmon