### PR TITLE
Add custom encode method to RouteAlertSubscription

### DIFF
--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -268,4 +268,27 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
         digestTimeMinutes = try container.decodeIfPresent(Int.self, forKey: .digestTimeMinutes)
         includePlannedWork = try container.decodeIfPresent(Bool.self, forKey: .includePlannedWork) ?? false
     }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(dataSource, forKey: .dataSource)
+        try container.encodeIfPresent(lineId, forKey: .lineId)
+        try container.encodeIfPresent(lineName, forKey: .lineName)
+        try container.encodeIfPresent(fromStationCode, forKey: .fromStationCode)
+        try container.encodeIfPresent(toStationCode, forKey: .toStationCode)
+        try container.encodeIfPresent(trainId, forKey: .trainId)
+        try container.encodeIfPresent(trainName, forKey: .trainName)
+        try container.encodeIfPresent(direction, forKey: .direction)
+        try container.encode(activeDays, forKey: .activeDays)
+        try container.encodeIfPresent(activeStartMinutes, forKey: .activeStartMinutes)
+        try container.encodeIfPresent(activeEndMinutes, forKey: .activeEndMinutes)
+        try container.encodeIfPresent(timezone, forKey: .timezone)
+        try container.encodeIfPresent(delayThresholdMinutes, forKey: .delayThresholdMinutes)
+        try container.encodeIfPresent(serviceThresholdPct, forKey: .serviceThresholdPct)
+        try container.encode(notifyRecovery, forKey: .notifyRecovery)
+        try container.encodeIfPresent(digestTimeMinutes, forKey: .digestTimeMinutes)
+        try container.encode(includePlannedWork, forKey: .includePlannedWork)
+        // weekdaysOnly intentionally not encoded — legacy decode-only key
+    }
 }

--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -169,7 +169,7 @@ struct EditRouteAlertsView: View {
             AlertCustomizationSheet(subscription: sub) { updated in
                 alertService.updateSubscription(updated)
             }
-            .presentationDetents([.medium, .large])
+            .presentationDetents([PresentationDetent.medium, .large])
             .presentationDragIndicator(.visible)
         }
     }


### PR DESCRIPTION
## Summary
This PR adds explicit encoding support to the `RouteAlertSubscription` struct and fixes a minor type annotation in the presentation detents configuration.

## Key Changes
- **Added custom `encode(to:)` method** to `RouteAlertSubscription`: Implements explicit Codable encoding that mirrors the existing `decode(from:)` method, ensuring all properties are properly serialized. Notably, the `weekdaysOnly` property is intentionally excluded from encoding as it's marked as a legacy decode-only key.
- **Fixed type annotation** in `EditRouteAlertsView`: Changed `.presentationDetents([.medium, .large])` to `.presentationDetents([PresentationDetent.medium, .large])` to improve type clarity and consistency.

## Implementation Details
The custom encode method handles both required and optional properties appropriately:
- Required fields (`id`, `dataSource`, `activeDays`, `notifyRecovery`, `includePlannedWork`) use `encode(_:forKey:)`
- Optional fields use `encodeIfPresent(_:forKey:)` to avoid encoding nil values
- The `weekdaysOnly` property is intentionally omitted from encoding to maintain backward compatibility with legacy data

https://claude.ai/code/session_018whmGboJ7H8kuVCDDZofXY