### PR TITLE
Filter alert subscriptions to systems with real-time data

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		A1AD0D182E106D1B003DA39F /* StationDepartures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1AD0D142E106D1B003DA39F /* StationDepartures.swift */; };
 		A1BA60EC2DFC73650002FB39 /* BuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E42DFC73650002FB39 /* BuildTests.swift */; };
 		A1BA60ED2DFC73650002FB39 /* StationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E52DFC73650002FB39 /* StationsTests.swift */; };
+		446F271841A8FA59C62FA628 /* TrainSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */; };
 		A1BA60EE2DFC73650002FB39 /* TrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E62DFC73650002FB39 /* TrainTests.swift */; };
 		A1BA60EF2DFC73650002FB39 /* APIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E72DFC73650002FB39 /* APIServiceTests.swift */; };
 		A1BA60F02DFC73650002FB39 /* StorageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E82DFC73650002FB39 /* StorageServiceTests.swift */; };
@@ -251,6 +252,7 @@
 		A1BA60DB2DFC73650002FB39 /* TrackRatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TrackRatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1BA60E42DFC73650002FB39 /* BuildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildTests.swift; sourceTree = "<group>"; };
 		A1BA60E52DFC73650002FB39 /* StationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationsTests.swift; sourceTree = "<group>"; };
+		BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainSystemTests.swift; sourceTree = "<group>"; };
 		A1BA60E62DFC73650002FB39 /* TrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainTests.swift; sourceTree = "<group>"; };
 		A1BA60E72DFC73650002FB39 /* APIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIServiceTests.swift; sourceTree = "<group>"; };
 		A1BA60E82DFC73650002FB39 /* StorageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 			isa = PBXGroup;
 			children = (
 				A1BA60E52DFC73650002FB39 /* StationsTests.swift */,
+				BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */,
 				A1BA60E62DFC73650002FB39 /* TrainTests.swift */,
 			);
 			path = Models;
@@ -744,6 +747,7 @@
 			files = (
 				A1BA60EC2DFC73650002FB39 /* BuildTests.swift in Sources */,
 				A1BA60ED2DFC73650002FB39 /* StationsTests.swift in Sources */,
+				446F271841A8FA59C62FA628 /* TrainSystemTests.swift in Sources */,
 				A1BA60EE2DFC73650002FB39 /* TrainTests.swift in Sources */,
 				A1BA60EF2DFC73650002FB39 /* APIServiceTests.swift in Sources */,
 				A18D98D82F1D2F3700F5D22F /* DateSelectorSheet.swift in Sources */,

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -84,6 +84,17 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     /// Subway and PATH use fixed platforms, not assignable tracks.
     static let noTrackDisplaySources: Set<String> = ["PATH", "SUBWAY"]
 
+    /// Whether this system has real-time data capable of generating meaningful route alerts.
+    /// Schedule-only systems (e.g., PATCO) cannot detect delays or cancellations.
+    var supportsAlerts: Bool {
+        switch self {
+        case .njt, .amtrak, .path, .lirr, .mnr, .subway:
+            return true
+        case .patco:
+            return false
+        }
+    }
+
     /// Whether this system is in beta (shown as label in UI)
     var isBeta: Bool {
         switch self {

--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -38,10 +38,14 @@ struct AddRouteAlertView: View {
     @State private var draftRoute: RouteLine? = nil
     @State private var showCustomizationSheet = false
 
-    /// Systems available for line mode: user's selected systems that have routes.
+    /// User's selected systems that support real-time alerts.
+    private var alertCapableSystems: Set<TrainSystem> {
+        appState.selectedSystems.filter { $0.supportsAlerts }
+    }
+
+    /// Systems available for line mode: alert-capable systems sorted for display.
     private var availableLineSystems: [TrainSystem] {
-        appState.selectedSystems
-            .sorted { $0.displayName < $1.displayName }
+        alertCapableSystems.sorted { $0.displayName < $1.displayName }
     }
 
     /// Routes filtered to the selected line system, excluding fully-subscribed lines.
@@ -160,56 +164,60 @@ struct AddRouteAlertView: View {
 
     private var lineList: some View {
         VStack(spacing: 0) {
-            lineSystemPickerRow
-
-            if lineSystem == nil {
-                Spacer()
-            } else if filteredRoutes.isEmpty {
-                VStack(spacing: 12) {
-                    Spacer()
-                    Image(systemName: "checkmark.circle")
-                        .font(.system(size: 40))
-                        .foregroundColor(.orange)
-                    Text("All available routes subscribed")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                    Spacer()
-                }
+            if availableLineSystems.isEmpty {
+                noEligibleSystemsView(detail: "Your selected systems are schedule-only and cannot detect delays.")
             } else {
-                List {
-                    ForEach(filteredRoutes) { route in
-                        Button {
-                            let ds = route.dataSource
-                            draftSubscription = RouteAlertSubscription(
-                                dataSource: ds,
-                                lineId: route.id,
-                                lineName: route.name,
-                                direction: nil
-                            )
-                            draftRoute = route
-                            showCustomizationSheet = true
-                        } label: {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(route.name)
-                                        .font(.headline)
-                                        .foregroundColor(.white)
-                                    if let subtitle = route.terminalSubtitle {
-                                        Text(subtitle)
-                                            .font(.caption)
-                                            .foregroundColor(.white.opacity(0.7))
-                                    }
-                                }
-                                Spacer()
-                                Image(systemName: "plus.circle")
-                                    .foregroundColor(.orange)
-                            }
-                        }
-                        .buttonStyle(.plain)
+                lineSystemPickerRow
+
+                if lineSystem == nil {
+                    Spacer()
+                } else if filteredRoutes.isEmpty {
+                    VStack(spacing: 12) {
+                        Spacer()
+                        Image(systemName: "checkmark.circle")
+                            .font(.system(size: 40))
+                            .foregroundColor(.orange)
+                        Text("All available routes subscribed")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                        Spacer()
                     }
+                } else {
+                    List {
+                        ForEach(filteredRoutes) { route in
+                            Button {
+                                let ds = route.dataSource
+                                draftSubscription = RouteAlertSubscription(
+                                    dataSource: ds,
+                                    lineId: route.id,
+                                    lineName: route.name,
+                                    direction: nil
+                                )
+                                draftRoute = route
+                                showCustomizationSheet = true
+                            } label: {
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(route.name)
+                                            .font(.headline)
+                                            .foregroundColor(.white)
+                                        if let subtitle = route.terminalSubtitle {
+                                            Text(subtitle)
+                                                .font(.caption)
+                                                .foregroundColor(.white.opacity(0.7))
+                                        }
+                                    }
+                                    Spacer()
+                                    Image(systemName: "plus.circle")
+                                        .foregroundColor(.orange)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                    .scrollContentBackground(.hidden)
                 }
-                .listStyle(.insetGrouped)
-                .scrollContentBackground(.hidden)
             }
         }
     }
@@ -218,6 +226,9 @@ struct AddRouteAlertView: View {
 
     private var stationPairPicker: some View {
         VStack(spacing: 16) {
+            if alertCapableSystems.isEmpty {
+                noEligibleSystemsView(detail: "Your selected systems are schedule-only and cannot detect delays.")
+            } else {
             // First station
             Button {
                 showFromPicker = true
@@ -259,9 +270,9 @@ struct AddRouteAlertView: View {
                     let toCode = to.code
                     let fromSystems = Stations.systemStringsForStation(fromCode)
                     let toSystems = Stations.systemStringsForStation(toCode)
-                    let selectedStrings = appState.selectedSystems.asRawStrings
-                    // Pick a system shared by both stations that the user has enabled
-                    let common = fromSystems.intersection(toSystems).intersection(selectedStrings)
+                    let alertCapableStrings = alertCapableSystems.asRawStrings
+                    // Pick a system shared by both stations that supports alerts
+                    let common = fromSystems.intersection(toSystems).intersection(alertCapableStrings)
                     let dataSource = common.first ?? fromSystems.intersection(toSystems).first ?? "NJT"
 
                     let bothExist = alertService.subscriptions.contains(where: {
@@ -315,13 +326,14 @@ struct AddRouteAlertView: View {
             }
 
             Spacer()
+            } // else alertCapableSystems not empty
         }
         .padding()
         .sheet(isPresented: $showFromPicker) {
             StationPickerSheet(
                 selectedStation: $fromStation,
                 disabledStation: toStation,
-                selectedSystems: appState.selectedSystems,
+                selectedSystems: alertCapableSystems,
                 onStationSelected: { station in
                     fromStation = station
                     showFromPicker = false
@@ -332,7 +344,7 @@ struct AddRouteAlertView: View {
             StationPickerSheet(
                 selectedStation: $toStation,
                 disabledStation: fromStation,
-                selectedSystems: appState.selectedSystems,
+                selectedSystems: alertCapableSystems,
                 onStationSelected: { station in
                     toStation = station
                     showToPicker = false
@@ -346,7 +358,7 @@ struct AddRouteAlertView: View {
     private var trainPicker: some View {
         VStack(spacing: 16) {
             if availableTrainSystems.isEmpty {
-                noEligibleSystemsView
+                noEligibleSystemsView(detail: "Train alerts require NJ Transit, Amtrak, LIRR, or Metro-North.")
             } else {
                 // System picker
                 systemPickerRow
@@ -384,15 +396,20 @@ struct AddRouteAlertView: View {
         }
     }
 
-    private var noEligibleSystemsView: some View {
+    private func noEligibleSystemsView(detail: String) -> some View {
         VStack(spacing: 12) {
             Spacer()
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 36))
                 .foregroundColor(.white.opacity(0.3))
-            Text("Train alerts require NJ Transit, Amtrak, LIRR, or Metro-North.")
+            Text("Route alerts require real-time data.")
                 .font(.subheadline)
                 .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Text(detail)
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.4))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
             Spacer()

--- a/ios/TrackRatTests/Models/TrainSystemTests.swift
+++ b/ios/TrackRatTests/Models/TrainSystemTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import TrackRat
+
+class TrainSystemTests: XCTestCase {
+
+    // MARK: - supportsAlerts
+
+    func testSupportsAlerts_realtimeSystems() {
+        let realtimeSystems: [TrainSystem] = [.njt, .amtrak, .path, .lirr, .mnr, .subway]
+        for system in realtimeSystems {
+            XCTAssertTrue(
+                system.supportsAlerts,
+                "\(system.displayName) has real-time data and should support alerts"
+            )
+        }
+    }
+
+    func testSupportsAlerts_scheduleOnlySystems() {
+        let scheduleOnlySystems: [TrainSystem] = [.patco]
+        for system in scheduleOnlySystems {
+            XCTAssertFalse(
+                system.supportsAlerts,
+                "\(system.displayName) is schedule-only and should not support alerts"
+            )
+        }
+    }
+
+    func testSupportsAlerts_coversAllCases() {
+        // Ensures every TrainSystem case has been considered.
+        // If a new case is added to TrainSystem, this test forces the developer
+        // to explicitly decide whether it supports alerts.
+        let allSystems = TrainSystem.allCases
+        let alertCapable = allSystems.filter { $0.supportsAlerts }
+        let scheduleOnly = allSystems.filter { !$0.supportsAlerts }
+
+        XCTAssertEqual(
+            alertCapable.count + scheduleOnly.count,
+            allSystems.count,
+            "Every TrainSystem must be classified as either alert-capable or schedule-only"
+        )
+        // Current expectations: 6 real-time, 1 schedule-only
+        XCTAssertEqual(alertCapable.count, 6, "Expected 6 alert-capable systems: \(alertCapable)")
+        XCTAssertEqual(scheduleOnly.count, 1, "Expected 1 schedule-only system: \(scheduleOnly)")
+    }
+
+    // MARK: - Alert-capable filtering (Set extension)
+
+    func testAlertCapableFiltering() {
+        let allSystems: Set<TrainSystem> = Set(TrainSystem.allCases)
+        let filtered = allSystems.filter { $0.supportsAlerts }
+
+        XCTAssertTrue(filtered.contains(.njt), "NJT should be in alert-capable set")
+        XCTAssertTrue(filtered.contains(.path), "PATH should be in alert-capable set")
+        XCTAssertFalse(filtered.contains(.patco), "PATCO should not be in alert-capable set")
+    }
+
+    func testAlertCapableFiltering_patcoOnly() {
+        let patcoOnly: Set<TrainSystem> = [.patco]
+        let filtered = patcoOnly.filter { $0.supportsAlerts }
+        XCTAssertTrue(filtered.isEmpty, "PATCO-only selection should yield empty alert-capable set")
+    }
+
+    func testAlertCapableFiltering_mixedSelection() {
+        let mixed: Set<TrainSystem> = [.patco, .njt, .path]
+        let filtered = mixed.filter { $0.supportsAlerts }
+        XCTAssertEqual(filtered.count, 2, "Should have 2 alert-capable systems from mixed selection")
+        XCTAssertTrue(filtered.contains(.njt))
+        XCTAssertTrue(filtered.contains(.path))
+        XCTAssertFalse(filtered.contains(.patco))
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a capability check to ensure route and station-pair alerts are only created for transit systems with real-time data. Schedule-only systems like PATCO cannot detect delays or cancellations, so they should not be available for alert subscriptions.

## Key Changes
- **Added `supportsAlerts` property to `TrainSystem`**: Distinguishes between real-time systems (NJT, Amtrak, PATH, LIRR, MNR, Subway) and schedule-only systems (PATCO)
- **Introduced `alertCapableSystems` computed property**: Filters the user's selected systems to only those supporting real-time alerts
- **Updated `AddRouteAlertView` to use alert-capable systems**:
  - Line mode now filters to alert-capable systems only
  - Station-pair picker restricts to alert-capable systems
  - Both modes show a contextual message when no eligible systems are available
- **Enhanced `noEligibleSystemsView`**: Now accepts a detail parameter to provide context-specific messaging for different alert types
- **Added comprehensive test coverage**: New `TrainSystemTests.swift` validates the `supportsAlerts` property across all system types and ensures complete case coverage

## Implementation Details
- The filtering is applied at the view level using the new `alertCapableSystems` property, ensuring consistency across all alert creation flows
- User-facing messages distinguish between "schedule-only" systems (line/station-pair modes) and specific system requirements (train mode)
- Tests enforce that every `TrainSystem` case is explicitly classified, preventing future regressions when new systems are added

https://claude.ai/code/session_01XHHK59KRU2kbRnbw5tVG4U