### PR TITLE
Update monthly subscription price from $2.99 to $4.99

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -42,7 +42,7 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, PATCO, LIRR, Metr
 - **Delay Forecasts**: AI-powered delay predictions
 - **1-Week Free Trial**: Apple introductory offer for new subscribers
 - **StoreKit 2 Integration**: Modern subscription management with PaywallView
-- **Monthly-Only Subscription**: $2.99/month pricing after trial
+- **Monthly-Only Subscription**: $4.99/month pricing after trial
 
 ### Train System Filtering
 - **Per-System Toggles**: Users can enable/disable each transit system in Settings

--- a/ios/TrackRat/Configuration.storekit
+++ b/ios/TrackRat/Configuration.storekit
@@ -76,7 +76,7 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "2.99",
+          "displayPrice" : "4.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "6740389182",


### PR DESCRIPTION
## Summary
Updated the monthly subscription pricing for the TrackRat iOS app from $2.99 to $4.99 per month following the trial period.

## Changes Made
- Updated README.md documentation to reflect the new $4.99/month pricing
- Updated StoreKit 2 configuration to set the new display price of $4.99 in the subscription product definition

## Details
This is a pricing adjustment for the monthly-only subscription tier. The change is reflected in both the user-facing documentation and the App Store configuration, ensuring consistency across the app's subscription offering.

https://claude.ai/code/session_01XLTHPa2XzG6SUMxDdCp6qX