### PR TITLE
Distinguish transient null data from genuine train-not-found errors

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/client.py
+++ b/backend_v2/src/trackrat/collectors/njt/client.py
@@ -28,6 +28,17 @@ class TrainNotFoundError(NJTransitAPIError):
     pass
 
 
+class NJTransitNullDataError(NJTransitAPIError):
+    """Exception raised when NJ Transit API returns a response with all key fields null.
+
+    This is a transient API issue — the train still appears on departure boards
+    but the detail API returns null data. Unlike TrainNotFoundError, this should
+    NOT count toward the expiry threshold since the train is still running.
+    """
+
+    pass
+
+
 class NJTransitClient:
     """Async client for NJ Transit rail data API."""
 
@@ -261,16 +272,19 @@ class NJTransitClient:
                 f"Train {train_id} not found - API returned empty response"
             )
 
-        # Check if all required fields are None (train no longer exists)
+        # Check if all required fields are None — transient NJT API issue.
+        # The train may still appear on departure boards (getTrainSchedule)
+        # even though getTrainStopList returns null data. This is distinct from
+        # a genuine TrainNotFoundError and should NOT count toward expiry.
         required_fields = ["TRAIN_ID", "LINECODE", "BACKCOLOR", "DESTINATION"]
         if all(response.get(field) is None for field in required_fields):
             logger.warning(
-                "train_not_found_all_fields_none",
+                "train_null_data_response",
                 train_id=train_id,
                 response_keys=list(response.keys()),
             )
-            raise TrainNotFoundError(
-                f"Train {train_id} not found - API returned null data"
+            raise NJTransitNullDataError(
+                f"Train {train_id} - API returned null data (transient)"
             )
 
         # Validate and parse response

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -14,7 +14,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from trackrat.collectors.base import BaseJourneyCollector
-from trackrat.collectors.njt.client import NJTransitClient, TrainNotFoundError
+from trackrat.collectors.njt.client import (
+    NJTransitClient,
+    NJTransitNullDataError,
+    TrainNotFoundError,
+)
 from trackrat.config.stations import get_station_name
 from trackrat.db.engine import get_session
 from trackrat.models.api import NJTransitStopData, NJTransitTrainData
@@ -761,8 +765,20 @@ class JourneyCollector(BaseJourneyCollector):
 
         try:
             train_data = await self.njt_client.get_train_stop_list(journey.train_id)
+        except NJTransitNullDataError:
+            # NJT API returned a response with all key fields null — transient
+            # API issue. The train likely still appears on departure boards.
+            # Do NOT increment api_error_count; keep last known data.
+            logger.info(
+                "train_null_data_skipped",
+                train_id=journey.train_id,
+                journey_id=journey.id,
+                api_error_count=journey.api_error_count,
+            )
+            return
         except TrainNotFoundError:
-            # Train is no longer available - increment error count
+            # Train is genuinely not available (empty/None response) —
+            # increment error count toward expiry threshold.
             journey.api_error_count = (journey.api_error_count or 0) + 1
             journey.last_updated_at = now_et()
             journey.update_count = (journey.update_count or 0) + 1

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -1498,7 +1498,10 @@ class SchedulerService:
             from sqlalchemy import and_, create_engine, delete, select
             from sqlalchemy.orm import selectinload, sessionmaker
 
-            from trackrat.collectors.njt.client import TrainNotFoundError
+            from trackrat.collectors.njt.client import (
+                NJTransitNullDataError,
+                TrainNotFoundError,
+            )
             from trackrat.models.database import JourneySnapshot, JourneyStop
             from trackrat.utils.time import now_et, parse_njt_time
 
@@ -1546,8 +1549,23 @@ class SchedulerService:
 
                 try:
                     train_data = await self.njt_client.get_train_stop_list(train_id)
+                except NJTransitNullDataError:
+                    # NJT API returned a response with all key fields null —
+                    # transient API issue. Do NOT increment api_error_count.
+                    logger.info(
+                        "train_null_data_skipped_sync",
+                        train_id=train_id,
+                        journey_id=journey.id,
+                        api_error_count=journey.api_error_count,
+                    )
+                    return {
+                        "train_id": train_id,
+                        "success": False,
+                        "error": "Transient null data",
+                        "expired": False,
+                    }
                 except TrainNotFoundError:
-                    # Train is no longer available - increment error count
+                    # Train is genuinely not available — increment error count.
                     with session.no_autoflush:
                         journey.api_error_count = (journey.api_error_count or 0) + 1
                         journey.last_updated_at = now_et()

--- a/backend_v2/tests/unit/collectors/njt/test_client_none_response.py
+++ b/backend_v2/tests/unit/collectors/njt/test_client_none_response.py
@@ -3,15 +3,25 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from trackrat.collectors.njt.client import NJTransitClient, TrainNotFoundError
+from trackrat.collectors.njt.client import (
+    NJTransitClient,
+    NJTransitNullDataError,
+    TrainNotFoundError,
+)
 
 
 @pytest.mark.asyncio
-async def test_get_train_stop_list_all_fields_none():
-    """Test handling when API returns dict with all None values."""
+async def test_get_train_stop_list_all_fields_none_raises_null_data_error():
+    """Test that all-fields-null raises NJTransitNullDataError (NOT TrainNotFoundError).
+
+    This is the key behavior change: when the NJT API returns a response with all
+    key fields null, it's a transient API issue, not a genuine "train not found".
+    The departure board (getTrainSchedule) often still shows these trains.
+    Using a distinct exception prevents the 3-strike expiry from triggering.
+    """
     client = NJTransitClient()
 
-    # Mock response with all fields None (what we're seeing in the logs)
+    # Mock response with all fields None (what we're seeing in production logs)
     mock_response = {
         "TRAIN_ID": None,
         "LINECODE": None,
@@ -25,12 +35,23 @@ async def test_get_train_stop_list_all_fields_none():
 
     client._make_request = AsyncMock(return_value=mock_response)
 
-    # This should raise TrainNotFoundError, not validation error
-    with pytest.raises(TrainNotFoundError) as exc_info:
+    # Must raise NJTransitNullDataError, NOT TrainNotFoundError
+    with pytest.raises(NJTransitNullDataError) as exc_info:
         async with client:
             await client.get_train_stop_list("3840")
 
-    assert "Train 3840 not found - API returned null data" in str(exc_info.value)
+    assert "transient" in str(exc_info.value).lower()
+    assert "3840" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_all_fields_none_is_not_train_not_found():
+    """Verify NJTransitNullDataError is NOT a subclass of TrainNotFoundError.
+
+    This is critical: code that catches TrainNotFoundError to increment
+    api_error_count must NOT catch NJTransitNullDataError.
+    """
+    assert not issubclass(NJTransitNullDataError, TrainNotFoundError)
 
 
 @pytest.mark.asyncio

--- a/backend_v2/tests/unit/test_expired_trains.py
+++ b/backend_v2/tests/unit/test_expired_trains.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from trackrat.collectors.njt.client import TrainNotFoundError
+from trackrat.collectors.njt.client import NJTransitNullDataError, TrainNotFoundError
 from trackrat.collectors.njt.journey import JourneyCollector
 from trackrat.models.database import TrainJourney, JourneyStop
 from trackrat.utils.time import now_et
@@ -337,3 +337,167 @@ async def test_train_not_found_counted_as_success_in_batch():
     # Journey2 should have incremented error count and be expired
     assert journey2.api_error_count == 3
     assert journey2.is_expired is True
+
+
+@pytest.mark.asyncio
+async def test_null_data_response_does_not_increment_error_count():
+    """Test that NJTransitNullDataError does NOT increment api_error_count.
+
+    When the NJT API returns a response with all key fields null, it's a
+    transient API issue — the train likely still appears on departure boards.
+    This must NOT count toward the 3-strike expiry threshold.
+    """
+    journey = TrainJourney(
+        id=1,
+        train_id="744",
+        journey_date=now_et().date(),
+        line_code="NE",
+        destination="New York",
+        origin_station_code="TR",
+        terminal_station_code="NY",
+        scheduled_departure=now_et() - timedelta(hours=1),
+        data_source="NJT",
+        has_complete_journey=True,
+        api_error_count=0,
+        is_expired=False,
+    )
+
+    session = AsyncMock(spec=AsyncSession)
+    session.flush = AsyncMock()
+
+    # Mock NJT client that raises NJTransitNullDataError (transient null data)
+    njt_client = AsyncMock()
+    njt_client.get_train_stop_list = AsyncMock(
+        side_effect=NJTransitNullDataError("Train 744 - API returned null data (transient)")
+    )
+
+    collector = JourneyCollector(njt_client)
+
+    # Call collect_journey_details multiple times
+    for _ in range(5):
+        await collector.collect_journey_details(session, journey)
+
+    # api_error_count must remain 0 — null data responses are NOT errors
+    assert journey.api_error_count == 0, (
+        f"api_error_count should be 0 but was {journey.api_error_count}. "
+        "NJTransitNullDataError must not increment the error counter."
+    )
+    assert journey.is_expired is False, (
+        "Train should NOT be expired after null data responses. "
+        "The train still appears on NJT departure boards."
+    )
+    # session.flush should NOT have been called (no state changes)
+    assert not session.flush.called, (
+        "session.flush should not be called for null data responses "
+        "since no database fields are modified."
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_data_does_not_reset_existing_error_count():
+    """Test that NJTransitNullDataError preserves the existing api_error_count.
+
+    If a train already has 2 genuine TrainNotFoundError strikes, a subsequent
+    null data response should NOT reset the counter — it should leave it as-is.
+    """
+    journey = TrainJourney(
+        id=1,
+        train_id="738",
+        journey_date=now_et().date(),
+        line_code="NE",
+        destination="New York",
+        origin_station_code="TR",
+        terminal_station_code="NY",
+        scheduled_departure=now_et() - timedelta(hours=1),
+        data_source="NJT",
+        has_complete_journey=True,
+        api_error_count=2,  # Already has 2 genuine errors
+        is_expired=False,
+    )
+
+    session = AsyncMock(spec=AsyncSession)
+    session.flush = AsyncMock()
+
+    njt_client = AsyncMock()
+    njt_client.get_train_stop_list = AsyncMock(
+        side_effect=NJTransitNullDataError("Train 738 - API returned null data (transient)")
+    )
+
+    collector = JourneyCollector(njt_client)
+    await collector.collect_journey_details(session, journey)
+
+    # Error count should remain at 2 — null data doesn't change it
+    assert journey.api_error_count == 2, (
+        f"api_error_count should remain at 2 but was {journey.api_error_count}. "
+        "Null data responses must not modify the error counter."
+    )
+    assert journey.is_expired is False
+
+
+@pytest.mark.asyncio
+async def test_genuine_not_found_still_expires_after_null_data():
+    """Test that genuine TrainNotFoundError still works after null data responses.
+
+    Scenario: train gets null data responses (ignored), then genuine not-found
+    responses. Only the genuine ones should count toward expiry.
+    """
+    journey = TrainJourney(
+        id=1,
+        train_id="736",
+        journey_date=now_et().date(),
+        line_code="NE",
+        destination="New York",
+        origin_station_code="TR",
+        terminal_station_code="NY",
+        scheduled_departure=now_et() - timedelta(hours=1),
+        data_source="NJT",
+        has_complete_journey=True,
+        api_error_count=0,
+        is_expired=False,
+    )
+
+    session = AsyncMock(spec=AsyncSession)
+    session.flush = AsyncMock()
+
+    njt_client = AsyncMock()
+    collector = JourneyCollector(njt_client)
+
+    # 3 null data responses — should NOT count
+    njt_client.get_train_stop_list = AsyncMock(
+        side_effect=NJTransitNullDataError("null data")
+    )
+    for _ in range(3):
+        await collector.collect_journey_details(session, journey)
+
+    assert journey.api_error_count == 0
+    assert journey.is_expired is False
+
+    # Now 2 genuine not-found responses — should count but not yet expire
+    njt_client.get_train_stop_list = AsyncMock(
+        side_effect=TrainNotFoundError("Train not found")
+    )
+    await collector.collect_journey_details(session, journey)
+    await collector.collect_journey_details(session, journey)
+
+    assert journey.api_error_count == 2
+    assert journey.is_expired is False
+
+    # 1 more null data response — should NOT push to expiry
+    njt_client.get_train_stop_list = AsyncMock(
+        side_effect=NJTransitNullDataError("null data")
+    )
+    await collector.collect_journey_details(session, journey)
+
+    assert journey.api_error_count == 2, (
+        "Null data response must not increment error count past 2"
+    )
+    assert journey.is_expired is False
+
+    # 1 more genuine not-found — THIS should expire
+    njt_client.get_train_stop_list = AsyncMock(
+        side_effect=TrainNotFoundError("Train not found")
+    )
+    await collector.collect_journey_details(session, journey)
+
+    assert journey.api_error_count == 3
+    assert journey.is_expired is True


### PR DESCRIPTION
## Summary
This PR introduces a new exception type `NJTransitNullDataError` to distinguish transient NJ Transit API issues (where the API returns null data) from genuine "train not found" scenarios. This prevents transient API glitches from incorrectly triggering the 3-strike expiry mechanism for trains that still appear on departure boards.

## Key Changes

- **New Exception Type**: Added `NJTransitNullDataError` in `trackrat/collectors/njt/client.py` as a distinct exception from `TrainNotFoundError`. This exception is raised when the NJT API returns a response with all key fields null, indicating a transient API issue rather than a genuinely missing train.

- **Client Detection Logic**: Updated `NJTransitClient.get_train_stop_list()` to raise `NJTransitNullDataError` instead of `TrainNotFoundError` when all required fields are null. This preserves the distinction between transient API failures and genuine train unavailability.

- **Journey Collector Handling**: Modified `JourneyCollector.collect_journey_details()` to catch `NJTransitNullDataError` separately and skip error count incrementation. The method now returns early without modifying the journey state when null data is encountered.

- **Scheduler Handling**: Updated `_collect_single_njt_journey_safe()` in the scheduler to handle `NJTransitNullDataError` distinctly, logging it as a transient issue without incrementing the error counter or marking the journey as expired.

- **Comprehensive Test Coverage**: Added three new test cases validating:
  - Null data responses do not increment `api_error_count`
  - Null data responses do not reset existing error counts
  - Genuine `TrainNotFoundError` still correctly triggers expiry even after null data responses

## Implementation Details

The key behavioral change is that `NJTransitNullDataError` is **not** a subclass of `TrainNotFoundError`, ensuring that exception handlers specifically catching `TrainNotFoundError` will not inadvertently catch transient null data responses. This allows the expiry logic to remain strict about genuine train unavailability while being tolerant of temporary API glitches.

https://claude.ai/code/session_0194cZCNXRVL9kfWtcwQrc17