### PR TITLE
Add lazy loading guards and increase station code length limit

### DIFF
--- a/backend_v2/src/trackrat/models/api.py
+++ b/backend_v2/src/trackrat/models/api.py
@@ -63,7 +63,7 @@ class LineInfo(BaseModel):
 class StationInfo(BaseModel):
     """Station information with timing data only."""
 
-    code: str = Field(..., min_length=1, max_length=4)
+    code: str = Field(..., min_length=1, max_length=10)
     name: str
     scheduled_time: datetime | None = None
     updated_time: datetime | None = None
@@ -78,7 +78,7 @@ class StationInfo(BaseModel):
 class SimpleStationInfo(BaseModel):
     """Simple station information without timing data."""
 
-    code: str = Field(..., min_length=1, max_length=4)
+    code: str = Field(..., min_length=1, max_length=10)
     name: str
 
 
@@ -344,7 +344,7 @@ class TrainHistoryResponse(BaseModel):
 class OccupiedTracksResponse(BaseModel):
     """Response for occupied tracks endpoint."""
 
-    station_code: str = Field(..., min_length=1, max_length=4)
+    station_code: str = Field(..., min_length=1, max_length=10)
     station_name: str
     occupied_tracks: list[str]
     last_updated: datetime
@@ -466,8 +466,8 @@ class AmtrakTrainData(BaseModel):
 class HistoricalRouteInfo(BaseModel):
     """Route information for route-based historical data."""
 
-    from_station: str = Field(..., min_length=1, max_length=4)
-    to_station: str = Field(..., min_length=1, max_length=4)
+    from_station: str = Field(..., min_length=1, max_length=10)
+    to_station: str = Field(..., min_length=1, max_length=10)
     total_trains: int = Field(..., ge=0)
     data_source: Literal["NJT", "AMTRAK", "PATH", "PATCO", "LIRR", "MNR", "SUBWAY"]
     baseline_train_count: float | None = Field(

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -185,7 +185,7 @@ class JourneyStop(Base):
 
     # Relationships
     journey: Mapped["TrainJourney"] = relationship(
-        "TrainJourney", back_populates="stops"
+        "TrainJourney", back_populates="stops", lazy="raise_on_sql"
     )
 
     __table_args__ = (
@@ -242,7 +242,7 @@ class JourneySnapshot(Base):
 
     # Relationships
     journey: Mapped["TrainJourney"] = relationship(
-        "TrainJourney", back_populates="snapshots"
+        "TrainJourney", back_populates="snapshots", lazy="raise_on_sql"
     )
 
     __table_args__ = (
@@ -309,6 +309,7 @@ class DeviceToken(Base):
         cascade="all, delete-orphan",
         foreign_keys="RouteAlertSubscription.device_id",
         primaryjoin="DeviceToken.device_id == RouteAlertSubscription.device_id",
+        lazy="raise_on_sql",
     )
 
 
@@ -359,6 +360,7 @@ class RouteAlertSubscription(Base):
         "DeviceToken",
         back_populates="subscriptions",
         foreign_keys=[device_id],
+        lazy="raise_on_sql",
     )
 
     __table_args__ = (
@@ -443,7 +445,7 @@ class SegmentTransitTime(Base):
 
     # Relationships
     journey: Mapped["TrainJourney"] = relationship(
-        "TrainJourney", back_populates="segment_times"
+        "TrainJourney", back_populates="segment_times", lazy="raise_on_sql"
     )
 
     __table_args__ = (
@@ -492,7 +494,7 @@ class StationDwellTime(Base):
 
     # Relationships
     journey: Mapped["TrainJourney"] = relationship(
-        "TrainJourney", back_populates="dwell_times"
+        "TrainJourney", back_populates="dwell_times", lazy="raise_on_sql"
     )
 
     __table_args__ = (
@@ -534,7 +536,7 @@ class JourneyProgress(Base):
 
     # Relationships
     journey: Mapped["TrainJourney"] = relationship(
-        "TrainJourney", back_populates="progress"
+        "TrainJourney", back_populates="progress", lazy="raise_on_sql"
     )
 
     __table_args__ = (Index("idx_journey_progress", "journey_id", "captured_at"),)
@@ -662,7 +664,8 @@ class GTFSRoute(Base):
 
     # Relationships
     trips: Mapped[list["GTFSTrip"]] = relationship(
-        "GTFSTrip", back_populates="route", cascade="all, delete-orphan"
+        "GTFSTrip", back_populates="route", cascade="all, delete-orphan",
+        lazy="raise_on_sql",
     )
 
     __table_args__ = (
@@ -686,9 +689,12 @@ class GTFSTrip(Base):
     direction_id = Column(Integer)  # 0=outbound, 1=inbound
 
     # Relationships
-    route: Mapped["GTFSRoute"] = relationship("GTFSRoute", back_populates="trips")
+    route: Mapped["GTFSRoute"] = relationship(
+        "GTFSRoute", back_populates="trips", lazy="raise_on_sql"
+    )
     stop_times: Mapped[list["GTFSStopTime"]] = relationship(
-        "GTFSStopTime", back_populates="trip", cascade="all, delete-orphan"
+        "GTFSStopTime", back_populates="trip", cascade="all, delete-orphan",
+        lazy="raise_on_sql",
     )
 
     __table_args__ = (
@@ -720,7 +726,9 @@ class GTFSStopTime(Base):
     drop_off_type = Column(Integer, default=0)
 
     # Relationships
-    trip: Mapped["GTFSTrip"] = relationship("GTFSTrip", back_populates="stop_times")
+    trip: Mapped["GTFSTrip"] = relationship(
+        "GTFSTrip", back_populates="stop_times", lazy="raise_on_sql"
+    )
 
     __table_args__ = (
         Index("idx_gtfs_stop_time_trip", "trip_id", "stop_sequence"),

--- a/backend_v2/src/trackrat/services/jit.py
+++ b/backend_v2/src/trackrat/services/jit.py
@@ -271,7 +271,21 @@ class JustInTimeUpdateService:
                     error=str(e),
                     error_type=type(e).__name__,
                 )
-                # Return stale data rather than failing
+                # Clear session error state (e.g., PendingRollbackError from failed
+                # flush/commit) so subsequent operations on this session still work.
+                try:
+                    await session.rollback()
+                except Exception:
+                    pass
+                # Re-query journey since rollback expires all ORM objects.
+                # Without this, accessing journey.stops would trigger a lazy load
+                # that fails with raise_on_sql.
+                try:
+                    journey = await session.scalar(stmt)
+                    if not journey:
+                        return None
+                except Exception:
+                    return None
         else:
             logger.debug(
                 "journey_data_fresh",


### PR DESCRIPTION
## Summary
This PR implements lazy loading guards across ORM relationships and increases the maximum station code length from 4 to 10 characters to support additional transit systems.

## Key Changes

### Lazy Loading Guards
- Added `lazy="raise_on_sql"` to all relationship definitions in the database models to prevent implicit lazy loading that could occur outside of async contexts
- Affected relationships:
  - `JourneyStop.journey`
  - `JourneySnapshot.journey`
  - `DeviceToken.subscriptions`
  - `RouteAlertSubscription.device`
  - `SegmentTransitTime.journey`
  - `StationDwellTime.journey`
  - `JourneyProgress.journey`
  - `GTFSRoute.trips`
  - `GTFSTrip.route` and `GTFSTrip.stop_times`
  - `GTFSStopTime.trip`

### Session Error Recovery
- Enhanced `do_refresh()` in `jit.py` to properly handle session errors when lazy loading guards are in place
- Added explicit session rollback after failed operations to clear error state
- Re-query the journey object after rollback since ORM objects expire after rollback, preventing lazy load failures

### API Schema Updates
- Increased `station_code` field maximum length from 4 to 10 characters in:
  - `StationInfo`
  - `SimpleStationInfo`
  - `OccupiedTracksResponse`
  - `HistoricalRouteInfo` (both `from_station` and `to_station`)

## Implementation Details
The lazy loading guards ensure that relationships are explicitly loaded during query construction rather than implicitly loaded later, which is critical for async SQLAlchemy operations. The session recovery logic in `jit.py` ensures that when lazy loading is attempted and fails, the session is properly reset and the data is re-fetched explicitly.

https://claude.ai/code/session_01CgdoFALvG7cqotagNh9MyE