### PR TITLE
Fix route segment filtering logic in RouteStatusView

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -323,7 +323,7 @@ final class RouteStatusViewModel: ObservableObject {
                 filteredSegments = response.aggregatedSegments
             } else {
                 filteredSegments = response.aggregatedSegments.filter { segment in
-                    routeStationCodes.contains(segment.fromStation.uppercased()) ||
+                    routeStationCodes.contains(segment.fromStation.uppercased()) &&
                     routeStationCodes.contains(segment.toStation.uppercased())
                 }
             }


### PR DESCRIPTION
## Summary
Fixed a logical operator in the route segment filtering logic that was causing incorrect filtering behavior.

## Key Changes
- Changed the OR operator (`||`) to AND operator (`&&`) in the segment filtering condition
- This ensures that both the `fromStation` and `toStation` must be present in `routeStationCodes` for a segment to be included in the filtered results

## Implementation Details
The filter now correctly requires that a segment's both origin and destination stations are in the route's station codes, rather than including segments where only one endpoint matches. This prevents segments with mismatched station pairs from being included in the filtered results.

https://claude.ai/code/session_01CKSBazVg6EJWK1BSJjPAct