### PR TITLE
Fix missing background on Developer Chat and Inbox buttons in Settings

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -323,6 +323,10 @@ struct SettingsSection: View {
                 }
                 .padding()
                 .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(.ultraThinMaterial)
+                )
             }
             .buttonStyle(.plain)
 
@@ -407,6 +411,10 @@ struct SettingsSection: View {
                     }
                     .padding()
                     .frame(maxWidth: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(.ultraThinMaterial)
+                    )
                 }
                 .buttonStyle(.plain)
             }


### PR DESCRIPTION
Both buttons were missing the .background(RoundedRectangle) modifier
that every other button in the Settings view has, causing them to
render without the frosted glass appearance.

https://claude.ai/code/session_01THCaRhEQxuXyTgNvQoRHBt