### PR TITLE
Enforce Pro subscription requirement for multiple route alerts

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -109,9 +109,13 @@ struct DirectionalAlertConfigurationSheet: View {
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Save") {
-                            let enabledSubs = directions
-                                .filter { !$0.alreadySubscribed && $0.subscription.activeDays != 0 }
-                                .map(\.subscription)
+                            let enabledSubs = directions.enumerated()
+                                .filter { index, draft in
+                                    !draft.alreadySubscribed
+                                    && draft.subscription.activeDays != 0
+                                    && (index == 0 || subscriptionService.isPro)
+                                }
+                                .map(\.element.subscription)
                             onSave(enabledSubs)
                             dismiss()
                         }
@@ -159,7 +163,7 @@ struct DirectionalAlertConfigurationSheet: View {
                 HStack {
                     Image(systemName: "lock.fill")
                         .foregroundColor(.orange)
-                    Text("Upgrade to Pro to add both directions")
+                    Text("Start a free trial and upgrade to Pro to add more than one route alert")
                         .foregroundColor(.white.opacity(0.7))
                     Spacer()
                     Text("PRO")

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -202,7 +202,7 @@ struct RouteStatusView: View {
                 notifyRecovery: template.notifyRecovery,
                 digestTimeMinutes: template.digestTimeMinutes
             )
-            alertService.addSubscriptions([subAB, subBA])
+            alertService.addSubscriptions(subscriptionService.isPro ? [subAB, subBA] : [subAB])
             // Move settings into edited subscriptions for the newly-created subs
             for sub in alertService.subscriptions(for: context) {
                 var edited = RouteAlertSubscription.copySettings(from: template, to: sub)


### PR DESCRIPTION
## Summary
This PR adds Pro subscription checks to enforce that free users can only create a single route alert, while Pro users can create multiple alerts in both directions.

## Key Changes
- **AlertConfigurationSection.swift**: Updated the "Save" button logic to filter out additional direction subscriptions for non-Pro users by checking `subscriptionService.isPro` and only allowing the first subscription (index == 0) for free users
- **AlertConfigurationSection.swift**: Updated the lock icon message from "Upgrade to Pro to add both directions" to "Start a free trial and upgrade to Pro to add more than one route alert" for better clarity
- **RouteStatusView.swift**: Modified the alert creation flow to only add bidirectional subscriptions (subAB, subBA) for Pro users; free users only get the primary direction subscription (subAB)

## Implementation Details
- The subscription filtering now uses `enumerated()` to track the index position, allowing the first subscription to always be available while restricting additional subscriptions to Pro users
- The change is applied at two levels: when saving alert configurations and when initially creating new alerts from templates
- The user-facing message was updated to be more descriptive about the Pro feature benefit

https://claude.ai/code/session_018zSemfdziGz5Ty24t6WHXD