### PR TITLE
Replace hardcoded headline font with TrackRatTheme typography

### DIFF
--- a/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
+++ b/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
@@ -34,7 +34,7 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
             // Center title - truly centered regardless of leading/trailing content
             VStack(spacing: 0) {
                 Text(title)
-                    .font(.headline)
+                    .font(TrackRatTheme.Typography.title3)
                     .foregroundColor(.white)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -36,7 +36,7 @@ struct SettingsView: View {
                 // Center title with Pro badge
                 HStack(spacing: 8) {
                     Text("Settings")
-                        .font(.headline)
+                        .font(TrackRatTheme.Typography.title3)
                         .foregroundColor(.white)
                         .onTapGesture(count: 5) {
                             if !chatService.isAdmin {

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -66,7 +66,7 @@ struct TrainListView: View {
                 // Center title
                 VStack(spacing: 2) {
                     Text(destination)
-                        .font(.headline)
+                        .font(TrackRatTheme.Typography.title3)
                         .foregroundColor(.white)
                         .lineLimit(1)
                         .minimumScaleFactor(0.7)


### PR DESCRIPTION
## Summary
Standardized navigation header typography across the app by replacing hardcoded `.headline` font declarations with the centralized `TrackRatTheme.Typography.title3` style.

## Key Changes
- Updated `TrackRatNavigationHeader` to use `TrackRatTheme.Typography.title3` instead of `.headline`
- Updated `SettingsView` navigation title to use the theme typography
- Updated `TrainListView` destination title to use the theme typography

## Implementation Details
This change ensures consistent typography styling across navigation headers by leveraging the app's centralized theme system. Using `TrackRatTheme.Typography.title3` instead of the generic `.headline` modifier provides better maintainability and allows for future design adjustments to be applied globally across all affected screens.

https://claude.ai/code/session_01EhYrJ8imA3tQqzuJGaA1VK