### PR TITLE
Simplify Service Alerts header styling

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -310,9 +310,8 @@ struct RouteStatusView: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
-                    Label("Service Alerts (\(viewModel.serviceAlerts.count))", systemImage: "exclamationmark.triangle.fill")
+                    Text("Service Alerts")
                         .font(.headline)
-                        .foregroundColor(.orange)
                     Spacer()
                     Picker("", selection: $selectedAlertFilter) {
                         ForEach(ServiceAlertFilter.allCases, id: \.self) { filter in


### PR DESCRIPTION
## Summary
Simplified the Service Alerts section header in RouteStatusView by removing the alert count badge, icon, and orange color styling.

## Changes
- Replaced `Label` with plain `Text` for the "Service Alerts" header
- Removed the dynamic alert count display from the header
- Removed the `exclamationmark.triangle.fill` system image icon
- Removed the orange foreground color styling

## Details
The header now displays a simple "Service Alerts" text with headline font styling. This change reduces visual complexity while maintaining the section's functionality. The alert count and visual indicators may be displayed elsewhere in the UI or through other means.

https://claude.ai/code/session_01D6MPsMVBYrQDC1o7jJka9S