### PR TITLE
Fix Route Details button not matching existing line-based alert subscriptions

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -121,7 +121,7 @@ struct TrainListView: View {
                     Button {
                         appState.pendingRouteStatus = RouteStatusContext(
                             dataSource: viewModel.trains.first?.dataSource ?? appState.selectedSystems.first?.rawValue ?? "NJT",
-                            lineId: nil,
+                            lineId: viewModel.trains.first?.line.code,
                             fromStationCode: departureStationCode,
                             toStationCode: destinationCode
                         )


### PR DESCRIPTION
Pass lineId from train data when building RouteStatusContext so that
line-based alert subscriptions are recognized by subscriptions(for:).

https://claude.ai/code/session_012yPUUbTwqyHmetjbbvhZ8m