### PR TITLE
Simplify route alert subtitle display logic

### DIFF
--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -105,13 +105,9 @@ struct EditRouteAlertsView: View {
                                 } else if let lineName = sub.lineName {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Label(lineDisplayName(sub: sub, lineName: lineName), systemImage: "tram.fill")
-                                        if let lineId = sub.lineId,
-                                           let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }),
-                                           let subtitle = route.terminalSubtitle {
-                                            Text(subtitle)
-                                                .font(.caption2)
-                                                .foregroundColor(.white.opacity(0.5))
-                                        }
+                                        Text("\(TrainSystem(rawValue: sub.dataSource)?.displayName ?? sub.dataSource): \(lineName)")
+                                            .font(.caption2)
+                                            .foregroundColor(.white.opacity(0.5))
                                     }
                                 } else if let from = sub.fromStationCode, let to = sub.toStationCode {
                                     Label(


### PR DESCRIPTION
## Summary
Refactored the subtitle display logic in EditRouteAlertsView to use a simpler, more direct approach that displays the train system and line name instead of looking up route topology data.

## Key Changes
- Replaced complex route lookup logic that searched `RouteTopology.allRoutes` with a direct display of the train system name and line name
- Changed subtitle from showing `route.terminalSubtitle` to showing `TrainSystem(rawValue: sub.dataSource)?.displayName` combined with the line name
- Simplified the conditional logic from a multi-line if-let chain to a single Text view with string interpolation

## Implementation Details
- The new subtitle format is: `"{TrainSystem}: {lineName}"` (e.g., "BART: Line 1")
- Falls back to the raw `dataSource` value if the TrainSystem enum case is not found
- Maintains the same visual styling (caption2 font, white text at 50% opacity)
- Removes the dependency on RouteTopology data for this display, making the view more self-contained

https://claude.ai/code/session_01MwRwuKC8oaqz2Bqckm5afd