### PR TITLE
Add per-system default map regions and dynamic map centering

### DIFF
--- a/ios/TrackRat/Shared/Stations.swift
+++ b/ios/TrackRat/Shared/Stations.swift
@@ -243,3 +243,99 @@ extension MKCoordinateRegion {
         span: MKCoordinateSpan(latitudeDelta: 1.5, longitudeDelta: 1.5)
     )
 }
+
+// MARK: - Per-System Default Map Regions
+
+extension TrainSystem {
+    /// Default map region showing the full extent of this system's network.
+    /// Used when the user has not set home/work stations.
+    var defaultMapRegion: MKCoordinateRegion {
+        switch self {
+        case .njt:
+            // Centered near Newark/Secaucus hub where most lines converge
+            // Covers Port Jervis (north) to Atlantic City (south), Philadelphia to NY Penn
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 40.73, longitude: -74.17),
+                span: MKCoordinateSpan(latitudeDelta: 2.5, longitudeDelta: 2.0)
+            )
+        case .amtrak:
+            // NEC corridor focus: Boston to Washington DC
+            // Centered near Trenton/Princeton area
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 40.20, longitude: -74.50),
+                span: MKCoordinateSpan(latitudeDelta: 5.0, longitudeDelta: 4.0)
+            )
+        case .path:
+            // Compact Newark-to-Manhattan corridor
+            // Centered near Journal Square where routes cross
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 40.730, longitude: -74.035),
+                span: MKCoordinateSpan(latitudeDelta: 0.08, longitudeDelta: 0.22)
+            )
+        case .patco:
+            // Lindenwold NJ to Center City Philadelphia
+            // Centered near Collingswood/Westmont midpoint
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 39.92, longitude: -75.08),
+                span: MKCoordinateSpan(latitudeDelta: 0.18, longitudeDelta: 0.25)
+            )
+        case .lirr:
+            // Long Island from Penn/GCT to Montauk/Greenport
+            // Centered near Hicksville where branches diverge; wide east-west span
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 40.75, longitude: -73.40),
+                span: MKCoordinateSpan(latitudeDelta: 0.65, longitudeDelta: 2.20)
+            )
+        case .mnr:
+            // GCT north to Poughkeepsie/Wassaic/New Haven
+            // Centered near White Plains area
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 41.15, longitude: -73.70),
+                span: MKCoordinateSpan(latitudeDelta: 1.20, longitudeDelta: 1.30)
+            )
+        case .subway:
+            // NYC five boroughs + Staten Island Railway
+            // Centered near Union Square, the operational heart
+            return MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: 40.730, longitude: -73.950),
+                span: MKCoordinateSpan(latitudeDelta: 0.45, longitudeDelta: 0.55)
+            )
+        }
+    }
+}
+
+extension Set where Element == TrainSystem {
+    /// Combined map region that shows all selected systems.
+    /// Computes a bounding box across all selected systems' default regions.
+    var combinedMapRegion: MKCoordinateRegion {
+        guard !isEmpty else { return .newarkPennDefault }
+        if count == 1 { return first!.defaultMapRegion }
+
+        // Compute bounding box of all selected systems
+        var minLat = Double.greatestFiniteMagnitude
+        var maxLat = -Double.greatestFiniteMagnitude
+        var minLon = Double.greatestFiniteMagnitude
+        var maxLon = -Double.greatestFiniteMagnitude
+
+        for system in self {
+            let region = system.defaultMapRegion
+            let halfLat = region.span.latitudeDelta / 2
+            let halfLon = region.span.longitudeDelta / 2
+            minLat = min(minLat, region.center.latitude - halfLat)
+            maxLat = max(maxLat, region.center.latitude + halfLat)
+            minLon = min(minLon, region.center.longitude - halfLon)
+            maxLon = max(maxLon, region.center.longitude + halfLon)
+        }
+
+        let centerLat = (minLat + maxLat) / 2
+        let centerLon = (minLon + maxLon) / 2
+        // Add 10% padding so edges aren't flush
+        let spanLat = (maxLat - minLat) * 1.1
+        let spanLon = (maxLon - minLon) * 1.1
+
+        return MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: centerLat, longitude: centerLon),
+            span: MKCoordinateSpan(latitudeDelta: spanLat, longitudeDelta: spanLon)
+        )
+    }
+}

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -8,7 +8,7 @@ struct CongestionMapView: View {
     @EnvironmentObject private var appState: AppState
     @ObservedObject private var subscriptionService = SubscriptionService.shared
     @StateObject private var viewModel = CongestionMapViewModel()
-    @State private var region = MKCoordinateRegion.newarkPennDefault
+    @State private var region = MKCoordinateRegion.newarkPennDefault // Updated to selected systems on appear
     @State private var selectedSegment: CongestionSegment?
     @State private var selectedIndividualSegment: IndividualJourneySegment?
     @State private var showingFilters = false
@@ -170,6 +170,10 @@ struct CongestionMapView: View {
         }
         .onChange(of: appState.selectedSystems) { _, newSystems in
             viewModel.setSelectedSystems(newSystems)
+            // Re-center map to show the newly selected systems
+            withAnimation(.easeInOut(duration: 0.3)) {
+                region = newSystems.combinedMapRegion
+            }
         }
         .onChange(of: appState.mapHighlightMode) { _, newMode in
             viewModel.highlightMode = newMode
@@ -182,6 +186,8 @@ struct CongestionMapView: View {
             viewModel.setSelectedSystems(appState.selectedSystems)
             viewModel.highlightMode = appState.mapHighlightMode
             viewModel.showStations = appState.showMapStations
+            // Set initial region based on selected systems
+            region = appState.selectedSystems.combinedMapRegion
         }
     }
 

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -309,6 +309,12 @@ struct MapContainerView: View {
             print("🗺️ MapContainer: selectedDetent = \(selectedDetent)")
             print("🗺️ MapContainer: Map already initialized by view model - Center: \(mapRegionVM.mapRegion.center.latitude), \(mapRegionVM.mapRegion.center.longitude), Span: \(mapRegionVM.mapRegion.span.latitudeDelta)°")
 
+            // If user has no home/work stations, use selected systems region instead of NY↔NP fallback
+            if RatSenseService.shared.getHomeStation() == nil && RatSenseService.shared.getWorkStation() == nil {
+                mapRegionVM.mapRegion = appState.selectedSystems.combinedMapRegion
+                print("🗺️ MapContainer: No home/work stations — using selected systems region")
+            }
+
             // Check for active Live Activity first
             checkForActiveLiveActivity()
 
@@ -602,33 +608,40 @@ struct MapContainerView: View {
     
     private func resetToDefaultMapView() {
         print("🗺️ Reset: Resetting to default map view")
-        
+
         // Clear state immediately (non-blocking)
         appState.selectedRoute = nil
         appState.mapDisplayMode = .overallCongestion
-        
+
         // Do map operations asynchronously to avoid blocking navigation
         Task { @MainActor in
-            // Recalculate default region based on current home/work stations
-            let homeCode = RatSenseService.shared.getHomeStation() ?? MapRegionViewModel.defaultFromStation
-            let workCode = RatSenseService.shared.getWorkStation() ?? MapRegionViewModel.defaultToStation
-            
-            let fromCoord = Stations.getCoordinates(for: homeCode) ?? 
-                           Stations.getCoordinates(for: MapRegionViewModel.defaultFromStation)!
-            let toCoord = Stations.getCoordinates(for: workCode) ?? 
-                         Stations.getCoordinates(for: MapRegionViewModel.defaultToStation)!
-            
-            let region = Self.calculateRegionForRoute(
-                from: fromCoord,
-                to: toCoord,
-                sheetDetent: .fraction(0.50)
-            )
-            
+            let region: MKCoordinateRegion
+            let homeCode = RatSenseService.shared.getHomeStation()
+            let workCode = RatSenseService.shared.getWorkStation()
+
+            if homeCode != nil || workCode != nil {
+                // User has home/work stations — calculate region between them
+                let fromCode = homeCode ?? MapRegionViewModel.defaultFromStation
+                let toCode = workCode ?? MapRegionViewModel.defaultToStation
+                let fromCoord = Stations.getCoordinates(for: fromCode) ??
+                               Stations.getCoordinates(for: MapRegionViewModel.defaultFromStation)!
+                let toCoord = Stations.getCoordinates(for: toCode) ??
+                             Stations.getCoordinates(for: MapRegionViewModel.defaultToStation)!
+                region = Self.calculateRegionForRoute(
+                    from: fromCoord,
+                    to: toCoord,
+                    sheetDetent: .fraction(0.50)
+                )
+            } else {
+                // No home/work stations — use selected systems region
+                region = appState.selectedSystems.combinedMapRegion
+            }
+
             withAnimation(.easeInOut(duration: 0.25)) {
                 mapRegionVM.mapRegion = region
-                print("🗺️ Reset: ✅ Map region reset to home/work default")
+                print("🗺️ Reset: ✅ Map region reset to default")
             }
-            
+
             // Clear route filter in background to avoid blocking
             mapViewModel.setRouteFilter(nil)
         }


### PR DESCRIPTION
## Summary
This PR adds intelligent map region defaults for each train system and implements dynamic map centering based on user-selected systems. When users don't have home/work stations configured, the map now displays a region tailored to show all their selected transit systems instead of defaulting to a fixed Newark-to-Penn Station view.

## Key Changes

- **Per-system default regions** (`Stations.swift`): Added `defaultMapRegion` computed property to `TrainSystem` enum with carefully calibrated center coordinates and zoom spans for each system (NJT, Amtrak, PATH, PATCO, LIRR, MNR, and NYC Subway)

- **Combined region calculation** (`Stations.swift`): Implemented `combinedMapRegion` on `Set<TrainSystem>` that computes a bounding box encompassing all selected systems with 10% padding for visual breathing room

- **Dynamic map centering in MapContainerView** (`MapContainerView.swift`): 
  - Updated initialization logic to use `selectedSystems.combinedMapRegion` when no home/work stations are set
  - Modified `resetToDefaultMapView()` to intelligently choose between home/work-based regions or selected systems regions

- **CongestionMapView updates** (`CongestionMapView.swift`):
  - Map now re-centers when `selectedSystems` changes via `onChange` modifier
  - Initial region is set based on selected systems on view appearance

## Implementation Details

- Region calculations use latitude/longitude deltas calibrated to each system's geographic footprint (e.g., PATH's compact 0.08° × 0.22° span vs. LIRR's wide 0.65° × 2.20° east-west coverage)
- Bounding box computation extracts min/max coordinates from each system's region and adds proportional padding to prevent edge clipping
- Fallback to `.newarkPennDefault` only when no systems are selected (edge case)
- All map transitions use smooth `easeInOut` animations for better UX

https://claude.ai/code/session_01KsAN7tFmeHfG5FXngXue5j