### PR TITLE
Relocate Report button in TrainDetailsView

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -143,19 +143,6 @@ struct TrainDetailsView: View {
                         .buttonStyle(.plain)
                     }
 
-                    // Report an Issue button
-                    FeedbackButton(
-                        screen: "train_details",
-                        trainId: train.trainId,
-                        originCode: appState.departureStationCode,
-                        destinationCode: appState.destinationStationCode,
-                        textColor: .white.opacity(0.8),
-                        label: "Report",
-                        font: .subheadline
-                    )
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 8)
-                    .background(Capsule().fill(Color.white.opacity(0.12)))
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 8)
@@ -226,6 +213,15 @@ struct TrainDetailsView: View {
                                     set: { alertSubscription = $0 }
                                 ))
                             }
+
+                            // Report an issue button
+                            FeedbackButton(
+                                screen: "train_details",
+                                trainId: train.trainId,
+                                originCode: appState.departureStationCode,
+                                destinationCode: appState.destinationStationCode
+                            )
+                            .padding(.top, 8)
                         }
                         .padding()
                         // Force view recreation when train identity or status changes


### PR DESCRIPTION
## Summary
Moved the "Report an Issue" button from the top action bar to the bottom of the train details content section in TrainDetailsView.

## Key Changes
- Removed `FeedbackButton` from the horizontal action bar at the top of the view (lines 146-157)
- Re-added `FeedbackButton` at the bottom of the details section, after the alert subscription toggle (lines 216-225)
- Simplified the button styling by removing custom text color, label, and font parameters, using the component's defaults
- Adjusted padding from horizontal/vertical spacing to top-only padding (8pt) to fit the new layout context

## Implementation Details
- The button maintains the same functionality and parameters (screen, trainId, originCode, destinationCode)
- The relocation places the report action closer to the detailed train information rather than in the top action bar
- This change improves the information hierarchy by grouping the report action with other interactive elements in the content area

https://claude.ai/code/session_0113cj1eVDdZhQdDFHmQYW7s