### PR TITLE
Remove departures toolbar button from RouteStatusView

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -54,25 +54,6 @@ struct RouteStatusView: View {
             .navigationTitle(context.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if let from = context.fromStationCode,
-                   let to = context.toStationCode {
-                    ToolbarItem(placement: .topBarLeading) {
-                        Button {
-                            let destinationName = Stations.displayName(for: to)
-                            dismiss()
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                                appState.pendingNavigation = .trainList(
-                                    destination: destinationName,
-                                    departureStationCode: from
-                                )
-                            }
-                        } label: {
-                            Label("Departures", systemImage: "list.bullet")
-                                .labelStyle(.titleAndIcon)
-                                .font(.subheadline)
-                        }
-                    }
-                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button { dismiss() } label: {
                         Image(systemName: "xmark.circle.fill")


### PR DESCRIPTION
The leading toolbar icon linking to the train listing view is no longer
needed. The "View All Departures" button within the upcoming trains
section still provides this navigation path.

https://claude.ai/code/session_01VN7156gB4vex7HqBz5bqRg