### PR TITLE
Add service alerts and upcoming trains to route status view

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -158,7 +158,20 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 if let appState = AppDelegate.appState {
                     appState.pendingRouteStatus = context
                 } else {
-                    // Cold launch: appState not yet available, stash for pickup in onAppear
+                    AppDelegate.pendingColdLaunchRouteStatus = context
+                }
+            }
+        } else if let serviceAlert = userInfo["service_alert"] as? [String: Any] {
+            let context = RouteStatusContext(
+                dataSource: serviceAlert["data_source"] as? String ?? "",
+                lineId: serviceAlert["line_id"] as? String,
+                fromStationCode: nil,
+                toStationCode: nil
+            )
+            Task { @MainActor in
+                if let appState = AppDelegate.appState {
+                    appState.pendingRouteStatus = context
+                } else {
                     AppDelegate.pendingColdLaunchRouteStatus = context
                 }
             }

--- a/ios/TrackRat/Models/V2APIModels.swift
+++ b/ios/TrackRat/Models/V2APIModels.swift
@@ -1128,6 +1128,50 @@ struct OperationsSummaryResponse: Codable {
     }
 }
 
+// MARK: - Service Alert Models
+
+struct V2ServiceAlertActivePeriod: Codable {
+    let start: Int?
+    let end: Int?
+}
+
+struct V2ServiceAlert: Codable, Identifiable {
+    let alertId: String
+    let dataSource: String
+    let alertType: String
+    let affectedRouteIds: [String]
+    let headerText: String
+    let descriptionText: String?
+    let activePeriods: [V2ServiceAlertActivePeriod]
+
+    var id: String { alertId }
+
+    enum CodingKeys: String, CodingKey {
+        case alertId = "alert_id"
+        case dataSource = "data_source"
+        case alertType = "alert_type"
+        case affectedRouteIds = "affected_route_ids"
+        case headerText = "header_text"
+        case descriptionText = "description_text"
+        case activePeriods = "active_periods"
+    }
+
+    /// Human-readable alert type label
+    var alertTypeLabel: String {
+        switch alertType {
+        case "planned_work": return "Planned Work"
+        case "alert": return "Alert"
+        case "elevator": return "Elevator"
+        default: return alertType.capitalized
+        }
+    }
+}
+
+struct V2ServiceAlertsResponse: Codable {
+    let alerts: [V2ServiceAlert]
+    let count: Int
+}
+
 // MARK: - Delay Forecast Models
 
 /// Delay probability breakdown

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -155,8 +155,30 @@ final class APIService: ObservableObject {
         }
     }
     
+    // MARK: - Service Alerts
+
+    func fetchServiceAlerts(dataSource: String) async throws -> [V2ServiceAlert] {
+        guard var components = URLComponents(string: "\(baseURL)/v2/alerts/service") else {
+            throw APIError.invalidURL
+        }
+
+        components.queryItems = [
+            URLQueryItem(name: "data_source", value: dataSource)
+        ]
+
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+
+        return try await executeWithRetry {
+            let (data, _) = try await self.session.data(from: url)
+            let response = try self.decoder.decode(V2ServiceAlertsResponse.self, from: data)
+            return response.alerts
+        }
+    }
+
     // MARK: - Train Details
-    
+
     func fetchTrainDetails(id: String, fromStationCode: String? = nil, date: Date? = nil, dataSource: String? = nil) async throws -> TrainV2 {
         var components = URLComponents(string: "\(baseURL)/v2/trains/\(id)")!
 

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -4,6 +4,7 @@ import MapKit
 struct RouteStatusView: View {
     let context: RouteStatusContext
     @StateObject private var viewModel: RouteStatusViewModel
+    @EnvironmentObject private var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
     /// Mutable subscription for inline configuration (nil when opened without alert context).
@@ -29,12 +30,18 @@ struct RouteStatusView: View {
         self.onSave = onSave
     }
 
+    /// Train selected for detail sheet
+    @State private var selectedTrain: TrainV2?
+
     var body: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
                     mapSection
                     operationsSummarySection
+                    serviceAlertsSection
+                    upcomingTrainsSection
+
                     historySections
 
                     if let _ = subscription {
@@ -65,6 +72,33 @@ struct RouteStatusView: View {
                     onSave?(subscription)
                 }
             }
+            .sheet(item: $selectedTrain) { train in
+                NavigationStack {
+                    TrainDetailsView(
+                        trainNumber: train.trainId,
+                        fromStation: context.effectiveFromStation,
+                        journeyDate: train.journeyDate,
+                        dataSource: train.dataSource,
+                        isSheet: true
+                    )
+                }
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+            }
+        }
+    }
+
+    /// Dismiss this sheet and navigate to the full departures list in the main app.
+    private func navigateToAllDepartures() {
+        guard let to = context.effectiveToStation,
+              let from = context.effectiveFromStation else { return }
+        let destination = Stations.displayName(for: to)
+        // Dismiss the route status sheet first, then navigate
+        dismiss()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            appState.navigationPath.append(
+                NavigationDestination.trainList(destination: destination, departureStationCode: from)
+            )
         }
     }
 
@@ -106,6 +140,64 @@ struct RouteStatusView: View {
             fromStation: context.effectiveFromStation,
             toStation: context.effectiveToStation
         )
+    }
+
+    // MARK: - Service Alerts Section
+
+    @ViewBuilder
+    private var serviceAlertsSection: some View {
+        if !viewModel.serviceAlerts.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Service Alerts (\(viewModel.serviceAlerts.count))", systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline)
+                    .foregroundColor(.orange)
+
+                ForEach(viewModel.serviceAlerts) { alert in
+                    ServiceAlertCard(alert: alert)
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        }
+    }
+
+    // MARK: - Upcoming Trains Section
+
+    @ViewBuilder
+    private var upcomingTrainsSection: some View {
+        if !viewModel.upcomingTrains.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Upcoming Trains")
+                    .font(.headline)
+
+                ForEach(viewModel.upcomingTrains) { train in
+                    Button {
+                        selectedTrain = train
+                    } label: {
+                        UpcomingTrainRow(train: train, dataSource: context.dataSource)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                if context.effectiveFromStation != nil && context.effectiveToStation != nil {
+                    Button {
+                        navigateToAllDepartures()
+                    } label: {
+                        HStack {
+                            Text("View All Departures")
+                                .font(.subheadline.bold())
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                        }
+                        .foregroundColor(.orange)
+                        .padding(.top, 4)
+                    }
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        }
     }
 
     // MARK: - History Sections (Past Hour, Past 24 Hours, Past 7 Days)
@@ -307,6 +399,141 @@ struct RouteStatusView: View {
     }
 }
 
+// MARK: - Service Alert Card
+
+private struct ServiceAlertCard: View {
+    let alert: V2ServiceAlert
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(alert.alertTypeLabel.uppercased())
+                    .font(.caption2.bold())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(alertTypeColor.opacity(0.2)))
+                    .foregroundColor(alertTypeColor)
+                Spacer()
+            }
+
+            Text(alert.headerText)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+
+            if let description = alert.descriptionText, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(isExpanded ? nil : 3)
+
+                if description.count > 120 {
+                    Button(isExpanded ? "Show Less" : "Show More") {
+                        withAnimation { isExpanded.toggle() }
+                    }
+                    .font(.caption.bold())
+                    .foregroundColor(.orange)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private var alertTypeColor: Color {
+        switch alert.alertType {
+        case "planned_work": return .yellow
+        case "alert": return .red
+        case "elevator": return .blue
+        default: return .orange
+        }
+    }
+}
+
+// MARK: - Upcoming Train Row
+
+private struct UpcomingTrainRow: View {
+    let train: TrainV2
+    let dataSource: String
+
+    /// Whether this transit system uses synthetic train IDs (e.g., subway, PATCO)
+    private var useSyntheticId: Bool {
+        TrainSystem.syntheticTrainIdSources.contains(dataSource)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Line color indicator
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: train.line.color))
+                .frame(width: 4, height: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    if useSyntheticId {
+                        Text(train.line.name)
+                            .font(.subheadline.bold())
+                    } else {
+                        Text("Train \(train.trainId)")
+                            .font(.subheadline.bold())
+                    }
+                    Text("→ \(train.destination)")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+                HStack(spacing: 8) {
+                    if let track = train.departure.track, !track.isEmpty {
+                        Text("Track \(track)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    if train.isCancelled {
+                        Text("Cancelled")
+                            .font(.caption.bold())
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(departureTimeString)
+                    .font(.subheadline.bold())
+                delayBadge
+            }
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private var departureTimeString: String {
+        let time = train.departure.updatedTime ?? train.departure.scheduledTime
+        guard let time = time else { return "--" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        formatter.timeZone = TimeZone(identifier: "America/New_York")
+        return formatter.string(from: time)
+    }
+
+    @ViewBuilder
+    private var delayBadge: some View {
+        if train.isCancelled {
+            EmptyView()
+        } else if train.departure.delayMinutes > 0 {
+            Text("+\(train.departure.delayMinutes)m")
+                .font(.caption.bold())
+                .foregroundColor(.red)
+        } else {
+            Text("On Time")
+                .font(.caption)
+                .foregroundColor(.green)
+        }
+    }
+}
+
 // MARK: - View Model
 
 @MainActor
@@ -319,6 +546,15 @@ final class RouteStatusViewModel: ObservableObject {
     @Published var mapRegion = MKCoordinateRegion()
     @Published var isLoadingMap = false
     @Published var mapError: String?
+
+    // Service alerts (MTA systems only)
+    @Published var serviceAlerts: [V2ServiceAlert] = []
+
+    // Upcoming trains
+    @Published var upcomingTrains: [TrainV2] = []
+
+    /// Data sources that have service alert data
+    private static let serviceAlertSystems: Set<String> = ["SUBWAY", "LIRR", "MNR"]
 
     // History state - per-section loading and error
     @Published var pastHourData: RouteHistoricalData?
@@ -339,6 +575,8 @@ final class RouteStatusViewModel: ObservableObject {
         await withTaskGroup(of: Void.self) { group in
             group.addTask { await self.loadCongestionMap() }
             group.addTask { await self.loadAllHistory() }
+            group.addTask { await self.loadServiceAlerts() }
+            group.addTask { await self.loadUpcomingTrains() }
         }
     }
 
@@ -412,6 +650,37 @@ final class RouteStatusViewModel: ObservableObject {
             longitudeDelta: (maxLon - minLon) * 1.4 + 0.01
         )
         mapRegion = MKCoordinateRegion(center: center, span: span)
+    }
+
+    // MARK: - Service Alerts
+
+    private func loadServiceAlerts() async {
+        guard Self.serviceAlertSystems.contains(context.dataSource) else { return }
+        do {
+            let alerts = try await APIService.shared.fetchServiceAlerts(dataSource: context.dataSource)
+            serviceAlerts = alerts
+        } catch {
+            // Silent failure — section just won't appear
+            print("⚠️ Failed to load service alerts: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Upcoming Trains
+
+    private func loadUpcomingTrains() async {
+        guard let from = context.effectiveFromStation,
+              let to = context.effectiveToStation else { return }
+        do {
+            let dataSource = TrainSystem(rawValue: context.dataSource)
+            let trains = try await APIService.shared.searchTrains(
+                fromStationCode: from,
+                toStationCode: to,
+                dataSources: dataSource.map { Set([$0]) }
+            )
+            upcomingTrains = Array(trains.prefix(5))
+        } catch {
+            print("⚠️ Failed to load upcoming trains: \(error.localizedDescription)")
+        }
     }
 
     // MARK: - History
@@ -498,4 +767,5 @@ final class RouteStatusViewModel: ObservableObject {
         fromStationCode: "NY",
         toStationCode: "TR"
     ))
+    .environmentObject(AppState())
 }


### PR DESCRIPTION
## Summary
Enhanced the RouteStatusView to display service alerts and upcoming trains for the selected route, providing users with more comprehensive real-time transit information.

## Key Changes

- **Service Alerts Section**: Added a new collapsible section displaying MTA service alerts (SUBWAY, LIRR, MNR) with expandable descriptions and color-coded alert types
- **Upcoming Trains Section**: Added a new section showing the next 5 upcoming trains with departure times, delays, and track information, with the ability to tap for full train details
- **Train Details Sheet**: Implemented a sheet modal for viewing full train details when tapping an upcoming train
- **Navigation Enhancement**: Added ability to navigate to the full departures list from the upcoming trains section via `AppState` navigation
- **API Integration**: 
  - Added `fetchServiceAlerts()` method to APIService for fetching service alerts by data source
  - Added `loadServiceAlerts()` and `loadUpcomingTrains()` methods to RouteStatusViewModel
  - Both data loads run concurrently with existing map and history loads
- **Data Models**: Added `V2ServiceAlert`, `V2ServiceAlertActivePeriod`, and `V2ServiceAlertsResponse` models with proper Codable support
- **UI Components**: 
  - Created `ServiceAlertCard` component for displaying individual alerts with type badges and expandable descriptions
  - Created `UpcomingTrainRow` component for displaying train information with line colors, delays, and cancellation status
- **Environment Integration**: Added `@EnvironmentObject AppState` to RouteStatusView to support navigation to departures list
- **Push Notification Handling**: Extended notification handling in AppDelegate to support service alert notifications

## Implementation Details

- Service alerts are only fetched for systems that support them (SUBWAY, LIRR, MNR)
- Upcoming trains are limited to 5 results and filtered by the selected route's stations
- Alert descriptions support "Show More/Less" expansion for longer text
- Train departure times respect updated times when available, falling back to scheduled times
- Delay information is color-coded (green for on-time, red for delays)
- All new data loads fail silently to prevent disrupting the main route status view

https://claude.ai/code/session_01J8hoTcBbbdMqdbstxJZnWe