### PR TITLE
Enable back button in Edit Favorites onboarding screen

### DIFF
--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -50,8 +50,8 @@ struct OnboardingView: View {
                     if isRepeating {
                         TrackRatNavigationHeader(
                             title: "Edit Favorites",
-                            showBackButton: false,
-                            showCloseButton: true
+                            showBackButton: true,
+                            onBackAction: { dismiss() }
                         )
                     }
 


### PR DESCRIPTION
## Summary
Updated the OnboardingView to display a back button instead of a close button in the "Edit Favorites" navigation header, allowing users to navigate back to the previous screen.

## Key Changes
- Changed `showBackButton` from `false` to `true` in the TrackRatNavigationHeader
- Removed `showCloseButton: true` parameter
- Added `onBackAction` callback that dismisses the current view when the back button is tapped

## Implementation Details
The back button now provides a more consistent navigation pattern for the Edit Favorites screen within the onboarding flow, enabling users to return to the previous step rather than closing the entire onboarding experience.

https://claude.ai/code/session_013eiiGEefHcGQfpjzdKh2g7