### PR TITLE
Update subscription banner: remove subtext, use dumbbell icon

### DIFF
--- a/ios/TrackRat/Views/Paywall/ProFeatureLockView.swift
+++ b/ios/TrackRat/Views/Paywall/ProFeatureLockView.swift
@@ -4,7 +4,7 @@ import UIKit
 /// A full-width upgrade prompt card
 struct UpgradePromptCard: View {
     var headline: String? = nil
-    let subtext: String
+    var subtext: String? = nil
     @Binding var showingPaywall: Bool
 
     var body: some View {
@@ -14,7 +14,7 @@ struct UpgradePromptCard: View {
         } label: {
             VStack(spacing: 12) {
                 HStack {
-                    Image(systemName: "heart.fill")
+                    Image(systemName: "dumbbell.fill")
                         .foregroundColor(.orange)
                     Text("TrackRat Pro")
                         .font(.headline)
@@ -29,10 +29,12 @@ struct UpgradePromptCard: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                Text(subtext)
-                    .font(.subheadline)
-                    .foregroundColor(.white.opacity(0.7))
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let subtext, !subtext.isEmpty {
+                    Text(subtext)
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.7))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
 
                 HStack {
                     Text("Learn More")

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -467,7 +467,6 @@ struct SubscriptionStatusSection: View {
         } else {
             // Not subscribed, no soft trial - show upgrade prompt
             UpgradePromptCard(
-                subtext: "Subscribe to help cover hosting costs and get direct access to the developer.",
                 showingPaywall: $showingPaywall
             )
         }


### PR DESCRIPTION
- Remove "Subscribe to help cover hosting costs..." subtext from SettingsView
- Replace heart.fill icon with dumbbell.fill for a "pro/strong" feel
- Make subtext optional in UpgradePromptCard so callers can omit it

https://claude.ai/code/session_01TFEQvgraZng8uXEHagSKTr