### PR TITLE
Add fallback coloring for map segments without frequency data

### DIFF
--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -449,7 +449,12 @@ struct CongestionMapKitView: UIViewRepresentable {
             if segment.cancellationRate > 0 { return UIColor.darkGray }
             guard highlightMode != .off else { return UIColor.clear }
             switch segment.preferredHighlightMode {
-            case .health: return getFrequencyUIColor(for: segment.frequencyFactor)
+            case .health:
+                // Fall back to delay coloring when no frequency baseline exists yet
+                if let _ = segment.frequencyFactor {
+                    return getFrequencyUIColor(for: segment.frequencyFactor)
+                }
+                return getUIColor(for: segment.congestionFactor)
             case .delays, .off: return getUIColor(for: segment.congestionFactor)
             }
         }
@@ -458,7 +463,15 @@ struct CongestionMapKitView: UIViewRepresentable {
             if segment.cancellationRate > 0 { return 10 }
             guard highlightMode != .off else { return 0 }
             switch segment.preferredHighlightMode {
-            case .health: return getFrequencyLineWidth(segment.frequencyFactor)
+            case .health:
+                // Fall back to delay-based width when no frequency baseline exists yet
+                guard let factor = segment.frequencyFactor else {
+                    return getCongestionLineWidth(segment.congestionFactor)
+                }
+                if factor >= 0.9 { return 5 }
+                else if factor >= 0.7 { return 7 }
+                else if factor >= 0.5 { return 8 }
+                else { return 9 }
             case .delays, .off: return getCongestionLineWidth(segment.congestionFactor)
             }
         }
@@ -576,14 +589,6 @@ struct CongestionMapKitView: UIViewRepresentable {
             else if factor >= 0.7 { return UIColor.systemYellow }
             else if factor >= 0.5 { return UIColor.systemOrange }
             else { return UIColor.systemRed }
-        }
-
-        private func getFrequencyLineWidth(_ frequencyFactor: Double?) -> CGFloat {
-            guard let factor = frequencyFactor else { return 5 }
-            if factor >= 0.9 { return 5 }
-            else if factor >= 0.7 { return 7 }
-            else if factor >= 0.5 { return 8 }
-            else { return 9 }
         }
 
         private func createStationPinView(for station: JourneyStation) -> UIView {

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -1370,7 +1370,11 @@ struct SystemCongestionMapView: UIViewRepresentable {
             guard highlightMode != .off else { return UIColor.clear }
             switch segment.preferredHighlightMode {
             case .health:
-                return getFrequencyUIColor(for: segment.frequencyFactor)
+                // Fall back to delay coloring when no frequency baseline exists yet
+                if let _ = segment.frequencyFactor {
+                    return getFrequencyUIColor(for: segment.frequencyFactor)
+                }
+                return getUIColor(for: segment.congestionFactor)
             case .delays, .off:
                 return getUIColor(for: segment.congestionFactor)
             }
@@ -1399,7 +1403,10 @@ struct SystemCongestionMapView: UIViewRepresentable {
             switch segment.preferredHighlightMode {
             case .health:
                 // Use frequency factor for line width (thicker = worse service)
-                guard let factor = segment.frequencyFactor else { return 5 }
+                // Fall back to delay-based width when no frequency baseline exists yet
+                guard let factor = segment.frequencyFactor else {
+                    return getCongestionLineWidth(segment.congestionFactor)
+                }
                 if factor >= 0.9 { return 5 }
                 else if factor >= 0.7 { return 7 }
                 else if factor >= 0.5 { return 8 }


### PR DESCRIPTION
## Summary
This PR adds fallback logic to handle map segments that don't yet have frequency baseline data. When frequency data is unavailable, segments now fall back to congestion-based coloring and line width calculations instead of failing to display properly.

## Key Changes
- **JourneyCongestionMapView.swift**:
  - Added null check in `.health` highlight mode color calculation to fall back to congestion-based coloring when `frequencyFactor` is nil
  - Inlined frequency-based line width logic directly into the `.health` case with fallback to congestion-based width when frequency data is unavailable
  - Removed the now-unused `getFrequencyLineWidth()` helper method

- **CongestionMapView.swift**:
  - Added null check in `.health` highlight mode color calculation to fall back to congestion-based coloring when `frequencyFactor` is nil
  - Updated line width calculation for `.health` mode to use congestion-based width as fallback when frequency data is unavailable

## Implementation Details
The changes ensure graceful degradation: segments without frequency baseline data will display using the existing congestion-based visualization (color and line width) rather than showing incomplete or missing data. This maintains visual consistency across the map while frequency baselines are being established.

https://claude.ai/code/session_01W5ihtG3Sd9Zw8KVpE6L77Q