### PR TITLE
Optimize data_source filtering in congestion queries

### DIFF
--- a/backend_v2/src/trackrat/services/api_cache.py
+++ b/backend_v2/src/trackrat/services/api_cache.py
@@ -159,7 +159,7 @@ class ApiCacheService:
             {"time_window_hours": 2, "max_per_segment": 100, "data_source": "AMTRAK"},
             {"time_window_hours": 2, "max_per_segment": 100, "data_source": "LIRR"},
             {"time_window_hours": 2, "max_per_segment": 100, "data_source": "MNR"},
-            {"time_window_hours": 2, "max_per_segment": 10, "data_source": "SUBWAY"},
+            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "SUBWAY"},
             {"time_window_hours": 2, "max_per_segment": 100, "data_source": "PATCO"},
             # Longer window views with NJT
             {"time_window_hours": 3, "max_per_segment": 100, "data_source": "NJT"},

--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -376,6 +376,7 @@ class CongestionAnalyzer:
             JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
             WHERE js.station_code IS NOT NULL
               AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
+              AND (CAST(:data_source AS TEXT) IS NULL OR tj_pre.data_source = CAST(:data_source AS TEXT))
             WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
         ),
         segment_data AS (
@@ -411,8 +412,6 @@ class CongestionAnalyzer:
                 sp.to_station IS NOT NULL
                 -- Within time window
                 AND COALESCE(sp.from_actual_departure, sp.from_scheduled_departure) >= :cutoff_time
-                -- Data source filter (if specified)
-                AND (CAST(:data_source AS TEXT) IS NULL OR tj.data_source = CAST(:data_source AS TEXT))
                 -- Valid times (at least scheduled times must exist)
                 AND sp.from_scheduled_departure IS NOT NULL
                 AND sp.to_scheduled_arrival IS NOT NULL
@@ -676,6 +675,7 @@ class CongestionAnalyzer:
                 JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
                 WHERE js.station_code IS NOT NULL
                   AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
+                  AND (CAST(:data_source AS TEXT) IS NULL OR tj_pre.data_source = CAST(:data_source AS TEXT))
                 WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
             ),
             segment_data AS (
@@ -713,8 +713,6 @@ class CongestionAnalyzer:
                     sp.to_station IS NOT NULL
                     -- Within time window
                     AND COALESCE(sp.from_actual_departure, sp.from_scheduled_departure) >= :cutoff_time
-                    -- Data source filter (if specified)
-                    AND (CAST(:data_source AS TEXT) IS NULL OR tj.data_source = CAST(:data_source AS TEXT))
                     -- Active journeys only (cancelled trains handled separately)
                     AND NOT tj.is_cancelled
                     -- Valid times
@@ -777,6 +775,7 @@ class CongestionAnalyzer:
                 JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
                 WHERE js.station_code IS NOT NULL
                   AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
+                  AND (CAST(:data_source AS TEXT) IS NULL OR tj_pre.data_source = CAST(:data_source AS TEXT))
                 WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
             ),
             segment_data AS (
@@ -814,8 +813,6 @@ class CongestionAnalyzer:
                     sp.to_station IS NOT NULL
                     -- Within time window
                     AND COALESCE(sp.from_actual_departure, sp.from_scheduled_departure) >= :cutoff_time
-                    -- Data source filter (if specified)
-                    AND (CAST(:data_source AS TEXT) IS NULL OR tj.data_source = CAST(:data_source AS TEXT))
                     -- Active journeys only
                     AND NOT tj.is_cancelled
                     -- Valid times

--- a/scripts/e2e-api-test.sh
+++ b/scripts/e2e-api-test.sh
@@ -65,6 +65,7 @@ urlencode() { jq -rn --arg v "$1" '$v | @uri'; }
 # Also writes response time (seconds) to $TMPDIR/last_time.txt for check_timing().
 api() {
   local result
+  > "$TMPDIR/resp.json"  # Clear stale response from previous call
   result=$(curl -s -o "$TMPDIR/resp.json" -w "%{http_code} %{time_total}" --max-time 15 "$1" 2>/dev/null) || result="000 0"
   echo "${result#* }" > "$TMPDIR/last_time.txt"
   echo "${result%% *}"


### PR DESCRIPTION
## Summary
This PR optimizes data source filtering in congestion service queries by moving the filter earlier in the query execution pipeline, and adjusts cache precomputation parameters for consistency.

## Key Changes

- **Moved data_source filter to CTE level**: In both `get_network_congestion_optimized()` and `get_individual_segments_optimized()`, the data source filter has been relocated from the main query WHERE clause to the `journey_stops` CTE. This allows the database to filter data earlier in the execution plan, reducing the amount of data processed in subsequent joins and aggregations.

- **Applied to multiple query paths**: The optimization was applied consistently across three separate query blocks in `get_individual_segments_optimized()` that handle different journey scenarios.

- **Unified SUBWAY cache parameters**: Updated the precomputation cache configuration to use `max_per_segment: 100` for SUBWAY data sources (previously 10), making it consistent with other transit providers (AMTRAK, LIRR, MNR, PATCO).

- **Fixed test script response handling**: Added explicit clearing of stale response files in the e2e test script to prevent false positives from previous API calls.

## Implementation Details

The data_source filter now operates at the CTE level where journey stops are joined with train journeys, enabling earlier predicate pushdown. This reduces the working set for the subsequent `segment_data` CTE and main query, improving query performance especially for large datasets or when filtering to specific data sources.

https://claude.ai/code/session_014UuU2NLcAq4JFXZNMqX9WR