### PR TITLE
Zoom out Amtrak default and adjust all system regions for bottom sheet

### DIFF
--- a/ios/TrackRat/Shared/Stations.swift
+++ b/ios/TrackRat/Shared/Stations.swift
@@ -242,6 +242,23 @@ extension MKCoordinateRegion {
         center: CLLocationCoordinate2D(latitude: 40.7348, longitude: -74.1644), // Newark Penn Station
         span: MKCoordinateSpan(latitudeDelta: 1.5, longitudeDelta: 1.5)
     )
+
+    /// Returns a new region adjusted so the intended area is visible in the top half
+    /// of the screen, accounting for a bottom sheet covering ~50% of the display.
+    /// Shifts center northward by half the latitude span and doubles the latitude span
+    /// so the original extent fits in the visible top portion.
+    func adjustedForBottomSheet() -> MKCoordinateRegion {
+        MKCoordinateRegion(
+            center: CLLocationCoordinate2D(
+                latitude: center.latitude + span.latitudeDelta / 2,
+                longitude: center.longitude
+            ),
+            span: MKCoordinateSpan(
+                latitudeDelta: span.latitudeDelta * 2,
+                longitudeDelta: span.longitudeDelta
+            )
+        )
+    }
 }
 
 // MARK: - Per-System Default Map Regions
@@ -259,11 +276,11 @@ extension TrainSystem {
                 span: MKCoordinateSpan(latitudeDelta: 2.5, longitudeDelta: 2.0)
             )
         case .amtrak:
-            // NEC corridor focus: Boston to Washington DC
+            // NEC corridor focus: Boston to Washington DC, with some buffer beyond
             // Centered near Trenton/Princeton area
             return MKCoordinateRegion(
                 center: CLLocationCoordinate2D(latitude: 40.20, longitude: -74.50),
-                span: MKCoordinateSpan(latitudeDelta: 5.0, longitudeDelta: 4.0)
+                span: MKCoordinateSpan(latitudeDelta: 10.0, longitudeDelta: 8.0)
             )
         case .path:
             // Compact Newark-to-Manhattan corridor

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -311,7 +311,7 @@ struct MapContainerView: View {
 
             // If user has no home/work stations, use selected systems region instead of NY↔NP fallback
             if RatSenseService.shared.getHomeStation() == nil && RatSenseService.shared.getWorkStation() == nil {
-                mapRegionVM.mapRegion = appState.selectedSystems.combinedMapRegion
+                mapRegionVM.mapRegion = appState.selectedSystems.combinedMapRegion.adjustedForBottomSheet()
                 print("🗺️ MapContainer: No home/work stations — using selected systems region")
             }
 
@@ -634,7 +634,7 @@ struct MapContainerView: View {
                 )
             } else {
                 // No home/work stations — use selected systems region
-                region = appState.selectedSystems.combinedMapRegion
+                region = appState.selectedSystems.combinedMapRegion.adjustedForBottomSheet()
             }
 
             withAnimation(.easeInOut(duration: 0.25)) {


### PR DESCRIPTION
- Double Amtrak span (5x4 → 10x8) to show more of the NEC + beyond
- Add adjustedForBottomSheet() on MKCoordinateRegion: shifts center north by half the lat span and doubles lat span so the intended area fits in the visible top half above the 50% bottom sheet
- Apply adjustment in MapContainerView where the bottom sheet is present
- CongestionMapView (full-screen) remains unadjusted

https://claude.ai/code/session_01KsAN7tFmeHfG5FXngXue5j