### PR TITLE
Fix SettingsSection layout alignment to leading edge

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -245,6 +245,7 @@ struct SettingsSection: View {
                     .padding()
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 12)
                     .fill(.ultraThinMaterial)


### PR DESCRIPTION
## Summary
Fixed the layout alignment of the SettingsSection view to properly align content to the leading edge and expand to fill available width.

## Key Changes
- Added `.frame(maxWidth: .infinity, alignment: .leading)` modifier to the SettingsSection VStack
- This ensures the section content stretches to fill the full available width while maintaining leading alignment

## Implementation Details
The frame modifier was applied before the background modifier, allowing the rounded rectangle background to properly fill the expanded frame width while keeping the internal content left-aligned. This prevents the section from being centered or compressed to its content size.

https://claude.ai/code/session_01NWn6MbNJLJjZvChUebrRE5