### PR TITLE
Move chat device_id from query params to X-Device-Id header

### DIFF
--- a/backend_v2/src/trackrat/api/chat.py
+++ b/backend_v2/src/trackrat/api/chat.py
@@ -9,7 +9,7 @@ registered in the admin_devices table.
 from datetime import UTC, datetime
 from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select, update
 from sqlalchemy.engine import CursorResult
@@ -192,13 +192,15 @@ async def _get_messages_page(
 
 @router.get("/messages", response_model=MessagesResponse)
 async def get_messages(
-    device_id: str,
     before: int | None = None,
     limit: int = 50,
+    x_device_id: str = Header(),
     db: AsyncSession = Depends(get_db),
 ) -> MessagesResponse:
     """Get paginated message history for a device."""
-    return await _get_messages_page(db, device_id, before, limit)
+    if not await _device_exists(db, x_device_id):
+        raise HTTPException(status_code=404, detail="Device not registered")
+    return await _get_messages_page(db, x_device_id, before, limit)
 
 
 @router.post("/messages", response_model=SendMessageResponse)
@@ -250,13 +252,15 @@ async def send_message(
 
 @router.get("/unread-count", response_model=UnreadCountResponse)
 async def get_unread_count(
-    device_id: str,
+    x_device_id: str = Header(),
     db: AsyncSession = Depends(get_db),
 ) -> UnreadCountResponse:
     """Get count of unread messages from admin for this device."""
+    if not await _device_exists(db, x_device_id):
+        raise HTTPException(status_code=404, detail="Device not registered")
     result = await db.execute(
         select(func.count(ChatMessage.id)).where(
-            ChatMessage.device_id == device_id,
+            ChatMessage.device_id == x_device_id,
             ChatMessage.sender_role == "admin",
             ChatMessage.read_at.is_(None),
         )
@@ -322,11 +326,11 @@ async def register_admin(
 
 @router.get("/admin/conversations", response_model=ConversationsResponse)
 async def get_conversations(
-    device_id: str,
+    x_device_id: str = Header(),
     db: AsyncSession = Depends(get_db),
 ) -> ConversationsResponse:
     """List all conversations (admin only)."""
-    if not await _is_admin(db, device_id):
+    if not await _is_admin(db, x_device_id):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     # Subquery for latest message per device
@@ -385,13 +389,13 @@ async def get_conversations(
 )
 async def get_conversation_messages(
     target_device_id: str,
-    device_id: str,
     before: int | None = None,
     limit: int = 50,
+    x_device_id: str = Header(),
     db: AsyncSession = Depends(get_db),
 ) -> MessagesResponse:
     """Get messages for a specific conversation (admin only)."""
-    if not await _is_admin(db, device_id):
+    if not await _is_admin(db, x_device_id):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     return await _get_messages_page(db, target_device_id, before, limit)
@@ -452,11 +456,11 @@ async def send_admin_message(
 )
 async def mark_admin_messages_read(
     target_device_id: str,
-    device_id: str,
+    x_device_id: str = Header(),
     db: AsyncSession = Depends(get_db),
 ) -> MarkReadResponse:
     """Mark user messages as read in a conversation (admin only)."""
-    if not await _is_admin(db, device_id):
+    if not await _is_admin(db, x_device_id):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     now = datetime.now(UTC)

--- a/backend_v2/tests/unit/api/test_chat.py
+++ b/backend_v2/tests/unit/api/test_chat.py
@@ -82,12 +82,24 @@ class TestUserGetMessages:
     """GET /api/v2/chat/messages"""
 
     def test_get_empty_messages(self, e2e_client: TestClient):
-        """Getting messages for a device with no messages returns empty list."""
-        resp = e2e_client.get("/api/v2/chat/messages?device_id=no-messages-device")
+        """Getting messages for a registered device with no messages returns empty list."""
+        _register_device(e2e_client, "no-messages-device")
+        resp = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers={"X-Device-Id": "no-messages-device"},
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert data["messages"] == []
         assert data["has_more"] is False
+
+    def test_get_messages_unregistered_device(self, e2e_client: TestClient):
+        """Getting messages for an unregistered device returns 404."""
+        resp = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers={"X-Device-Id": "nonexistent-device"},
+        )
+        assert resp.status_code == 404
 
     def test_get_messages_after_send(self, e2e_client: TestClient):
         """Messages appear in the list after being sent."""
@@ -101,7 +113,10 @@ class TestUserGetMessages:
             json={"device_id": "chat-user-getmsg", "message": "Second message"},
         )
 
-        resp = e2e_client.get("/api/v2/chat/messages?device_id=chat-user-getmsg")
+        resp = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers={"X-Device-Id": "chat-user-getmsg"},
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert len(data["messages"]) == 2
@@ -123,7 +138,8 @@ class TestUserGetMessages:
 
         # Get messages before the last one, limit 2
         resp = e2e_client.get(
-            f"/api/v2/chat/messages?device_id=chat-user-page&before={msg_ids[-1]}&limit=2"
+            f"/api/v2/chat/messages?before={msg_ids[-1]}&limit=2",
+            headers={"X-Device-Id": "chat-user-page"},
         )
         data = resp.json()
         assert len(data["messages"]) == 2
@@ -137,9 +153,21 @@ class TestUnreadCount:
 
     def test_unread_count_zero(self, e2e_client: TestClient):
         """Unread count is 0 when no admin messages exist."""
-        resp = e2e_client.get("/api/v2/chat/unread-count?device_id=unread-user")
+        _register_device(e2e_client, "unread-user")
+        resp = e2e_client.get(
+            "/api/v2/chat/unread-count",
+            headers={"X-Device-Id": "unread-user"},
+        )
         assert resp.status_code == 200
         assert resp.json()["unread_count"] == 0
+
+    def test_unread_count_unregistered_device(self, e2e_client: TestClient):
+        """Unread count for an unregistered device returns 404."""
+        resp = e2e_client.get(
+            "/api/v2/chat/unread-count",
+            headers={"X-Device-Id": "nonexistent-device"},
+        )
+        assert resp.status_code == 404
 
     def test_unread_count_after_admin_reply(self, e2e_client: TestClient):
         """Unread count reflects admin messages not yet read."""
@@ -162,7 +190,10 @@ class TestUnreadCount:
             json={"device_id": "admin-unread", "message": "What's up?"},
         )
 
-        resp = e2e_client.get("/api/v2/chat/unread-count?device_id=chat-user-unread")
+        resp = e2e_client.get(
+            "/api/v2/chat/unread-count",
+            headers={"X-Device-Id": "chat-user-unread"},
+        )
         assert resp.json()["unread_count"] == 2
 
 
@@ -192,7 +223,10 @@ class TestMarkRead:
         assert mark_resp.json()["marked_count"] == 1
 
         # Unread count should be 1
-        unread = e2e_client.get("/api/v2/chat/unread-count?device_id=chat-user-read")
+        unread = e2e_client.get(
+            "/api/v2/chat/unread-count",
+            headers={"X-Device-Id": "chat-user-read"},
+        )
         assert unread.json()["unread_count"] == 1
 
         # Mark all as read
@@ -202,7 +236,10 @@ class TestMarkRead:
         )
         assert mark_resp2.json()["marked_count"] == 1
 
-        unread2 = e2e_client.get("/api/v2/chat/unread-count?device_id=chat-user-read")
+        unread2 = e2e_client.get(
+            "/api/v2/chat/unread-count",
+            headers={"X-Device-Id": "chat-user-read"},
+        )
         assert unread2.json()["unread_count"] == 0
 
 
@@ -246,7 +283,10 @@ class TestAdminConversations:
 
     def test_non_admin_rejected(self, e2e_client: TestClient):
         """Non-admin device gets 403."""
-        resp = e2e_client.get("/api/v2/chat/admin/conversations?device_id=not-admin")
+        resp = e2e_client.get(
+            "/api/v2/chat/admin/conversations",
+            headers={"X-Device-Id": "not-admin"},
+        )
         assert resp.status_code == 403
 
     def test_list_conversations(self, e2e_client: TestClient):
@@ -265,7 +305,10 @@ class TestAdminConversations:
             json={"device_id": "conv-user-b", "message": "Hello from B"},
         )
 
-        resp = e2e_client.get("/api/v2/chat/admin/conversations?device_id=admin-conv")
+        resp = e2e_client.get(
+            "/api/v2/chat/admin/conversations",
+            headers={"X-Device-Id": "admin-conv"},
+        )
         assert resp.status_code == 200
         data = resp.json()
         conversations = data["conversations"]
@@ -304,7 +347,10 @@ class TestAdminSendMessage:
         assert resp.json()["id"] > 0
 
         # User should see both messages
-        msgs = e2e_client.get("/api/v2/chat/messages?device_id=chat-user-reply")
+        msgs = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers={"X-Device-Id": "chat-user-reply"},
+        )
         messages = msgs.json()["messages"]
         assert len(messages) == 2
         assert messages[0]["sender_role"] == "user"
@@ -350,14 +396,16 @@ class TestAdminMarkRead:
 
         # Admin marks as read
         resp = e2e_client.post(
-            "/api/v2/chat/admin/conversations/user-markread/read?device_id=admin-markread"
+            "/api/v2/chat/admin/conversations/user-markread/read",
+            headers={"X-Device-Id": "admin-markread"},
         )
         assert resp.status_code == 200
         assert resp.json()["marked_count"] == 2
 
         # Conversation should show 0 unread
         convs = e2e_client.get(
-            "/api/v2/chat/admin/conversations?device_id=admin-markread"
+            "/api/v2/chat/admin/conversations",
+            headers={"X-Device-Id": "admin-markread"},
         )
         for conv in convs.json()["conversations"]:
             if conv["device_id"] == "user-markread":
@@ -366,7 +414,8 @@ class TestAdminMarkRead:
     def test_admin_mark_read_non_admin_rejected(self, e2e_client: TestClient):
         """Non-admin cannot mark admin messages as read."""
         resp = e2e_client.post(
-            "/api/v2/chat/admin/conversations/some-user/read?device_id=not-admin"
+            "/api/v2/chat/admin/conversations/some-user/read",
+            headers={"X-Device-Id": "not-admin"},
         )
         assert resp.status_code == 403
 
@@ -390,7 +439,8 @@ class TestAdminGetConversationMessages:
         )
 
         resp = e2e_client.get(
-            "/api/v2/chat/admin/conversations/chat-user-view/messages?device_id=admin-view"
+            "/api/v2/chat/admin/conversations/chat-user-view/messages",
+            headers={"X-Device-Id": "admin-view"},
         )
         assert resp.status_code == 200
         messages = resp.json()["messages"]
@@ -401,6 +451,7 @@ class TestAdminGetConversationMessages:
     def test_non_admin_rejected(self, e2e_client: TestClient):
         """Non-admin cannot view conversation messages."""
         resp = e2e_client.get(
-            "/api/v2/chat/admin/conversations/some-user/messages?device_id=not-admin"
+            "/api/v2/chat/admin/conversations/some-user/messages",
+            headers={"X-Device-Id": "not-admin"},
         )
         assert resp.status_code == 403

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -1445,12 +1445,13 @@ extension APIService {
         guard var components = URLComponents(string: "\(baseURL)/v2/chat/messages") else {
             throw APIError.invalidURL
         }
-        var items = [URLQueryItem(name: "device_id", value: deviceId),
-                     URLQueryItem(name: "limit", value: String(limit))]
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
         if let before { items.append(URLQueryItem(name: "before", value: String(before))) }
         components.queryItems = items
         guard let url = components.url else { throw APIError.invalidURL }
-        let (data, _) = try await session.data(from: url)
+        var request = URLRequest(url: url)
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
+        let (data, _) = try await session.data(for: request)
         return try JSONDecoder().decode(ChatMessagesResponse.self, from: data)
     }
 
@@ -1469,12 +1470,12 @@ extension APIService {
     }
 
     func getChatUnreadCount(deviceId: String) async throws -> Int {
-        guard var components = URLComponents(string: "\(baseURL)/v2/chat/unread-count") else {
+        guard let url = URL(string: "\(baseURL)/v2/chat/unread-count") else {
             throw APIError.invalidURL
         }
-        components.queryItems = [URLQueryItem(name: "device_id", value: deviceId)]
-        guard let url = components.url else { throw APIError.invalidURL }
-        let (data, _) = try await session.data(from: url)
+        var request = URLRequest(url: url)
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
+        let (data, _) = try await session.data(for: request)
         let resp = try JSONDecoder().decode(ChatUnreadCountResponse.self, from: data)
         return resp.unread_count
     }
@@ -1506,12 +1507,12 @@ extension APIService {
     }
 
     func getChatConversations(deviceId: String) async throws -> [ChatConversationResponse] {
-        guard var components = URLComponents(string: "\(baseURL)/v2/chat/admin/conversations") else {
+        guard let url = URL(string: "\(baseURL)/v2/chat/admin/conversations") else {
             throw APIError.invalidURL
         }
-        components.queryItems = [URLQueryItem(name: "device_id", value: deviceId)]
-        guard let url = components.url else { throw APIError.invalidURL }
-        let (data, _) = try await session.data(from: url)
+        var request = URLRequest(url: url)
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
+        let (data, _) = try await session.data(for: request)
         return try JSONDecoder().decode(ChatConversationsResponse.self, from: data).conversations
     }
 
@@ -1519,12 +1520,13 @@ extension APIService {
         guard var components = URLComponents(string: "\(baseURL)/v2/chat/admin/conversations/\(targetDeviceId)/messages") else {
             throw APIError.invalidURL
         }
-        var items = [URLQueryItem(name: "device_id", value: deviceId),
-                     URLQueryItem(name: "limit", value: String(limit))]
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
         if let before { items.append(URLQueryItem(name: "before", value: String(before))) }
         components.queryItems = items
         guard let url = components.url else { throw APIError.invalidURL }
-        let (data, _) = try await session.data(from: url)
+        var request = URLRequest(url: url)
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
+        let (data, _) = try await session.data(for: request)
         return try JSONDecoder().decode(ChatMessagesResponse.self, from: data)
     }
 
@@ -1545,13 +1547,12 @@ extension APIService {
     }
 
     func markAdminChatMessagesRead(deviceId: String, targetDeviceId: String) async throws {
-        guard var components = URLComponents(string: "\(baseURL)/v2/chat/admin/conversations/\(targetDeviceId)/read") else {
+        guard let url = URL(string: "\(baseURL)/v2/chat/admin/conversations/\(targetDeviceId)/read") else {
             throw APIError.invalidURL
         }
-        components.queryItems = [URLQueryItem(name: "device_id", value: deviceId)]
-        guard let url = components.url else { throw APIError.invalidURL }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        request.setValue(deviceId, forHTTPHeaderField: "X-Device-Id")
         let (_, response) = try await session.data(for: request)
         if let http = response as? HTTPURLResponse, http.statusCode != 200 {
             throw APIError.invalidParameters


### PR DESCRIPTION
Prevents device_id leaking into server/load-balancer logs by moving it
from URL query parameters to the X-Device-Id request header for all
chat endpoints that previously accepted it as a query param.

Also adds _device_exists() guard to GET /messages and GET /unread-count
which previously had no device validation.

Endpoints changed (query param → header):
- GET /chat/messages
- GET /chat/unread-count
- GET /chat/admin/conversations
- GET /chat/admin/conversations/{id}/messages
- POST /chat/admin/conversations/{id}/read

POST body endpoints unchanged (device_id already not in URL):
- POST /chat/messages
- POST /chat/messages/read
- POST /chat/admin/register
- POST /chat/admin/conversations/{id}/messages

https://claude.ai/code/session_01Rpa9QevGG8XNWviy2xHyKS