### PR TITLE
Add chat navigation from push notifications

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -39,6 +39,11 @@ struct TrackRatApp: App {
                     AppDelegate.pendingColdLaunchRouteStatus = nil
                     appState.pendingRouteStatus = pending
                 }
+                // Pick up any chat navigation from a cold-launch notification tap
+                if let pendingChat = AppDelegate.pendingColdLaunchChatNavigation {
+                    AppDelegate.pendingColdLaunchChatNavigation = nil
+                    appState.pendingChatNavigation = pendingChat
+                }
                 // Start polling for chat unread count
                 ChatService.shared.startUnreadPolling()
             }
@@ -86,6 +91,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
     /// Pending route status from notification tap during cold launch (before appState is set)
     @MainActor static var pendingColdLaunchRouteStatus: RouteStatusContext?
+
+    /// Pending chat navigation from notification tap during cold launch (before appState is set)
+    @MainActor static var pendingColdLaunchChatNavigation: ChatNavigationContext?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         // Set up notification delegate
@@ -176,9 +184,16 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 }
             }
         } else if let type = userInfo["type"] as? String, type == "chat_message" {
-            // Chat push notification — refresh unread count
+            // Chat push notification — navigate to chat and refresh unread count
+            let fromDeviceId = userInfo["from_device_id"] as? String
+            let chatContext = ChatNavigationContext(targetDeviceId: fromDeviceId ?? "")
             Task { @MainActor in
                 await ChatService.shared.refreshUnreadCount()
+                if let appState = AppDelegate.appState {
+                    appState.pendingChatNavigation = chatContext
+                } else {
+                    AppDelegate.pendingColdLaunchChatNavigation = chatContext
+                }
             }
         }
         completionHandler()
@@ -651,6 +666,19 @@ struct RouteStatusContext: Identifiable, Equatable {
     }
 }
 
+// MARK: - Chat Navigation Context
+/// Wraps chat notification data for `.sheet(item:)` presentation
+struct ChatNavigationContext: Identifiable {
+    let id = UUID()
+    /// Empty string = user's own chat; non-empty = admin viewing a specific device's conversation
+    let targetDeviceId: String
+
+    /// Returns nil for user chat, or the device ID for admin mode
+    var adminTargetDeviceId: String? {
+        targetDeviceId.isEmpty ? nil : targetDeviceId
+    }
+}
+
 // MARK: - Map Display Mode
 enum MapDisplayMode: Equatable {
     case overallCongestion
@@ -683,6 +711,9 @@ final class AppState: ObservableObject {
 
     // Route status sheet - set by notification tap or EditRouteAlertsView row tap
     @Published var pendingRouteStatus: RouteStatusContext? = nil
+
+    // Chat sheet - set by chat notification tap
+    @Published var pendingChatNavigation: ChatNavigationContext? = nil
 
     private let apiService = APIService()
     private let storageService = StorageService()

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -217,6 +217,13 @@ struct MapContainerView: View {
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)
             }
+            .sheet(item: $appState.pendingChatNavigation) { context in
+                NavigationStack {
+                    ChatView(targetDeviceId: context.adminTargetDeviceId)
+                }
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+            }
         }
         .task {
             // Load congestion data when map container appears, but don't block UI


### PR DESCRIPTION
## Summary
This PR adds support for navigating to chat conversations when users tap on chat push notifications, including support for cold launches (when the app is not running).

## Key Changes
- **New `ChatNavigationContext` struct**: Wraps chat notification data for sheet presentation, supporting both user chat and admin device-specific chat modes
- **Cold launch handling**: Added `pendingColdLaunchChatNavigation` to `AppDelegate` to capture chat navigation intents before `AppState` is initialized, similar to existing route status handling
- **Notification processing**: Enhanced chat push notification handling to extract the `from_device_id` and set up navigation context
- **AppState integration**: Added `pendingChatNavigation` published property to trigger chat sheet presentation
- **UI presentation**: Added `.sheet(item:)` modifier to `MapContainerView` to display `ChatView` when chat navigation is triggered

## Implementation Details
- The `ChatNavigationContext.adminTargetDeviceId` property returns `nil` for regular user chat or the device ID for admin viewing a specific device's conversation
- Chat navigation is handled consistently whether the app is in foreground (direct `appState` update) or cold-launched (stored in `AppDelegate` and transferred to `appState` on initialization)
- The chat sheet uses `.presentationDetents([.large])` to match the existing route status sheet presentation style

https://claude.ai/code/session_01P8sonuqmx8KnCXhw8KTHTL