### PR TITLE
Add empty spacer to AddRouteAlertView when no station selected

### DIFF
--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -364,6 +364,8 @@ struct AddRouteAlertView: View {
                     Spacer()
                 } else if trainStation != nil {
                     departuresList
+                } else {
+                    Spacer()
                 }
             }
         }


### PR DESCRIPTION
## Summary
Added a fallback `Spacer()` view to handle the case when neither a train station nor other conditions are met in the AddRouteAlertView.

## Key Changes
- Added an `else` clause to the conditional view logic in AddRouteAlertView that displays an empty `Spacer()` when `trainStation` is `nil` and no other conditions are satisfied
- This ensures the view hierarchy remains consistent and prevents potential layout issues when no content should be displayed

## Implementation Details
The change adds a defensive fallback to the view's conditional rendering logic. Previously, if `trainStation` was `nil` and the preceding condition wasn't met, the view would have no content in that branch. The `Spacer()` provides a safe, empty placeholder that maintains proper layout behavior.

https://claude.ai/code/session_01PwXmBYcNMBoDDS4d3724CV