### PR TITLE
Improve onboarding UX: always show Continue button and update paywall messaging

### DIFF
--- a/ios/TrackRat/Services/SubscriptionService.swift
+++ b/ios/TrackRat/Services/SubscriptionService.swift
@@ -43,7 +43,7 @@ enum PaywallContext {
     var subtext: String? {
         switch self {
         case .trainSystems:
-            return "Free users can follow one train system. Upgrade to Pro to track all 7 systems \u{2014} start with a free 1-week trial."
+            return "Start a 1-week free trial to follow multiple train systems at a time"
         case .routeAlerts:
             return "Free users get one route alert. Upgrade to Pro for unlimited alerts across all your routes \u{2014} start with a free 1-week trial."
         case .developerChat, .generic:

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -147,7 +147,6 @@ struct OnboardingView: View {
                     SystemSelectionCard(
                         system: system,
                         isSelected: isSelected,
-                        showProBadge: atFreeLimit,
                         onTap: {
                             if atFreeLimit {
                                 showingPaywall = true
@@ -165,25 +164,21 @@ struct OnboardingView: View {
 
             Spacer()
 
-            // Continue button (hidden until at least one system selected)
-            Group {
-                if !appState.selectedSystems.isEmpty {
-                    Button("Continue") {
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            showSystemSelection = false
-                        }
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                    }
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(height: 50)
-                    .frame(minWidth: 160)
-                    .background(Color.orange)
-                    .cornerRadius(TrackRatTheme.CornerRadius.md)
-                    .buttonStyle(.plain)
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            // Continue button (always visible, disabled until at least one system selected)
+            Button("Continue") {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    showSystemSelection = false
                 }
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
             }
+            .font(.headline)
+            .foregroundColor(.white)
+            .frame(height: 50)
+            .frame(minWidth: 160)
+            .background(appState.selectedSystems.isEmpty ? Color.gray : Color.orange)
+            .cornerRadius(TrackRatTheme.CornerRadius.md)
+            .buttonStyle(.plain)
+            .disabled(appState.selectedSystems.isEmpty)
             .padding(.horizontal, 20)
             .padding(.bottom, 40)
         }


### PR DESCRIPTION
## Summary
This PR improves the onboarding experience by making the Continue button always visible (but disabled when no systems are selected) and updates the paywall messaging to be more concise and user-focused.

## Key Changes
- **OnboardingView.swift**
  - Changed Continue button from conditionally rendered (hidden/shown) to always visible with disabled state
  - Button now uses gray background when disabled and orange when enabled, providing clearer visual feedback
  - Removed the `showProBadge` parameter from `SystemSelectionCard` (no longer needed)
  - Removed the conditional `Group` wrapper and transition animation, simplifying the layout
  - Updated comment to reflect that button is "always visible, disabled until at least one system selected"

- **SubscriptionService.swift**
  - Simplified the paywall subtext for the `.trainSystems` context
  - Changed from detailed messaging about free tier limitations to a more action-oriented message focused on the trial benefit
  - New message: "Start a 1-week free trial to follow multiple train systems at a time"

## Implementation Details
The Continue button now uses `.disabled()` modifier instead of conditional rendering, which is a more standard iOS pattern. The button's background color dynamically changes based on selection state, providing immediate visual feedback to users about whether they can proceed.

https://claude.ai/code/session_01DuTZ9FxWnMbBMTGRbjmPpG