### PR TITLE
Add minimum scale factor to train card destination text

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -373,6 +373,7 @@ struct TrainCard: View {
                         .foregroundColor(isCancelled || hasDeparted ? .black.opacity(0.5) : (isBoardingAtOrigin ? .white : .black))
                         .strikethrough(isCancelled)
                         .lineLimit(1)
+                        .minimumScaleFactor(0.8)
 
                     if isExpress {
                         Image(systemName: "bolt.fill")


### PR DESCRIPTION
## Summary
Improved text rendering on the train card by adding a minimum scale factor to the destination text label, allowing it to shrink gracefully when space is constrained rather than being truncated.

## Key Changes
- Added `.minimumScaleFactor(0.8)` modifier to the destination text in `TrainCard`
- This allows the text to scale down to 80% of its original size while maintaining readability
- Works in conjunction with the existing `.lineLimit(1)` to prevent text wrapping

## Implementation Details
The change ensures that long destination names will scale down proportionally rather than being cut off with an ellipsis, providing better UX on devices with limited horizontal space while maintaining the single-line layout constraint.

https://claude.ai/code/session_01K6wWV2jxJViueSUifuYnks