### PR TITLE
Improve cancellation rate visualization with graduated color escalation

### DIFF
--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -325,13 +325,8 @@ struct CongestionMapKitView: UIViewRepresentable {
             for polyline in context.coordinator.polylines {
                 if let renderer = mapView.renderer(for: polyline) as? MKPolylineRenderer,
                    let segment = polyline.segment {
-                    if segment.cancellationRate > 0 {
-                        renderer.strokeColor = UIColor.darkGray
-                        renderer.lineWidth = 10
-                    } else {
-                        renderer.strokeColor = context.coordinator.colorForSegment(segment)
-                        renderer.lineWidth = context.coordinator.lineWidthForSegment(segment)
-                    }
+                    renderer.strokeColor = context.coordinator.colorForSegment(segment)
+                    renderer.lineWidth = context.coordinator.lineWidthForSegment(segment)
                     renderer.setNeedsDisplay()
                 }
             }
@@ -446,16 +441,22 @@ struct CongestionMapKitView: UIViewRepresentable {
 
         // MARK: - Public color/width helpers (used by updateUIView and rendererFor)
         func colorForSegment(_ segment: CongestionSegment) -> UIColor {
-            if segment.cancellationRate > 0 { return UIColor.darkGray }
             guard highlightMode != .off else { return UIColor.clear }
+            var color: UIColor
             switch segment.preferredHighlightMode {
-            case .health: return getFrequencyUIColor(for: segment.frequencyFactor)
-            case .delays, .off: return getUIColor(for: segment.congestionFactor)
+            case .health: color = getFrequencyUIColor(for: segment.frequencyFactor)
+            case .delays, .off: color = getUIColor(for: segment.congestionFactor)
             }
+            // Escalate color for significant cancellation rates
+            if segment.cancellationRate > 20 {
+                color = UIColor.systemRed
+            } else if segment.cancellationRate > 10 {
+                color = escalateColor(color)
+            }
+            return color
         }
 
         func lineWidthForSegment(_ segment: CongestionSegment) -> CGFloat {
-            if segment.cancellationRate > 0 { return 10 }
             guard highlightMode != .off else { return 0 }
             switch segment.preferredHighlightMode {
             case .health: return getFrequencyLineWidth(segment.frequencyFactor)
@@ -584,6 +585,13 @@ struct CongestionMapKitView: UIViewRepresentable {
             else if factor >= 0.7 { return 7 }
             else if factor >= 0.5 { return 8 }
             else { return 9 }
+        }
+
+        /// Escalate a health color by one level toward red for cancellation impact
+        private func escalateColor(_ color: UIColor) -> UIColor {
+            if color == UIColor.systemGreen { return UIColor.systemYellow }
+            if color == UIColor.systemYellow { return UIColor.systemOrange }
+            return UIColor.systemRed
         }
 
         private func createStationPinView(for station: JourneyStation) -> UIView {

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -1007,13 +1007,14 @@ struct SystemCongestionMapView: UIViewRepresentable {
             for (_, overlay) in context.coordinator.aggregatedOverlayMap {
                 if let renderer = mapView.renderer(for: overlay) as? MKPolylineRenderer,
                    let segment = overlay.segment {
-                    if segment.cancellationRate > 0 {
-                        // Keep cancelled segments red with dashes
-                        renderer.strokeColor = UIColor.systemRed
-                    } else {
-                        renderer.strokeColor = context.coordinator.getColorForSegmentPublic(segment)
-                        renderer.lineWidth = context.coordinator.getSegmentLineWidthPublic(segment)
+                    var color = context.coordinator.getColorForSegmentPublic(segment)
+                    if segment.cancellationRate > 20 {
+                        color = UIColor.systemRed
+                    } else if segment.cancellationRate > 10 {
+                        color = context.coordinator.escalateColorPublic(color)
                     }
+                    renderer.strokeColor = color
+                    renderer.lineWidth = context.coordinator.getSegmentLineWidthPublic(segment)
                 }
             }
             // Update individual segment colors
@@ -1249,18 +1250,22 @@ struct SystemCongestionMapView: UIViewRepresentable {
                 let renderer = MKPolylineRenderer(polyline: polyline)
 
                 if let segment = polyline.segment {
-                    // Check if this segment has cancellations
-                    if segment.cancellationRate > 0 {
-                        renderer.strokeColor = UIColor.systemRed
-                        renderer.lineWidth = 10
-                    } else {
-                        // Use highlight mode to determine color
-                        renderer.strokeColor = getColorForSegment(segment)
-                        renderer.lineWidth = getSegmentLineWidth(segment)
-                        // Add dashed pattern for other types of cancellations
-                        if let dashPattern = segment.dashPattern {
-                            renderer.lineDashPattern = dashPattern
-                        }
+                    // Base color from delay/frequency metrics
+                    var color = getColorForSegment(segment)
+
+                    // Escalate color for significant cancellation rates
+                    if segment.cancellationRate > 20 {
+                        color = UIColor.systemRed
+                    } else if segment.cancellationRate > 10 {
+                        color = escalateColor(color)
+                    }
+
+                    renderer.strokeColor = color
+                    renderer.lineWidth = getSegmentLineWidth(segment)
+
+                    // Dash pattern indicates cancellation severity (>5%)
+                    if let dashPattern = segment.dashPattern {
+                        renderer.lineDashPattern = dashPattern
                     }
                     renderer.alpha = polyline.isDimmed ? 0.3 : 0.8 // Dim when showing individual segments
                 } else {
@@ -1412,6 +1417,18 @@ struct SystemCongestionMapView: UIViewRepresentable {
         /// Public accessor for getSegmentLineWidth (used by updateUIView for mode changes)
         func getSegmentLineWidthPublic(_ segment: CongestionSegment) -> CGFloat {
             getSegmentLineWidth(segment)
+        }
+
+        /// Escalate a health color by one level toward red for cancellation impact
+        private func escalateColor(_ color: UIColor) -> UIColor {
+            if color == UIColor.systemGreen { return UIColor.systemYellow }
+            if color == UIColor.systemYellow { return UIColor.systemOrange }
+            return UIColor.systemRed // orange/red stay red
+        }
+
+        /// Public accessor for escalateColor (used by updateUIView for mode changes)
+        func escalateColorPublic(_ color: UIColor) -> UIColor {
+            escalateColor(color)
         }
 
         private func getRecencyBasedAlpha(for departureTime: Date) -> CGFloat {


### PR DESCRIPTION
## Summary
Enhanced the cancellation rate visualization on congestion maps by implementing a graduated color escalation system instead of binary red/gray coloring. Segments now display colors that progressively shift toward red based on cancellation severity thresholds.

## Key Changes
- **Graduated cancellation thresholds**: Replaced binary cancellation detection (>0%) with two-tier thresholds:
  - Cancellation rate >20%: Display as red
  - Cancellation rate >10%: Escalate base color one level toward red
  - Cancellation rate ≤10%: Use standard congestion-based coloring

- **New color escalation utility**: Added `escalateColor()` method that progressively shifts colors:
  - Green → Yellow
  - Yellow → Orange
  - Orange/Red → Red

- **Unified rendering logic**: Applied consistent cancellation visualization across both `SystemCongestionMapView` and `JourneyCongestionMapView`

- **Simplified color assignment**: Removed special-case handling for cancellations in color/width determination, consolidating logic into a single color calculation path with post-processing for cancellation impact

## Implementation Details
- The escalation system preserves the base congestion color information while adding cancellation severity as an overlay
- Dash patterns continue to indicate cancellation presence (>5%) independently of color
- Line width is now determined solely by congestion metrics, not cancellation rate
- Both map views now use the same escalation logic for consistency

https://claude.ai/code/session_019fqruNxiBUaduASRhSopb6