### PR TITLE
Restore informative summary headline/body for train listing views

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -1032,13 +1032,14 @@ async def _generate_digest_summary(
         else:
             return None
 
-        # Combine headline and body for a concise push notification
-        parts = []
-        if result.headline:
-            parts.append(result.headline)
+        # For push notifications, use body (descriptive) over headline (terse)
+        # to avoid redundancy — headline contains stats like "85% on time" or
+        # "every ~10 min" that the body already describes in natural language.
         if result.body:
-            parts.append(result.body)
-        return " ".join(parts) if parts else None
+            return result.body
+        if result.headline:
+            return result.headline
+        return None
     except Exception:
         logger.warning(
             "digest_summary_generation_failed",

--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1136,7 +1136,7 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         else:
-            headline = "Past two hours"
+            headline = f"Past two hours: {dep_on_time_pct:.0f}% on time"
 
         # Status clause
         if cancellations > 0:
@@ -1202,7 +1202,14 @@ class SummaryService:
                 body_parts.append(
                     f"{remaining} others departed, averaging every {headway:.0f} minutes."
                 )
-        elif train_count == 0:
+        elif train_count > 0:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
+            train_word = "train" if train_count == 1 else "trains"
+            body_parts.append(
+                f"{train_count} {train_word} departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
+                f"averaging every {headway:.0f} minutes."
+            )
+        else:
             body_parts.append(
                 f"No trains departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours."
             )
@@ -1428,9 +1435,9 @@ class SummaryService:
             cancel_word = "cancellation" if cancellations == 1 else "cancellations"
             headline = f"{cancellations} {cancel_word}"
         elif dep_stats.has_data:
-            headline = "Past two hours"
+            headline = f"Past two hours: {dep_stats.on_time_percentage:.0f}% on time"
         elif train_stats.has_data:
-            headline = "Past two hours"
+            headline = f"Past two hours: {train_stats.on_time_percentage:.0f}% on time"
         else:
             return "", ""  # No data
 
@@ -1512,6 +1519,14 @@ class SummaryService:
         if cancellations > 0:
             cancel_word = "train" if cancellations == 1 else "trains"
             body_parts.append(f"{cancellations} similar {cancel_word} cancelled.")
+
+        if similar_count > 0:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / similar_count
+            body_parts.append(
+                f"{similar_count} similar trains departed in the past "
+                f"{SUMMARY_TIME_WINDOW_MINUTES // 60} hours, "
+                f"averaging every {headway:.0f} minutes."
+            )
 
         if train_stats.has_data:
             train_display = f"This {destination} train" if destination else "This train"

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -280,7 +280,8 @@ class TestSummaryService:
         summary = summary_service._generate_route_summary(route_journeys, "NY", "NP")
 
         assert summary.scope == "route"
-        assert summary.headline == "Past two hours"
+        assert "Past two hours:" in summary.headline
+        assert "% on time" in summary.headline
         assert summary.metrics is not None
         assert summary.metrics.train_count == 2
 
@@ -495,7 +496,7 @@ class TestSummaryService:
         )
 
         assert summary.scope == "train"
-        assert summary.headline == "Past two hours"
+        assert "on time" in summary.headline.lower()
         assert summary.metrics.on_time_percentage >= 90
 
     def test_generate_train_summary_poor_performance(self, summary_service):
@@ -542,7 +543,7 @@ class TestSummaryService:
         )
 
         assert summary.scope == "train"
-        assert summary.headline == "Past two hours"
+        assert "on time" in summary.headline.lower()  # Shows on-time percentage (0%)
         assert summary.metrics.on_time_percentage == 0  # All late
 
     def test_generate_train_summary_no_history(self, summary_service):
@@ -613,7 +614,7 @@ class TestSummaryService:
 
         assert summary.scope == "train"
         # Should show similar trains data even with no history for this train
-        assert summary.headline == "Past two hours"
+        assert "on time" in summary.headline.lower()
         assert "NJ Transit" in summary.body
         assert summary.metrics is not None
         assert summary.metrics.train_count == 5
@@ -1257,7 +1258,8 @@ class TestFormatFrequencyRouteHeadlineBody:
         print(f"body: {body!r}")
         print(f"expected_headway: {expected_headway}")
         assert headline == "Past two hours: every ~10 min"
-        assert body == ""
+        assert "12 trains departed" in body
+        assert "every 10 minutes" in body
 
     def test_single_train_headway(self, summary_service):
         """1 train over 120min → large headway."""
@@ -1320,13 +1322,13 @@ class TestFormatFrequencyRouteHeadlineBody:
         # No "others departed" since train_count=0
         assert "others departed" not in body
 
-    def test_normal_service_has_empty_body(self, summary_service):
-        """Normal service body should be empty since headline has all the info."""
+    def test_body_mentions_time_window(self, summary_service):
+        """Body should reference the 2-hour time window."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=12, cancellations=0
         )
         print(f"body: {body!r}")
-        assert body == ""
+        assert "2 hours" in body
 
 
 class TestFormatFrequencyTrainHeadlineBody:
@@ -1472,8 +1474,8 @@ class TestFormatFrequencyTrainHeadlineBody:
         assert "Cancelled 3 times" in body
         assert "past 30 days" in body
 
-    def test_similar_trains_no_redundant_headway_in_body(self, summary_service):
-        """Body should not repeat headway info already in headline."""
+    def test_similar_trains_body_includes_headway(self, summary_service):
+        """Body should show headway calculation for similar trains."""
         dep_stats = OnTimeStats(
             on_time_percentage=95.0,
             average_delay_minutes=1.0,
@@ -1492,6 +1494,4 @@ class TestFormatFrequencyTrainHeadlineBody:
         print(f"headline: {headline!r}")
         print(f"body: {body!r}")
         expected_headway = SUMMARY_TIME_WINDOW_MINUTES / 6  # 20
-        assert headline == f"Past two hours: every ~{expected_headway:.0f} min"
-        # No redundant body - headline already conveys frequency
-        assert body == ""
+        assert "every 20 minutes" in body


### PR DESCRIPTION
The previous commit (6b2175b) removed useful info from summary
headline and body to avoid redundancy in push notifications,
but this also degraded the in-app train listing and detail views
where the headline is shown collapsed.

Restores:
- Non-frequency routes: "Past two hours: 85% on time" headline
- Frequency routes: body text with train count and headway
- Train-level formatters: same pattern for both types

Moves deduplication to the notification consumer instead:
_generate_digest_summary now uses body-only for notifications
(body is self-contained natural language), avoiding the redundancy
that prompted the original change.

https://claude.ai/code/session_01HM6azwX1wia8xWKfxb9ysX