### PR TITLE
Add back button to Developer Chat and Developer Inbox views

### DIFF
--- a/ios/TrackRat/Views/Screens/AdminChatListView.swift
+++ b/ios/TrackRat/Views/Screens/AdminChatListView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct AdminChatListView: View {
+    @Environment(\.dismiss) private var dismiss
     @ObservedObject private var chatService = ChatService.shared
     @State private var conversations: [ChatConversation] = []
     @State private var isLoading = false
@@ -10,7 +11,8 @@ struct AdminChatListView: View {
         VStack(spacing: 0) {
             TrackRatNavigationHeader(
                 title: "Developer Inbox",
-                showBackButton: false
+                showBackButton: true,
+                onBackAction: { dismiss() }
             )
 
             if isLoading && conversations.isEmpty {

--- a/ios/TrackRat/Views/Screens/ChatView.swift
+++ b/ios/TrackRat/Views/Screens/ChatView.swift
@@ -4,6 +4,7 @@ struct ChatView: View {
     /// When nil, this is the user's own chat. When set, this is admin viewing a specific conversation.
     let targetDeviceId: String?
 
+    @Environment(\.dismiss) private var dismiss
     @ObservedObject private var chatService = ChatService.shared
     @State private var messages: [ChatMessage] = []
     @State private var messageText = ""
@@ -34,7 +35,8 @@ struct ChatView: View {
         VStack(spacing: 0) {
             TrackRatNavigationHeader(
                 title: headerTitle,
-                showBackButton: false
+                showBackButton: true,
+                onBackAction: { dismiss() }
             )
 
             // Error banner


### PR DESCRIPTION
Match the pattern used by EditRouteAlertsView: showBackButton + onBackAction
using dismiss(). This also fixes a bug where tapping X in an admin conversation
would dismiss the entire Settings sheet instead of popping back to the inbox.

https://claude.ai/code/session_013EZJs9g7QFRnDmHHrcpv1n