### PR TITLE
Refactor route alert display names and show subscriptions in settings

### DIFF
--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -147,6 +147,28 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
     var digestTimeMinutes: Int?  // Minutes from midnight, nil = disabled
     var includePlannedWork: Bool
 
+    /// Human-readable name for this subscription (e.g. "Hoboken to 33rd Street").
+    var displayName: String {
+        if let trainName = trainName {
+            return trainName
+        } else if let lineName = lineName {
+            guard let direction = direction else { return lineName }
+            let directionName = Stations.displayName(for: direction)
+            if let lineId = lineId,
+               let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
+                let stations = route.stationCodes
+                let fromCode = direction == stations.last ? stations.first : stations.last
+                if let fromCode = fromCode {
+                    return "\(Stations.displayName(for: fromCode)) to \(directionName)"
+                }
+            }
+            return "\(lineName) to \(directionName)"
+        } else if let from = fromStationCode, let to = toStationCode {
+            return "\(Stations.displayName(for: from)) to \(Stations.displayName(for: to))"
+        }
+        return "Unknown"
+    }
+
     /// Frequency-first systems use service threshold; delay-first use delay threshold.
     static let frequencyFirstSources: Set<String> = ["SUBWAY", "PATH", "PATCO"]
 

--- a/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
+++ b/ios/TrackRat/Views/Screens/EditRouteAlertsView.swift
@@ -90,14 +90,14 @@ struct EditRouteAlertsView: View {
                             selectedSubscription = sub
                         } label: {
                             HStack {
-                                if let trainName = sub.trainName, sub.trainId != nil {
+                                if sub.trainName != nil && sub.trainId != nil {
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Label(trainName, systemImage: "train.side.front.car")
+                                        Label(sub.displayName, systemImage: "train.side.front.car")
                                         scheduleSummary(for: sub)
                                     }
                                 } else if let lineName = sub.lineName {
                                     VStack(alignment: .leading, spacing: 4) {
-                                        Label(lineDisplayName(sub: sub, lineName: lineName), systemImage: "tram.fill")
+                                        Label(sub.displayName, systemImage: "tram.fill")
                                         Text("\(TrainSystem(rawValue: sub.dataSource)?.displayName ?? sub.dataSource): \(lineName)")
                                             .font(.caption2)
                                             .foregroundColor(.white.opacity(0.5))
@@ -108,12 +108,9 @@ struct EditRouteAlertsView: View {
                                         }
                                         scheduleSummary(for: sub)
                                     }
-                                } else if let from = sub.fromStationCode, let to = sub.toStationCode {
+                                } else if sub.fromStationCode != nil && sub.toStationCode != nil {
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Label(
-                                            "\(Stations.displayName(for: from)) to \(Stations.displayName(for: to))",
-                                            systemImage: "arrow.right"
-                                        )
+                                        Label(sub.displayName, systemImage: "arrow.right")
                                         scheduleSummary(for: sub)
                                     }
                                 }
@@ -231,22 +228,6 @@ struct EditRouteAlertsView: View {
             guard let token = AppDelegate.deviceToken else { return }
             await alertService.syncWithBackend(apnsToken: token)
         }
-    }
-
-    /// Build display name for a line subscription, showing "{from} to {destination}".
-    private func lineDisplayName(sub: RouteAlertSubscription, lineName: String) -> String {
-        guard let direction = sub.direction else { return lineName }
-        let directionName = Stations.displayName(for: direction)
-        // Use route station codes to find the "from" terminus
-        if let lineId = sub.lineId,
-           let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
-            let stations = route.stationCodes
-            let fromCode = direction == stations.last ? stations.first : stations.last
-            if let fromCode = fromCode {
-                return "\(Stations.displayName(for: fromCode)) to \(directionName)"
-            }
-        }
-        return "\(lineName) to \(directionName)"
     }
 
     /// Build a RouteStatusContext for a subscription, using direction to set from/to.

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -172,6 +172,13 @@ struct SettingsSection: View {
     @Binding var paywallContext: PaywallContext
     var showDebugSections: Bool
     @State private var isEditingTrainSystems = false
+    @ObservedObject private var alertService = AlertSubscriptionService.shared
+
+    private var routeAlertsSummary: String? {
+        let subs = alertService.subscriptions
+        guard !subs.isEmpty else { return nil }
+        return subs.map { $0.displayName }.sorted().joined(separator: "\n")
+    }
 
     private var enabledSystemsSummary: String {
         let sorted = TrainSystem.allCases
@@ -265,25 +272,40 @@ struct SettingsSection: View {
                 navigationPath.append(SettingsDestination.routeAlerts)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
             } label: {
-                HStack(spacing: 16) {
-                    Image(systemName: "bell.badge.fill")
-                        .font(.title2)
-                        .foregroundColor(.orange)
-                        .frame(width: 24, height: 24)
+                VStack(spacing: 0) {
+                    HStack(spacing: 16) {
+                        Image(systemName: "bell.badge.fill")
+                            .font(.title2)
+                            .foregroundColor(.orange)
+                            .frame(width: 24, height: 24)
 
-                    Text("Route Alerts (beta)")
-                        .font(.headline)
-                        .fontWeight(.medium)
-                        .foregroundColor(.white)
-                        .multilineTextAlignment(.leading)
+                        Text("Route Alerts")
+                            .font(.headline)
+                            .fontWeight(.medium)
+                            .foregroundColor(.white)
 
-                    Spacer()
+                        Spacer()
 
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+                    .padding()
+
+                    if let summary = routeAlertsSummary {
+                        Divider()
+                            .background(Color.white.opacity(0.1))
+
+                        HStack(spacing: 16) {
+                            Text(summary)
+                                .font(.subheadline)
+                                .foregroundColor(.white.opacity(0.7))
+                                .lineLimit(nil)
+                            Spacer()
+                        }
+                        .padding()
+                    }
                 }
-                .padding()
                 .frame(maxWidth: .infinity)
                 .background(
                     RoundedRectangle(cornerRadius: 12)


### PR DESCRIPTION
## Summary
This PR centralizes the logic for generating human-readable display names for route alert subscriptions and enhances the Settings view to show a summary of active route alerts.

## Key Changes
- **Added `displayName` computed property to `RouteAlertSubscription`**: Consolidates all display name logic in one place, handling trains, lines (with direction), and station-to-station routes
- **Enhanced Settings view**: Now displays a summary of active route alert subscriptions below the "Route Alerts" button, showing each subscription's display name
- **Removed "(beta)" label**: Updated "Route Alerts (beta)" to "Route Alerts" in the settings button
- **Refactored `EditRouteAlertsView`**: Replaced inline display name generation with calls to the new `displayName` property, removing the now-redundant `lineDisplayName()` helper method
- **Improved code reusability**: The centralized `displayName` property is now used consistently across both the settings view and the edit alerts view

## Implementation Details
- The `displayName` property handles three subscription types:
  - Train subscriptions: Returns the train name directly
  - Line subscriptions: Constructs "{from terminus} to {direction}" format using route topology
  - Station-to-station subscriptions: Returns "{from station} to {to station}" format
- The settings view conditionally displays the subscriptions summary only when alerts exist, using an `AlertSubscriptionService` observer to stay in sync with subscription changes
- The summary displays subscription names sorted alphabetically, separated by newlines

https://claude.ai/code/session_01EeTfKMhL8nErF7k8eBDDxc