### PR TITLE
Replace "Past 2h" with "Past two hours" in summary headlines

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1131,7 +1131,7 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         else:
-            headline = f"Past 2h: {dep_on_time_pct:.0f}% on time"
+            headline = f"Past two hours: {dep_on_time_pct:.0f}% on time"
 
         # Status clause
         if cancellations > 0:
@@ -1182,9 +1182,9 @@ class SummaryService:
             headline = f"{cancellations} {cancel_word}"
         elif train_count > 0:
             headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
-            headline = f"Past 2h: every ~{headway:.0f} min"
+            headline = f"Past two hours: every ~{headway:.0f} min"
         else:
-            headline = "Past 2h: 0 trains"
+            headline = "Past two hours: 0 trains"
 
         # Body
         body_parts = []
@@ -1430,9 +1430,9 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         elif dep_stats.has_data:
-            headline = f"Past 2h: {dep_stats.on_time_percentage:.0f}% on time"
+            headline = f"Past two hours: {dep_stats.on_time_percentage:.0f}% on time"
         elif train_stats.has_data:
-            headline = f"Past 2h: {train_stats.on_time_percentage:.0f}% on time"
+            headline = f"Past two hours: {train_stats.on_time_percentage:.0f}% on time"
         else:
             return "", ""  # No data
 
@@ -1502,7 +1502,7 @@ class SummaryService:
             headline = f"{cancellations} {cancel_word}"
         elif similar_total > 0:
             headway = SUMMARY_TIME_WINDOW_MINUTES / similar_total
-            headline = f"Past 2h: every ~{headway:.0f} min"
+            headline = f"Past two hours: every ~{headway:.0f} min"
         elif train_stats.has_data:
             headline = f"Historically ~{train_stats.total_count} trains per month"
         else:

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -280,7 +280,7 @@ class TestSummaryService:
         summary = summary_service._generate_route_summary(route_journeys, "NY", "NP")
 
         assert summary.scope == "route"
-        assert "Past 2h:" in summary.headline
+        assert "Past two hours:" in summary.headline
         assert "% on time" in summary.headline
         assert summary.metrics is not None
         assert summary.metrics.train_count == 2
@@ -1249,7 +1249,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         return SummaryService()
 
     def test_normal_service_shows_headway(self, summary_service):
-        """12 trains over 120min → headline shows Past 2h + ~10 min headway."""
+        """12 trains over 120min → headline shows Past two hours + ~10 min headway."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=12, cancellations=0
         )
@@ -1257,7 +1257,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
         print(f"expected_headway: {expected_headway}")
-        assert headline == "Past 2h: every ~10 min"
+        assert headline == "Past two hours: every ~10 min"
         assert "12 trains departed" in body
         assert "every 10 minutes" in body
 
@@ -1268,7 +1268,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         )
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
-        assert headline == "Past 2h: every ~120 min"
+        assert headline == "Past two hours: every ~120 min"
 
     def test_high_frequency_headway(self, summary_service):
         """30 trains over 120min → 4 min headway."""
@@ -1277,7 +1277,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         )
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
-        assert headline == "Past 2h: every ~4 min"
+        assert headline == "Past two hours: every ~4 min"
 
     def test_cancellations_lead_headline(self, summary_service):
         """Cancellations should lead the headline, with remaining train headway in body."""
@@ -1301,13 +1301,13 @@ class TestFormatFrequencyRouteHeadlineBody:
         assert "1 train was cancelled" in body
 
     def test_zero_trains_shows_no_service(self, summary_service):
-        """No trains and no cancellations → 'Past 2h: 0 trains'."""
+        """No trains and no cancellations → 'Past two hours: 0 trains'."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=0, cancellations=0
         )
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
-        assert headline == "Past 2h: 0 trains"
+        assert headline == "Past two hours: 0 trains"
         assert "No trains departed" in body
 
     def test_all_cancelled_no_remaining(self, summary_service):
@@ -1359,7 +1359,7 @@ class TestFormatFrequencyTrainHeadlineBody:
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
         expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 8  # 15
-        assert headline == "Past 2h: every ~15 min"
+        assert headline == "Past two hours: every ~15 min"
         assert "World Trade Center" in body
         assert "on time" in body
 


### PR DESCRIPTION
## Summary
Updated all summary headline text to use the more readable phrase "Past two hours" instead of the abbreviated "Past 2h" for better clarity and consistency across the application.

## Key Changes
- Updated `_format_route_headline_body()` to use "Past two hours" in on-time percentage headlines
- Updated `_format_frequency_route_headline_body()` to use "Past two hours" in headway and zero-trains headlines
- Updated `_format_train_headline_body()` to use "Past two hours" in on-time percentage headlines
- Updated `_format_frequency_train_headline_body()` to use "Past two hours" in headway headlines
- Updated all corresponding unit tests to assert the new text format

## Implementation Details
This is a straightforward text replacement across the summary service that improves readability of user-facing headlines. The change affects four headline formatting methods and maintains consistency across route summaries, frequency summaries, train summaries, and frequency train summaries. All test assertions have been updated to match the new expected output.

https://claude.ai/code/session_01MvuSoiyDBRrREyJviM3WT8