### PR TITLE
Remove Amtrak NEC-only toggle, make Amtrak a simple on/off like other systems

### DIFF
--- a/ios/DESIGN.md
+++ b/ios/DESIGN.md
@@ -124,7 +124,7 @@ This document contains detailed design specifications, screen documentation, and
 - **Favorite Stations**: Inline editing (no separate view)
 - **Route Alerts**: Inline management (no separate EditRouteAlertsView)
 - **Train System Preferences**: Enable/disable transit systems
-- **Amtrak Mode**: Tri-state toggle (Off / NEC Only / All)
+- **Train System Toggles**: Simple on/off per system (including Amtrak)
 - User preferences and settings
 - Quick access to advanced configuration
 
@@ -640,7 +640,7 @@ All services follow the singleton pattern with `shared` instance for app-wide ac
 
 #### Settings Redesign
 - **Rebranded "My Profile" to "Settings"** with gear icon in tab bar
-- **Amtrak Tri-State Toggle**: Off → NEC Only → All (consolidated from separate toggles)
+- **Train System Toggles**: Simple on/off per system (Amtrak simplified from tri-state to binary toggle)
 - **Health Indicator Auto-Coloring**: Congestion map segments auto-colored by train system (deprecated manual picker)
 
 #### NYC Subway Support (iOS)

--- a/ios/README.md
+++ b/ios/README.md
@@ -47,7 +47,7 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, PATCO, LIRR, Metr
 ### Train System Filtering
 - **Per-System Toggles**: Users can enable/disable each transit system in Settings
 - **Default Systems**: NJT and Amtrak enabled by default; others require opt-in
-- **Amtrak Tri-State**: Off → NEC Only → All (covers Southeast Corridor expansion)
+- **Simple Toggles**: Each system is on or off (Amtrak shows all routes when enabled)
 - **Map Layer Filtering**: Disabled systems hidden from congestion map and route overlays
 - **Station Filtering**: Disabled systems excluded from station picker and onboarding
 - **TrainSystem.swift**: Model for system preferences with UserDefaults persistence

--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -732,13 +732,6 @@ final class AppState: ObservableObject {
         }
     }
 
-    // Amtrak coverage mode: NEC Only vs All Routes (persisted via UserDefaults)
-    @Published var amtrakMode: AmtrakMode = .all {
-        didSet {
-            UserDefaults.standard.set(amtrakMode.rawValue, forKey: "amtrakMode")
-        }
-    }
-
     // Map display settings (persisted via UserDefaults)
     @Published var mapHighlightMode: SegmentHighlightMode = .delays {
         didSet {
@@ -867,26 +860,14 @@ final class AppState: ObservableObject {
     /// Load selected systems from UserDefaults (with migration from legacy AMTRAK_NEC)
     private func loadSelectedSystems() {
         if let stored = UserDefaults.standard.string(forKey: "selectedTrainSystems"), !stored.isEmpty {
-            // Migration: convert legacy "AMTRAK_NEC" to "AMTRAK" + necOnly mode
-            if stored.contains("AMTRAK_NEC") {
-                let migrated = stored
-                    .replacingOccurrences(of: "AMTRAK_NEC", with: "AMTRAK")
-                let loaded = Set<TrainSystem>.from(commaSeparated: migrated)
-                selectedSystems = loaded.isEmpty ? .defaultEnabled : loaded
-                amtrakMode = .necOnly
-                return
-            }
-
-            let loaded = Set<TrainSystem>.from(commaSeparated: stored)
+            // Migration: convert legacy "AMTRAK_NEC" to "AMTRAK"
+            let migrated = stored.contains("AMTRAK_NEC")
+                ? stored.replacingOccurrences(of: "AMTRAK_NEC", with: "AMTRAK")
+                : stored
+            let loaded = Set<TrainSystem>.from(commaSeparated: migrated)
             selectedSystems = loaded.isEmpty ? .defaultEnabled : loaded
         } else {
             selectedSystems = .defaultEnabled
-        }
-
-        // Load persisted amtrak mode
-        if let storedMode = UserDefaults.standard.string(forKey: "amtrakMode"),
-           let mode = AmtrakMode(rawValue: storedMode) {
-            amtrakMode = mode
         }
     }
 
@@ -895,31 +876,14 @@ final class AppState: ObservableObject {
         selectedSystems.contains(system)
     }
 
-    /// Toggle a system's selection state
-    /// For Amtrak: cycles Off → NEC Only → All → Off
-    /// Set allowEmpty to true during onboarding where the UI hides the Continue button when empty
+    /// Toggle a system's selection state.
+    /// Set allowEmpty to true during onboarding where the UI hides the Continue button when empty.
     func toggleSystem(_ system: TrainSystem, allowEmpty: Bool = false) {
-        if system == .amtrak {
-            if !selectedSystems.contains(.amtrak) {
-                // Off → NEC Only
-                selectedSystems.insert(.amtrak)
-                amtrakMode = .necOnly
-            } else if amtrakMode == .necOnly {
-                // NEC Only → All
-                amtrakMode = .all
-            } else {
-                // All → Off (unless it's the last system and allowEmpty is false)
-                guard allowEmpty || selectedSystems.count > 1 else { return }
-                selectedSystems.remove(.amtrak)
-                amtrakMode = .necOnly
-            }
+        if selectedSystems.contains(system) {
+            guard allowEmpty || selectedSystems.count > 1 else { return }
+            selectedSystems.remove(system)
         } else {
-            if selectedSystems.contains(system) {
-                guard allowEmpty || selectedSystems.count > 1 else { return }
-                selectedSystems.remove(system)
-            } else {
-                selectedSystems.insert(system)
-            }
+            selectedSystems.insert(system)
         }
     }
 

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -1,27 +1,5 @@
 import Foundation
 
-/// Amtrak coverage mode: NEC-only or all routes
-enum AmtrakMode: String, CaseIterable {
-    case necOnly = "NEC_ONLY"
-    case all = "ALL"
-
-    /// Label shown as subtitle on Amtrak toggle buttons
-    var label: String {
-        switch self {
-        case .necOnly: return "NEC Only"
-        case .all: return "All Routes"
-        }
-    }
-
-    /// Cycle to next mode
-    var next: AmtrakMode {
-        switch self {
-        case .necOnly: return .all
-        case .all: return .necOnly
-        }
-    }
-}
-
 /// Represents the different train systems supported by TrackRat
 enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     case njt = "NJT"
@@ -153,16 +131,6 @@ extension Set where Element == TrainSystem {
 // MARK: - Stations Extensions (TrainSystem-aware wrappers)
 
 extension Stations {
-    /// Station codes on the Amtrak NEC + Keystone routes (used for NEC-only filtering)
-    static let amtrakNECStations: Set<String> = {
-        let necRouteIds: Set<String> = ["amtrak-nec", "amtrak-keystone"]
-        var codes = Set<String>()
-        for route in RouteTopology.allRoutes where necRouteIds.contains(route.id) {
-            codes.formUnion(route.stationCodes)
-        }
-        return codes
-    }()
-
     /// Returns the train systems that serve a given station
     /// Defaults to NJT + Amtrak if not explicitly mapped (most NJT commuter stations)
     static func systemsForStation(_ code: String) -> Set<TrainSystem> {
@@ -170,17 +138,12 @@ extension Stations {
         return Set(rawSystems.compactMap { TrainSystem(rawValue: $0) })
     }
 
-    /// Check if a station should be visible based on selected systems and Amtrak mode
-    /// A station is visible if ANY of the selected systems serve it
-    static func isStationVisible(_ code: String, withSystems selectedSystems: Set<TrainSystem>, amtrakMode: AmtrakMode = .all) -> Bool {
+    /// Check if a station should be visible based on selected systems.
+    /// A station is visible if ANY of the selected systems serve it.
+    static func isStationVisible(_ code: String, withSystems selectedSystems: Set<TrainSystem>) -> Bool {
+        let stationSystems = systemStringsForStation(code)
         for system in selectedSystems {
-            if system == .amtrak && amtrakMode == .necOnly {
-                // NEC-only: restrict to NEC + Keystone stations
-                if amtrakNECStations.contains(code) { return true }
-            } else {
-                let stationSystems = systemStringsForStation(code)
-                if stationSystems.contains(system.rawValue) { return true }
-            }
+            if stationSystems.contains(system.rawValue) { return true }
         }
         return false
     }
@@ -189,15 +152,14 @@ extension Stations {
     /// Returns stations matching selected systems first, then stations on other systems.
     static func searchGrouped(
         _ query: String,
-        selectedSystems: Set<TrainSystem>,
-        amtrakMode: AmtrakMode = .all
+        selectedSystems: Set<TrainSystem>
     ) -> (primary: [String], other: [String]) {
         let all = search(query)
         var primary: [String] = []
         var other: [String] = []
         for name in all {
             guard let code = getStationCode(name) else { continue }
-            if isStationVisible(code, withSystems: selectedSystems, amtrakMode: amtrakMode) {
+            if isStationVisible(code, withSystems: selectedSystems) {
                 primary.append(name)
             } else {
                 other.append(name)

--- a/ios/TrackRat/Views/Components/StationPickerSheet.swift
+++ b/ios/TrackRat/Views/Components/StationPickerSheet.swift
@@ -12,7 +12,6 @@ struct StationPickerSheet: View {
     @Binding var selectedStation: Station?
     let disabledStation: Station?  // Station that should be shown as disabled
     var selectedSystems: Set<TrainSystem>? = nil  // Optional: filter stations by selected systems
-    var amtrakMode: AmtrakMode = .all
     let onStationSelected: (Station) -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -27,7 +26,7 @@ struct StationPickerSheet: View {
 
         if let systems = selectedSystems, !systems.isEmpty {
             allStations = allStations.filter { station in
-                Stations.isStationVisible(station.code, withSystems: systems, amtrakMode: amtrakMode)
+                Stations.isStationVisible(station.code, withSystems: systems)
             }
         }
 

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -152,10 +152,7 @@ struct CongestionMapView: View {
             await viewModel.fetchCongestionData()
         }
         .onChange(of: appState.selectedSystems) { _, newSystems in
-            viewModel.setSelectedSystems(newSystems, amtrakMode: appState.amtrakMode)
-        }
-        .onChange(of: appState.amtrakMode) { _, newMode in
-            viewModel.setSelectedSystems(appState.selectedSystems, amtrakMode: newMode)
+            viewModel.setSelectedSystems(newSystems)
         }
         .onChange(of: appState.mapHighlightMode) { _, newMode in
             viewModel.highlightMode = newMode
@@ -165,7 +162,7 @@ struct CongestionMapView: View {
         }
         .onAppear {
             // Sync AppState settings to ViewModel on appear
-            viewModel.setSelectedSystems(appState.selectedSystems, amtrakMode: appState.amtrakMode)
+            viewModel.setSelectedSystems(appState.selectedSystems)
             viewModel.highlightMode = appState.mapHighlightMode
             viewModel.showStations = appState.showMapStations
         }
@@ -269,7 +266,6 @@ struct CongestionMapView: View {
                 SystemToggleButton(
                     system: system,
                     isSelected: appState.isSystemSelected(system),
-                    subtitle: system == .amtrak ? appState.amtrakMode.label : nil,
                     action: {
                         appState.toggleSystem(system)
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -491,7 +487,6 @@ class CongestionMapViewModel: ObservableObject {
 
     // System filter
     private var selectedSystems: Set<TrainSystem> = .all
-    private var amtrakMode: AmtrakMode = .all
 
     // Live Activity observation
     private var liveActivityCancellables = Set<AnyCancellable>()
@@ -517,22 +512,21 @@ class CongestionMapViewModel: ObservableObject {
         }
         // Apply system filter to get visible stations
         routeStations = allRouteStations.filter { station in
-            Stations.isStationVisible(station.code, withSystems: selectedSystems, amtrakMode: amtrakMode)
+            Stations.isStationVisible(station.code, withSystems: selectedSystems)
         }
         print("🗺️ Loaded \(allRouteStations.count) route topology stations, \(routeStations.count) visible with current systems")
     }
 
     /// Updates the selected systems filter and reapplies all filtering
-    func setSelectedSystems(_ systems: Set<TrainSystem>, amtrakMode: AmtrakMode = .all) {
-        let changed = systems != selectedSystems || amtrakMode != self.amtrakMode
+    func setSelectedSystems(_ systems: Set<TrainSystem>) {
+        let changed = systems != selectedSystems
         selectedSystems = systems
-        self.amtrakMode = amtrakMode
         guard changed else { return }
         print("🚦 Selected systems updated: \(systems.map(\.rawValue).sorted().joined(separator: ", "))")
 
         // Refilter route stations
         routeStations = allRouteStations.filter { station in
-            Stations.isStationVisible(station.code, withSystems: selectedSystems, amtrakMode: amtrakMode)
+            Stations.isStationVisible(station.code, withSystems: selectedSystems)
         }
 
         // Reapply all filters
@@ -746,11 +740,11 @@ class CongestionMapViewModel: ObservableObject {
         // First filter by effective systems
         let systemFilteredAggregated = allAggregatedSegments.filter { effectiveSystemStrings.contains($0.dataSource) }
         let systemFilteredIndividual = allIndividualSegments.filter { effectiveSystemStrings.contains($0.dataSource) }
-        let systemFilteredStations = allStations.filter { Stations.isStationVisible($0.code, withSystems: effectiveSystems, amtrakMode: amtrakMode) }
+        let systemFilteredStations = allStations.filter { Stations.isStationVisible($0.code, withSystems: effectiveSystems) }
 
         // Update route station visibility to match effective systems
         routeStations = allRouteStations.filter { station in
-            Stations.isStationVisible(station.code, withSystems: effectiveSystems, amtrakMode: amtrakMode)
+            Stations.isStationVisible(station.code, withSystems: effectiveSystems)
         }
 
         // Then apply route filter if we have one

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -88,7 +88,7 @@ struct DeparturePickerView: View {
         let query = searchText.trimmingCharacters(in: .whitespaces)
 
         // Search stations grouped by active system membership
-        let grouped = Stations.searchGrouped(query, selectedSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
+        let grouped = Stations.searchGrouped(query, selectedSystems: appState.selectedSystems)
 
         // Check if input also looks like a train number
         let trainNumber = isLikelyTrainNumber(query) ? query : nil

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -9,7 +9,7 @@ struct DestinationPickerView: View {
     @State private var searchTask: Task<Void, Never>?
 
     private var searchResults: (stations: [String], otherSystemStations: [String]) {
-        let grouped = Stations.searchGrouped(searchText, selectedSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
+        let grouped = Stations.searchGrouped(searchText, selectedSystems: appState.selectedSystems)
         // Filter out the current departure station from both lists
         let primary = grouped.primary.filter { $0 != appState.selectedDeparture }
         let other = grouped.other.filter { $0 != appState.selectedDeparture }

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -95,7 +95,6 @@ struct OnboardingView: View {
                 selectedStation: binding(for: stationBeingEdited),
                 disabledStation: disabledStation(for: stationBeingEdited),
                 selectedSystems: appState.selectedSystems,
-                amtrakMode: appState.amtrakMode,
                 onStationSelected: { station in
                     // Explicitly handle station assignment with proper state update
                     DispatchQueue.main.async {
@@ -139,7 +138,6 @@ struct OnboardingView: View {
                     SystemSelectionCard(
                         system: system,
                         isSelected: appState.isSystemSelected(system),
-                        subtitle: system == .amtrak ? appState.amtrakMode.label : nil,
                         onTap: {
                             withAnimation(.easeInOut(duration: 0.2)) {
                                 appState.toggleSystem(system, allowEmpty: true)

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -215,11 +215,7 @@ struct SettingsSection: View {
             .sorted(by: { $0.displayName < $1.displayName })
         if sorted.isEmpty { return "No systems selected" }
         let lines = sorted.map { system in
-            var name = system.displayName
-            if system == .amtrak {
-                name += " (\(appState.amtrakMode.label))"
-            }
-            return "• \(name)"
+            "• \(system.displayName)"
         }
         return "Following:\n" + lines.joined(separator: "\n")
     }
@@ -263,8 +259,7 @@ struct SettingsSection: View {
                         TrainSystemRow(
                             system: system,
                             isSelected: appState.isSystemSelected(system),
-                            isLast: system == sortedSystems.last,
-                            subtitle: system == .amtrak ? appState.amtrakMode.label : nil
+                            isLast: system == sortedSystems.last
                         ) {
                             appState.toggleSystem(system)
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -731,8 +726,7 @@ struct SettingsSection: View {
             StationPickerSheet(
                 selectedStation: $pickerStation,
                 disabledStation: nil,
-                selectedSystems: appState.selectedSystems,
-                amtrakMode: appState.amtrakMode
+                selectedSystems: appState.selectedSystems
             ) { station in
                 switch stationPickerRole {
                 case .home:

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -41,7 +41,7 @@ struct TripSelectionView: View {
         let query = searchText.trimmingCharacters(in: .whitespaces)
 
         // Search stations grouped by active system membership
-        let grouped = Stations.searchGrouped(query, selectedSystems: appState.selectedSystems, amtrakMode: appState.amtrakMode)
+        let grouped = Stations.searchGrouped(query, selectedSystems: appState.selectedSystems)
 
         // Generate potential train numbers for dual search
         let trainNumbers = getPotentialTrainNumbers(query)

--- a/ios/TrackRatTests/Models/TrainSystemTests.swift
+++ b/ios/TrackRatTests/Models/TrainSystemTests.swift
@@ -124,15 +124,14 @@ class TrainSystemTests: XCTestCase {
                       "Jamaica should not be in 'primary' for NJT-only, primary: \(grouped.primary)")
     }
 
-    func testSearchGrouped_amtrakNECMode() {
-        // With Amtrak NEC-only, non-NEC Amtrak stations should go to other
+    func testSearchGrouped_amtrakSelected() {
+        // With Amtrak selected, Amtrak stations should appear in primary
         let amtrakOnly: Set<TrainSystem> = [.amtrak]
-        let grouped = Stations.searchGrouped("Boston", selectedSystems: amtrakOnly, amtrakMode: .necOnly)
+        let grouped = Stations.searchGrouped("Boston", selectedSystems: amtrakOnly)
 
-        // Boston South is on the NEC, should be in primary
         let primaryHasBoston = grouped.primary.contains { $0.contains("Boston") }
         XCTAssertTrue(primaryHasBoston,
-                     "Boston South should be primary for Amtrak NEC-only, primary: \(grouped.primary)")
+                     "Boston should be primary when Amtrak is selected, primary: \(grouped.primary)")
     }
 
     func testSearchGrouped_emptySelectedSystemsPutsAllInOther() {


### PR DESCRIPTION
The NEC-only mode was iOS-only client-side station filtering that added
unnecessary complexity. Amtrak now uses the same binary toggle as every
other train system. Legacy AMTRAK_NEC UserDefaults migration preserved.

https://claude.ai/code/session_01U6GLCrEqCKDAkpNrGEUAqP