### PR TITLE
Hide track numbers for PATH and Subway systems

### DIFF
--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -80,6 +80,10 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     /// These systems should display destination or line name instead of raw train ID.
     static let syntheticTrainIdSources: Set<String> = ["PATH", "PATCO", "LIRR", "MNR", "SUBWAY"]
 
+    /// Systems where boarding track numbers are not meaningful to display.
+    /// Subway and PATH use fixed platforms, not assignable tracks.
+    static let noTrackDisplaySources: Set<String> = ["PATH", "SUBWAY"]
+
     /// Whether this system is in beta (shown as label in UI)
     var isBeta: Bool {
         switch self {

--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -70,7 +70,8 @@ struct TrainV2: Identifiable, Codable {
     }
     
     var track: String? {
-        departure.track
+        guard !TrainSystem.noTrackDisplaySources.contains(dataSource) else { return nil }
+        return departure.track
     }
     
     var delayMinutes: Int {

--- a/ios/TrackRat/Services/TripRecordingService.swift
+++ b/ios/TrackRat/Services/TripRecordingService.swift
@@ -76,7 +76,7 @@ final class TripRecordingService {
                 scheduled: destStop?.scheduledArrival,
                 actual: destStop?.actualArrival ?? destStop?.updatedArrival
             ),
-            track: originStop?.track,
+            track: train.track,
             lastUpdated: Date()
         )
 

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -625,7 +625,7 @@ private struct UpcomingTrainRow: View {
                         .font(.subheadline.bold())
                 }
                 HStack(spacing: 8) {
-                    if let track = train.departure.track, !track.isEmpty {
+                    if let track = train.track, !track.isEmpty {
                         Text("Track \(track)")
                             .font(.caption)
                             .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary
This PR adds logic to hide track numbers for transit systems where boarding tracks are not meaningful to passengers. PATH and Subway systems use fixed platforms rather than assignable tracks, so displaying track information is not useful.

## Key Changes
- Added `noTrackDisplaySources` constant to `TrainSystem` to identify systems where track display should be suppressed (PATH and Subway)
- Modified `TrainV2.track` computed property to return `nil` for systems in `noTrackDisplaySources`
- Updated `TripRecordingService` to use the computed `train.track` property instead of directly accessing `originStop?.track`, ensuring recorded trips respect the track display logic
- Updated `RouteStatusView` to use the computed `train.track` property instead of directly accessing `train.departure.track` for consistency

## Implementation Details
The change centralizes track display logic in the `TrainV2.track` computed property, making it the single source of truth for whether track information should be displayed. This ensures consistent behavior across all views and services that need track information.

https://claude.ai/code/session_01WAp4YZp95ZvuXqBLr8mfXQ