### PR TITLE
Fix NJT collection connection pool exhaustion via session splitting

### DIFF
--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -77,6 +77,7 @@ class SchedulerService:
         self.jit_service: JustInTimeUpdateService | None = None
         self._running_tasks: dict[str, asyncio.Task[Any]] = {}
         self._sync_engine: Any = None  # Lazily created sync engine for NJT
+        self._njt_collection_semaphore = asyncio.Semaphore(10)  # Cap concurrent NJT collections
 
     def _get_sync_engine(self) -> Any:
         """Get or create a cached synchronous database engine."""
@@ -1565,8 +1566,10 @@ class SchedulerService:
     ) -> dict[str, Any] | None:
         """Safely collect a single NJT journey using synchronous database operations.
 
-        This method bypasses async database sessions entirely to avoid greenlet issues
-        when called from APScheduler job contexts.
+        This method splits DB access into read and write phases around the external
+        NJT API call, so that no database connection is held while waiting for the
+        network response.  This prevents connection pool exhaustion when many trains
+        are collected concurrently.
 
         Args:
             train_id: The train ID to collect
@@ -1576,9 +1579,8 @@ class SchedulerService:
             Dict with journey info if successful, None if failed
         """
         try:
-            # Use synchronous database operations entirely to avoid greenlet issues
             from sqlalchemy import and_, delete, select
-            from sqlalchemy.orm import selectinload, sessionmaker
+            from sqlalchemy.orm import sessionmaker
 
             from trackrat.collectors.njt.client import (
                 NJTransitNullDataError,
@@ -1587,271 +1589,271 @@ class SchedulerService:
             from trackrat.models.database import JourneySnapshot, JourneyStop
             from trackrat.utils.time import now_et, parse_njt_time
 
-            # Default to today's date if not provided
             if journey_date is None:
                 journey_date = now_et().date()
 
             SyncSession = sessionmaker(self._get_sync_engine())
-
             with SyncSession() as session:
-                # Find the journey for this train on the specific date (eager load stops)
-                stmt = (
-                    select(TrainJourney)
-                    .where(
-                        and_(
-                            TrainJourney.train_id == train_id,
-                            TrainJourney.journey_date == journey_date,
-                            TrainJourney.data_source == "NJT",
-                        )
+                stmt = select(
+                    TrainJourney.id,
+                    TrainJourney.is_expired,
+                    TrainJourney.api_error_count,
+                ).where(
+                    and_(
+                        TrainJourney.train_id == train_id,
+                        TrainJourney.journey_date == journey_date,
+                        TrainJourney.data_source == "NJT",
                     )
-                    .options(selectinload(TrainJourney.stops))
                 )
-                journey = session.scalar(stmt)
+                row = session.execute(stmt).first()
 
-                if not journey:
-                    logger.warning("journey_not_found_sync", train_id=train_id)
-                    return None
+            # Connection returned to pool here
 
-                if journey.is_expired:
-                    logger.debug("skipping_expired_train_sync", train_id=train_id)
-                    return None
+            if not row:
+                logger.warning("journey_not_found_sync", train_id=train_id)
+                return None
 
-                # Get train data from API (this is still async)
-                if not self.njt_client:
-                    logger.error("njt_client_not_initialized", train_id=train_id)
-                    return None
+            journey_id = row.id
+            journey_is_expired = row.is_expired
+            journey_api_error_count = row.api_error_count or 0
 
-                try:
+            if journey_is_expired:
+                logger.debug("skipping_expired_train_sync", train_id=train_id)
+                return None
+
+            # ── Phase 2: Call NJT API (no DB connection held) ──
+            # Semaphore caps concurrent API calls to prevent overwhelming
+            # the NJT API and downstream DB write contention.
+            if not self.njt_client:
+                logger.error("njt_client_not_initialized", train_id=train_id)
+                return None
+
+            try:
+                async with self._njt_collection_semaphore:
                     train_data = await self.njt_client.get_train_stop_list(train_id)
-                except NJTransitNullDataError:
-                    # NJT API returned a response with all key fields null —
-                    # transient API issue. Do NOT increment api_error_count.
-                    logger.info(
-                        "train_null_data_skipped_sync",
-                        train_id=train_id,
-                        journey_id=journey.id,
-                        api_error_count=journey.api_error_count,
-                    )
-                    return {
-                        "train_id": train_id,
-                        "success": False,
-                        "error": "Transient null data",
-                        "expired": False,
-                    }
-                except TrainNotFoundError:
-                    # Train is genuinely not available — increment error count.
-                    with session.no_autoflush:
-                        journey.api_error_count = (journey.api_error_count or 0) + 1
+            except NJTransitNullDataError:
+                logger.info(
+                    "train_null_data_skipped_sync",
+                    train_id=train_id,
+                    journey_id=journey_id,
+                    api_error_count=journey_api_error_count,
+                )
+                return {
+                    "train_id": train_id,
+                    "success": False,
+                    "error": "Transient null data",
+                    "expired": False,
+                }
+            except TrainNotFoundError:
+                # Train is genuinely not available — increment error count.
+                new_error_count = journey_api_error_count + 1
+                is_now_expired = new_error_count >= 3
+
+                with SyncSession() as session:
+                    journey = session.get(TrainJourney, journey_id)
+                    if journey:
+                        journey.api_error_count = new_error_count
                         journey.last_updated_at = now_et()
                         journey.update_count = (journey.update_count or 0) + 1
-
-                        # After 3 failed attempts, mark as expired
-                        if journey.api_error_count >= 3:
+                        if is_now_expired:
                             journey.is_expired = True
                             logger.warning(
                                 "train_marked_expired_sync",
                                 train_id=train_id,
-                                journey_id=journey.id,
-                                error_count=journey.api_error_count,
+                                journey_id=journey_id,
+                                error_count=new_error_count,
                             )
+                        commit_with_retry(session, log_context={"train_id": train_id})
 
-                    commit_with_retry(session, log_context={"train_id": train_id})
+                return {
+                    "train_id": train_id,
+                    "success": False,
+                    "error": "Train not found",
+                    "expired": is_now_expired,
+                }
 
-                    return {
-                        "train_id": train_id,
-                        "success": False,
-                        "error": "Train not found",
-                        "expired": journey.is_expired,
-                    }
+            if not train_data:
+                logger.warning("no_train_data_received_sync", train_id=train_id)
+                return None
 
-                # Process the data synchronously
-                if train_data:
-                    # Reset error count on successful fetch
-                    journey.api_error_count = 0
-
-                    # Use no_autoflush to prevent premature flushes during updates
-                    with session.no_autoflush:
-                        # Update journey metadata synchronously
-                        # Note: DIRECTION is not available in NJTransitTrainData
-                        journey.destination = train_data.DESTINATION
-                        journey.line_color = train_data.BACKCOLOR.strip()
-                        journey.has_complete_journey = True
-                        journey.stops_count = len(train_data.STOPS)
-                        journey.last_updated_at = now_et()
-                        journey.update_count = (journey.update_count or 0) + 1
-
-                        # Update origin/terminal/scheduled_departure from stops
-                        # This fixes journeys discovered at intermediate stations
-                        if train_data.STOPS:
-                            first_stop = train_data.STOPS[0]
-                            last_stop = train_data.STOPS[-1]
-
-                            journey.origin_station_code = first_stop.STATION_2CHAR
-                            journey.terminal_station_code = last_stop.STATION_2CHAR
-                            if first_stop.DEP_TIME:
-                                journey.scheduled_departure = parse_njt_time(
-                                    first_stop.DEP_TIME
-                                )
-                            if last_stop.TIME:
-                                journey.scheduled_arrival = parse_njt_time(
-                                    last_stop.TIME
-                                )
-
-                        # Delete existing stops
-                        session.execute(
-                            delete(JourneyStop).where(
-                                JourneyStop.journey_id == journey.id
-                            )
-                        )
-
-                        # Create new stops
-                        for idx, stop_data in enumerate(train_data.STOPS):
-                            # Parse scheduled times
-                            scheduled_arrival = (
-                                parse_njt_time(stop_data.TIME)
-                                if stop_data.TIME
-                                else None
-                            )
-                            scheduled_departure = (
-                                parse_njt_time(stop_data.DEP_TIME)
-                                if stop_data.DEP_TIME
-                                else None
-                            )
-
-                            # For NJT API, actual times are same as scheduled when DEPARTED = YES
-                            # Cancelled stops never physically departed
-                            is_stop_cancelled = (
-                                stop_data.STOP_STATUS or ""
-                            ) == "CANCELLED"
-                            actual_arrival = None
-                            actual_departure = None
-                            if stop_data.DEPARTED == "YES" and not is_stop_cancelled:
-                                actual_arrival = scheduled_arrival
-                                actual_departure = scheduled_departure
-
-                            stop = JourneyStop(
-                                journey_id=journey.id,
-                                station_code=stop_data.STATION_2CHAR,
-                                station_name=stop_data.STATIONNAME,
-                                stop_sequence=idx,
-                                scheduled_departure=scheduled_departure,
-                                scheduled_arrival=scheduled_arrival,
-                                actual_departure=actual_departure,
-                                actual_arrival=actual_arrival,
-                                track=stop_data.TRACK or None,
-                                track_assigned_at=now_et() if stop_data.TRACK else None,
-                                raw_njt_departed_flag=stop_data.DEPARTED,
-                                # Time validation: Never mark as departed if scheduled time is in future
-                                # Cancelled stops never departed regardless of DEPARTED flag
-                                has_departed_station=(
-                                    stop_data.DEPARTED == "YES"
-                                    and not is_stop_cancelled
-                                    and (
-                                        not scheduled_departure
-                                        or scheduled_departure <= now_et()
-                                    )
-                                ),
-                            )
-                            session.add(stop)
-
-                        # Create/update journey snapshot (only one per journey)
-                        # Delete existing snapshots first to maintain single snapshot per journey
-                        session.execute(
-                            delete(JourneySnapshot).where(
-                                JourneySnapshot.journey_id == journey.id
-                            )
-                        )
-
-                        # Calculate completed stops (exclude cancelled stops)
-                        completed_stops = sum(
-                            1
-                            for stop in train_data.STOPS
-                            if stop.DEPARTED == "YES"
-                            and (stop.STOP_STATUS or "") != "CANCELLED"
-                        )
-
-                        # Extract track assignments
-                        track_assignments = {
-                            stop.STATION_2CHAR: stop.TRACK
-                            for stop in train_data.STOPS
-                            if stop.TRACK
-                        }
-
-                        # Calculate delay (simplified - from stop status)
-                        delay_minutes = 0
-                        for stop in reversed(train_data.STOPS):
-                            if stop.DEPARTED == "YES" and stop.STOP_STATUS:
-                                if "LATE" in (stop.STOP_STATUS or ""):
-                                    try:
-                                        parts = stop.STOP_STATUS.split()
-                                        if "MINUTES" in parts:
-                                            idx = parts.index("MINUTES")
-                                            if idx > 0:
-                                                delay_minutes = int(parts[idx - 1])
-                                        elif "MINS" in parts:
-                                            idx = parts.index("MINS")
-                                            if idx > 0:
-                                                delay_minutes = int(parts[idx - 1])
-                                    except (ValueError, IndexError):
-                                        pass
-                                break
-
-                        # Determine train status
-                        train_status = self._determine_train_status_sync(
-                            train_data.STOPS
-                        )
-
-                        snapshot = JourneySnapshot(
-                            journey_id=journey.id,
-                            captured_at=now_et(),
-                            raw_stop_list_data={},  # Deactivated to reduce database size
-                            train_status=train_status,
-                            delay_minutes=delay_minutes,
-                            completed_stops=completed_stops,
-                            total_stops=len(train_data.STOPS),
-                            track_assignments=track_assignments,
-                        )
-                        session.add(snapshot)
-
-                        # Update journey status from stops
-                        # Check if last stop has departed (matches async path logic)
-                        is_completed = bool(
-                            train_data.STOPS and train_data.STOPS[-1].DEPARTED == "YES"
-                        )
-                        journey.is_completed = is_completed
-
-                        # Check for cancellation
-                        is_cancelled = all(
-                            (stop.STOP_STATUS or "") == "CANCELLED"
-                            for stop in train_data.STOPS
-                        )
-                        if is_cancelled:
-                            journey.is_cancelled = True
-                            journey.cancellation_reason = "All stops cancelled by NJT"
-
-                    # Capture data we need before committing/closing session
-                    result_data = {
-                        "train_id": train_id,
-                        "stops_count": len(train_data.STOPS),
-                        "destination": train_data.DESTINATION,
-                        "success": True,
-                        "is_completed": is_completed,
-                    }
-
-                    commit_with_retry(session, log_context={"train_id": train_id})
-
-                    logger.info(
-                        "journey_collection_completed_sync",
+            # ── Phase 3: Write results to DB (connection held only for writes) ──
+            with SyncSession() as session:
+                journey = session.get(TrainJourney, journey_id)
+                if not journey:
+                    logger.warning(
+                        "journey_disappeared_before_write",
                         train_id=train_id,
-                        journey_id=journey.id,
-                        stops_count=len(train_data.STOPS),
-                        is_completed=is_completed,
+                        journey_id=journey_id,
+                    )
+                    return None
+
+                # Reset error count on successful fetch
+                journey.api_error_count = 0
+
+                with session.no_autoflush:
+                    # Update journey metadata
+                    journey.destination = train_data.DESTINATION
+                    journey.line_color = train_data.BACKCOLOR.strip()
+                    journey.has_complete_journey = True
+                    journey.stops_count = len(train_data.STOPS)
+                    journey.last_updated_at = now_et()
+                    journey.update_count = (journey.update_count or 0) + 1
+
+                    # Update origin/terminal/scheduled_departure from stops
+                    if train_data.STOPS:
+                        first_stop = train_data.STOPS[0]
+                        last_stop = train_data.STOPS[-1]
+
+                        journey.origin_station_code = first_stop.STATION_2CHAR
+                        journey.terminal_station_code = last_stop.STATION_2CHAR
+                        if first_stop.DEP_TIME:
+                            journey.scheduled_departure = parse_njt_time(
+                                first_stop.DEP_TIME
+                            )
+                        if last_stop.TIME:
+                            journey.scheduled_arrival = parse_njt_time(
+                                last_stop.TIME
+                            )
+
+                    # Delete existing stops
+                    session.execute(
+                        delete(JourneyStop).where(
+                            JourneyStop.journey_id == journey.id
+                        )
                     )
 
-                    return result_data
-                else:
-                    logger.warning("no_train_data_received_sync", train_id=train_id)
-                    return None
+                    # Create new stops
+                    for idx, stop_data in enumerate(train_data.STOPS):
+                        scheduled_arrival = (
+                            parse_njt_time(stop_data.TIME)
+                            if stop_data.TIME
+                            else None
+                        )
+                        scheduled_departure = (
+                            parse_njt_time(stop_data.DEP_TIME)
+                            if stop_data.DEP_TIME
+                            else None
+                        )
+
+                        is_stop_cancelled = (
+                            stop_data.STOP_STATUS or ""
+                        ) == "CANCELLED"
+                        actual_arrival = None
+                        actual_departure = None
+                        if stop_data.DEPARTED == "YES" and not is_stop_cancelled:
+                            actual_arrival = scheduled_arrival
+                            actual_departure = scheduled_departure
+
+                        stop = JourneyStop(
+                            journey_id=journey.id,
+                            station_code=stop_data.STATION_2CHAR,
+                            station_name=stop_data.STATIONNAME,
+                            stop_sequence=idx,
+                            scheduled_departure=scheduled_departure,
+                            scheduled_arrival=scheduled_arrival,
+                            actual_departure=actual_departure,
+                            actual_arrival=actual_arrival,
+                            track=stop_data.TRACK or None,
+                            track_assigned_at=now_et() if stop_data.TRACK else None,
+                            raw_njt_departed_flag=stop_data.DEPARTED,
+                            has_departed_station=(
+                                stop_data.DEPARTED == "YES"
+                                and not is_stop_cancelled
+                                and (
+                                    not scheduled_departure
+                                    or scheduled_departure <= now_et()
+                                )
+                            ),
+                        )
+                        session.add(stop)
+
+                    # Create/update journey snapshot
+                    session.execute(
+                        delete(JourneySnapshot).where(
+                            JourneySnapshot.journey_id == journey.id
+                        )
+                    )
+
+                    completed_stops = sum(
+                        1
+                        for stop in train_data.STOPS
+                        if stop.DEPARTED == "YES"
+                        and (stop.STOP_STATUS or "") != "CANCELLED"
+                    )
+
+                    track_assignments = {
+                        stop.STATION_2CHAR: stop.TRACK
+                        for stop in train_data.STOPS
+                        if stop.TRACK
+                    }
+
+                    delay_minutes = 0
+                    for stop in reversed(train_data.STOPS):
+                        if stop.DEPARTED == "YES" and stop.STOP_STATUS:
+                            if "LATE" in (stop.STOP_STATUS or ""):
+                                try:
+                                    parts = stop.STOP_STATUS.split()
+                                    if "MINUTES" in parts:
+                                        idx = parts.index("MINUTES")
+                                        if idx > 0:
+                                            delay_minutes = int(parts[idx - 1])
+                                    elif "MINS" in parts:
+                                        idx = parts.index("MINS")
+                                        if idx > 0:
+                                            delay_minutes = int(parts[idx - 1])
+                                except (ValueError, IndexError):
+                                    pass
+                            break
+
+                    train_status = self._determine_train_status_sync(
+                        train_data.STOPS
+                    )
+
+                    snapshot = JourneySnapshot(
+                        journey_id=journey.id,
+                        captured_at=now_et(),
+                        raw_stop_list_data={},
+                        train_status=train_status,
+                        delay_minutes=delay_minutes,
+                        completed_stops=completed_stops,
+                        total_stops=len(train_data.STOPS),
+                        track_assignments=track_assignments,
+                    )
+                    session.add(snapshot)
+
+                    # Update journey status from stops
+                    is_completed = bool(
+                        train_data.STOPS and train_data.STOPS[-1].DEPARTED == "YES"
+                    )
+                    journey.is_completed = is_completed
+
+                    is_cancelled = all(
+                        (stop.STOP_STATUS or "") == "CANCELLED"
+                        for stop in train_data.STOPS
+                    )
+                    if is_cancelled:
+                        journey.is_cancelled = True
+                        journey.cancellation_reason = "All stops cancelled by NJT"
+
+                result_data = {
+                    "train_id": train_id,
+                    "stops_count": len(train_data.STOPS),
+                    "destination": train_data.DESTINATION,
+                    "success": True,
+                    "is_completed": is_completed,
+                }
+
+                commit_with_retry(session, log_context={"train_id": train_id})
+
+            logger.info(
+                "journey_collection_completed_sync",
+                train_id=train_id,
+                journey_id=journey_id,
+                stops_count=len(train_data.STOPS),
+                is_completed=is_completed,
+            )
+
+            return result_data
 
         except Exception as e:
             error_msg = str(e).lower()

--- a/backend_v2/tests/unit/test_njt_collection_pool_safety.py
+++ b/backend_v2/tests/unit/test_njt_collection_pool_safety.py
@@ -1,0 +1,693 @@
+"""
+Tests for NJT journey collection connection pool safety.
+
+Verifies that _collect_single_njt_journey_safe does NOT hold a database connection
+open while waiting for external NJT API responses, and that concurrent collections
+are capped by a semaphore.
+"""
+
+import asyncio
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from tests.fixtures.njt_api_responses import StopBuilder, create_stop_list_response
+from trackrat.models.database import TrainJourney
+from trackrat.services.scheduler import SchedulerService
+from trackrat.settings import Settings
+
+
+@pytest.fixture
+def mock_settings():
+    return Settings(
+        njt_api_url="https://test.api.com",
+        njt_api_token="test_token",
+        discovery_interval_minutes=60,
+    )
+
+
+@pytest.fixture
+def scheduler_service(mock_settings):
+    service = SchedulerService(mock_settings)
+    service.scheduler = Mock(spec=AsyncIOScheduler)
+    service.njt_client = AsyncMock()
+    return service
+
+
+def _make_journey_row(journey_id=1, is_expired=False, api_error_count=0):
+    """Create a mock row matching the Phase 1 column query."""
+    row = Mock()
+    row.id = journey_id
+    row.is_expired = is_expired
+    row.api_error_count = api_error_count
+    return row
+
+
+def _make_journey_orm(journey_id=1, api_error_count=0, update_count=0):
+    """Create a mock ORM TrainJourney for Phase 3 writes."""
+    journey = Mock(spec=TrainJourney)
+    journey.id = journey_id
+    journey.api_error_count = api_error_count
+    journey.update_count = update_count
+    journey.is_completed = False
+    journey.is_cancelled = False
+    journey.cancellation_reason = None
+    return journey
+
+
+def _make_train_data():
+    """Create realistic NJT train stop list response."""
+    builder = StopBuilder()
+    stops = [
+        builder.build_stop("NY", "New York Penn", "11-Mar-2026 08:00:00 AM", departed=True, track="5"),
+        builder.build_stop("NP", "Newark Penn", "11-Mar-2026 08:20:00 AM", departed=True),
+        builder.build_stop("TR", "Trenton", "11-Mar-2026 09:00:00 AM", departed=False),
+    ]
+    return create_stop_list_response("1234", stops=stops)
+
+
+class TestSessionSplitting:
+    """Verify DB sessions are NOT held during NJT API calls."""
+
+    @pytest.mark.asyncio
+    async def test_session_closed_before_api_call(self, scheduler_service):
+        """The sync DB session opened for Phase 1 (read) must be closed
+        BEFORE the NJT API call in Phase 2.  This is the core fix for
+        connection pool exhaustion."""
+
+        session_open_during_api_call = False
+        session_context_active = False
+
+        class TrackingSession:
+            """Session that tracks whether it's open during the API call."""
+
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row()
+
+            def __enter__(self):
+                nonlocal session_context_active
+                session_context_active = True
+                return self
+
+            def __exit__(self, *args):
+                nonlocal session_context_active
+                session_context_active = False
+
+            def execute(self, stmt):
+                return self._execute_result
+
+            def get(self, model, pk):
+                return _make_journey_orm()
+
+            def add(self, obj):
+                pass
+
+            # no_autoflush context manager
+            @property
+            def no_autoflush(self):
+                return MagicMock()
+
+        call_count = [0]
+
+        class TrackingSessionMaker:
+            def __call__(self):
+                call_count[0] += 1
+                return TrackingSession()
+
+        async def mock_api_call(train_id):
+            """Capture whether any sync session is active during API call."""
+            nonlocal session_open_during_api_call
+            if session_context_active:
+                session_open_during_api_call = True
+            return _make_train_data()
+
+        scheduler_service.njt_client.get_train_stop_list = mock_api_call
+
+        with patch("trackrat.services.scheduler.commit_with_retry"):
+            # Patch sessionmaker to return our tracking sessions
+            with patch("sqlalchemy.orm.sessionmaker", return_value=TrackingSessionMaker()):
+                result = await scheduler_service._collect_single_njt_journey_safe(
+                    "1234", date(2026, 3, 11)
+                )
+
+        assert result is not None, "Collection should succeed"
+        assert result["success"] is True
+        assert not session_open_during_api_call, (
+            "DB session was still open during NJT API call! "
+            "This causes connection pool exhaustion under concurrent load."
+        )
+        # Phase 1 read + Phase 3 write = 2 separate sessions
+        assert call_count[0] == 2, (
+            f"Expected 2 separate session opens (read + write), got {call_count[0]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_sessions_for_train_not_found(self, scheduler_service):
+        """TrainNotFoundError path should also use split sessions:
+        Phase 1 (read) then Phase 3 (write error count)."""
+
+        from trackrat.collectors.njt.client import TrainNotFoundError
+
+        session_open_during_api_call = False
+        session_context_active = False
+        call_count = [0]
+
+        class TrackingSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row(api_error_count=0)
+
+            def __enter__(self):
+                nonlocal session_context_active
+                session_context_active = True
+                return self
+
+            def __exit__(self, *args):
+                nonlocal session_context_active
+                session_context_active = False
+
+            def execute(self, stmt):
+                return self._execute_result
+
+            def get(self, model, pk):
+                return _make_journey_orm()
+
+            @property
+            def no_autoflush(self):
+                return MagicMock()
+
+        class TrackingSessionMaker:
+            def __call__(self):
+                nonlocal call_count
+                call_count[0] += 1
+                return TrackingSession()
+
+        async def mock_api_call(train_id):
+            nonlocal session_open_during_api_call
+            if session_context_active:
+                session_open_during_api_call = True
+            raise TrainNotFoundError(f"Train {train_id} not found")
+
+        scheduler_service.njt_client.get_train_stop_list = mock_api_call
+
+        with patch("trackrat.services.scheduler.commit_with_retry"):
+            with patch("sqlalchemy.orm.sessionmaker", return_value=TrackingSessionMaker()):
+                result = await scheduler_service._collect_single_njt_journey_safe(
+                    "1234", date(2026, 3, 11)
+                )
+
+        assert result is not None
+        assert result["success"] is False
+        assert result["error"] == "Train not found"
+        assert not session_open_during_api_call, (
+            "DB session was open during API call on TrainNotFoundError path"
+        )
+        # Phase 1 read + error write = 2 sessions
+        assert call_count[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_one_session_for_null_data(self, scheduler_service):
+        """NJTransitNullDataError path should only open one session (Phase 1 read).
+        No DB write is needed — just return immediately."""
+
+        from trackrat.collectors.njt.client import NJTransitNullDataError
+
+        call_count = [0]
+
+        class TrackingSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+        class TrackingSessionMaker:
+            def __call__(self):
+                nonlocal call_count
+                call_count[0] += 1
+                return TrackingSession()
+
+        async def mock_api_call(train_id):
+            raise NJTransitNullDataError("Null data")
+
+        scheduler_service.njt_client.get_train_stop_list = mock_api_call
+
+        with patch("sqlalchemy.orm.sessionmaker", return_value=TrackingSessionMaker()):
+            result = await scheduler_service._collect_single_njt_journey_safe(
+                "1234", date(2026, 3, 11)
+            )
+
+        assert result is not None
+        assert result["success"] is False
+        assert result["error"] == "Transient null data"
+        # Only Phase 1 read — no write needed
+        assert call_count[0] == 1, (
+            f"NullDataError should only open 1 session (read), got {call_count[0]}"
+        )
+
+
+class TestSemaphoreConcurrencyLimit:
+    """Verify the semaphore caps concurrent NJT API calls."""
+
+    @pytest.mark.asyncio
+    async def test_semaphore_limits_concurrent_api_calls(self, scheduler_service):
+        """When 20 collections run concurrently, at most 10 should be
+        making API calls simultaneously (semaphore limit)."""
+
+        max_concurrent = 0
+        current_concurrent = 0
+        lock = asyncio.Lock()
+
+        class SimpleSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+            def get(self, model, pk):
+                return _make_journey_orm()
+
+            def add(self, obj):
+                pass
+
+            @property
+            def no_autoflush(self):
+                return MagicMock()
+
+        class SimpleSessionMaker:
+            def __call__(self):
+                return SimpleSession()
+
+        async def slow_api_call(train_id):
+            """Simulate a slow API call while tracking concurrency."""
+            nonlocal max_concurrent, current_concurrent
+            async with lock:
+                current_concurrent += 1
+                if current_concurrent > max_concurrent:
+                    max_concurrent = current_concurrent
+            # Simulate API latency
+            await asyncio.sleep(0.05)
+            async with lock:
+                current_concurrent -= 1
+            return _make_train_data()
+
+        scheduler_service.njt_client.get_train_stop_list = slow_api_call
+
+        with patch("trackrat.services.scheduler.commit_with_retry"):
+            with patch("sqlalchemy.orm.sessionmaker", return_value=SimpleSessionMaker()):
+                # Fire 20 concurrent collections
+                tasks = [
+                    asyncio.create_task(
+                        scheduler_service._collect_single_njt_journey_safe(
+                            str(i), date(2026, 3, 11)
+                        )
+                    )
+                    for i in range(20)
+                ]
+                results = await asyncio.gather(*tasks)
+
+        # All should succeed
+        successful = [r for r in results if r and r.get("success")]
+        assert len(successful) == 20, f"Expected 20 successes, got {len(successful)}"
+
+        # Concurrency should be capped at semaphore limit (10)
+        assert max_concurrent <= 10, (
+            f"Max concurrent API calls was {max_concurrent}, expected <= 10. "
+            "Semaphore is not limiting concurrency properly."
+        )
+        # Should actually hit the limit (all 20 tasks compete for 10 slots)
+        assert max_concurrent >= 5, (
+            f"Max concurrent was only {max_concurrent} — semaphore may not be needed, "
+            "but this is unexpectedly low for 20 tasks."
+        )
+
+    @pytest.mark.asyncio
+    async def test_semaphore_does_not_block_reads(self, scheduler_service):
+        """Phase 1 (DB read) should happen OUTSIDE the semaphore,
+        so even if the semaphore is full, new tasks can still check
+        if the journey exists/is expired without waiting."""
+
+        # Set semaphore to 1 to make contention obvious
+        scheduler_service._njt_collection_semaphore = asyncio.Semaphore(1)
+
+        phase1_completed = asyncio.Event()
+        api_started = asyncio.Event()
+        api_can_finish = asyncio.Event()
+
+        class SimpleSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                # Return expired journey for task 2 so it exits early
+                self._execute_result.first.return_value = _make_journey_row(is_expired=True)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+        first_call = [True]
+
+        class SimpleSessionMaker:
+            def __call__(self):
+                s = SimpleSession()
+                # First call returns non-expired, second returns expired
+                if first_call[0]:
+                    first_call[0] = False
+                    row = _make_journey_row(is_expired=False)
+                else:
+                    row = _make_journey_row(is_expired=True)
+                s._execute_result.first.return_value = row
+                return s
+
+        async def blocking_api_call(train_id):
+            api_started.set()
+            await api_can_finish.wait()
+            return _make_train_data()
+
+        scheduler_service.njt_client.get_train_stop_list = blocking_api_call
+
+        async def task1():
+            """Holds the semaphore during a long API call."""
+            with patch("trackrat.services.scheduler.commit_with_retry"):
+                with patch("sqlalchemy.orm.sessionmaker", return_value=SimpleSessionMaker()):
+                    return await scheduler_service._collect_single_njt_journey_safe(
+                        "1111", date(2026, 3, 11)
+                    )
+
+        async def task2():
+            """Should be able to read DB and exit early (expired journey)
+            even while task1 holds the semaphore."""
+            await api_started.wait()  # Ensure task1 has the semaphore
+            with patch("sqlalchemy.orm.sessionmaker", return_value=SimpleSessionMaker()):
+                return await scheduler_service._collect_single_njt_journey_safe(
+                    "2222", date(2026, 3, 11)
+                )
+
+        t1 = asyncio.create_task(task1())
+        t2 = asyncio.create_task(task2())
+
+        # Task 2 should complete quickly (expired journey, no API call needed)
+        result2 = await asyncio.wait_for(t2, timeout=2.0)
+        assert result2 is None, "Expired journey should return None without waiting for semaphore"
+
+        # Let task 1 finish
+        api_can_finish.set()
+        await t1
+
+
+class TestCodePaths:
+    """Verify all code paths in the refactored method produce correct results."""
+
+    @pytest.mark.asyncio
+    async def test_journey_not_found_returns_none(self, scheduler_service):
+        """When no journey exists in DB, return None immediately."""
+
+        class EmptySession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+        class SessionMaker:
+            def __call__(self):
+                return EmptySession()
+
+        with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+            result = await scheduler_service._collect_single_njt_journey_safe(
+                "9999", date(2026, 3, 11)
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_expired_journey_returns_none(self, scheduler_service):
+        """Expired journeys should be skipped without an API call."""
+
+        api_called = False
+
+        class ExpiredSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row(is_expired=True)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+        class SessionMaker:
+            def __call__(self):
+                return ExpiredSession()
+
+        async def should_not_be_called(train_id):
+            nonlocal api_called
+            api_called = True
+
+        scheduler_service.njt_client.get_train_stop_list = should_not_be_called
+
+        with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+            result = await scheduler_service._collect_single_njt_journey_safe(
+                "1234", date(2026, 3, 11)
+            )
+
+        assert result is None
+        assert not api_called, "API should not be called for expired journeys"
+
+    @pytest.mark.asyncio
+    async def test_train_not_found_increments_error_count(self, scheduler_service):
+        """TrainNotFoundError should increment api_error_count and mark expired after 3."""
+
+        from trackrat.collectors.njt.client import TrainNotFoundError
+
+        written_journey = None
+
+        class WriteSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row(api_error_count=2)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+            def get(self, model, pk):
+                nonlocal written_journey
+                written_journey = _make_journey_orm(api_error_count=2, update_count=5)
+                return written_journey
+
+        class SessionMaker:
+            def __call__(self):
+                return WriteSession()
+
+        async def raise_not_found(train_id):
+            raise TrainNotFoundError(f"Train {train_id} not found")
+
+        scheduler_service.njt_client.get_train_stop_list = raise_not_found
+
+        with patch("trackrat.services.scheduler.commit_with_retry"):
+            with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+                result = await scheduler_service._collect_single_njt_journey_safe(
+                    "1234", date(2026, 3, 11)
+                )
+
+        assert result["success"] is False
+        assert result["error"] == "Train not found"
+        assert result["expired"] is True  # 2 + 1 = 3 >= 3
+        assert written_journey is not None
+        assert written_journey.api_error_count == 3
+        assert written_journey.is_expired is True
+
+    @pytest.mark.asyncio
+    async def test_njt_client_not_initialized_returns_none(self, scheduler_service):
+        """Missing NJT client should return None without attempting API call."""
+
+        scheduler_service.njt_client = None
+
+        class ReadSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+        class SessionMaker:
+            def __call__(self):
+                return ReadSession()
+
+        with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+            result = await scheduler_service._collect_single_njt_journey_safe(
+                "1234", date(2026, 3, 11)
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_successful_collection_returns_correct_data(self, scheduler_service):
+        """Successful API call should write to DB and return result dict."""
+
+        written_objects = []
+
+        class WriteSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+            def get(self, model, pk):
+                return _make_journey_orm()
+
+            def add(self, obj):
+                written_objects.append(obj)
+
+            @property
+            def no_autoflush(self):
+                return MagicMock()
+
+        class SessionMaker:
+            def __call__(self):
+                return WriteSession()
+
+        train_data = _make_train_data()
+        scheduler_service.njt_client.get_train_stop_list = AsyncMock(return_value=train_data)
+
+        with patch("trackrat.services.scheduler.commit_with_retry"):
+            with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+                result = await scheduler_service._collect_single_njt_journey_safe(
+                    "1234", date(2026, 3, 11)
+                )
+
+        assert result is not None
+        assert result["success"] is True
+        assert result["train_id"] == "1234"
+        assert result["stops_count"] == 3
+        assert result["destination"] == "Test Destination"
+        # Should have written stops + snapshot
+        assert len(written_objects) >= 3, (
+            f"Expected at least 3 written objects (3 stops + snapshot), got {len(written_objects)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_journey_disappeared_between_phases(self, scheduler_service):
+        """If the journey is deleted between Phase 1 and Phase 3, handle gracefully."""
+
+        call_count = [0]
+
+        class DisappearingSession:
+            def __init__(self):
+                self._execute_result = Mock()
+                self._execute_result.first.return_value = _make_journey_row()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                return self._execute_result
+
+            def get(self, model, pk):
+                # Journey was deleted between Phase 1 and Phase 3
+                return None
+
+            @property
+            def no_autoflush(self):
+                return MagicMock()
+
+        class SessionMaker:
+            def __call__(self):
+                nonlocal call_count
+                call_count[0] += 1
+                return DisappearingSession()
+
+        scheduler_service.njt_client.get_train_stop_list = AsyncMock(
+            return_value=_make_train_data()
+        )
+
+        with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+            result = await scheduler_service._collect_single_njt_journey_safe(
+                "1234", date(2026, 3, 11)
+            )
+
+        assert result is None, "Should return None when journey disappears between phases"
+
+    @pytest.mark.asyncio
+    async def test_transient_db_error_returns_retry_needed(self, scheduler_service):
+        """Serialization failures should be flagged as transient with retry_needed."""
+
+        class FailSession:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def execute(self, stmt):
+                raise Exception("serialization failure")
+
+        class SessionMaker:
+            def __call__(self):
+                return FailSession()
+
+        with patch("sqlalchemy.orm.sessionmaker", return_value=SessionMaker()):
+            result = await scheduler_service._collect_single_njt_journey_safe(
+                "1234", date(2026, 3, 11)
+            )
+
+        assert result is not None
+        assert result["success"] is False
+        assert result["retry_needed"] is True


### PR DESCRIPTION
## Summary

Refactors `_collect_single_njt_journey_safe` to split database access into separate read and write phases around the external NJT API call. This prevents database connections from being held while waiting for network responses, eliminating connection pool exhaustion under concurrent load.

## Key Changes

- **Session Splitting**: Reorganized the method into three distinct phases:
  - **Phase 1 (Read)**: Opens a session, reads journey metadata (id, is_expired, api_error_count), then closes the connection before any API calls
  - **Phase 2 (API Call)**: Makes the async NJT API request with no database connection held, protected by a semaphore to cap concurrent calls at 10
  - **Phase 3 (Write)**: Opens a fresh session only to write results back to the database

- **Semaphore-Based Concurrency Control**: Added `_njt_collection_semaphore` (limit: 10) to prevent overwhelming the NJT API and reduce downstream database write contention. The semaphore only protects the API call phase, allowing Phase 1 reads to proceed without waiting.

- **Optimized Phase 1 Query**: Changed from loading full `TrainJourney` objects with eager-loaded stops to a minimal column query (`id`, `is_expired`, `api_error_count`), reducing memory overhead and query time.

- **Graceful Error Handling**: 
  - `NJTransitNullDataError`: Returns immediately after Phase 1 (no write needed)
  - `TrainNotFoundError`: Opens a separate Phase 3 session to increment error count and mark expired after 3 failures
  - Journey disappearance: Handles case where journey is deleted between Phase 1 and Phase 3

- **Comprehensive Test Suite**: Added 693 lines of unit tests covering:
  - Session closure verification before API calls
  - Semaphore concurrency limits (max 10 concurrent API calls with 20 tasks)
  - Semaphore non-blocking behavior for Phase 1 reads
  - All error paths and edge cases
  - Correct data flow through all three phases

## Implementation Details

- Uses synchronous `sessionmaker` for all database operations to avoid greenlet issues in APScheduler contexts
- Captures only necessary journey metadata in Phase 1 to minimize connection hold time
- Semaphore wraps only the `get_train_stop_list` call, not the entire method
- Maintains backward compatibility with existing error handling and logging
- All three phases use separate session instances to ensure clean connection lifecycle

https://claude.ai/code/session_01RvdgtwhbcHAv7dTLkU9kyx