### PR TITLE
Refactor Settings UI: Reorder menu items and remove feedback sheet

### DIFF
--- a/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
+++ b/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
@@ -10,7 +10,24 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
     var subtitle: String? = nil
     var showBackButton: Bool = true
     var showCloseButton: Bool = true
+    var onBackAction: (() -> Void)? = nil
     var trailingContent: (() -> TrailingContent)?
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        showBackButton: Bool = true,
+        showCloseButton: Bool = true,
+        onBackAction: (() -> Void)? = nil,
+        @ViewBuilder trailingContent: @escaping () -> TrailingContent
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.showBackButton = showBackButton
+        self.showCloseButton = showCloseButton
+        self.onBackAction = onBackAction
+        self.trailingContent = trailingContent
+    }
 
     var body: some View {
         ZStack {
@@ -36,7 +53,9 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
                 // Back button
                 if showBackButton {
                     Button {
-                        if !appState.navigationPath.isEmpty {
+                        if let onBackAction = onBackAction {
+                            onBackAction()
+                        } else if !appState.navigationPath.isEmpty {
                             appState.navigationPath.removeLast()
                         }
                     } label: {
@@ -78,12 +97,14 @@ extension TrackRatNavigationHeader where TrailingContent == EmptyView {
         title: String,
         subtitle: String? = nil,
         showBackButton: Bool = true,
-        showCloseButton: Bool = true
+        showCloseButton: Bool = true,
+        onBackAction: (() -> Void)? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
         self.showBackButton = showBackButton
         self.showCloseButton = showCloseButton
+        self.onBackAction = onBackAction
         self.trailingContent = nil
     }
 }

--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct EditRouteAlertsView: View {
     @EnvironmentObject private var appState: AppState
+    @Environment(\.dismiss) private var dismiss
     @ObservedObject private var alertService = AlertSubscriptionService.shared
     @State private var showAddSheet = false
     @State private var selectedSubscription: RouteAlertSubscription?
@@ -17,7 +18,8 @@ struct EditRouteAlertsView: View {
         VStack(spacing: 0) {
             TrackRatNavigationHeader(
                 title: "Route Alerts",
-                showBackButton: false
+                showBackButton: true,
+                onBackAction: { dismiss() }
             ) {
                 Button {
                     showAddSheet = true

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -172,8 +172,6 @@ struct SettingsSection: View {
     @Binding var paywallContext: PaywallContext
     var showDebugSections: Bool
 
-    @State private var showingFeedbackSheet = false
-
     var body: some View {
         VStack(spacing: 16) {
             // Train Systems
@@ -206,6 +204,38 @@ struct SettingsSection: View {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(.ultraThinMaterial)
             )
+
+            // Route Alerts
+            Button {
+                navigationPath.append(SettingsDestination.routeAlerts)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            } label: {
+                HStack(spacing: 16) {
+                    Image(systemName: "bell.badge.fill")
+                        .font(.title2)
+                        .foregroundColor(.orange)
+                        .frame(width: 24, height: 24)
+
+                    Text("Route Alerts (beta)")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.leading)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.5))
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(.ultraThinMaterial)
+                )
+            }
+            .buttonStyle(.plain)
 
             // Favorite Stations
             Button {
@@ -241,39 +271,7 @@ struct SettingsSection: View {
             }
             .buttonStyle(.plain)
 
-            // Route Alerts
-            Button {
-                navigationPath.append(SettingsDestination.routeAlerts)
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            } label: {
-                HStack(spacing: 16) {
-                    Image(systemName: "bell.badge.fill")
-                        .font(.title2)
-                        .foregroundColor(.orange)
-                        .frame(width: 24, height: 24)
-
-                    Text("Route Alerts (beta)")
-                        .font(.headline)
-                        .fontWeight(.medium)
-                        .foregroundColor(.white)
-                        .multilineTextAlignment(.leading)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
-                .padding()
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(.ultraThinMaterial)
-                )
-            }
-            .buttonStyle(.plain)
-
-            // Chat with Developer
+            // Developer Chat
             Button {
                 if subscriptionService.hasAccess(to: .developerChat) {
                     navigationPath.append(SettingsDestination.chat)
@@ -289,7 +287,7 @@ struct SettingsSection: View {
                         .foregroundColor(.orange)
                         .frame(width: 24, height: 24)
 
-                    Text("Chat with Developer")
+                    Text("Developer Chat")
                         .font(.headline)
                         .fontWeight(.medium)
                         .foregroundColor(.white)
@@ -325,46 +323,8 @@ struct SettingsSection: View {
                 }
                 .padding()
                 .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(.ultraThinMaterial)
-                )
             }
             .buttonStyle(.plain)
-
-            // Admin Inbox (visible only to admin)
-            if chatService.isAdmin {
-                Button {
-                    navigationPath.append(SettingsDestination.adminChat)
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                } label: {
-                    HStack(spacing: 16) {
-                        Image(systemName: "tray.full.fill")
-                            .font(.title2)
-                            .foregroundColor(.orange)
-                            .frame(width: 24, height: 24)
-
-                        Text("Developer Inbox")
-                            .font(.headline)
-                            .fontWeight(.medium)
-                            .foregroundColor(.white)
-                            .multilineTextAlignment(.leading)
-
-                        Spacer()
-
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                    }
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(.ultraThinMaterial)
-                    )
-                }
-                .buttonStyle(.plain)
-            }
 
             // YouTube & Instagram
             HStack(spacing: 12) {
@@ -421,46 +381,34 @@ struct SettingsSection: View {
                 .buttonStyle(.plain)
             }
 
-            // Report an Issue
-            Button {
-                showingFeedbackSheet = true
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            } label: {
-                HStack(spacing: 16) {
-                    Image(systemName: "exclamationmark.bubble.fill")
-                        .font(.title2)
-                        .foregroundColor(.orange)
-                        .frame(width: 24, height: 24)
+            // Admin Inbox (visible only to admin)
+            if chatService.isAdmin {
+                Button {
+                    navigationPath.append(SettingsDestination.adminChat)
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                } label: {
+                    HStack(spacing: 16) {
+                        Image(systemName: "tray.full.fill")
+                            .font(.title2)
+                            .foregroundColor(.orange)
+                            .frame(width: 24, height: 24)
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Report an Issue")
+                        Text("Developer Inbox")
                             .font(.headline)
                             .fontWeight(.medium)
                             .foregroundColor(.white)
                             .multilineTextAlignment(.leading)
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
                     }
-
-                    Spacer()
-
-                    Image(systemName: "arrow.up.right")
-                        .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
+                    .padding()
+                    .frame(maxWidth: .infinity)
                 }
-                .padding()
-                .frame(maxWidth: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(.ultraThinMaterial)
-                )
-            }
-            .buttonStyle(.plain)
-            .sheet(isPresented: $showingFeedbackSheet) {
-                FeedbackSheet(
-                    screen: "settings",
-                    trainId: nil,
-                    originCode: nil,
-                    destinationCode: nil
-                )
+                .buttonStyle(.plain)
             }
 
             // Debug/TestFlight-only: Advanced Configuration


### PR DESCRIPTION
## Summary
This PR refactors the Settings view to improve menu organization and removes the feedback sheet functionality. It also enhances the navigation header component to support custom back button actions.

## Key Changes

**SettingsView.swift:**
- Removed the `showingFeedbackSheet` state variable
- Reordered menu items: "Route Alerts" now appears before "Favorite Stations"
- Removed the "Report an Issue" button and associated feedback sheet functionality
- Moved "Admin Inbox" section to appear after social media links
- Simplified "Developer Chat" label (removed "with Developer" suffix)
- Removed background styling from the "Developer Chat" button

**TrackRatNavigationHeader.swift:**
- Added `onBackAction` optional closure parameter to support custom back button behavior
- Added explicit initializer for the generic case with `TrailingContent`
- Added extension initializer for `EmptyView` case with `onBackAction` parameter
- Updated back button logic to execute custom action if provided, otherwise fall back to navigation path removal

**EditRouteAlertsView.swift:**
- Added `@Environment(\.dismiss)` for programmatic dismissal
- Updated navigation header to use `showBackButton: true` with custom `onBackAction` that calls dismiss()

## Implementation Details
The navigation header enhancement allows views to define custom behavior when the back button is tapped, enabling proper dismissal of presented views while maintaining backward compatibility with existing navigation path-based navigation.

https://claude.ai/code/session_01KE2rgsnQ4ksDPoK28DmPKB