### PR TITLE
Consolidate digest settings into collapsible alert configuration

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -17,7 +17,6 @@ struct AlertConfigurationSheetWrapper: View {
             ScrollView {
                 VStack(spacing: 12) {
                     AlertConfigurationSection(subscription: $sub)
-                    DigestConfigurationSection(subscription: $sub)
                 }
                 .padding()
             }
@@ -54,10 +53,18 @@ enum AlertSensitivity: String, CaseIterable {
 
 // MARK: - Alert Configuration Section
 
-/// Unified alert settings card: alert types, recovery, planned work, active days, time window.
-/// Digest is handled separately by `DigestConfigurationSection`.
+/// Unified alert settings card: active days, alert types, and collapsible advanced options
+/// (recovery, planned work, time window, daily digest).
 struct AlertConfigurationSection: View {
     @Binding var subscription: RouteAlertSubscription
+    @State private var showCustomDays = false
+    @State private var showMoreOptions = false
+
+    private static let presetBitmasks: Set<Int> = [0, 31, 96, 127]
+
+    private var isCustomDays: Bool {
+        !Self.presetBitmasks.contains(subscription.activeDays)
+    }
 
     private var isFrequencyBased: Bool {
         RouteAlertSubscription.frequencyFirstSources.contains(subscription.dataSource)
@@ -71,6 +78,13 @@ struct AlertConfigurationSection: View {
             && Self.plannedWorkSystems.contains(subscription.dataSource)
     }
 
+    private var hasActiveAdvancedOptions: Bool {
+        subscription.notifyRecovery
+            || subscription.includePlannedWork
+            || subscription.activeStartMinutes != nil
+            || subscription.digestTimeMinutes != nil
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Alert Settings")
@@ -82,89 +96,184 @@ struct AlertConfigurationSection: View {
                     .font(.subheadline.bold())
                     .foregroundColor(.secondary)
                 dayPresetRow
-                dayGrid
+
+                if isCustomDays || showCustomDays {
+                    dayGrid
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
 
                 Divider().opacity(0.3)
 
                 // Cancellations
                 sensitivityRow(
                     label: "Cancellations",
+                    hint: cancellationSensitivity.wrappedValue == .severeOnly
+                        ? "Major cancellations only"
+                        : "All cancellations",
                     sensitivity: cancellationSensitivity
                 )
 
                 // Reduced Service / Delays
                 sensitivityRow(
                     label: isFrequencyBased ? "Reduced Service" : "Delays",
+                    hint: isFrequencyBased
+                        ? (delaySensitivity.wrappedValue == .severeOnly ? "50%+ service reduction" : "Any service reduction")
+                        : (delaySensitivity.wrappedValue == .severeOnly ? "20+ min delays" : "5+ min delays"),
                     sensitivity: delaySensitivity
                 )
 
-                // Recovery (only when at least one alert type is active)
-                if subscription.notifyCancellation || subscription.notifyDelay {
-                    Divider().opacity(0.3)
-                    Toggle(isOn: $subscription.notifyRecovery) {
-                        Text("Notify on recovery")
-                    }
-                    .tint(.orange)
-                }
-
-                // Planned work (MTA systems only)
-                if showPlannedWork {
-                    Divider().opacity(0.3)
-                    Toggle(isOn: $subscription.includePlannedWork) {
-                        Text("Planned work")
-                    }
-                    .tint(.orange)
-                }
-
                 Divider().opacity(0.3)
 
-                // Time Window
-                Toggle(isOn: timeWindowEnabled) {
-                    Text("Time Window")
-                }
-                .tint(.orange)
+                // More Options (collapsible advanced settings)
+                moreOptionsButton
 
-                if subscription.activeStartMinutes != nil {
-                    HStack {
-                        Text("From")
-                            .foregroundColor(.white.opacity(0.6))
-                        Spacer()
-                        minutePicker(selection: Binding(
-                            get: { subscription.activeStartMinutes ?? 360 },
-                            set: { subscription.activeStartMinutes = $0 }
-                        ))
-                    }
-                    HStack {
-                        Text("To")
-                            .foregroundColor(.white.opacity(0.6))
-                        Spacer()
-                        minutePicker(selection: Binding(
-                            get: { subscription.activeEndMinutes ?? 1200 },
-                            set: { subscription.activeEndMinutes = $0 }
-                        ))
-                    }
-
-                    Text("Alerts only sent during this window. Overnight ranges (e.g. 10pm–6am) are supported.")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+                if showMoreOptions || hasActiveAdvancedOptions {
+                    moreOptionsContent
+                        .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
         }
     }
 
-    // MARK: - Sensitivity Rows
+    // MARK: - More Options
 
-    private func sensitivityRow(label: String, sensitivity: Binding<AlertSensitivity>) -> some View {
-        HStack {
-            Text(label)
-            Spacer()
-            Picker("", selection: sensitivity) {
-                ForEach(AlertSensitivity.allCases, id: \.self) { level in
-                    Text(level.rawValue).tag(level)
+    private var moreOptionsButton: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                showMoreOptions.toggle()
+            }
+        } label: {
+            HStack {
+                Text("More Options")
+                    .foregroundColor(.white)
+                if hasActiveAdvancedOptions {
+                    Circle()
+                        .fill(Color.orange)
+                        .frame(width: 6, height: 6)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .rotationEffect(.degrees(showMoreOptions || hasActiveAdvancedOptions ? 90 : 0))
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var moreOptionsContent: some View {
+        // Recovery (only when at least one alert type is active)
+        if subscription.notifyCancellation || subscription.notifyDelay {
+            Toggle(isOn: $subscription.notifyRecovery) {
+                Text("Notify on recovery")
+            }
+            .tint(.orange)
+        }
+
+        // Planned work (MTA systems only)
+        if showPlannedWork {
+            Toggle(isOn: $subscription.includePlannedWork) {
+                Text("Planned work")
+            }
+            .tint(.orange)
+        }
+
+        // Time Window
+        Toggle(isOn: timeWindowEnabled) {
+            Text("Time window")
+        }
+        .tint(.orange)
+
+        if subscription.activeStartMinutes != nil {
+            HStack {
+                Text("From")
+                    .foregroundColor(.white.opacity(0.6))
+                Spacer()
+                minutePicker(selection: Binding(
+                    get: { subscription.activeStartMinutes ?? 360 },
+                    set: { subscription.activeStartMinutes = $0 }
+                ))
+            }
+            HStack {
+                Text("To")
+                    .foregroundColor(.white.opacity(0.6))
+                Spacer()
+                minutePicker(selection: Binding(
+                    get: { subscription.activeEndMinutes ?? 1200 },
+                    set: { subscription.activeEndMinutes = $0 }
+                ))
+            }
+
+            Text("Alerts only sent during this window. Overnight ranges (e.g. 10pm–6am) are supported.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+
+        Divider().opacity(0.3)
+
+        // Daily Digest
+        Toggle(isOn: digestEnabled) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Daily digest")
+                Text("Route status summary at a set time")
+                    .font(.caption2)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+        }
+        .tint(.orange)
+
+        if subscription.digestTimeMinutes != nil {
+            HStack {
+                Text("Digest time")
+                    .foregroundColor(.white.opacity(0.6))
+                Spacer()
+                minutePicker(selection: Binding(
+                    get: { subscription.digestTimeMinutes ?? 420 },
+                    set: { subscription.digestTimeMinutes = $0 }
+                ))
+            }
+        }
+    }
+
+    // MARK: - Digest
+
+    private var digestEnabled: Binding<Bool> {
+        Binding(
+            get: { subscription.digestTimeMinutes != nil },
+            set: { enabled in
+                if enabled {
+                    subscription.digestTimeMinutes = 420  // 7:00 AM
+                    if subscription.timezone == nil {
+                        subscription.timezone = TimeZone.current.identifier
+                    }
+                } else {
+                    subscription.digestTimeMinutes = nil
                 }
             }
-            .pickerStyle(.segmented)
-            .frame(width: 180)
+        )
+    }
+
+    // MARK: - Sensitivity Rows
+
+    private func sensitivityRow(label: String, hint: String?, sensitivity: Binding<AlertSensitivity>) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                Spacer()
+                Picker("", selection: sensitivity) {
+                    ForEach(AlertSensitivity.allCases, id: \.self) { level in
+                        Text(level.rawValue).tag(level)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 180)
+            }
+            if let hint, sensitivity.wrappedValue != .none {
+                Text(hint)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 
@@ -244,17 +353,37 @@ struct AlertConfigurationSection: View {
     // MARK: - Days
 
     private var dayPresetRow: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 8) {
             presetButton("None", bitmask: 0)
             presetButton("Weekdays", bitmask: 31)
             presetButton("Weekends", bitmask: 96)
             presetButton("Every Day", bitmask: 127)
+
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    showCustomDays.toggle()
+                }
+            } label: {
+                Text("Custom")
+                    .font(.caption)
+                    .fontWeight(isCustomDays ? .bold : .regular)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(
+                        Capsule().fill(isCustomDays ? Color.orange : Color.white.opacity(0.1))
+                    )
+                    .foregroundColor(isCustomDays ? .black : .white)
+            }
+            .buttonStyle(.plain)
         }
     }
 
     private func presetButton(_ label: String, bitmask: Int) -> some View {
         Button {
             subscription.activeDays = bitmask
+            withAnimation(.easeInOut(duration: 0.2)) {
+                showCustomDays = false
+            }
         } label: {
             Text(label)
                 .font(.caption)
@@ -344,78 +473,3 @@ struct AlertConfigurationSection: View {
     }
 }
 
-// MARK: - Digest Configuration Section
-
-/// Standalone digest card, separated from alert settings.
-struct DigestConfigurationSection: View {
-    @Binding var subscription: RouteAlertSubscription
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Daily Digest")
-                .font(.headline)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Toggle(isOn: digestEnabled) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Daily digest")
-                        Text("Route status summary at a set time")
-                            .font(.caption2)
-                            .foregroundColor(.white.opacity(0.5))
-                    }
-                }
-                .tint(.orange)
-
-                if subscription.digestTimeMinutes != nil {
-                    HStack {
-                        Text("Digest time")
-                            .foregroundColor(.white.opacity(0.6))
-                        Spacer()
-                        minutePicker(selection: Binding(
-                            get: { subscription.digestTimeMinutes ?? 420 },
-                            set: { subscription.digestTimeMinutes = $0 }
-                        ))
-                    }
-
-                    Text("Sends a route status summary once per day at this time.")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
-        }
-    }
-
-    private var digestEnabled: Binding<Bool> {
-        Binding(
-            get: { subscription.digestTimeMinutes != nil },
-            set: { enabled in
-                if enabled {
-                    subscription.digestTimeMinutes = 420  // 7:00 AM
-                    if subscription.timezone == nil {
-                        subscription.timezone = TimeZone.current.identifier
-                    }
-                } else {
-                    subscription.digestTimeMinutes = nil
-                }
-            }
-        )
-    }
-
-    private func minutePicker(selection: Binding<Int>) -> some View {
-        let date = Binding<Date>(
-            get: {
-                Calendar.current.startOfDay(for: Date())
-                    .addingTimeInterval(TimeInterval(selection.wrappedValue * 60))
-            },
-            set: { newDate in
-                let comps = Calendar.current.dateComponents([.hour, .minute], from: newDate)
-                selection.wrappedValue = (comps.hour ?? 0) * 60 + (comps.minute ?? 0)
-            }
-        )
-        return DatePicker("", selection: date, displayedComponents: .hourAndMinute)
-            .labelsHidden()
-    }
-}

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -113,7 +113,6 @@ struct RouteStatusView: View {
                 .onChange(of: alertConfigBinding.wrappedValue.activeDays) { _, newDays in
                     handleActiveDaysChange(newDays)
                 }
-            DigestConfigurationSection(subscription: alertConfigBinding)
         }
     }
 


### PR DESCRIPTION
## Summary
Refactored the alert configuration UI to consolidate the separate digest configuration section into a collapsible "More Options" section within the main alert settings card. This simplifies the settings interface by grouping related advanced options together.

## Key Changes
- **Removed `DigestConfigurationSection`**: Eliminated the standalone digest configuration component that was displayed separately in the sheet
- **Added collapsible "More Options" section**: Created a new expandable section within `AlertConfigurationSection` that contains advanced settings (recovery notifications, planned work, time window, and daily digest)
- **Improved day selection UX**: 
  - Added a "Custom" button to the day preset row for easier access to custom day selection
  - Made the custom day grid conditionally visible based on selection state
  - Added smooth transitions when toggling between preset and custom day views
- **Enhanced sensitivity rows**: Added contextual hint text below cancellation and delay sensitivity pickers to clarify what each setting means
- **Smart "More Options" indicator**: Added a visual indicator (orange dot) that appears when any advanced options are actively configured
- **Consolidated digest logic**: Moved digest toggle and time picker into the more options section while maintaining all existing functionality

## Implementation Details
- Used `@State` variables (`showCustomDays`, `showMoreOptions`) to manage UI state
- Added `hasActiveAdvancedOptions` computed property to determine when to show the indicator and auto-expand the section
- Implemented smooth `.opacity.combined(with: .move(edge: .top))` transitions for collapsible sections
- Maintained all existing binding logic and timezone handling for digest functionality
- Updated the sheet wrapper to remove the now-redundant `DigestConfigurationSection` instantiation

https://claude.ai/code/session_01XJxjkbhqoRD48H54eRUmuG