### PR TITLE
Add force_chat_token to handle app reinstalls and token recovery

### DIFF
--- a/backend_v2/src/trackrat/api/alerts.py
+++ b/backend_v2/src/trackrat/api/alerts.py
@@ -34,6 +34,7 @@ class DeviceRegisterRequest(BaseModel):
 
     device_id: str
     apns_token: str
+    force_chat_token: bool = False
 
 
 class DeviceRegisterResponse(BaseModel):
@@ -129,6 +130,9 @@ async def register_device(
     Returns a chat_token on first registration or when none exists.
     Subsequent calls with an existing token return chat_token=None
     (the client should keep the token it already has).
+
+    Set force_chat_token=true to rotate and receive a new chat token
+    (e.g. after app reinstall when the client lost its stored token).
     """
     existing = await db.execute(
         select(DeviceToken).where(DeviceToken.device_id == request.device_id)
@@ -138,8 +142,8 @@ async def register_device(
     chat_token: str | None = None
     if device:
         device.apns_token = request.apns_token
-        if not device.chat_token_hash:
-            # First time issuing a token for a legacy device
+        if not device.chat_token_hash or request.force_chat_token:
+            # Issue a new token: first time for legacy device, or client lost its token
             chat_token = secrets.token_urlsafe(32)
             device.chat_token_hash = hashlib.sha256(chat_token.encode()).hexdigest()
     else:

--- a/backend_v2/tests/unit/api/test_chat.py
+++ b/backend_v2/tests/unit/api/test_chat.py
@@ -656,3 +656,99 @@ class TestDeviceRegistration:
             json={"device_id": "reg-change-test", "apns_token": "tok2"},
         )
         assert resp2.json()["chat_token"] is None
+
+    def test_force_chat_token_issues_new_token(self, e2e_client: TestClient):
+        """force_chat_token=true rotates the token and returns a new one.
+
+        This covers the reinstall scenario: client lost its stored token
+        but the server still has the old hash. Without force_chat_token,
+        the server returns None and the client is permanently locked out.
+        """
+        # Initial registration — get the first token
+        resp1 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "force-tok-dev", "apns_token": "tok1"},
+        )
+        original_token = resp1.json()["chat_token"]
+        assert original_token is not None
+
+        # Normal re-registration — no token returned
+        resp2 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "force-tok-dev", "apns_token": "tok2"},
+        )
+        assert resp2.json()["chat_token"] is None
+
+        # Force token rotation — new token returned
+        resp3 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={
+                "device_id": "force-tok-dev",
+                "apns_token": "tok3",
+                "force_chat_token": True,
+            },
+        )
+        new_token = resp3.json()["chat_token"]
+        assert new_token is not None, "force_chat_token should return a new token"
+        assert new_token != original_token, "New token should differ from original"
+
+    def test_force_chat_token_invalidates_old_token(self, e2e_client: TestClient):
+        """After force_chat_token, the old token no longer works for chat."""
+        # Register and get original token
+        resp1 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "force-inval-dev", "apns_token": "tok1"},
+        )
+        old_token = resp1.json()["chat_token"]
+
+        # Verify old token works
+        resp_ok = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers=_user_headers("force-inval-dev", old_token),
+        )
+        assert resp_ok.status_code == 200
+
+        # Force rotation
+        resp2 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={
+                "device_id": "force-inval-dev",
+                "apns_token": "tok2",
+                "force_chat_token": True,
+            },
+        )
+        new_token = resp2.json()["chat_token"]
+
+        # Old token should no longer work
+        resp_fail = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers=_user_headers("force-inval-dev", old_token),
+        )
+        assert resp_fail.status_code == 401, (
+            f"Old token should be rejected after rotation, got {resp_fail.status_code}"
+        )
+
+        # New token should work
+        resp_new = e2e_client.get(
+            "/api/v2/chat/messages",
+            headers=_user_headers("force-inval-dev", new_token),
+        )
+        assert resp_new.status_code == 200
+
+    def test_force_chat_token_false_does_not_rotate(self, e2e_client: TestClient):
+        """Explicitly passing force_chat_token=false behaves like omitting it."""
+        resp1 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": "force-false-dev", "apns_token": "tok1"},
+        )
+        assert resp1.json()["chat_token"] is not None
+
+        resp2 = e2e_client.post(
+            "/api/v2/devices/register",
+            json={
+                "device_id": "force-false-dev",
+                "apns_token": "tok2",
+                "force_chat_token": False,
+            },
+        )
+        assert resp2.json()["chat_token"] is None

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -1240,6 +1240,7 @@ enum APIError: LocalizedError {
     case invalidParameters
     case encodingError
     case serverError
+    case chatNotRegistered
 
     var errorDescription: String? {
         switch self {
@@ -1249,6 +1250,7 @@ enum APIError: LocalizedError {
         case .invalidParameters: return "Invalid parameters provided"
         case .encodingError: return "Failed to encode request body"
         case .serverError: return "Server error"
+        case .chatNotRegistered: return "Enable notifications to use chat"
         }
     }
 }
@@ -1334,7 +1336,7 @@ extension APIService {
         let chat_token: String?
     }
 
-    func registerDevice(deviceId: String, apnsToken: String) async throws -> DeviceRegisterResponse {
+    func registerDevice(deviceId: String, apnsToken: String, forceChatToken: Bool = false) async throws -> DeviceRegisterResponse {
         let endpoint = "/v2/devices/register"
         guard let url = URL(string: "\(baseURL)\(endpoint)") else {
             throw APIError.invalidURL
@@ -1343,9 +1345,10 @@ extension APIService {
         struct RegisterRequest: Encodable {
             let device_id: String
             let apns_token: String
+            let force_chat_token: Bool
         }
 
-        let body = RegisterRequest(device_id: deviceId, apns_token: apnsToken)
+        let body = RegisterRequest(device_id: deviceId, apns_token: apnsToken, force_chat_token: forceChatToken)
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -1473,6 +1476,16 @@ extension APIService {
         let status: String
     }
 
+    private func checkChatResponse(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse, http.statusCode != 200 else { return }
+        switch http.statusCode {
+        case 401: throw APIError.chatNotRegistered
+        case 404: throw APIError.chatNotRegistered
+        case 429: throw APIError.invalidParameters
+        default: throw APIError.serverError
+        }
+    }
+
     func getChatMessages(deviceId: String, before: Int? = nil, limit: Int = 50) async throws -> ChatMessagesResponse {
         guard var components = URLComponents(string: "\(baseURL)/v2/chat/messages") else {
             throw APIError.invalidURL
@@ -1486,7 +1499,8 @@ extension APIService {
         if let token = AlertSubscriptionService.shared.chatToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        let (data, _) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request)
+        try checkChatResponse(response)
         return try JSONDecoder().decode(ChatMessagesResponse.self, from: data)
     }
 
@@ -1516,7 +1530,8 @@ extension APIService {
         if let token = AlertSubscriptionService.shared.chatToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        let (data, _) = try await session.data(for: request)
+        let (data, response) = try await session.data(for: request)
+        try checkChatResponse(response)
         let resp = try JSONDecoder().decode(ChatUnreadCountResponse.self, from: data)
         return resp.unread_count
     }
@@ -1532,9 +1547,7 @@ extension APIService {
         }
         request.httpBody = try JSONEncoder().encode(Req(device_id: deviceId, up_to_id: upToId))
         let (_, response) = try await session.data(for: request)
-        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
-            throw APIError.invalidParameters
-        }
+        try checkChatResponse(response)
     }
 
     func registerChatAdmin(deviceId: String, registrationCode: String) async throws {

--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -137,7 +137,11 @@ final class AlertSubscriptionService: ObservableObject {
 
     func syncWithBackend(apnsToken: String) async {
         do {
-            let response = try await APIService.shared.registerDevice(deviceId: deviceId, apnsToken: apnsToken)
+            // Request a new chat token if we don't have one (e.g. after app reinstall)
+            let needsToken = chatToken == nil
+            let response = try await APIService.shared.registerDevice(
+                deviceId: deviceId, apnsToken: apnsToken, forceChatToken: needsToken
+            )
             if let token = response.chat_token {
                 UserDefaults.standard.set(token, forKey: chatTokenKey)
             }

--- a/ios/TrackRat/Views/Screens/ChatView.swift
+++ b/ios/TrackRat/Views/Screens/ChatView.swift
@@ -37,6 +37,17 @@ struct ChatView: View {
                 showBackButton: false
             )
 
+            // Error banner
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.red.opacity(0.8))
+            }
+
             // Messages
             ScrollViewReader { proxy in
                 ScrollView {
@@ -161,6 +172,8 @@ struct ChatView: View {
             messages = result.messages
             hasMore = result.hasMore
             errorMessage = nil
+        } catch let error as APIError where error == .chatNotRegistered {
+            errorMessage = error.errorDescription
         } catch {
             errorMessage = "Could not load messages"
         }


### PR DESCRIPTION
## Summary
This PR adds support for forcing chat token rotation when clients lose their stored tokens (e.g., after app reinstall). It includes backend logic to issue new tokens on demand, iOS client support for automatic token recovery, and improved error handling for chat authentication failures.

## Key Changes

**Backend (Python)**
- Added `force_chat_token` boolean parameter to device registration endpoint
- Modified token issuance logic to generate new tokens when `force_chat_token=true` or on first registration
- Added comprehensive test coverage for token rotation scenarios:
  - Token rotation returns a new token
  - Old tokens are invalidated after rotation
  - Explicit `force_chat_token=false` behaves like omitting the parameter

**iOS Client (Swift)**
- Added `forceChatToken` parameter to `registerDevice()` API call
- Implemented automatic token recovery: requests a new token if none is stored locally
- Added `chatNotRegistered` error case to `APIError` enum with user-friendly message
- Added `checkChatResponse()` helper to consistently handle chat endpoint errors (401/404 → chatNotRegistered)
- Updated chat message and unread count endpoints to use the new error checking
- Added error banner to ChatView to display chat registration errors to users

## Implementation Details

- The iOS client automatically sets `forceChatToken=true` when `chatToken == nil`, enabling seamless recovery after app reinstall without user intervention
- Old tokens are invalidated server-side when a new token is issued, preventing security issues with stale credentials
- Error handling distinguishes between "not registered for chat" (401/404) and other server errors, allowing the UI to provide specific guidance to users

https://claude.ai/code/session_018tGRypJBfGPaNyQ98b8FwR