### PR TITLE
Filter out trains terminating at origin station in departures

### DIFF
--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -506,8 +506,13 @@ struct AddRouteAlertView: View {
                     fromStationCode: station.code,
                     dataSources: [system]
                 )
+                // Filter out trains whose terminal stop is the selected station
+                let filtered = results.filter { train in
+                    guard let destCode = Stations.getStationCode(train.destination) else { return true }
+                    return !Stations.areEquivalentStations(destCode, station.code)
+                }
                 await MainActor.run {
-                    departures = results
+                    departures = filtered
                     isLoadingDepartures = false
                 }
             } catch {


### PR DESCRIPTION
## Summary
Updated the departure board logic to exclude trains whose final destination is the selected origin station, preventing users from seeing trains that terminate where they're starting from.

## Key Changes
- Added filtering logic after fetching train departures to remove trains where the terminal stop matches the selected station
- Uses `Stations.getStationCode()` to resolve the train's destination to a station code
- Uses `Stations.areEquivalentStations()` to compare station codes, accounting for station equivalencies
- Safely handles cases where destination cannot be resolved by including the train in results (conservative approach)

## Implementation Details
- The filter is applied on the main thread before updating the `departures` state
- Maintains the existing loading state management and error handling
- Uses a guard statement to gracefully handle trains with unresolvable destinations

https://claude.ai/code/session_0169JXRsKZV2v36yXkxZbMWL