### PR TITLE
Fix staging boot loop: increase migration subprocess timeout from 30s to 600s

### DIFF
--- a/backend_v2/src/trackrat/db/migrations_runner.py
+++ b/backend_v2/src/trackrat/db/migrations_runner.py
@@ -93,7 +93,7 @@ async def run_migrations() -> None:
                 env=env,
                 capture_output=True,
                 text=True,
-                timeout=30,  # 30 second timeout should be plenty
+                timeout=600,  # 10 minutes for data-heavy backfill migrations
                 cwd=str(backend_dir),  # Run from backend_v2 directory
                 check=False,  # We'll check returncode ourselves for better error messages
             )
@@ -124,7 +124,7 @@ async def run_migrations() -> None:
             logger.info("Alembic upgrade completed successfully")
 
         except subprocess.TimeoutExpired as err:
-            logger.error("Database migrations timed out after 30 seconds")
+            logger.error("Database migrations timed out after 600 seconds")
             raise RuntimeError(
                 "Migration timeout - possible database connection issue"
             ) from err


### PR DESCRIPTION
The backfill_arrival_source migration processes journey_stops in 10k-row
batches. On staging with months of data, total runtime exceeds 30s. The
subprocess timeout kills the migration mid-run, preventing uvicorn from
starting, which causes the MIG health check to fail and restart the
instance in a loop.

The batching (commit 8f56d0a) ensures each chunk commits independently,
so progress is preserved across restarts — but the 30s timeout prevents
any single run from completing all remaining batches.

https://claude.ai/code/session_01J2HkDrahncEkoEcnUgFNBY