### PR TITLE
Fix 11 issues from code review

### DIFF
--- a/backend_v2/src/trackrat/api/admin.py
+++ b/backend_v2/src/trackrat/api/admin.py
@@ -195,9 +195,10 @@ def _render_html(
 
     # -- Popular route searches --
     route_rows = ""
-    for (from_code, to_code), count in request_stats["route_searches"].items():
-        from_name = get_station_name(from_code)
-        to_name = get_station_name(to_code)
+    for entry in request_stats["route_searches"]:
+        from_name = get_station_name(entry["from"])
+        to_name = get_station_name(entry["to"])
+        count = entry["count"]
         route_rows += (
             f"<tr><td>{_esc(from_name)}</td>"
             f"<td>{_esc(to_name)}</td>"
@@ -350,12 +351,10 @@ async def stats_json(
     request_data = get_request_stats().snapshot()
     db_data = await _db_stats(db)
 
-    # Convert tuple keys to strings for JSON serialization
+    # Convert list-of-dicts to string-keyed dict for JSON consumers
     route_searches = {
-        f"{from_code} -> {to_code}": count
-        for (from_code, to_code), count in get_request_stats()
-        .snapshot()["route_searches"]
-        .items()
+        f"{entry['from']} -> {entry['to']}": entry["count"]
+        for entry in request_data["route_searches"]
     }
     request_data["route_searches"] = route_searches
 

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -1753,13 +1753,6 @@ class JourneyCollector(BaseJourneyCollector):
                 if last_stop_db.actual_arrival is None:
                     last_stop_db.actual_arrival = arrival_time
 
-                # Propagate to the terminal stop record — the stop-update loop
-                # skips actual_arrival for time_inference stops, but at completion
-                # the API TIME field is real data. Without this, the OTP query
-                # (which reads journey_stops.actual_arrival) excludes these trains.
-                if last_stop_db.actual_arrival is None:
-                    last_stop_db.actual_arrival = journey.actual_arrival
-
             logger.info(
                 "journey_completed",
                 train_id=journey.train_id,

--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -149,6 +149,7 @@ async def evaluate_route_alerts(
                 )
                 if sent:
                     alerts_sent += 1
+                    state_changed = True
                 continue
 
             # Build query for relevant journeys (line / station-pair modes)

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -76,6 +76,29 @@ class SchedulerService:
         self.njt_client: NJTransitClient | None = None
         self.jit_service: JustInTimeUpdateService | None = None
         self._running_tasks: dict[str, asyncio.Task[Any]] = {}
+        self._sync_engine: Any = None  # Lazily created sync engine for NJT
+
+    def _get_sync_engine(self) -> Any:
+        """Get or create a cached synchronous database engine."""
+        if self._sync_engine is None:
+            from sqlalchemy import create_engine
+
+            db_url = str(self.settings.database_url).replace(
+                "postgresql+asyncpg", "postgresql"
+            )
+            self._sync_engine = create_engine(db_url, pool_pre_ping=True)
+        return self._sync_engine
+
+    @staticmethod
+    def _log_task_exception(task: asyncio.Task[Any]) -> None:
+        """Log unhandled exceptions from fire-and-forget tasks."""
+        if not task.cancelled() and task.exception() is not None:
+            logger.error(
+                "background_task_failed",
+                task_name=task.get_name(),
+                error=str(task.exception()),
+                error_type=type(task.exception()).__name__,
+            )
 
     async def start(self) -> None:
         """Start the scheduler and configure jobs."""
@@ -318,10 +341,14 @@ class SchedulerService:
         self.scheduler.start()
 
         # Run initial collections staggered to avoid startup CPU spike
-        asyncio.create_task(self._run_startup_collectors())
+        asyncio.create_task(self._run_startup_collectors()).add_done_callback(
+            self._log_task_exception
+        )
 
         # Check and initialize GTFS feeds on startup (downloads if missing)
-        asyncio.create_task(self.check_and_initialize_gtfs_feeds())
+        asyncio.create_task(self.check_and_initialize_gtfs_feeds()).add_done_callback(
+            self._log_task_exception
+        )
 
         logger.info(
             "scheduler_started", jobs=[job.id for job in self.scheduler.get_jobs()]
@@ -358,6 +385,11 @@ class SchedulerService:
         # Close NJ Transit client
         if self.njt_client:
             await self.njt_client.close()
+
+        # Dispose cached sync engine
+        if self._sync_engine is not None:
+            self._sync_engine.dispose()
+            self._sync_engine = None
 
         logger.info("scheduler_stopped")
 
@@ -1532,10 +1564,9 @@ class SchedulerService:
         Returns:
             Dict with journey info if successful, None if failed
         """
-        sync_engine = None
         try:
             # Use synchronous database operations entirely to avoid greenlet issues
-            from sqlalchemy import and_, create_engine, delete, select
+            from sqlalchemy import and_, delete, select
             from sqlalchemy.orm import selectinload, sessionmaker
 
             from trackrat.collectors.njt.client import (
@@ -1549,15 +1580,7 @@ class SchedulerService:
             if journey_date is None:
                 journey_date = now_et().date()
 
-            # Create synchronous database connection
-            db_url = str(self.settings.database_url).replace(
-                "postgresql+asyncpg", "postgresql"
-            )
-            sync_engine = create_engine(
-                db_url,
-                # PostgreSQL doesn't need special connect_args for basic operations
-            )
-            SyncSession = sessionmaker(sync_engine)
+            SyncSession = sessionmaker(self._get_sync_engine())
 
             with SyncSession() as session:
                 # Find the journey for this train on the specific date (eager load stops)
@@ -1820,19 +1843,23 @@ class SchedulerService:
                     return None
 
         except Exception as e:
-            # Check if it's a database locking issue
-            if "database is locked" in str(e) or "database is busy" in str(e):
+            error_msg = str(e).lower()
+            is_transient = (
+                "serialization failure" in error_msg
+                or "deadlock detected" in error_msg
+                or "could not serialize access" in error_msg
+            )
+            if is_transient:
                 logger.warning(
-                    "safe_journey_collection_database_locked",
+                    "safe_journey_collection_transient_error",
                     train_id=train_id,
                     error=str(e),
                     error_type=type(e).__name__,
                 )
-                # Return a special result indicating we should retry
                 return {
                     "train_id": train_id,
                     "success": False,
-                    "error": "Database locked",
+                    "error": "Transient DB error",
                     "retry_needed": True,
                 }
             else:
@@ -1843,10 +1870,6 @@ class SchedulerService:
                     error_type=type(e).__name__,
                 )
                 return None
-        finally:
-            # Always dispose the sync engine to prevent connection leaks
-            if sync_engine is not None:
-                sync_engine.dispose()
 
     async def collect_njt_journeys_batch(
         self, train_ids: list[str], journey_date: date | None = None
@@ -2291,17 +2314,10 @@ class SchedulerService:
                 logger.info("starting_live_activity_token_cleanup")
 
                 # Use sync database access for consistency with other scheduler methods
-                from sqlalchemy import create_engine, update
+                from sqlalchemy import update
                 from sqlalchemy.orm import sessionmaker
 
-                db_url = str(self.settings.database_url).replace(
-                    "postgresql+asyncpg", "postgresql"
-                )
-                sync_engine = create_engine(
-                    db_url,
-                    # PostgreSQL doesn't need special connect_args for basic operations
-                )
-                SyncSession = sessionmaker(sync_engine)
+                SyncSession = sessionmaker(self._get_sync_engine())
 
                 with SyncSession() as session:
                     # Find expired tokens that are still active
@@ -2330,9 +2346,6 @@ class SchedulerService:
                         tokens_cleaned=cleaned_count,
                         cutoff_time=current_time.isoformat(),
                     )
-
-                # Close sync engine when done
-                sync_engine.dispose()
 
             except Exception as e:
                 logger.error(
@@ -2603,19 +2616,11 @@ class SchedulerService:
                 if task:
                     self._running_tasks[task_id] = task
 
-                from sqlalchemy import and_, create_engine, select
+                from sqlalchemy import and_, select
                 from sqlalchemy.orm import selectinload, sessionmaker
 
                 # Use synchronous database access to avoid greenlet issues in scheduler context
-                # This is a workaround for APScheduler's async executor not properly initializing greenlets
-                db_url = str(self.settings.database_url).replace(
-                    "postgresql+asyncpg", "postgresql"
-                )
-                sync_engine = create_engine(
-                    db_url,
-                    # PostgreSQL doesn't need special connect_args for basic operations
-                )
-                SyncSession = sessionmaker(sync_engine)
+                SyncSession = sessionmaker(self._get_sync_engine())
 
                 with SyncSession() as session:
                     # Get active tokens that haven't expired
@@ -2834,9 +2839,6 @@ class SchedulerService:
                         "live_activity_updates_completed",
                         trains_updated=len(trains_to_update),
                     )
-
-                # Close sync engine when done
-                sync_engine.dispose()
 
             except Exception as e:
                 # Add more context for debugging

--- a/backend_v2/src/trackrat/utils/request_stats.py
+++ b/backend_v2/src/trackrat/utils/request_stats.py
@@ -5,6 +5,7 @@ Provides lightweight middleware-compatible tracking of inbound HTTP requests,
 route searches, and client activity. All data resets on server restart.
 """
 
+import random
 import re
 import threading
 import time
@@ -27,8 +28,9 @@ class RequestStats:
     requests_by_client: Counter[str] = field(default_factory=Counter)
     route_searches: Counter[tuple[str, str]] = field(default_factory=Counter)
 
-    # Latency tracking: path_template -> list of durations (capped)
+    # Latency tracking: path_template -> list of durations (reservoir sampling)
     _latencies: dict[str, list[float]] = field(default_factory=dict)
+    _latency_counts: dict[str, int] = field(default_factory=dict)
     _MAX_LATENCY_SAMPLES: int = 500
 
     def record_request(
@@ -49,10 +51,17 @@ class RequestStats:
             self.requests_by_status[status_code] += 1
             self.requests_by_client[client] += 1
 
-            # Latency
+            # Latency — reservoir sampling to keep stats representative
             samples = self._latencies.setdefault(path_template, [])
+            count = self._latency_counts.get(path_template, 0) + 1
+            self._latency_counts[path_template] = count
             if len(samples) < self._MAX_LATENCY_SAMPLES:
                 samples.append(duration)
+            else:
+                # Replace a random sample with decreasing probability
+                idx = random.randint(0, count - 1)
+                if idx < self._MAX_LATENCY_SAMPLES:
+                    samples[idx] = duration
 
             # Track route searches from departures endpoint
             if query_params and path_template == "/api/v2/trains/departures":
@@ -82,7 +91,10 @@ class RequestStats:
                 "requests_by_path": dict(self.requests_by_path.most_common()),
                 "requests_by_status": dict(self.requests_by_status.most_common()),
                 "requests_by_client": dict(self.requests_by_client.most_common()),
-                "route_searches": dict(self.route_searches.most_common(20)),
+                "route_searches": [
+                    {"from": k[0], "to": k[1], "count": v}
+                    for k, v in self.route_searches.most_common(20)
+                ],
                 "latency": latency_stats,
             }
 

--- a/backend_v2/src/trackrat/utils/scheduler_utils.py
+++ b/backend_v2/src/trackrat/utils/scheduler_utils.py
@@ -27,11 +27,10 @@ def commit_with_retry(
     log_context: dict[str, Any] | None = None,
 ) -> None:
     """
-    Commit a synchronous database session with retry logic for SQLite locks.
+    Commit a synchronous database session.
 
-    SQLite can raise "database is locked" errors when multiple processes
-    access the database simultaneously. This function retries with exponential
-    backoff to handle transient lock contention.
+    Simple wrapper that commits, retrying on transient PostgreSQL errors
+    (e.g., serialization failures).
 
     Args:
         session: Synchronous SQLAlchemy session to commit
@@ -48,12 +47,15 @@ def commit_with_retry(
             session.commit()
             return
         except Exception as e:
-            is_lock_error = "database is locked" in str(e) or "database is busy" in str(
-                e
+            error_msg = str(e).lower()
+            is_transient = (
+                "serialization failure" in error_msg
+                or "deadlock detected" in error_msg
+                or "could not serialize access" in error_msg
             )
-            if is_lock_error and retry < max_retries - 1:
+            if is_transient and retry < max_retries - 1:
                 logger.warning(
-                    "database_locked_retrying",
+                    "database_transient_error_retrying",
                     retry=retry + 1,
                     error=str(e),
                     **context,

--- a/backend_v2/tests/unit/test_production_health_fixes.py
+++ b/backend_v2/tests/unit/test_production_health_fixes.py
@@ -491,11 +491,11 @@ class TestLiveActivitySessionScope:
             mock_db = AsyncMock()
             mock_get_session.return_value.__aenter__.return_value = mock_db
 
-            with patch("sqlalchemy.create_engine") as mock_create_engine:
+            with patch.object(
+                scheduler_service, "_get_sync_engine", return_value=Mock()
+            ):
                 with patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker:
                     mock_sync_session = Mock()
-                    mock_sync_engine = Mock()
-                    mock_create_engine.return_value = mock_sync_engine
                     mock_sessionmaker.return_value = Mock(
                         return_value=mock_sync_session
                     )
@@ -540,11 +540,11 @@ class TestLiveActivitySessionScope:
             mock_db = AsyncMock()
             mock_get_session.return_value.__aenter__.return_value = mock_db
 
-            with patch("sqlalchemy.create_engine") as mock_create_engine:
+            with patch.object(
+                scheduler_service, "_get_sync_engine", return_value=Mock()
+            ):
                 with patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker:
                     mock_sync_session = Mock()
-                    mock_sync_engine = Mock()
-                    mock_create_engine.return_value = mock_sync_engine
                     mock_sessionmaker.return_value = Mock(
                         return_value=mock_sync_session
                     )
@@ -621,11 +621,11 @@ class TestLiveActivitySessionScope:
             mock_db = AsyncMock()
             mock_get_session.return_value.__aenter__.return_value = mock_db
 
-            with patch("sqlalchemy.create_engine") as mock_create_engine:
+            with patch.object(
+                scheduler_service, "_get_sync_engine", return_value=Mock()
+            ):
                 with patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker:
                     mock_sync_session = Mock()
-                    mock_sync_engine = Mock()
-                    mock_create_engine.return_value = mock_sync_engine
                     mock_sessionmaker.return_value = Mock(
                         return_value=mock_sync_session
                     )
@@ -687,27 +687,26 @@ class TestLiveActivitySessionScope:
                     mock_sync_session.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_engine_disposed_after_session_closes(self, scheduler_service):
-        """sync_engine.dispose() should be called after the session context
-        manager exits, to clean up the connection pool.
+    async def test_cached_engine_reused_across_calls(self, scheduler_service):
+        """Sync engine is cached on the scheduler and reused, not created per call.
 
-        Note: dispose() is called after the `with SyncSession()` block ends.
-        When there are active tokens, the full code path runs and dispose()
-        is called. With no tokens, early return skips dispose().
+        The engine is disposed once in stop(), not after each method invocation.
         """
         mock_apns = AsyncMock()
         mock_apns.send_live_activity_update = AsyncMock(return_value=True)
         scheduler_service.apns_service = mock_apns
 
+        mock_sync_engine = Mock()
+
         with patch("trackrat.services.scheduler.get_session") as mock_get_session:
             mock_db = AsyncMock()
             mock_get_session.return_value.__aenter__.return_value = mock_db
 
-            with patch("sqlalchemy.create_engine") as mock_create_engine:
+            with patch.object(
+                scheduler_service, "_get_sync_engine", return_value=mock_sync_engine
+            ):
                 with patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker:
                     mock_sync_session = Mock()
-                    mock_sync_engine = Mock()
-                    mock_create_engine.return_value = mock_sync_engine
                     mock_sessionmaker.return_value = Mock(
                         return_value=mock_sync_session
                     )
@@ -759,5 +758,5 @@ class TestLiveActivitySessionScope:
 
                             await scheduler_service.update_live_activities()
 
-                    # Engine should be disposed after use
-                    mock_sync_engine.dispose.assert_called_once()
+                    # Engine is NOT disposed per-call (cached); dispose happens in stop()
+                    mock_sync_engine.dispose.assert_not_called()

--- a/backend_v2/tests/unit/test_request_stats.py
+++ b/backend_v2/tests/unit/test_request_stats.py
@@ -164,8 +164,9 @@ class TestRequestStats:
         )
 
         snap = stats.snapshot()
-        assert snap["route_searches"][("NY", "TR")] == 2
-        assert snap["route_searches"][("NP", "NY")] == 1
+        searches = {(e["from"], e["to"]): e["count"] for e in snap["route_searches"]}
+        assert searches[("NY", "TR")] == 2
+        assert searches[("NP", "NY")] == 1
 
     def test_route_search_not_tracked_for_other_endpoints(self):
         """Only /departures endpoint triggers route search tracking."""

--- a/ios/TrackRat/Utilities/Extensions.swift
+++ b/ios/TrackRat/Utilities/Extensions.swift
@@ -333,3 +333,25 @@ extension Stations {
         return getStationCode(normalizedStopName) == stationCode
     }
 }
+
+// MARK: - Congestion Map Color Helpers
+
+/// Shared color helpers used by CongestionMapView and JourneyCongestionMapView.
+enum CongestionColors {
+    /// Color for delay-based congestion factor (higher = more delayed).
+    static func color(forCongestionFactor factor: Double) -> UIColor {
+        if factor < 1.05 { return .systemGreen }
+        else if factor < 1.25 { return .systemYellow }
+        else if factor < 2.0 { return .systemOrange }
+        else { return .systemRed }
+    }
+
+    /// Color for frequency factor (higher = healthier service).
+    static func color(forFrequencyFactor factor: Double?) -> UIColor {
+        guard let factor else { return .systemGray }
+        if factor >= 0.9 { return .systemGreen }
+        else if factor >= 0.7 { return .systemYellow }
+        else if factor >= 0.5 { return .systemOrange }
+        else { return .systemRed }
+    }
+}

--- a/ios/TrackRat/Views/Components/AlertCustomizationSheet.swift
+++ b/ios/TrackRat/Views/Components/AlertCustomizationSheet.swift
@@ -38,8 +38,9 @@ struct AlertCustomizationSheet: View {
                         onSave(sub)
                         dismiss()
                     }
-                    .foregroundColor(.orange)
+                    .foregroundColor(sub.activeDays == 0 ? .gray : .orange)
                     .fontWeight(.semibold)
+                    .disabled(sub.activeDays == 0)
                 }
             }
         }
@@ -90,7 +91,10 @@ struct AlertCustomizationSheet: View {
                 let isOn = sub.activeDays & bit != 0
                 Button {
                     if isOn {
-                        sub.activeDays &= ~bit
+                        // Don't allow deselecting the last active day
+                        if sub.activeDays & ~bit != 0 {
+                            sub.activeDays &= ~bit
+                        }
                     } else {
                         sub.activeDays |= bit
                     }
@@ -144,7 +148,7 @@ struct AlertCustomizationSheet: View {
             Text("Time Window")
         } footer: {
             if sub.activeStartMinutes != nil {
-                Text("Alerts only sent during this window. Uses your device timezone.")
+                Text("Alerts only sent during this window. Overnight ranges (e.g. 10pm–6am) are supported.")
             }
         }
     }

--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -574,23 +574,11 @@ struct CongestionMapKitView: UIViewRepresentable {
         }
 
         private func getUIColor(for congestionFactor: Double) -> UIColor {
-            if congestionFactor < 1.05 {
-                return UIColor.systemGreen
-            } else if congestionFactor < 1.25 {
-                return UIColor.systemYellow
-            } else if congestionFactor < 2.0 {
-                return UIColor.systemOrange
-            } else {
-                return UIColor.systemRed
-            }
+            CongestionColors.color(forCongestionFactor: congestionFactor)
         }
 
         private func getFrequencyUIColor(for frequencyFactor: Double?) -> UIColor {
-            guard let factor = frequencyFactor else { return UIColor.systemGray }
-            if factor >= 0.9 { return UIColor.systemGreen }
-            else if factor >= 0.7 { return UIColor.systemYellow }
-            else if factor >= 0.5 { return UIColor.systemOrange }
-            else { return UIColor.systemRed }
+            CongestionColors.color(forFrequencyFactor: frequencyFactor)
         }
 
         private func getFrequencyLineWidth(_ frequencyFactor: Double?) -> CGFloat {

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -1343,31 +1343,11 @@ struct SystemCongestionMapView: UIViewRepresentable {
         }
         
         private func getUIColor(for congestionFactor: Double) -> UIColor {
-            if congestionFactor < 1.05 {
-                return UIColor.systemGreen
-            } else if congestionFactor < 1.25 {
-                return UIColor.systemYellow
-            } else if congestionFactor < 2.0 {
-                return UIColor.systemOrange
-            } else {
-                return UIColor.systemRed
-            }
+            CongestionColors.color(forCongestionFactor: congestionFactor)
         }
 
-        /// Get color for frequency factor (higher is better)
         private func getFrequencyUIColor(for frequencyFactor: Double?) -> UIColor {
-            guard let factor = frequencyFactor else {
-                return UIColor.systemGray  // No frequency data available
-            }
-            if factor >= 0.9 {
-                return UIColor.systemGreen   // Healthy: ≥90% of baseline
-            } else if factor >= 0.7 {
-                return UIColor.systemYellow  // Moderate: 70-90%
-            } else if factor >= 0.5 {
-                return UIColor.systemOrange  // Reduced: 50-70%
-            } else {
-                return UIColor.systemRed     // Severe: <50%
-            }
+            CongestionColors.color(forFrequencyFactor: frequencyFactor)
         }
 
         /// Get color for aggregated segment based on its data source's preferred mode

--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -168,6 +168,7 @@ struct EditRouteAlertsView: View {
         .sheet(item: $customizingSubscription) { sub in
             AlertCustomizationSheet(subscription: sub) { updated in
                 alertService.updateSubscription(updated)
+                syncIfPossible()
             }
             .presentationDetents([PresentationDetent.medium, .large])
             .presentationDragIndicator(.visible)


### PR DESCRIPTION
## Summary

Comprehensive fix for 11 issues identified during code review of main vs origin/production.

**Critical fixes:**
- **Duplicate push notifications**: Train subscription alerts never committed `state_changed = True`, so `last_alerted_at` / `last_alert_hash` were lost every cycle — same notification re-sent every 5 minutes
- **Silent subscription death**: Users could deselect all 7 days in AlertCustomizationSheet, producing `activeDays=0` which silently disabled all alerts with no UI warning

**High-ROI improvements:**
- **Connection pool exhaustion**: Sync engine was created and disposed per NJT journey call; now cached on SchedulerService and disposed in `stop()`
- **Stale alert customizations**: Backend sync now triggers immediately after customization save, not just on `onDisappear`
- **Overnight time windows**: Footer text now notes overnight ranges (e.g. 10pm–6am) are supported (backend already handled wrap-around)
- **Stale latency stats**: Reservoir sampling replaces cap-and-stop, keeping stats representative over server lifetime

**Cleanup:**
- Remove unreachable duplicate guard in NJT terminal stop fix
- Replace SQLite-specific "database is locked" retry with PostgreSQL transient error handling
- Serialize `route_searches` as JSON-friendly list-of-dicts; update admin HTML/JSON consumers
- Add `done_callback` to fire-and-forget startup tasks so exceptions are logged
- Extract duplicated `getUIColor`/`getFrequencyUIColor` to shared `CongestionColors` enum

## Test plan

- [x] All 12 previously failing tests now pass
- [x] Black and Ruff clean on all changed backend files
- [ ] Verify alert customization sync triggers immediately on iOS
- [ ] Verify activeDays cannot reach 0 on iOS
- [ ] Verify `/admin/stats` and `/admin/stats.json` render correctly with new route_searches format

🤖 Generated with [Claude Code](https://claude.com/claude-code)