### PR TITLE
Fix sheet dismissal timing for pending navigation

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -245,9 +245,11 @@ struct RouteStatusView: View {
         guard let to = context.effectiveToStation,
               let from = context.effectiveFromStation else { return }
         let destination = Stations.displayName(for: to)
-        // Use pendingNavigation so the main NavigationStack handles it after sheet dismisses
+        // Use pendingNavigation so the main NavigationStack handles it after sheets dismiss.
+        // Setting pendingNavigation triggers TripSelectionView to dismiss its settings sheet,
+        // while dismiss() closes this RouteStatusView sheet. The delay allows both to animate out.
         dismiss()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             appState.pendingNavigation = .trainList(
                 destination: destination,
                 departureStationCode: from

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -315,6 +315,14 @@ struct TripSelectionView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        .onChange(of: appState.pendingNavigation) { _, pending in
+            // Dismiss settings sheets when pending navigation is set (e.g. "View All Departures")
+            // so the destination view isn't hidden behind them
+            if pending != nil {
+                showingSettings = false
+                showSettingsForTrainSystems = false
+            }
+        }
         .onDisappear {
             // Cancel any pending validation tasks
             for task in validationTasks.values {


### PR DESCRIPTION
## Summary
Improved the sheet dismissal flow when navigating to the train list view from RouteStatusView. The changes ensure that both the RouteStatusView sheet and the TripSelectionView settings sheets dismiss properly before the destination view is presented.

## Key Changes
- Added `onChange` modifier to TripSelectionView that dismisses settings sheets when `pendingNavigation` is set, preventing the destination view from being hidden behind open sheets
- Updated the delay in RouteStatusView from 0.3s to 0.5s when setting `pendingNavigation`, allowing sufficient time for both sheets to animate out before navigation occurs
- Enhanced code comments to clarify the sheet dismissal coordination between views

## Implementation Details
The fix addresses a race condition where navigation could occur before all sheets had finished dismissing. By listening to `pendingNavigation` changes in TripSelectionView, the settings sheets are proactively dismissed. The increased delay (0.5s) provides adequate time for both the RouteStatusView sheet dismissal and the TripSelectionView settings sheet dismissals to complete their animations before the NavigationStack presents the destination view.

https://claude.ai/code/session_01TrWnTJ7FdpHKNLEsx9eCxb