### PR TITLE
Add interactive congestion map: fix tap gestures, add route navigation

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		A1BA60EC2DFC73650002FB39 /* BuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E42DFC73650002FB39 /* BuildTests.swift */; };
 		A1BA60ED2DFC73650002FB39 /* StationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E52DFC73650002FB39 /* StationsTests.swift */; };
 		446F271841A8FA59C62FA628 /* TrainSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */; };
+		C1A1B2C3D4E5F60718293A4B /* RouteTopologyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A1B2C3D4E5F60718293A4C /* RouteTopologyTests.swift */; };
 		A1BA60EE2DFC73650002FB39 /* TrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E62DFC73650002FB39 /* TrainTests.swift */; };
 		A1BA60EF2DFC73650002FB39 /* APIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E72DFC73650002FB39 /* APIServiceTests.swift */; };
 		A1BA60F02DFC73650002FB39 /* StorageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60E82DFC73650002FB39 /* StorageServiceTests.swift */; };
@@ -256,6 +257,7 @@
 		A1BA60E42DFC73650002FB39 /* BuildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildTests.swift; sourceTree = "<group>"; };
 		A1BA60E52DFC73650002FB39 /* StationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationsTests.swift; sourceTree = "<group>"; };
 		BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainSystemTests.swift; sourceTree = "<group>"; };
+		C1A1B2C3D4E5F60718293A4C /* RouteTopologyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTopologyTests.swift; sourceTree = "<group>"; };
 		A1BA60E62DFC73650002FB39 /* TrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainTests.swift; sourceTree = "<group>"; };
 		A1BA60E72DFC73650002FB39 /* APIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIServiceTests.swift; sourceTree = "<group>"; };
 		A1BA60E82DFC73650002FB39 /* StorageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceTests.swift; sourceTree = "<group>"; };
@@ -462,6 +464,7 @@
 		A1BA60F42DFC73650002FB39 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				C1A1B2C3D4E5F60718293A4C /* RouteTopologyTests.swift */,
 				A1BA60E52DFC73650002FB39 /* StationsTests.swift */,
 				BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */,
 				A1BA60E62DFC73650002FB39 /* TrainTests.swift */,
@@ -752,6 +755,7 @@
 			files = (
 				A1BA60EC2DFC73650002FB39 /* BuildTests.swift in Sources */,
 				A1BA60ED2DFC73650002FB39 /* StationsTests.swift in Sources */,
+				C1A1B2C3D4E5F60718293A4B /* RouteTopologyTests.swift in Sources */,
 				446F271841A8FA59C62FA628 /* TrainSystemTests.swift in Sources */,
 				A1BA60EE2DFC73650002FB39 /* TrainTests.swift in Sources */,
 				A1BA60EF2DFC73650002FB39 /* APIServiceTests.swift in Sources */,

--- a/ios/TrackRat/Shared/RouteTopology.swift
+++ b/ios/TrackRat/Shared/RouteTopology.swift
@@ -811,4 +811,30 @@ struct RouteTopology {
         }
         return codes
     }
+
+    /// Finds the route line that contains both station codes for a given data source.
+    /// Returns the first matching route, preferring routes where both stations appear
+    /// in the correct order (from before to).
+    static func routeContaining(from: String, to: String, dataSource: String) -> RouteLine? {
+        let candidates = allRoutes.filter { $0.dataSource == dataSource }
+
+        // Prefer a route where both stations exist and from appears before to
+        for route in candidates {
+            if let fromIdx = route.stationCodes.firstIndex(of: from),
+               let toIdx = route.stationCodes.firstIndex(of: to),
+               fromIdx < toIdx {
+                return route
+            }
+        }
+
+        // Fall back to any route containing both stations (reverse direction)
+        for route in candidates {
+            if route.stationCodes.contains(from) && route.stationCodes.contains(to) {
+                return route
+            }
+        }
+
+        // Last resort: any route containing at least one of the stations
+        return candidates.first { $0.stationCodes.contains(from) || $0.stationCodes.contains(to) }
+    }
 }

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -9,6 +9,7 @@ struct CongestionMapView: View {
     @StateObject private var viewModel = CongestionMapViewModel()
     @State private var region = MKCoordinateRegion.newarkPennDefault
     @State private var selectedSegment: CongestionSegment?
+    @State private var selectedIndividualSegment: IndividualJourneySegment?
     @State private var showingFilters = false
     @State private var timeWindow = 1
     @State private var selectedDataSource: String = "All"
@@ -32,7 +33,7 @@ struct CongestionMapView: View {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 },
                 onIndividualSegmentTap: { individualSegment in
-                    print("Tapped individual segment: \(individualSegment.trainDisplayName) \(individualSegment.fromStation) → \(individualSegment.toStation)")
+                    selectedIndividualSegment = individualSegment
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }
             )
@@ -147,6 +148,17 @@ struct CongestionMapView: View {
             SegmentTrainDetailsView(segment: segment)
                 .presentationDetents([.height(600), .large])
                 .presentationDragIndicator(.visible)
+        }
+        .sheet(item: $selectedIndividualSegment) { segment in
+            TrainDetailsView(
+                trainNumber: segment.trainId,
+                fromStation: segment.fromStation,
+                journeyDate: segment.actualDeparture,
+                dataSource: segment.dataSource,
+                isSheet: true
+            )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
         }
         .task {
             await viewModel.fetchCongestionData()
@@ -967,6 +979,10 @@ struct SystemCongestionMapView: UIViewRepresentable {
         mapView.showsCompass = true
         mapView.showsScale = true
 
+        // Add tap gesture recognizer for polyline interaction
+        let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleMapTap(_:)))
+        mapView.addGestureRecognizer(tapGesture)
+
         return mapView
     }
     
@@ -1446,7 +1462,69 @@ struct SystemCongestionMapView: UIViewRepresentable {
                 return 0.3
             }
         }
-        
+
+        // MARK: - Tap Handling
+
+        @objc func handleMapTap(_ gesture: UITapGestureRecognizer) {
+            guard let mapView = gesture.view as? MKMapView else { return }
+
+            let tapPoint = gesture.location(in: mapView)
+            let tapCoordinate = mapView.convert(tapPoint, toCoordinateFrom: mapView)
+
+            // Check individual journey polylines first (they're on top visually)
+            for (_, polyline) in individualOverlayMap {
+                if isCoordinate(tapCoordinate, nearPolyline: polyline, inMapView: mapView) {
+                    if let segment = polyline.individualSegment {
+                        onIndividualSegmentTap(segment)
+                        return
+                    }
+                }
+            }
+
+            // Then check aggregated segment polylines
+            for (_, polyline) in aggregatedOverlayMap {
+                if isCoordinate(tapCoordinate, nearPolyline: polyline, inMapView: mapView) {
+                    if let segment = polyline.segment {
+                        onSegmentTap(segment)
+                        return
+                    }
+                }
+            }
+        }
+
+        private func isCoordinate(_ coordinate: CLLocationCoordinate2D, nearPolyline polyline: MKPolyline, inMapView mapView: MKMapView) -> Bool {
+            guard polyline.pointCount >= 2 else { return false }
+
+            let points = polyline.points()
+            let tapPoint = mapView.convert(coordinate, toPointTo: mapView)
+
+            // Check each line segment in the polyline
+            for i in 0..<(polyline.pointCount - 1) {
+                let screenPoint1 = mapView.convert(points[i].coordinate, toPointTo: mapView)
+                let screenPoint2 = mapView.convert(points[i + 1].coordinate, toPointTo: mapView)
+
+                let distance = distanceFromPoint(tapPoint, toLineSegmentBetween: screenPoint1, and: screenPoint2)
+                if distance <= 30 {
+                    return true
+                }
+            }
+            return false
+        }
+
+        private func distanceFromPoint(_ point: CGPoint, toLineSegmentBetween p1: CGPoint, and p2: CGPoint) -> CGFloat {
+            let dx = p2.x - p1.x
+            let dy = p2.y - p1.y
+            let lengthSquared = dx * dx + dy * dy
+
+            if lengthSquared == 0 {
+                return hypot(point.x - p1.x, point.y - p1.y)
+            }
+
+            let t = max(0, min(1, ((point.x - p1.x) * dx + (point.y - p1.y) * dy) / lengthSquared))
+            let closestPoint = CGPoint(x: p1.x + t * dx, y: p1.y + t * dy)
+            return hypot(point.x - closestPoint.x, point.y - closestPoint.y)
+        }
+
     }
 }
 
@@ -1537,18 +1615,22 @@ struct SegmentTrainDetailsView: View {
     let segment: CongestionSegment
     @StateObject private var viewModel: SegmentTrainDetailsViewModel
     @Environment(\.dismiss) private var dismiss
-    
+    @State private var routeStatusContext: RouteStatusContext?
+
     init(segment: CongestionSegment) {
         self.segment = segment
         self._viewModel = StateObject(wrappedValue: SegmentTrainDetailsViewModel(segment: segment))
     }
-    
+
     var body: some View {
         NavigationStack {
             ScrollView {
                 LazyVStack(spacing: 20) {
                     // Segment Header
                     segmentHeaderSection
+
+                    // View Full Route button
+                    viewFullRouteButton
 
                     // Summary Stats
                     if let summary = viewModel.segmentDetails?.summary {
@@ -1585,6 +1667,9 @@ struct SegmentTrainDetailsView: View {
         .preferredColorScheme(.dark)
         .task {
             await viewModel.loadTrainDetails()
+        }
+        .sheet(item: $routeStatusContext) { context in
+            RouteStatusView(context: context)
         }
     }
     
@@ -1632,8 +1717,54 @@ struct SegmentTrainDetailsView: View {
         }
     }
     
+    // MARK: - View Full Route Button
+
+    private var viewFullRouteButton: some View {
+        Button {
+            let route = RouteTopology.routeContaining(
+                from: segment.fromStation,
+                to: segment.toStation,
+                dataSource: segment.dataSource
+            )
+            routeStatusContext = RouteStatusContext(
+                dataSource: segment.dataSource,
+                lineId: route?.id,
+                fromStationCode: segment.fromStation,
+                toStationCode: segment.toStation
+            )
+        } label: {
+            HStack {
+                Image(systemName: "map")
+                    .font(.body)
+                Text("View Full Route")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if let route = RouteTopology.routeContaining(
+                    from: segment.fromStation,
+                    to: segment.toStation,
+                    dataSource: segment.dataSource
+                ) {
+                    Text(route.name)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.ultraThinMaterial)
+            )
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.orange)
+    }
+
     // MARK: - Summary Stats Section
-    
+
     private func summaryStatsSection(summary: SegmentSummary) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -57,6 +57,7 @@ struct MapContainerView: View {
     @StateObject private var mapViewModel = CongestionMapViewModel()
     @StateObject private var mapRegionVM = MapRegionViewModel()
     @State private var selectedSegment: CongestionSegment?
+    @State private var selectedIndividualSegment: IndividualJourneySegment?
     @ObservedObject private var liveActivityService = LiveActivityService.shared
     @ObservedObject private var ratSenseService = RatSenseService.shared
     @ObservedObject private var feedbackService = JourneyFeedbackService.shared
@@ -141,7 +142,7 @@ struct MapContainerView: View {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 },
                 onIndividualSegmentTap: { individualSegment in
-                    print("Tapped individual segment: \(individualSegment.trainDisplayName)")
+                    selectedIndividualSegment = individualSegment
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }
             )
@@ -362,8 +363,19 @@ struct MapContainerView: View {
                 .presentationDetents([.height(600), .large])
                 .presentationDragIndicator(.visible)
         }
+        .sheet(item: $selectedIndividualSegment) { segment in
+            TrainDetailsView(
+                trainNumber: segment.trainId,
+                fromStation: segment.fromStation,
+                journeyDate: segment.actualDeparture,
+                dataSource: segment.dataSource,
+                isSheet: true
+            )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
     }
-    
+
     private func handleNavigationChange(_ navigationPath: NavigationPath) {
         if navigationPath.isEmpty {
             // Back to home - cancel any pending operations

--- a/ios/TrackRatTests/Models/RouteTopologyTests.swift
+++ b/ios/TrackRatTests/Models/RouteTopologyTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import TrackRat
+
+class RouteTopologyTests: XCTestCase {
+
+    // MARK: - routeContaining Tests
+
+    func testRouteContainingFindsNJTNortheastCorridor() {
+        // NY (New York Penn) and TR (Trenton) are on the NJT Northeast Corridor
+        let route = RouteTopology.routeContaining(from: "NY", to: "TR", dataSource: "NJT")
+        XCTAssertNotNil(route, "Should find a route containing NY and TR on NJT")
+        XCTAssertEqual(route?.id, "njt-nec", "NY to TR should be on the Northeast Corridor")
+        XCTAssertEqual(route?.dataSource, "NJT")
+    }
+
+    func testRouteContainingFindsReverseDirection() {
+        // TR → NY is reverse direction but should still match NEC
+        let route = RouteTopology.routeContaining(from: "TR", to: "NY", dataSource: "NJT")
+        XCTAssertNotNil(route, "Should find a route for reverse direction TR → NY")
+        XCTAssertEqual(route?.id, "njt-nec", "TR to NY should still match the Northeast Corridor")
+    }
+
+    func testRouteContainingFiltersByDataSource() {
+        // NY exists on NJT routes but searching with wrong data source should not match NJT routes
+        let route = RouteTopology.routeContaining(from: "NY", to: "TR", dataSource: "PATH")
+        // PATH doesn't have NY→TR so this should either be nil or find a different route
+        if let route = route {
+            XCTAssertEqual(route.dataSource, "PATH", "Returned route should match requested data source")
+        }
+    }
+
+    func testRouteContainingReturnsNilForUnknownStations() {
+        let route = RouteTopology.routeContaining(from: "NONEXISTENT1", to: "NONEXISTENT2", dataSource: "NJT")
+        XCTAssertNil(route, "Should return nil for stations that don't exist on any route")
+    }
+
+    func testRouteContainingPrefersForwardDirection() {
+        // When from < to in the route's station order, that route should be preferred
+        let route = RouteTopology.routeContaining(from: "NY", to: "TR", dataSource: "NJT")
+        XCTAssertNotNil(route)
+        if let route = route {
+            let fromIdx = route.stationCodes.firstIndex(of: "NY")
+            let toIdx = route.stationCodes.firstIndex(of: "TR")
+            XCTAssertNotNil(fromIdx, "From station should exist in route")
+            XCTAssertNotNil(toIdx, "To station should exist in route")
+            if let f = fromIdx, let t = toIdx {
+                XCTAssertLessThan(f, t, "Forward direction match should have from before to")
+            }
+        }
+    }
+
+    func testRouteContainingFindsPATHRoute() {
+        // PNK (Newark) and PWC (World Trade Center) are on PATH
+        let route = RouteTopology.routeContaining(from: "PNK", to: "PWC", dataSource: "PATH")
+        XCTAssertNotNil(route, "Should find a PATH route containing PNK and PWC")
+        XCTAssertEqual(route?.dataSource, "PATH")
+    }
+
+    func testRouteContainingFallsBackToPartialMatch() {
+        // Test that a station on only one end still returns a route (last resort)
+        let route = RouteTopology.routeContaining(from: "NY", to: "NONEXISTENT", dataSource: "NJT")
+        XCTAssertNotNil(route, "Should fall back to route containing at least one station")
+        guard let route = route else { return }
+        XCTAssertEqual(route.dataSource, "NJT")
+        XCTAssertTrue(route.stationCodes.contains("NY"), "Fallback route should contain the known station")
+    }
+
+    // MARK: - allRoutes Validation
+
+    func testAllRoutesNotEmpty() {
+        XCTAssertFalse(RouteTopology.allRoutes.isEmpty, "Should have route definitions")
+        XCTAssertGreaterThan(RouteTopology.allRoutes.count, 10, "Should have substantial number of routes")
+    }
+
+    func testAllRoutesHaveUniqueIds() {
+        let ids = RouteTopology.allRoutes.map { $0.id }
+        let uniqueIds = Set(ids)
+        XCTAssertEqual(ids.count, uniqueIds.count, "All route IDs should be unique")
+    }
+
+    func testAllRoutesHaveAtLeastTwoStations() {
+        for route in RouteTopology.allRoutes {
+            XCTAssertGreaterThanOrEqual(
+                route.stationCodes.count, 2,
+                "Route \(route.id) (\(route.name)) should have at least 2 stations, has \(route.stationCodes.count)"
+            )
+        }
+    }
+
+    // MARK: - allStationCodes
+
+    func testAllStationCodesNotEmpty() {
+        XCTAssertFalse(RouteTopology.allStationCodes.isEmpty, "Should have station codes across all routes")
+        XCTAssertGreaterThan(RouteTopology.allStationCodes.count, 50, "Should have substantial number of station codes")
+    }
+}


### PR DESCRIPTION
- Fix missing UITapGestureRecognizer on SystemCongestionMapView (main map)
  that prevented segment/train taps from firing (the callbacks were wired
  but no gesture recognizer was added in makeUIView)
- Add handleMapTap to SystemCongestionMapView.Coordinator with hit testing
  for both aggregated and individual journey polylines
- Add "View Full Route" button to SegmentTrainDetailsView that opens
  RouteStatusView with history, alerts, upcoming trains, and operations summary
- Wire onIndividualSegmentTap in both CongestionMapView and MapContainerView
  to present TrainDetailsView as a sheet
- Add RouteTopology.routeContaining(from:to:dataSource:) helper to find
  the parent route line for a segment pair
- Add RouteTopologyTests with coverage for route lookup, direction handling,
  data source filtering, and fallback behavior

https://claude.ai/code/session_01GjjersqJAskWKUWLHV3fjn