### PR TITLE
Fix Alembic multiple heads causing staging crash loop

### DIFF
--- a/backend_v2/src/trackrat/db/migrations/versions/20260312_1200-e6f7a8b9c0d1_add_cancellation_threshold_pct.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260312_1200-e6f7a8b9c0d1_add_cancellation_threshold_pct.py
@@ -1,7 +1,7 @@
 """add_cancellation_threshold_pct
 
 Revision ID: e6f7a8b9c0d1
-Revises: d4e5f6a7b8ca
+Revises: d5e6f7a8b9c0
 Create Date: 2026-03-12 12:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "e6f7a8b9c0d1"
-down_revision = "d4e5f6a7b8ca"
+down_revision = "d5e6f7a8b9c0"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The cancellation_threshold_pct migration (e6f7a8b9c0d1) incorrectly
had the same down_revision as notify_cancellation_delay_fields
(d5e6f7a8b9c0), both pointing to d4e5f6a7b8ca. This created two
heads, causing `alembic upgrade head` to fail on startup with
"Multiple head revisions are present". Re-parented e6f7a8b9c0d1
to depend on d5e6f7a8b9c0 to restore a linear migration chain.

https://claude.ai/code/session_01GyuQFtTntS1FSUGZ8KMdgy