### PR TITLE
Optimize JIT refresh for high-frequency data sources

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -287,10 +287,12 @@ async def _calculate_route_stats_sql(
                     AS arrival_delay_minutes
             FROM journey_stops js
             INNER JOIN route_journeys rj ON rj.journey_id = js.journey_id
+            INNER JOIN train_journeys tj ON tj.id = rj.journey_id
             WHERE js.station_code = ANY(:to_codes)
               AND js.actual_arrival IS NOT NULL
               AND js.scheduled_arrival IS NOT NULL
-              AND js.arrival_source = 'api_observed'
+              AND (js.arrival_source = 'api_observed'
+                   OR (tj.is_completed = true AND js.arrival_source IS NOT NULL))
             ORDER BY js.journey_id, js.stop_sequence ASC
         ),
         origin_stops AS (

--- a/backend_v2/src/trackrat/collectors/path/collector.py
+++ b/backend_v2/src/trackrat/collectors/path/collector.py
@@ -740,6 +740,8 @@ class PathCollector:
                     TrainJourney.origin_station_code == origin_station,
                     TrainJourney.scheduled_departure >= time_min,
                     TrainJourney.scheduled_departure <= time_max,
+                    TrainJourney.is_completed == False,  # noqa: E712
+                    TrainJourney.is_expired == False,  # noqa: E712
                 )
             )
             .with_for_update(skip_locked=True)

--- a/backend_v2/src/trackrat/db/engine.py
+++ b/backend_v2/src/trackrat/db/engine.py
@@ -46,6 +46,8 @@ def _is_postgresql_concurrency_error(error: Exception) -> bool:
         "deadlock detected",
         "could not serialize access due to concurrent update",
         "could not serialize access due to read/write dependencies",
+        # Statement cancellation (e.g., asyncpg command_timeout)
+        "canceling statement due to user request",
         # Temporary resource issues
         "too many connections",
         "connection pool exhausted",

--- a/backend_v2/src/trackrat/services/jit.py
+++ b/backend_v2/src/trackrat/services/jit.py
@@ -301,6 +301,12 @@ class JustInTimeUpdateService:
 
         return journey
 
+    # Data sources with high-frequency background collectors (every 4 min).
+    # JIT refresh for these sources creates lock contention with negligible
+    # freshness gain, so we use the collector interval as the staleness baseline.
+    _HIGH_FREQ_COLLECTOR_SOURCES = {"PATH", "LIRR", "MNR", "SUBWAY"}
+    _HIGH_FREQ_STALENESS_SECONDS = 240  # 4 minutes, matches collector interval
+
     def needs_refresh(self, journey: TrainJourney) -> bool:
         """Determine if a journey needs a data refresh.
 
@@ -321,6 +327,11 @@ class JustInTimeUpdateService:
         # Check staleness
         if journey.last_updated_at is None:
             return True
+
+        # High-frequency collector sources use longer staleness to avoid
+        # lock contention between JIT and the background collector
+        if journey.data_source in self._HIGH_FREQ_COLLECTOR_SOURCES:
+            return is_stale(journey.last_updated_at, self._HIGH_FREQ_STALENESS_SECONDS)
 
         # Use tighter staleness for trains departing soon
         staleness_threshold = self.settings.data_staleness_seconds


### PR DESCRIPTION
## Summary
This PR optimizes data refresh behavior for high-frequency transit data sources (PATH, LIRR, MNR, SUBWAY) to reduce lock contention with background collectors while maintaining data freshness. It also includes improvements to route statistics queries and journey matching logic.

## Key Changes

- **JIT Refresh Optimization**: Introduced `_HIGH_FREQ_COLLECTOR_SOURCES` and `_HIGH_FREQ_STALENESS_SECONDS` constants to use a 4-minute staleness baseline for sources with background collectors running at that interval. This prevents unnecessary JIT refresh calls that create lock contention with minimal freshness gains.

- **Route Statistics Query Fix**: Updated `_calculate_route_stats_sql` to include completed journeys in arrival delay calculations by:
  - Adding `INNER JOIN train_journeys` to access completion status
  - Expanding the arrival source filter to include completed journeys with any non-null arrival source, not just 'api_observed' sources

- **Journey Matching Refinement**: Enhanced `_find_matching_journey` in the PATH collector to filter out completed and expired journeys when searching for matching train journeys, improving matching accuracy and preventing stale journey updates.

- **Concurrency Error Handling**: Extended PostgreSQL concurrency error detection to include statement cancellation errors (e.g., from asyncpg command timeouts), improving resilience to timeout-related failures.

## Implementation Details

The high-frequency collector optimization is based on the observation that sources like PATH, LIRR, MNR, and SUBWAY have background collectors that refresh data every 4 minutes. JIT refresh calls within this interval create unnecessary lock contention without meaningful freshness improvements. The 240-second staleness threshold aligns with the collector interval to balance freshness with performance.

https://claude.ai/code/session_01B75tM5oR4TRxReRCzm4NJc