### PR TITLE
Fix segment detail sheets not appearing on congestion map tap

### DIFF
--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -225,6 +225,22 @@ struct MapContainerView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
             }
+            .sheet(item: $selectedSegment) { segment in
+                SegmentTrainDetailsView(segment: segment)
+                    .presentationDetents([.height(600), .large])
+                    .presentationDragIndicator(.visible)
+            }
+            .sheet(item: $selectedIndividualSegment) { segment in
+                TrainDetailsView(
+                    trainNumber: segment.trainId,
+                    fromStation: segment.fromStation,
+                    journeyDate: segment.actualDeparture,
+                    dataSource: segment.dataSource,
+                    isSheet: true
+                )
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+            }
         }
         .task {
             // Load congestion data when map container appears, but don't block UI
@@ -357,22 +373,6 @@ struct MapContainerView: View {
             // This ensures sheet is fully expanded before NavigationStack swaps content
             guard let destination = pendingDestination else { return }
             handlePendingNavigation(destination)
-        }
-        .sheet(item: $selectedSegment) { segment in
-            SegmentTrainDetailsView(segment: segment)
-                .presentationDetents([.height(600), .large])
-                .presentationDragIndicator(.visible)
-        }
-        .sheet(item: $selectedIndividualSegment) { segment in
-            TrainDetailsView(
-                trainNumber: segment.trainId,
-                fromStation: segment.fromStation,
-                journeyDate: segment.actualDeparture,
-                dataSource: segment.dataSource,
-                isSheet: true
-            )
-            .presentationDetents([.large])
-            .presentationDragIndicator(.visible)
         }
     }
 


### PR DESCRIPTION
The segment detail sheets (.sheet(item: $selectedSegment) and .sheet(item: $selectedIndividualSegment)) were attached to the outer ZStack which already had a persistent always-on sheet (isSheetPresented = true with interactiveDismissDisabled). SwiftUI silently ignores additional .sheet modifiers when one is already presented on the same view level.

Move both sheets to nest inside the persistent bottom sheet's content, alongside the existing feedback/routeStatus/chat sheets that already use this pattern successfully.

https://claude.ai/code/session_01GjjersqJAskWKUWLHV3fjn