### PR TITLE
Link other-system search results to train systems settings

### DIFF
--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -83,6 +83,7 @@ struct DeparturePickerView: View {
     @State private var trainSearchError: String?
     @State private var isSearchingTrain = false
     @State private var searchTask: Task<Void, Never>?
+    @State private var showSettingsForTrainSystems = false
 
     private var searchResults: (stations: [String], otherSystemStations: [String], trainNumber: String?) {
         let query = searchText.trimmingCharacters(in: .whitespaces)
@@ -194,12 +195,17 @@ struct DeparturePickerView: View {
                 print("🐀🐀🐀 DeparturePickerView appeared - updating Rat Sense")
                 // Update Rat Sense suggestion when view appears
                 ratSenseService.updateSuggestion()
-                
+
                 // Uncomment to test Rat Sense with sample data
                 // ratSenseService.addTestData()
-                
+
                 // Uncomment to clear all Rat Sense data
                 // ratSenseService.clearAllData()
+            }
+            .sheet(isPresented: $showSettingsForTrainSystems) {
+                SettingsView(editTrainSystems: true)
+                    .presentationDetents([.large])
+                    .presentationDragIndicator(.visible)
             }
     }
     
@@ -333,7 +339,7 @@ struct DeparturePickerView: View {
 
             // Stations from non-active transit systems
             if !searchResults.otherSystemStations.isEmpty {
-                Text("Other systems")
+                Text("Other systems — edit your train systems to use")
                     .font(.caption)
                     .foregroundColor(.white.opacity(0.5))
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -441,13 +447,11 @@ struct DeparturePickerView: View {
             )
             .padding(.horizontal, 24)
             .onTapGesture {
-                if let code = Stations.getStationCode(station) {
-                    selectDeparture(name: station, code: code)
-                }
+                showSettingsForTrainSystems = true
             }
         }
     }
-    
+
     @ViewBuilder
     private var popularStationsSection: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -7,6 +7,7 @@ struct DestinationPickerView: View {
     @FocusState private var searchFieldFocused: Bool
     @State private var navigationBarVisible = false
     @State private var searchTask: Task<Void, Never>?
+    @State private var showSettingsForTrainSystems = false
 
     private var searchResults: (stations: [String], otherSystemStations: [String]) {
         let grouped = Stations.searchGrouped(searchText, selectedSystems: appState.selectedSystems)
@@ -130,7 +131,7 @@ struct DestinationPickerView: View {
 
                                 // Stations from non-active transit systems
                                 if !searchResults.otherSystemStations.isEmpty {
-                                    Text("Other systems")
+                                    Text("Other systems — edit your train systems to use")
                                         .font(.caption)
                                         .foregroundColor(.white.opacity(0.5))
                                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -139,7 +140,7 @@ struct DestinationPickerView: View {
 
                                     ForEach(searchResults.otherSystemStations, id: \.self) { station in
                                         Button {
-                                            selectDestination(station)
+                                            showSettingsForTrainSystems = true
                                         } label: {
                                             otherSystemDestinationRow(station: station)
                                         }
@@ -176,6 +177,11 @@ struct DestinationPickerView: View {
         .onAppear {
             // Load favorite stations when view appears
             appState.loadFavoriteStations()
+        }
+        .sheet(isPresented: $showSettingsForTrainSystems) {
+            SettingsView(editTrainSystems: true)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
     

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -14,6 +14,8 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var subscriptionService = SubscriptionService.shared
 
+    var editTrainSystems: Bool = false
+
     @State private var showingPaywall = false
     @State private var paywallContext: PaywallContext = .generic
     @State private var navigationPath = NavigationPath()
@@ -92,7 +94,8 @@ struct SettingsView: View {
                         navigationPath: $navigationPath,
                         showingPaywall: $showingPaywall,
                         paywallContext: $paywallContext,
-                        showDebugSections: showDebugSections
+                        showDebugSections: showDebugSections,
+                        initialEditTrainSystems: editTrainSystems
                     )
                 }
                 .padding()
@@ -166,6 +169,7 @@ struct SettingsSection: View {
     @Binding var showingPaywall: Bool
     @Binding var paywallContext: PaywallContext
     var showDebugSections: Bool
+    var initialEditTrainSystems: Bool = false
     @State private var isEditingTrainSystems = false
     @State private var isEditingFavorites = false
     @State private var isEditingRouteAlerts = false
@@ -741,6 +745,11 @@ struct SettingsSection: View {
                     )
                 }
                 .buttonStyle(.plain)
+            }
+        }
+        .onAppear {
+            if initialEditTrainSystems {
+                isEditingTrainSystems = true
             }
         }
         .sheet(isPresented: $showStationPicker) {

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -13,6 +13,7 @@ struct TripSelectionView: View {
     @State private var searchText = ""
     @State private var isSearching = false
     @State private var showingSettings = false
+    @State private var showSettingsForTrainSystems = false
     @FocusState private var searchFieldFocused: Bool
     @StateObject private var liveActivityService = LiveActivityService.shared
     @StateObject private var ratSenseService = RatSenseService.shared
@@ -247,7 +248,7 @@ struct TripSelectionView: View {
 
                             // Stations from non-active transit systems
                             if !searchResults.otherSystemStations.isEmpty {
-                                Text("Other systems")
+                                Text("Other systems — edit your train systems to use")
                                     .font(.caption)
                                     .foregroundColor(.white.opacity(0.5))
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -256,9 +257,7 @@ struct TripSelectionView: View {
 
                                 ForEach(searchResults.otherSystemStations.prefix(5), id: \.self) { station in
                                     Button {
-                                        if let code = Stations.getStationCode(station) {
-                                            selectOriginStation(name: station, code: code)
-                                        }
+                                        showSettingsForTrainSystems = true
                                     } label: {
                                         otherSystemStationRow(station: station)
                                     }
@@ -308,6 +307,11 @@ struct TripSelectionView: View {
         }
         .sheet(isPresented: $showingSettings) {
             SettingsView()
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showSettingsForTrainSystems) {
+            SettingsView(editTrainSystems: true)
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }


### PR DESCRIPTION
When searching for stations not in the user's active transit systems,
the "Other systems" header now reads "Other systems — edit your train
systems to use" and tapping any station in that section opens the
Settings sheet with Train Systems already in edit mode.

https://claude.ai/code/session_015AfWahzyxNc7ZDxfK6vidN