### PR TITLE
Reset activeDays when showing paywall on freemium limit

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -160,6 +160,8 @@ struct RouteStatusView: View {
             // Check freemium limit before auto-subscribing
             if !subscriptionService.isPro
                 && alertService.subscriptions.count >= SubscriptionService.freeRouteAlertLimit {
+                // Reset activeDays so the UI reverts to "None" when paywall is dismissed
+                draftSubscription?.activeDays = 0
                 showingPaywall = true
                 return
             }


### PR DESCRIPTION
## Summary
Fixed UI state management when the subscription paywall is displayed due to reaching the freemium route alert limit. The draft subscription's `activeDays` is now reset to prevent stale UI state.

## Key Changes
- Reset `draftSubscription?.activeDays` to 0 before showing the paywall when the freemium alert limit is reached
- This ensures the UI reverts to "None" when the paywall is dismissed, preventing inconsistent state between the user's selection and the actual subscription data

## Implementation Details
The fix is applied in the freemium limit check within `RouteStatusView`. When a user attempts to create a route alert but has reached the free tier limit, the draft subscription state is now properly cleared before presenting the paywall, ensuring a clean slate if the user dismisses the paywall without subscribing.

https://claude.ai/code/session_01Y7CigeosFJvPrvGnZxakjT