### PR TITLE
Fix three staging issues: empty summaries, null OTP, PATH duplicates

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -1358,6 +1358,12 @@ class JourneyCollector(BaseJourneyCollector):
                 ):
                     stop.actual_arrival = normalized["actual_arrival"]
                     stop.arrival_source = "api_observed"
+                elif (
+                    stop.actual_arrival is not None
+                    and stop.arrival_source is None
+                ):
+                    # Backfill arrival_source for stops written before the column existed
+                    stop.arrival_source = "api_observed"
             else:
                 # Clear any stale actual_arrival from legacy code that wrote
                 # it unconditionally. Non-departed stops shouldn't show arrival.

--- a/backend_v2/src/trackrat/collectors/path/collector.py
+++ b/backend_v2/src/trackrat/collectors/path/collector.py
@@ -159,6 +159,12 @@ def _generate_path_train_id(
     """Generate a stable train ID for PATH trains.
 
     Uses origin station, destination, and departure time to create a unique ID.
+    The departure time is rounded to the nearest minute before generating the
+    timestamp, because the RidePATH API only provides integer-minute countdown
+    precision. Without rounding, the same physical train observed at different
+    stations (or across collection cycles) produces slightly different
+    back-calculated origin times due to sub-minute noise, creating duplicate
+    journey records.
 
     Args:
         origin_station: Station code where train departs (e.g., 'PHO')
@@ -169,7 +175,14 @@ def _generate_path_train_id(
         Generated train ID (e.g., 'PATH_PHO_33rd_1705500000')
     """
     dest_short = headsign[:10].replace(" ", "").lower() if headsign else "unk"
-    ts = int(departure_time.timestamp()) if departure_time else 0
+    if departure_time:
+        # Round to nearest minute to eliminate false sub-minute precision
+        rounded = departure_time.replace(second=0, microsecond=0)
+        if departure_time.second >= 30:
+            rounded += timedelta(minutes=1)
+        ts = int(rounded.timestamp())
+    else:
+        ts = 0
     return f"PATH_{origin_station}_{dest_short}_{ts}"
 
 

--- a/backend_v2/src/trackrat/db/migrations/versions/20260312_1700-f7a8b9c0d1e2_backfill_arrival_source.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260312_1700-f7a8b9c0d1e2_backfill_arrival_source.py
@@ -1,0 +1,82 @@
+"""backfill_arrival_source_for_existing_stops
+
+Revision ID: f7a8b9c0d1e2
+Revises: e6f7a8b9c0d1
+Create Date: 2026-03-12 17:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f7a8b9c0d1e2"
+down_revision = "e6f7a8b9c0d1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Backfill arrival_source for stops written before the column was added.
+
+    The arrival_source column was added in d4e5f6a7b8ca but without a data
+    backfill. Stops with actual_arrival data but NULL arrival_source are
+    excluded from OTP calculations, causing routes to report NULL on-time
+    percentage despite having hundreds of trains with arrival data.
+    """
+    # Batch 1: Stops on completed journeys where actual != scheduled
+    # (strong signal these were API-observed arrivals)
+    op.execute(
+        """
+        UPDATE journey_stops js
+        SET arrival_source = 'api_observed'
+        FROM train_journeys tj
+        WHERE tj.id = js.journey_id
+          AND js.arrival_source IS NULL
+          AND js.actual_arrival IS NOT NULL
+          AND js.scheduled_arrival IS NOT NULL
+          AND js.actual_arrival != js.scheduled_arrival
+        """
+    )
+
+    # Batch 2: Stops on completed journeys where actual == scheduled
+    # (could be scheduled_fallback or exact on-time, but on a completed
+    # journey we trust the data)
+    op.execute(
+        """
+        UPDATE journey_stops js
+        SET arrival_source = 'api_observed'
+        FROM train_journeys tj
+        WHERE tj.id = js.journey_id
+          AND js.arrival_source IS NULL
+          AND js.actual_arrival IS NOT NULL
+          AND tj.is_completed = true
+        """
+    )
+
+    # Batch 3: Remaining stops with actual_arrival on non-completed journeys
+    # where actual == scheduled. These are departed intermediate stops.
+    op.execute(
+        """
+        UPDATE journey_stops
+        SET arrival_source = 'api_observed'
+        WHERE arrival_source IS NULL
+          AND actual_arrival IS NOT NULL
+          AND has_departed_station = true
+        """
+    )
+
+
+def downgrade() -> None:
+    """Clear backfilled arrival_source values.
+
+    Note: This cannot distinguish between backfilled and newly-written values,
+    so it clears all arrival_source. This is safe because the column was
+    recently added and a full re-collection will repopulate it.
+    """
+    op.execute(
+        """
+        UPDATE journey_stops
+        SET arrival_source = NULL
+        WHERE arrival_source IS NOT NULL
+        """
+    )

--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -1206,6 +1206,12 @@ class SummaryService:
             body_parts.append(
                 f"No trains departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours."
             )
+        else:
+            headway = SUMMARY_TIME_WINDOW_MINUTES / train_count
+            body_parts.append(
+                f"{train_count} trains departed in the past {SUMMARY_TIME_WINDOW_MINUTES // 60} hours,"
+                f" averaging every {headway:.0f} minutes."
+            )
 
         return headline, " ".join(body_parts)
 

--- a/backend_v2/tests/unit/collectors/path/test_collector.py
+++ b/backend_v2/tests/unit/collectors/path/test_collector.py
@@ -58,6 +58,36 @@ class TestGeneratePathTrainId:
         id2 = _generate_path_train_id("PJS", "33rd Street", dt)
         assert id1 != id2
 
+    def test_sub_minute_differences_produce_same_id(self):
+        """Departure times within the same minute should produce the same ID.
+
+        The RidePATH API only provides integer-minute precision. Back-calculating
+        origin departure from different stations can produce sub-minute differences
+        due to the API's last_updated timestamp. Rounding prevents duplicate
+        journey records for the same physical train.
+        """
+        dt1 = datetime(2026, 1, 19, 10, 30, 5)
+        dt2 = datetime(2026, 1, 19, 10, 30, 25)
+        id1 = _generate_path_train_id("PHO", "33rd Street", dt1)
+        id2 = _generate_path_train_id("PHO", "33rd Street", dt2)
+        assert id1 == id2, f"Sub-minute difference should produce same ID: {id1} vs {id2}"
+
+    def test_rounding_crosses_minute_boundary(self):
+        """Departure at :45 seconds should round up to the next minute."""
+        dt1 = datetime(2026, 1, 19, 10, 30, 45)
+        dt2 = datetime(2026, 1, 19, 10, 31, 10)
+        id1 = _generate_path_train_id("PHO", "33rd Street", dt1)
+        id2 = _generate_path_train_id("PHO", "33rd Street", dt2)
+        assert id1 == id2, f"45s rounds up, 10s rounds down — both to :31: {id1} vs {id2}"
+
+    def test_five_minute_difference_produces_different_ids(self):
+        """Departure times 5+ minutes apart should still produce different IDs."""
+        dt1 = datetime(2026, 1, 19, 10, 30, 0)
+        dt2 = datetime(2026, 1, 19, 10, 35, 0)
+        id1 = _generate_path_train_id("PHO", "33rd Street", dt1)
+        id2 = _generate_path_train_id("PHO", "33rd Street", dt2)
+        assert id1 != id2, "5-minute difference should produce different IDs"
+
 
 class TestGetLineInfoFromHeadsign:
     """Tests for line info extraction from headsign."""

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -1248,7 +1248,7 @@ class TestFormatFrequencyRouteHeadlineBody:
         return SummaryService()
 
     def test_normal_service_shows_headway(self, summary_service):
-        """12 trains over 120min → headline shows Past two hours + ~10 min headway."""
+        """12 trains over 120min → headline shows headway, body has train count."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=12, cancellations=0
         )
@@ -1257,7 +1257,8 @@ class TestFormatFrequencyRouteHeadlineBody:
         print(f"body: {body!r}")
         print(f"expected_headway: {expected_headway}")
         assert headline == "Past two hours: every ~10 min"
-        assert body == ""
+        assert "12 trains departed" in body
+        assert "every 10 minutes" in body
 
     def test_single_train_headway(self, summary_service):
         """1 train over 120min → large headway."""
@@ -1320,13 +1321,14 @@ class TestFormatFrequencyRouteHeadlineBody:
         # No "others departed" since train_count=0
         assert "others departed" not in body
 
-    def test_normal_service_has_empty_body(self, summary_service):
-        """Normal service body should be empty since headline has all the info."""
+    def test_normal_service_body_describes_frequency(self, summary_service):
+        """Normal service body should describe train count and average headway."""
         headline, body = summary_service._format_frequency_route_headline_body(
             train_count=12, cancellations=0
         )
         print(f"body: {body!r}")
-        assert body == ""
+        assert "12 trains departed in the past 2 hours" in body
+        assert "averaging every 10 minutes" in body
 
 
 class TestFormatFrequencyTrainHeadlineBody:


### PR DESCRIPTION
1. Empty summary body for PATH/Subway/PATCO routes: Added missing else
   branch in _format_frequency_route_headline_body for the normal case
   (trains running, no cancellations). The body now describes train count
   and average headway.

2. Null OTP and delay_breakdown on NJT/Amtrak routes: The arrival_source
   column added on March 10 had no data backfill, so historical stops were
   excluded from OTP calculations. Adds a backfill migration and fixes the
   NJT collector to set arrival_source on pre-existing stops that already
   have actual_arrival data.

3. PATH duplicate train IDs: Back-calculated origin departure times had
   false sub-minute precision from integer-minute API countdowns. Now
   rounds to nearest minute before generating the train ID timestamp,
   preventing the same physical train from creating two journey records.

https://claude.ai/code/session_01347HZ8dFm7wqqRHm2cVdvq