### PR TITLE
Make Train Systems section header and summary clickable

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -237,12 +237,19 @@ struct SettingsSection: View {
                     Divider()
                         .background(Color.white.opacity(0.1))
 
-                    HStack(spacing: 16) {
-                        Text(enabledSystemsSummary)
-                            .font(.subheadline)
-                            .foregroundColor(.white.opacity(0.7))
-                            .lineLimit(2)
-                        Spacer()
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isEditingTrainSystems.toggle()
+                        }
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    } label: {
+                        HStack(spacing: 16) {
+                            Text(enabledSystemsSummary)
+                                .font(.subheadline)
+                                .foregroundColor(.white.opacity(0.7))
+                                .lineLimit(2)
+                            Spacer()
+                        }
                     }
                     .padding()
                 }


### PR DESCRIPTION
## Summary
Refactored the Train Systems settings section to make both the header and summary areas clickable buttons that toggle the edit mode, improving the user experience by providing more intuitive interaction patterns.

## Key Changes
- Wrapped the Train Systems header (icon, title, and Edit/Done text) in a Button component that toggles edit mode
- Converted the static summary display at the bottom of the section into a clickable Button
- Both buttons now trigger the same animation and haptic feedback when tapped
- Maintained all existing styling and visual hierarchy

## Implementation Details
- Used `withAnimation(.easeInOut(duration: 0.2))` for smooth transitions when toggling edit mode
- Added `UIImpactFeedbackGenerator(style: .light)` haptic feedback to both interactive areas for better tactile feedback
- The Edit/Done text is now part of the button label rather than a separate button, creating a more cohesive header interaction area
- Summary area button uses the same toggle logic, allowing users to close the expanded view by clicking the summary

https://claude.ai/code/session_014u7VLRhH2WauJdCNowYcV8