### PR TITLE
Update paywall messaging to clarify free tier and Pro benefits

### DIFF
--- a/ios/TrackRat/Views/Paywall/PaywallView.swift
+++ b/ios/TrackRat/Views/Paywall/PaywallView.swift
@@ -62,7 +62,7 @@ struct PaywallView: View {
                             .lineSpacing(4)
                             .fixedSize(horizontal: false, vertical: true)
 
-                        Text("The core app experience is free. Subscribing helps me keep the servers running and experiment with new capabilities.\n\nAs a thank you, TrackRat Pro members can use the in-app chat system to request new features, flag potential issues, or brainstorm ways an app like this can make people\u{2019}s commutes better.")
+                        Text("The app is free to use with one train system and one route alert. Subscribing unlocks all seven systems and unlimited alerts \u{2014} and helps me keep the servers running.\n\nPro members also get access to the in-app chat to request features, flag issues, or brainstorm ways to make commutes better.")
                             .font(.subheadline)
                             .foregroundColor(.white.opacity(0.8))
                             .multilineTextAlignment(.leading)


### PR DESCRIPTION
## Summary
Updated the paywall view copy to more clearly communicate the app's free tier limitations and Pro subscription benefits.

## Key Changes
- Clarified that the free tier includes access to one train system and one route alert
- Specified that Pro unlocks all seven systems and unlimited alerts
- Reframed the value proposition to emphasize feature access alongside server support
- Simplified the messaging about Pro member benefits (in-app chat for feature requests and issue reporting)
- Improved overall clarity and conciseness of the subscription pitch

## Details
The updated messaging now leads with concrete feature differences between free and Pro tiers, making it immediately clear what users gain by subscribing. The secondary benefit of in-app chat access is presented more concisely while maintaining its importance as a Pro member perk.

https://claude.ai/code/session_0163rY7eAjSPzTNrQUueM5Nu