### PR TITLE
Update paywall developer message icon from heart to wave

### DIFF
--- a/ios/TrackRat/Views/Paywall/PaywallView.swift
+++ b/ios/TrackRat/Views/Paywall/PaywallView.swift
@@ -51,7 +51,7 @@ struct PaywallView: View {
 
                     // Developer message
                     VStack(spacing: 20) {
-                        Image(systemName: "heart.fill")
+                        Image(systemName: "hand.wave.fill")
                             .font(.system(size: 36))
                             .foregroundColor(.orange)
 


### PR DESCRIPTION
## Summary
Updated the icon displayed in the paywall developer message section from a heart to a waving hand icon.

## Changes
- Changed the SF Symbol icon in the paywall view from `heart.fill` to `hand.wave.fill`
- The icon maintains its existing styling (36pt size, orange color)

## Details
This is a minor UI update to the paywall view's developer message section. The waving hand icon provides a more friendly, welcoming greeting gesture compared to the previous heart icon.

https://claude.ai/code/session_01JiVgw4GY9MVgroUTXATcH4