### PR TITLE
Fix misleading 0% on-time / 0m delay when no arrival data exists

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -154,6 +154,7 @@ async def get_route_history(
             train_id_filter=highlight_train,
         )
         if highlighted_stats["total_journeys"] > 0:
+            hl_breakdown = highlighted_stats["delay_breakdown"]
             highlighted_train_data = HighlightedTrain(
                 train_id=highlight_train,
                 on_time_percentage=highlighted_stats["on_time_percentage"],
@@ -161,7 +162,7 @@ async def get_route_history(
                 average_departure_delay_minutes=highlighted_stats[
                     "average_departure_delay_minutes"
                 ],
-                delay_breakdown=DelayBreakdown(**highlighted_stats["delay_breakdown"]),
+                delay_breakdown=DelayBreakdown(**hl_breakdown) if hl_breakdown else None,
                 track_usage_at_origin=highlighted_stats["track_usage"],
             )
 
@@ -185,7 +186,11 @@ async def get_route_history(
                 "average_departure_delay_minutes"
             ],
             cancellation_rate=aggregate_stats["cancellation_rate"],
-            delay_breakdown=DelayBreakdown(**aggregate_stats["delay_breakdown"]),
+            delay_breakdown=(
+                DelayBreakdown(**aggregate_stats["delay_breakdown"])
+                if aggregate_stats["delay_breakdown"]
+                else None
+            ),
             track_usage_at_origin=aggregate_stats["track_usage"],
         ),
         highlighted_train=highlighted_train_data,
@@ -222,16 +227,11 @@ async def _calculate_route_stats_sql(
 
     empty_stats = {
         "total_journeys": 0,
-        "on_time_percentage": 0.0,
-        "average_delay_minutes": 0.0,
+        "on_time_percentage": None,
+        "average_delay_minutes": None,
         "average_departure_delay_minutes": 0.0,
         "cancellation_rate": 0.0,
-        "delay_breakdown": {
-            "on_time": 0,
-            "slight": 0,
-            "significant": 0,
-            "major": 0,
-        },
+        "delay_breakdown": None,
         "track_usage": {},
     }
 
@@ -365,19 +365,20 @@ async def _calculate_route_stats_sql(
     cancelled_count = row["cancelled_count"]
     with_arrival_data = row["with_arrival_data_count"]
     on_time_count = row["on_time_count"]
-    avg_arrival = float(row["avg_arrival_delay"] or 0)
+    avg_arrival = float(row["avg_arrival_delay"]) if row["avg_arrival_delay"] is not None else None
     avg_departure = float(row["avg_departure_delay"] or 0)
 
     # Calculate delay breakdown percentages using trains with arrival data as denominator
+    # Return None when no arrival data exists to distinguish "no data" from "0% on-time"
     if with_arrival_data > 0:
-        delay_breakdown = {
+        delay_breakdown: dict[str, int] | None = {
             "on_time": round(on_time_count / with_arrival_data * 100),
             "slight": round(row["slight_count"] / with_arrival_data * 100),
             "significant": round(row["significant_count"] / with_arrival_data * 100),
             "major": round(row["major_count"] / with_arrival_data * 100),
         }
     else:
-        delay_breakdown = {"on_time": 0, "slight": 0, "significant": 0, "major": 0}
+        delay_breakdown = None
 
     # Track usage query (separate for clarity)
     track_sql = text(f"""
@@ -406,7 +407,7 @@ async def _calculate_route_stats_sql(
     return {
         "total_journeys": total_journeys,
         "on_time_percentage": (
-            (on_time_count / with_arrival_data * 100) if with_arrival_data > 0 else 0
+            (on_time_count / with_arrival_data * 100) if with_arrival_data > 0 else None
         ),
         "average_delay_minutes": avg_arrival,
         "average_departure_delay_minutes": avg_departure,

--- a/backend_v2/src/trackrat/models/api.py
+++ b/backend_v2/src/trackrat/models/api.py
@@ -489,13 +489,22 @@ class DelayBreakdown(BaseModel):
 class AggregateStats(BaseModel):
     """Aggregate statistics for all trains on the route."""
 
-    on_time_percentage: float = Field(..., ge=0.0, le=100.0)
-    average_delay_minutes: float = Field(..., ge=0.0)
+    on_time_percentage: float | None = Field(
+        None, ge=0.0, le=100.0,
+        description="Null when no arrival data available for non-cancelled trains",
+    )
+    average_delay_minutes: float | None = Field(
+        None, ge=0.0,
+        description="Null when no arrival data available for non-cancelled trains",
+    )
     average_departure_delay_minutes: float = Field(
         0.0, ge=0.0, description="Average departure delay at origin in minutes"
     )
     cancellation_rate: float = Field(..., ge=0.0, le=100.0)
-    delay_breakdown: DelayBreakdown
+    delay_breakdown: DelayBreakdown | None = Field(
+        None,
+        description="Null when no arrival data available for non-cancelled trains",
+    )
     track_usage_at_origin: dict[str, int] = Field(
         default_factory=dict, description="Track number to usage percentage mapping"
     )
@@ -505,12 +514,12 @@ class HighlightedTrain(BaseModel):
     """Statistics for a specific train compared to the route."""
 
     train_id: str
-    on_time_percentage: float = Field(..., ge=0.0, le=100.0)
-    average_delay_minutes: float = Field(..., ge=0.0)
+    on_time_percentage: float | None = Field(None, ge=0.0, le=100.0)
+    average_delay_minutes: float | None = Field(None, ge=0.0)
     average_departure_delay_minutes: float = Field(
         0.0, ge=0.0, description="Average departure delay at origin in minutes"
     )
-    delay_breakdown: DelayBreakdown
+    delay_breakdown: DelayBreakdown | None = None
     track_usage_at_origin: dict[str, int] = Field(
         default_factory=dict, description="Track number to usage percentage mapping"
     )

--- a/backend_v2/tests/unit/api/test_route_history.py
+++ b/backend_v2/tests/unit/api/test_route_history.py
@@ -93,20 +93,22 @@ async def _run_stats(
 class TestCalculateRouteStatsEmpty:
     """Verify correct defaults when no journeys match."""
 
-    async def test_empty_journeys_returns_zeros(self, db_session: AsyncSession):
+    async def test_empty_journeys_returns_nulls_for_arrival_metrics(self, db_session: AsyncSession):
         result = await _run_stats(db_session)
 
         assert result["total_journeys"] == 0
-        assert result["on_time_percentage"] == 0.0
-        assert result["average_delay_minutes"] == 0.0
+        assert result["on_time_percentage"] is None, (
+            "on_time_percentage should be None when no arrival data exists, "
+            "not 0.0 which would misleadingly suggest all trains are late"
+        )
+        assert result["average_delay_minutes"] is None, (
+            "average_delay_minutes should be None when no arrival data exists"
+        )
         assert result["average_departure_delay_minutes"] == 0.0
         assert result["cancellation_rate"] == 0.0
-        assert result["delay_breakdown"] == {
-            "on_time": 0,
-            "slight": 0,
-            "significant": 0,
-            "major": 0,
-        }
+        assert result["delay_breakdown"] is None, (
+            "delay_breakdown should be None when no arrival data exists"
+        )
         assert result["track_usage"] == {}
 
 
@@ -596,6 +598,118 @@ class TestOnTimePercentageDenominator:
         assert breakdown["slight"] == 25
         assert breakdown["significant"] == 25
         assert breakdown["major"] == 25
+
+
+@pytest.mark.asyncio
+class TestNoArrivalDataReturnsNull:
+    """Verify metrics are null (not zero) when no non-cancelled trains have arrival data.
+
+    Reproduces the bug where a route with cancelled trains and in-progress trains
+    showed 0% on-time and 0m delay, which misleadingly looked like all trains
+    were late when in reality there was simply no arrival data yet.
+    """
+
+    async def test_cancelled_plus_in_progress_returns_null_metrics(
+        self, db_session: AsyncSession
+    ):
+        """1 cancelled train + 1 departed-but-not-arrived train = null arrival metrics.
+
+        This is the exact scenario reported: Trenton to NY Penn shows 0% on-time
+        and 0m delay when trains are cancelled and remaining haven't arrived yet.
+        """
+        # Cancelled train
+        await _create_journey(
+            db_session,
+            train_id="cancelled_train",
+            is_cancelled=True,
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME,
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                },
+            ],
+        )
+        # In-progress train: has departed but no arrival data yet
+        await _create_journey(
+            db_session,
+            train_id="in_progress_train",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME,
+                    "actual_departure": BASE_TIME + timedelta(seconds=20),
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+                    "actual_arrival": None,
+                },
+            ],
+        )
+        await db_session.commit()
+
+        result = await _run_stats(db_session)
+
+        assert result["total_journeys"] == 2
+        assert result["cancellation_rate"] == 50.0
+
+        # Arrival-based metrics must be None, not 0
+        assert result["on_time_percentage"] is None, (
+            f"on_time_percentage should be None when no trains have arrival data, "
+            f"got {result['on_time_percentage']}. Showing 0% misleads users into "
+            "thinking all trains are late when there's simply no data yet."
+        )
+        assert result["average_delay_minutes"] is None, (
+            f"average_delay_minutes should be None when no trains have arrival data, "
+            f"got {result['average_delay_minutes']}. Showing 0m misleads users."
+        )
+        assert result["delay_breakdown"] is None, (
+            f"delay_breakdown should be None when no arrival data exists, "
+            f"got {result['delay_breakdown']}."
+        )
+
+        # Departure delay should still work (in-progress train has actual_departure)
+        assert result["average_departure_delay_minutes"] >= 0, (
+            "Departure delay should still be computed for trains that have departed"
+        )
+
+    async def test_all_cancelled_returns_null_metrics(self, db_session: AsyncSession):
+        """When all trains are cancelled, arrival metrics should be null."""
+        for i in range(3):
+            await _create_journey(
+                db_session,
+                train_id=f"all_cancelled_{i}",
+                is_cancelled=True,
+                stops=[
+                    {
+                        "station_code": "NY",
+                        "stop_sequence": 0,
+                        "scheduled_departure": BASE_TIME + timedelta(minutes=i * 30),
+                    },
+                    {
+                        "station_code": "TR",
+                        "stop_sequence": 1,
+                        "scheduled_arrival": BASE_TIME + timedelta(hours=1, minutes=i * 30),
+                    },
+                ],
+            )
+        await db_session.commit()
+
+        result = await _run_stats(db_session)
+
+        assert result["total_journeys"] == 3
+        assert result["cancellation_rate"] == 100.0
+        assert result["on_time_percentage"] is None
+        assert result["average_delay_minutes"] is None
+        assert result["delay_breakdown"] is None
 
 
 @pytest.mark.asyncio

--- a/ios/TrackRat/Models/Train.swift
+++ b/ios/TrackRat/Models/Train.swift
@@ -1012,14 +1012,14 @@ struct RouteHistoricalData {
     }
     
     struct Stats {
-        let onTimePercentage: Double
-        let averageDelayMinutes: Double
+        let onTimePercentage: Double?
+        let averageDelayMinutes: Double?
         let averageDepartureDelayMinutes: Double
         let cancellationRate: Double
-        let delayBreakdown: DelayBreakdown
+        let delayBreakdown: DelayBreakdown?
         let trackUsageAtOrigin: [String: Int]
     }
-    
+
     struct DelayBreakdown {
         let onTime: Int
         let slight: Int

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -420,11 +420,11 @@ final class APIService: ObservableObject {
             }
             
             struct AggregateStats: Decodable {
-                let onTimePercentage: Double
-                let averageDelayMinutes: Double
+                let onTimePercentage: Double?
+                let averageDelayMinutes: Double?
                 let averageDepartureDelayMinutes: Double?
                 let cancellationRate: Double
-                let delayBreakdown: DelayBreakdown
+                let delayBreakdown: DelayBreakdown?
                 let trackUsageAtOrigin: [String: Int]
 
                 private enum CodingKeys: String, CodingKey {
@@ -436,13 +436,13 @@ final class APIService: ObservableObject {
                     case trackUsageAtOrigin = "track_usage_at_origin"
                 }
             }
-            
+
             struct HighlightedTrainStats: Decodable {
                 let trainId: String
-                let onTimePercentage: Double
-                let averageDelayMinutes: Double
+                let onTimePercentage: Double?
+                let averageDelayMinutes: Double?
                 let averageDepartureDelayMinutes: Double?
-                let delayBreakdown: DelayBreakdown
+                let delayBreakdown: DelayBreakdown?
                 let trackUsageAtOrigin: [String: Int]
 
                 private enum CodingKeys: String, CodingKey {
@@ -498,12 +498,12 @@ final class APIService: ObservableObject {
                 averageDelayMinutes: response.aggregateStats.averageDelayMinutes,
                 averageDepartureDelayMinutes: response.aggregateStats.averageDepartureDelayMinutes ?? 0,
                 cancellationRate: response.aggregateStats.cancellationRate,
-                delayBreakdown: RouteHistoricalData.DelayBreakdown(
-                    onTime: response.aggregateStats.delayBreakdown.onTime,
-                    slight: response.aggregateStats.delayBreakdown.slight,
-                    significant: response.aggregateStats.delayBreakdown.significant,
-                    major: response.aggregateStats.delayBreakdown.major
-                ),
+                delayBreakdown: response.aggregateStats.delayBreakdown.map {
+                    RouteHistoricalData.DelayBreakdown(
+                        onTime: $0.onTime, slight: $0.slight,
+                        significant: $0.significant, major: $0.major
+                    )
+                },
                 trackUsageAtOrigin: response.aggregateStats.trackUsageAtOrigin
             ),
             highlightedTrain: response.highlightedTrain.map { highlighted in
@@ -512,12 +512,12 @@ final class APIService: ObservableObject {
                     averageDelayMinutes: highlighted.averageDelayMinutes,
                     averageDepartureDelayMinutes: highlighted.averageDepartureDelayMinutes ?? 0,
                     cancellationRate: 0.0, // Not provided for individual trains
-                    delayBreakdown: RouteHistoricalData.DelayBreakdown(
-                        onTime: highlighted.delayBreakdown.onTime,
-                        slight: highlighted.delayBreakdown.slight,
-                        significant: highlighted.delayBreakdown.significant,
-                        major: highlighted.delayBreakdown.major
-                    ),
+                    delayBreakdown: highlighted.delayBreakdown.map {
+                        RouteHistoricalData.DelayBreakdown(
+                            onTime: $0.onTime, slight: $0.slight,
+                            significant: $0.significant, major: $0.major
+                        )
+                    },
                     trackUsageAtOrigin: highlighted.trackUsageAtOrigin
                 )
             }

--- a/ios/TrackRat/Views/Screens/HistoricalDataView.swift
+++ b/ios/TrackRat/Views/Screens/HistoricalDataView.swift
@@ -485,13 +485,14 @@ class HistoricalDataViewModel: ObservableObject {
     
     private func convertRouteDataToHistoricalData(_ routeData: RouteHistoricalData) -> HistoricalData {
         // Convert route aggregate stats to route stats
+        let breakdown = routeData.aggregateStats.delayBreakdown
         let routeStats = DelayStats(
-            onTime: routeData.aggregateStats.delayBreakdown.onTime,
-            slight: routeData.aggregateStats.delayBreakdown.slight,
-            significant: routeData.aggregateStats.delayBreakdown.significant,
-            major: routeData.aggregateStats.delayBreakdown.major,
+            onTime: breakdown?.onTime ?? 0,
+            slight: breakdown?.slight ?? 0,
+            significant: breakdown?.significant ?? 0,
+            major: breakdown?.major ?? 0,
             total: routeData.route.totalTrains,
-            avgDelay: Int(routeData.aggregateStats.averageDelayMinutes.rounded())
+            avgDelay: routeData.aggregateStats.averageDelayMinutes.map { Int($0.rounded()) } ?? 0
         )
         
         // Convert route track usage to route track stats
@@ -514,13 +515,14 @@ class HistoricalDataViewModel: ObservableObject {
         let trainTrackStats: TrackStats?
         
         if let highlighted = routeData.highlightedTrain {
+            let hlBreakdown = highlighted.delayBreakdown
             trainStats = DelayStats(
-                onTime: highlighted.delayBreakdown.onTime,
-                slight: highlighted.delayBreakdown.slight,
-                significant: highlighted.delayBreakdown.significant,
-                major: highlighted.delayBreakdown.major,
+                onTime: hlBreakdown?.onTime ?? 0,
+                slight: hlBreakdown?.slight ?? 0,
+                significant: hlBreakdown?.significant ?? 0,
+                major: hlBreakdown?.major ?? 0,
                 total: 1, // Individual train has at most 1 journey in the time period
-                avgDelay: Int(highlighted.averageDelayMinutes.rounded())
+                avgDelay: highlighted.averageDelayMinutes.map { Int($0.rounded()) } ?? 0
             )
             
             // Convert highlighted train track usage

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -149,6 +149,10 @@ struct RouteStatusView: View {
         let total = history.route.totalTrains
         let freqColor = frequencyColor(totalTrains: total, baseline: history.route.baselineTrainCount)
 
+        let stats = history.aggregateStats
+        let onTimeValue = stats.onTimePercentage.map { "\(Int($0))%" } ?? "N/A"
+        let onTimeColor = onTimePercentageColor(stats.onTimePercentage)
+
         if preferredMode == .health {
             // Frequency-focused stats for rapid transit (PATH, Subway, PATCO)
             HStack(spacing: 12) {
@@ -157,34 +161,26 @@ struct RouteStatusView: View {
                     value: formatFrequency(totalTrains: total, hours: hours),
                     color: freqColor
                 )
-                statCard(
-                    title: "On Time",
-                    value: "\(Int(history.aggregateStats.onTimePercentage))%",
-                    color: history.aggregateStats.onTimePercentage >= 80 ? .green : .orange
-                )
+                statCard(title: "On Time", value: onTimeValue, color: onTimeColor)
             }
 
-            if history.aggregateStats.cancellationRate > 0 {
+            if stats.cancellationRate > 0 {
                 HStack(spacing: 12) {
                     statCard(
                         title: "Cancelled",
-                        value: "\(Int(history.aggregateStats.cancellationRate))%",
-                        color: history.aggregateStats.cancellationRate <= 5 ? .green : .red
+                        value: "\(Int(stats.cancellationRate))%",
+                        color: stats.cancellationRate <= 5 ? .green : .red
                     )
                 }
             }
         } else {
             // Delay-focused stats for commuter/intercity rail
             HStack(spacing: 12) {
-                statCard(
-                    title: "On Time",
-                    value: "\(Int(history.aggregateStats.onTimePercentage))%",
-                    color: history.aggregateStats.onTimePercentage >= 80 ? .green : .orange
-                )
+                statCard(title: "On Time", value: onTimeValue, color: onTimeColor)
                 statCard(
                     title: "Cancelled",
-                    value: "\(Int(history.aggregateStats.cancellationRate))%",
-                    color: history.aggregateStats.cancellationRate <= 5 ? .green : .red
+                    value: "\(Int(stats.cancellationRate))%",
+                    color: stats.cancellationRate <= 5 ? .green : .red
                 )
                 statCard(
                     title: "Frequency",
@@ -200,18 +196,34 @@ struct RouteStatusView: View {
                 HStack(spacing: 12) {
                     delayStatCard(
                         title: "Avg Departure Delay",
-                        value: formatDelay(history.aggregateStats.averageDepartureDelayMinutes),
-                        color: history.aggregateStats.averageDepartureDelayMinutes <= 5 ? .green : .orange
+                        value: formatDelay(stats.averageDepartureDelayMinutes),
+                        color: delayColor(stats.averageDepartureDelayMinutes)
                     )
                     delayStatCard(
                         title: "Avg Arrival Delay",
-                        value: formatDelay(history.aggregateStats.averageDelayMinutes),
-                        color: history.aggregateStats.averageDelayMinutes <= 5 ? .green : .orange
+                        value: stats.averageDelayMinutes.map { formatDelay($0) } ?? "N/A",
+                        color: delayColor(stats.averageDelayMinutes)
                     )
                 }
             }
 
         }
+    }
+
+    /// Color for on-time percentage: green >= 80%, orange >= 50%, red < 50%, gray if no data.
+    private func onTimePercentageColor(_ percentage: Double?) -> Color {
+        guard let pct = percentage else { return .secondary }
+        if pct >= 80 { return .green }
+        if pct >= 50 { return .orange }
+        return .red
+    }
+
+    /// Color for delay minutes: green <= 5m, orange <= 15m, red > 15m, gray if no data.
+    private func delayColor(_ minutes: Double?) -> Color {
+        guard let m = minutes else { return .secondary }
+        if m <= 5 { return .green }
+        if m <= 15 { return .orange }
+        return .red
     }
 
     /// Color for frequency based on comparison to historical baseline.


### PR DESCRIPTION
When all non-cancelled trains lack arrival data (e.g. cancelled + in-progress),
the backend returned 0% on-time and 0m avg delay, which looked like every train
was late. Now returns null for arrival-based metrics (on_time_percentage,
average_delay_minutes, delay_breakdown) to distinguish "no data" from "all late".

Backend: return None instead of 0 for arrival metrics when with_arrival_data == 0
iOS: handle optional metrics, show "N/A" in gray, add three-tier color thresholds
  (green/orange/red) for on-time percentage and delay minutes.

https://claude.ai/code/session_01P4oDURPMHd2Fr7fcNrof4N