### PR TITLE
Fix enabled systems summary display to show all items

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -184,7 +184,7 @@ struct SettingsSection: View {
                 name += " (\(appState.amtrakMode.label))"
             }
             return name
-        }.joined(separator: ", ")
+        }.joined(separator: "\n")
     }
 
     var body: some View {
@@ -239,7 +239,7 @@ struct SettingsSection: View {
                         Text(enabledSystemsSummary)
                             .font(.subheadline)
                             .foregroundColor(.white.opacity(0.7))
-                            .lineLimit(2)
+                            .lineLimit(nil)
                         Spacer()
                     }
                     .padding()


### PR DESCRIPTION
## Summary
Updated the enabled systems summary display in SettingsView to properly show all selected systems without truncation.

## Key Changes
- Changed the separator in `enabledSystemsSummary` from comma-space (`", "`) to newline (`"\n"`) to display each system on its own line
- Removed the 2-line limit on the summary text by changing `lineLimit(2)` to `lineLimit(nil)`, allowing the text to expand and display all enabled systems

## Implementation Details
These changes work together to improve the UX of the settings screen:
1. The newline separator makes the list more readable by stacking items vertically
2. Removing the line limit ensures no systems are hidden due to space constraints, preventing important information from being cut off

This is particularly useful when users have multiple systems enabled, as all selections will now be visible without requiring interaction or scrolling.

https://claude.ai/code/session_01MQtqGJrkC58gFadRG8cdJU