### PR TITLE
Add service alerts, developer chat, and route alert customization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,27 @@ script and provide a narrative summary that highlights:
 - Uses GTFS static schedules from SEPTA feed
 - No real-time API available; times are scheduled only
 
+**MTA Service Alerts Collection:**
+- Collector in `backend_v2/src/trackrat/collectors/service_alerts.py`
+- Fetches GTFS-RT service alert feeds for Subway, LIRR, and Metro-North
+- Three alert types: `planned_work`, `alert` (real-time), `elevator` (outages)
+- Upserts into `service_alerts` table; marks missing alerts as inactive
+- Used to send planned work / service change push notifications to subscribed users
+
+**Route Alert Customization:**
+- Per-subscription settings: active days (bitmask), time windows, delay/service thresholds
+- Per-type toggles: `notify_cancellation`, `notify_delay`, `notify_recovery`, `include_planned_work`
+- Digest mode: `digest_time_minutes` batches notifications to a scheduled time
+- Stored on `RouteAlertSubscription` model with new columns added via migration
+
+**Developer Chat:**
+- Two-party messaging between users and the developer (admin)
+- Backend: `backend_v2/src/trackrat/api/chat.py` — full CRUD + admin endpoints
+- iOS: `ChatService.swift`, `ChatView.swift`, `AdminChatListView.swift`
+- Database: `chat_messages` and `admin_devices` tables
+- Admin registration via secret code (`CHAT_ADMIN_REGISTRATION_CODE` env var)
+- Push notifications for new messages via APNS
+
 **Key Design Principles:**
 - Single Journey Record: One database row per train per day
 - Horizontal Scaling: Database-coordinated scheduler with row-level locking
@@ -396,7 +417,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - Backend services: `backend_v2/src/trackrat/services/`
 - Backend API endpoints: `backend_v2/src/trackrat/api/`
 - Backend models: `backend_v2/src/trackrat/models/`
-- Backend collectors: `backend_v2/src/trackrat/collectors/` (njt, amtrak, path, lirr, mnr, subway)
+- Backend collectors: `backend_v2/src/trackrat/collectors/` (njt, amtrak, path, lirr, mnr, subway, service_alerts)
 - Backend config: `backend_v2/src/trackrat/config/` (stations/ package, route_topology, station_configs)
 - Backend tests: `backend_v2/tests/`
 - iOS views: `ios/TrackRat/Views/Screens/`, `ios/TrackRat/Views/Components/`
@@ -433,6 +454,20 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 # Route Alerts
 /api/v2/devices/register           # Register APNS device token
 /api/v2/alerts/subscriptions       # Sync route alert subscriptions (PUT)
+/api/v2/alerts/service             # MTA service alerts (planned work, delays)
+
+# Developer Chat
+/api/v2/chat/messages              # GET message history, POST send message
+/api/v2/chat/unread-count          # GET unread message count
+/api/v2/chat/messages/read         # POST mark messages as read
+/api/v2/chat/admin/register        # POST register admin device
+/api/v2/chat/admin/conversations   # GET all conversations (admin)
+/api/v2/chat/admin/conversations/{device_id}/messages  # GET/POST conversation messages (admin)
+/api/v2/chat/admin/conversations/{device_id}/read      # POST mark read (admin)
+
+# Admin
+/admin/stats                       # Server usage statistics page (HTML)
+/admin/stats.json                  # Server usage statistics (JSON)
 
 # System Operations
 /api/v2/live-activities/register   # iOS Live Activity registration

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ TrackRat tracks trains across seven transit systems in real time, predicts platf
 - **Real-Time Tracking** — Live train status, delays, and journey progress across all systems
 - **Delay Forecasting** — ML-powered delay and cancellation probability predictions
 - **Live Activities** — Real-time iOS Lock Screen and Dynamic Island updates
-- **Route Alerts** — Push notifications for delays and cancellations on subscribed routes
+- **Route Alerts** — Push notifications for delays, cancellations, and service changes on subscribed routes, with customizable schedules, thresholds, and per-type toggles
+- **Service Alerts** — MTA planned work and service change notifications for Subway, LIRR, and Metro-North
+- **Developer Chat** — In-app messaging between users and the developer
 - **Congestion Maps** — Live network congestion monitoring
 - **1,000+ Stations** across the Northeast Corridor
 
@@ -112,6 +114,7 @@ open TrackRat.xcodeproj
 | `APNS_TEAM_ID` | No | Apple Developer Team ID (for Live Activities) |
 | `APNS_KEY_ID` | No | Apple Push Notification key ID |
 | `APNS_AUTH_KEY_PATH` | No | Path to `.p8` auth key file |
+| `CHAT_ADMIN_REGISTRATION_CODE` | No | Secret code for registering admin devices for developer chat |
 
 See `backend_v2/.env.example` for the full list.
 
@@ -122,7 +125,7 @@ TrackRat/
 ├── backend_v2/          # Python FastAPI backend
 │   ├── src/trackrat/
 │   │   ├── api/         # API endpoints (FastAPI routers)
-│   │   ├── collectors/  # Transit data collectors (njt, amtrak, path, lirr, mnr, subway)
+│   │   ├── collectors/  # Transit data collectors (njt, amtrak, path, lirr, mnr, subway, service_alerts)
 │   │   ├── config/      # Station configs, route topology
 │   │   ├── models/      # SQLAlchemy + Pydantic models
 │   │   ├── services/    # Business logic, ML predictions, scheduling
@@ -171,6 +174,10 @@ GET  /api/v2/predictions/track              # ML platform predictions
 GET  /api/v2/predictions/delay              # Delay/cancellation forecasts
 POST /api/v2/devices/register              # Register device for push notifications
 PUT  /api/v2/alerts/subscriptions          # Sync route alert subscriptions
+GET  /api/v2/alerts/service                # MTA service alerts (planned work, delays)
+GET  /api/v2/chat/messages                 # Chat message history
+POST /api/v2/chat/messages                 # Send a chat message
+GET  /admin/stats                           # Server usage statistics
 GET  /health                                # Health check
 ```
 


### PR DESCRIPTION
## Summary
This PR adds three major features to TrackRat: MTA service alerts collection, in-app developer chat messaging, and enhanced route alert customization with per-subscription settings and digest mode support.

## Key Changes

**Service Alerts Collection**
- New `service_alerts.py` collector fetches GTFS-RT service alert feeds for MTA Subway, LIRR, and Metro-North
- Supports three alert types: `planned_work`, `alert` (real-time), and `elevator` (outages)
- Upserts alerts into `service_alerts` table and marks missing alerts as inactive
- New API endpoint `/api/v2/alerts/service` to retrieve MTA service alerts

**Route Alert Customization**
- Extended `RouteAlertSubscription` model with per-subscription settings:
  - Active days bitmask and time windows for notification scheduling
  - Delay and service change thresholds
  - Per-type toggles: `notify_cancellation`, `notify_delay`, `notify_recovery`, `include_planned_work`
  - Digest mode with `digest_time_minutes` to batch notifications to a scheduled time
- Enables users to customize when and how they receive route alerts

**Developer Chat**
- Two-party messaging system between users and developer (admin)
- Backend implementation in `chat.py` with full CRUD operations and admin-only endpoints
- iOS implementation with `ChatService.swift`, `ChatView.swift`, and `AdminChatListView.swift`
- Database tables: `chat_messages` and `admin_devices`
- Admin registration via secret code (`CHAT_ADMIN_REGISTRATION_CODE` env var)
- Push notifications for new messages via APNS
- API endpoints:
  - `/api/v2/chat/messages` — GET history, POST send message
  - `/api/v2/chat/unread-count` — GET unread count
  - `/api/v2/chat/messages/read` — POST mark as read
  - `/api/v2/chat/admin/*` — Admin conversation management endpoints

**Documentation Updates**
- Updated CLAUDE.md with detailed descriptions of all three features
- Updated README.md with feature highlights and new environment variable
- Added new API endpoints to documentation
- Updated project structure references to include `service_alerts` collector

**Admin Dashboard**
- New `/admin/stats` endpoint for server usage statistics (HTML)
- New `/admin/stats.json` endpoint for JSON statistics

https://claude.ai/code/session_013hbT9EUQ2LGMUiqJAKznGc