### PR TITLE
Simplify summary headlines by removing on-time percentages

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1136,7 +1136,7 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         else:
-            headline = f"Past two hours: {dep_on_time_pct:.0f}% on time"
+            headline = "Past two hours"
 
         # Status clause
         if cancellations > 0:
@@ -1202,14 +1202,7 @@ class SummaryService:
                 body_parts.append(
                     f"{remaining} others departed, averaging every {headway:.0f} minutes."
                 )
-        elif train_count > 0:
-            headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
-            train_word = "train" if train_count == 1 else "trains"
-            body_parts.append(
-                f"{train_count} {train_word} departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
-                f"averaging every {headway:.0f} minutes."
-            )
-        else:
+        elif train_count == 0:
             body_parts.append(
                 f"No trains departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours."
             )
@@ -1435,9 +1428,9 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         elif dep_stats.has_data:
-            headline = f"Past two hours: {dep_stats.on_time_percentage:.0f}% on time"
+            headline = "Past two hours"
         elif train_stats.has_data:
-            headline = f"Past two hours: {train_stats.on_time_percentage:.0f}% on time"
+            headline = "Past two hours"
         else:
             return "", ""  # No data
 
@@ -1519,14 +1512,6 @@ class SummaryService:
         if cancellations > 0:
             cancel_word = "train" if cancellations == 1 else "trains"
             body_parts.append(f"{cancellations} similar {cancel_word} cancelled.")
-
-        if similar_count > 0:
-            headway = SUMMARY_TIME_WINDOW_MINUTES / similar_count
-            body_parts.append(
-                f"{similar_count} similar trains departed in the past "
-                f"{SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
-                f"averaging every {headway:.0f} minutes."
-            )
 
         if train_stats.has_data:
             train_display = f"This {destination} train" if destination else "This train"

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -280,8 +280,7 @@ class TestSummaryService:
         summary = summary_service._generate_route_summary(route_journeys, "NY", "NP")
 
         assert summary.scope == "route"
-        assert "Past two hours:" in summary.headline
-        assert "% on time" in summary.headline
+        assert summary.headline == "Past two hours"
         assert summary.metrics is not None
         assert summary.metrics.train_count == 2
 
@@ -496,7 +495,7 @@ class TestSummaryService:
         )
 
         assert summary.scope == "train"
-        assert "on time" in summary.headline.lower()
+        assert summary.headline == "Past two hours"
         assert summary.metrics.on_time_percentage >= 90
 
     def test_generate_train_summary_poor_performance(self, summary_service):
@@ -543,7 +542,7 @@ class TestSummaryService:
         )
 
         assert summary.scope == "train"
-        assert "on time" in summary.headline.lower()  # Shows on-time percentage (0%)
+        assert summary.headline == "Past two hours"
         assert summary.metrics.on_time_percentage == 0  # All late
 
     def test_generate_train_summary_no_history(self, summary_service):
@@ -614,7 +613,7 @@ class TestSummaryService:
 
         assert summary.scope == "train"
         # Should show similar trains data even with no history for this train
-        assert "on time" in summary.headline.lower()
+        assert summary.headline == "Past two hours"
         assert "NJ Transit" in summary.body
         assert summary.metrics is not None
         assert summary.metrics.train_count == 5
@@ -1258,8 +1257,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         print(f"body: {body!r}")
         print(f"expected_headway: {expected_headway}")
         assert headline == "Past two hours: every ~10 min"
-        assert "12 trains departed" in body
-        assert "every 10 minutes" in body
+        assert body == ""
 
     def test_single_train_headway(self, summary_service):
         """1 train over 120min → large headway."""
@@ -1322,13 +1320,13 @@ class TestFormatFrequencyRouteHeadlineBody:
         # No "others departed" since train_count=0
         assert "others departed" not in body
 
-    def test_body_mentions_time_window(self, summary_service):
-        """Body should reference the 2-hour time window."""
+    def test_normal_service_has_empty_body(self, summary_service):
+        """Normal service body should be empty since headline has all the info."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=12, cancellations=0
         )
         print(f"body: {body!r}")
-        assert "2 hours" in body
+        assert body == ""
 
 
 class TestFormatFrequencyTrainHeadlineBody:
@@ -1474,8 +1472,8 @@ class TestFormatFrequencyTrainHeadlineBody:
         assert "Cancelled 3 times" in body
         assert "past 30 days" in body
 
-    def test_similar_trains_body_includes_headway(self, summary_service):
-        """Body should show headway calculation for similar trains."""
+    def test_similar_trains_no_redundant_headway_in_body(self, summary_service):
+        """Body should not repeat headway info already in headline."""
         dep_stats = OnTimeStats(
             on_time_percentage=95.0,
             average_delay_minutes=1.0,
@@ -1494,4 +1492,6 @@ class TestFormatFrequencyTrainHeadlineBody:
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
         expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 6  # 20
-        assert "every 20 minutes" in body
+        assert headline == f"Past two hours: every ~{expected_headway:.0f} min"
+        # No redundant body - headline already conveys frequency
+        assert body == ""


### PR DESCRIPTION
## Summary
This PR simplifies the summary service by removing on-time percentage information from headlines and reducing redundant body text. The changes make headlines more concise while moving detailed metrics to the metrics object.

## Key Changes
- **Route summaries**: Changed headline from "Past two hours: X% on time" to just "Past two hours"
- **Train summaries**: Simplified headlines to "Past two hours" instead of including on-time percentages
- **Frequency route bodies**: Removed redundant headway information from body text when train count is greater than 0, keeping only the "no trains" message for the empty case
- **Frequency train bodies**: Removed the similar trains headway calculation from body text to avoid duplication with headline information
- **Test updates**: Updated all corresponding test assertions to match the new simplified headline and body format

## Implementation Details
- The on-time percentage data is still calculated and available in the `metrics` object for consumers that need it
- Headway information remains in the headline for frequency-based summaries (e.g., "Past two hours: every ~10 min")
- Body text is now reserved for important status information (cancellations, alerts) rather than repeating frequency data already in the headline
- This reduces cognitive load by keeping headlines concise and avoiding redundant information between headline and body

https://claude.ai/code/session_01VZagACxGvhagwTwxy93awh