### PR TITLE
Fix favorites pane not expanding when tapping "Set your home and work stations"

### DIFF
--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -132,7 +132,7 @@ struct TripSelectionView: View {
                 // Home station setup nudge — shown every launch until user sets a home station
                 if !isSearching && ratSenseService.getHomeStation() == nil {
                     Button {
-                        appState.navigationPath.append(NavigationDestination.favoriteStations)
+                        appState.pendingNavigation = .favoriteStations
                     } label: {
                         HStack(spacing: 10) {
                             Image(systemName: "house.fill")


### PR DESCRIPTION
Use pendingNavigation instead of directly appending to navigationPath,
so the sheet expands to full height before navigating to OnboardingView.

https://claude.ai/code/session_01DwAqXFcRwYXKVAG47YUoji