### PR TITLE
Update alert sensitivity terminology from "Reduced Service" to "Fewer Trains"

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -182,7 +182,7 @@ struct DirectionalAlertConfigurationSheet: View {
 
 // MARK: - Alert Sensitivity
 
-/// Tri-state alert sensitivity for cancellation and delay/reduced-service controls.
+/// Tri-state alert sensitivity for cancellation and delay/fewer-trains controls.
 enum AlertSensitivity: String, CaseIterable {
     case none = "None"
     case severeOnly = "Severe"
@@ -251,11 +251,11 @@ struct AlertConfigurationSection: View {
                     sensitivity: cancellationSensitivity
                 )
 
-                // Reduced Service / Delays
+                // Fewer Trains / Delays
                 sensitivityRow(
-                    label: isFrequencyBased ? "Reduced Service" : "Delays",
+                    label: isFrequencyBased ? "Fewer Trains" : "Delays",
                     hint: isFrequencyBased
-                        ? (delaySensitivity.wrappedValue == .severeOnly ? "50%+ service reduction" : "Any service reduction")
+                        ? (delaySensitivity.wrappedValue == .severeOnly ? "50%+ fewer trains" : "Any reduction in trains")
                         : (delaySensitivity.wrappedValue == .severeOnly ? "20+ min delays" : "5+ min delays"),
                     sensitivity: delaySensitivity
                 )
@@ -442,7 +442,7 @@ struct AlertConfigurationSection: View {
         )
     }
 
-    // MARK: - Delay / Reduced Service Sensitivity Binding
+    // MARK: - Delay / Fewer Trains Sensitivity Binding
 
     private var delaySensitivity: Binding<AlertSensitivity> {
         Binding(


### PR DESCRIPTION
## Summary
Updated terminology throughout the alert configuration UI to use "Fewer Trains" instead of "Reduced Service" for better clarity and consistency with user-facing language.

## Key Changes
- Updated `AlertSensitivity` enum documentation comment to reference "fewer-trains" instead of "reduced-service"
- Changed the label for frequency-based alerts from "Reduced Service" to "Fewer Trains"
- Updated hint text for frequency-based alerts:
  - "50%+ service reduction" → "50%+ fewer trains"
  - "Any service reduction" → "Any reduction in trains"
- Updated section mark comment from "Delay / Reduced Service Sensitivity Binding" to "Delay / Fewer Trains Sensitivity Binding"

## Implementation Details
These changes improve the user experience by using more intuitive terminology when describing service disruptions on frequency-based transit lines. The term "Fewer Trains" is more concrete and easier to understand than the abstract "Reduced Service" terminology.

https://claude.ai/code/session_015LjxCUNShAEFC4ZhSBZjWH