### PR TITLE
Remove divider from alert configuration section

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -282,8 +282,6 @@ struct AlertConfigurationSection: View {
                         .tint(.orange)
                     }
 
-                    Divider().opacity(0.3)
-
                     // Daily status summary
                     Toggle(isOn: digestEnabled) {
                         Text("Daily Status Summary")


### PR DESCRIPTION
## Summary
Removed a visual divider element from the AlertConfigurationSection component to improve the UI layout.

## Changes
- Removed the `Divider().opacity(0.3)` element that was positioned between the notification sound toggle and the daily status summary toggle

## Details
This change simplifies the visual hierarchy of the alert configuration section by eliminating the intermediate divider. The daily status summary toggle now directly follows the notification sound toggle without the separator element.

https://claude.ai/code/session_01J83kmsZa4ntGXwo7CKR3Xw