### PR TITLE
Fix SQLAlchemy greenlet context issues in async schedulers

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/schedule.py
+++ b/backend_v2/src/trackrat/collectors/njt/schedule.py
@@ -175,13 +175,17 @@ class NJTScheduleCollector:
                         datetime.combine(journey_date, datetime.min.time())
                     )
 
-                    result = await self._process_schedule_item(
-                        session,
-                        item,
-                        station_code,
-                        station_name or "",
-                        journey_start_time,
-                    )
+                    # Use savepoint so a single item failure (e.g. unique
+                    # constraint violation) doesn't poison the session for
+                    # all subsequent items in this batch.
+                    async with session.begin_nested():
+                        result = await self._process_schedule_item(
+                            session,
+                            item,
+                            station_code,
+                            station_name or "",
+                            journey_start_time,
+                        )
 
                     if result == "new":
                         stats["new_schedules"] += 1
@@ -410,8 +414,12 @@ class NJTScheduleCollector:
                 # Fetch the train stop list
                 train_data = await self.client.get_train_stop_list(journey.train_id)
 
-                # Process and store the stops
-                await self._update_journey_with_stops(session, journey, train_data)
+                # Use savepoint so a single train failure doesn't poison the
+                # session for all subsequent trains in this batch.
+                async with session.begin_nested():
+                    await self._update_journey_with_stops(
+                        session, journey, train_data
+                    )
 
                 stats["stop_collections_successful"] += 1
 

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2447,21 +2447,28 @@ class SchedulerService:
                 # Import here to avoid circular imports
                 from trackrat.services.api_cache import ApiCacheService
 
-                # Use async database session for the cache service
-                async with get_session() as session:
-                    cache_service = ApiCacheService()
+                # Wrap in create_task to ensure fresh greenlet context.
+                # APScheduler's AsyncIOExecutor doesn't reliably initialize
+                # SQLAlchemy's greenlet bridge (same pattern as departure cache).
+                async def _inner() -> None:
+                    async with get_session() as session:
+                        cache_service = ApiCacheService()
 
-                    # Pre-compute congestion responses
-                    await cache_service.precompute_congestion_responses(session)
+                        # Pre-compute congestion responses
+                        await cache_service.precompute_congestion_responses(session)
 
-                    # Clean up expired cache entries while we're here
-                    deleted_count = await cache_service.cleanup_expired_cache(session)
-
-                    if deleted_count > 0:
-                        logger.info(
-                            "cleaned_up_expired_api_cache_entries",
-                            deleted_count=deleted_count,
+                        # Clean up expired cache entries while we're here
+                        deleted_count = await cache_service.cleanup_expired_cache(
+                            session
                         )
+
+                        if deleted_count > 0:
+                            logger.info(
+                                "cleaned_up_expired_api_cache_entries",
+                                deleted_count=deleted_count,
+                            )
+
+                await asyncio.create_task(_inner())
 
                 logger.info("congestion_cache_precomputation_completed")
             finally:


### PR DESCRIPTION
## Summary
This PR fixes SQLAlchemy greenlet bridge initialization issues in async scheduler tasks by ensuring proper context setup and adds transaction isolation for batch processing operations.

## Key Changes

- **Scheduler cache precomputation**: Wrapped the congestion cache precomputation logic in `asyncio.create_task()` to ensure a fresh greenlet context is initialized. APScheduler's AsyncIOExecutor doesn't reliably set up SQLAlchemy's greenlet bridge, which can cause runtime errors when accessing the database.

- **NJT schedule processing**: Added savepoint transactions (`session.begin_nested()`) around individual schedule item processing to isolate failures. This prevents a single item failure (e.g., unique constraint violation) from poisoning the session for all subsequent items in the batch.

- **NJT stop list collection**: Added savepoint transactions around train stop list updates to isolate failures per train, preventing a single train's processing failure from affecting the entire batch.

## Implementation Details

The greenlet context fix follows the same pattern already used elsewhere in the codebase for departure cache processing. By wrapping the async work in `asyncio.create_task()`, we ensure SQLAlchemy's greenlet bridge is properly initialized before any database operations occur.

The savepoint additions use SQLAlchemy's `session.begin_nested()` context manager, which provides transaction isolation at the item/train level while maintaining the outer transaction for batch-level operations. This allows the batch to continue processing even if individual items fail.

https://claude.ai/code/session_01Lg99qc5JQGHdDx6AuLSkaY