### PR TITLE
Remove context-specific paywall messaging

### DIFF
--- a/ios/TrackRat/Services/SubscriptionService.swift
+++ b/ios/TrackRat/Services/SubscriptionService.swift
@@ -40,16 +40,6 @@ enum PaywallContext {
     case routeAlerts
     case generic
 
-    var subtext: String? {
-        switch self {
-        case .trainSystems:
-            return "Start a 1-week free trial to follow multiple train systems at a time"
-        case .routeAlerts:
-            return "Free users get one route alert. Upgrade to Pro for unlimited alerts across all your routes \u{2014} start with a free 1-week trial."
-        case .developerChat, .generic:
-            return nil
-        }
-    }
 }
 
 // MARK: - Subscription Service

--- a/ios/TrackRat/Views/Paywall/PaywallView.swift
+++ b/ios/TrackRat/Views/Paywall/PaywallView.swift
@@ -94,15 +94,6 @@ struct PaywallView: View {
                     )
                     .padding(.horizontal)
 
-                    // Context-specific messaging (for train system / route alert limits)
-                    if let subtext = context.subtext {
-                        Text(subtext)
-                            .font(.subheadline.weight(.medium))
-                            .foregroundColor(.orange)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 24)
-                    }
-
                     // Pricing options
                     if subscriptionService.isLoading && subscriptionService.availableProducts.isEmpty {
                         ProgressView()


### PR DESCRIPTION
## Summary
Removed context-specific subtext messaging from the paywall flow. The `subtext` computed property in `PaywallContext` and its corresponding UI rendering in `PaywallView` have been deleted.

## Key Changes
- Removed `subtext` computed property from `PaywallContext` enum that provided context-specific messaging for train systems and route alerts
- Removed conditional rendering of context-specific subtext in `PaywallView` that displayed orange-colored messaging below the main paywall content

## Details
This change simplifies the paywall presentation by removing feature-specific messaging that was previously shown for different upgrade contexts (train systems, route alerts, etc.). The paywall will now display a more generic experience without context-dependent promotional text.

https://claude.ai/code/session_019Vn7qJ1DgYYszS4Pa7gA7s