### PR TITLE
Add beta feature toggle for tapping route segments on maps

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -802,6 +802,13 @@ final class AppState: ObservableObject {
         }
     }
 
+    // Beta feature: Enable tapping route segments to view details
+    @Published var enableSegmentTap: Bool = false {
+        didSet {
+            UserDefaults.standard.set(enableSegmentTap, forKey: "enableSegmentTap")
+        }
+    }
+
     init() {
         loadRecentTrips()
         loadFavoriteStations()
@@ -966,6 +973,7 @@ final class AppState: ObservableObject {
 
         // Load beta features
         showDepartureOdds = UserDefaults.standard.bool(forKey: "showDepartureOdds")
+        enableSegmentTap = UserDefaults.standard.bool(forKey: "enableSegmentTap")
     }
 
 }

--- a/ios/TrackRat/Views/Screens/AdvancedConfigurationView.swift
+++ b/ios/TrackRat/Views/Screens/AdvancedConfigurationView.swift
@@ -177,6 +177,33 @@ struct AdvancedConfigurationView: View {
                             .stroke(.white.opacity(0.1), lineWidth: 1)
                     )
             )
+
+            // Segment Tap toggle
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Tap Route Segments (beta)")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    Text("Tap map segments to view route details")
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+
+                Spacer()
+
+                Toggle("", isOn: $appState.enableSegmentTap)
+                    .labelsHidden()
+                    .tint(.orange)
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.white.opacity(0.05))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(.white.opacity(0.1), lineWidth: 1)
+                    )
+            )
         }
         .padding()
         .background(

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -31,6 +31,7 @@ struct CongestionMapView: View {
                 selectedSystems: appState.selectedSystems,
                 highlightMode: viewModel.highlightMode,
                 onSegmentTap: { segment in
+                    guard appState.enableSegmentTap else { return }
                     let route = RouteTopology.routeContaining(
                         from: segment.fromStation,
                         to: segment.toStation,
@@ -45,6 +46,7 @@ struct CongestionMapView: View {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 },
                 onIndividualSegmentTap: { individualSegment in
+                    guard appState.enableSegmentTap else { return }
                     selectedIndividualSegment = individualSegment
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }

--- a/ios/TrackRat/Views/Screens/HistoricalDataView.swift
+++ b/ios/TrackRat/Views/Screens/HistoricalDataView.swift
@@ -621,6 +621,7 @@ struct CongestionDataView: View {
                                 userOrigin: viewModel.userOrigin,
                                 userDestination: viewModel.userDestination,
                                 onSegmentTap: { segment in
+                                    guard appState.enableSegmentTap else { return }
                                     let route = RouteTopology.routeContaining(
                                         from: segment.fromStation,
                                         to: segment.toStation,

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -138,6 +138,7 @@ struct MapContainerView: View {
                 selectedSystems: appState.selectedSystems,
                 highlightMode: mapViewModel.highlightMode,
                 onSegmentTap: { segment in
+                    guard appState.enableSegmentTap else { return }
                     let route = RouteTopology.routeContaining(
                         from: segment.fromStation,
                         to: segment.toStation,
@@ -152,6 +153,7 @@ struct MapContainerView: View {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 },
                 onIndividualSegmentTap: { individualSegment in
+                    guard appState.enableSegmentTap else { return }
                     selectedIndividualSegment = individualSegment
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 }


### PR DESCRIPTION
## Summary
This PR introduces a new beta feature that allows users to tap on route segments in the map views to see route details. The feature is controlled by a toggle in the Advanced Configuration settings and is disabled by default.

## Key Changes
- **AdvancedConfigurationView**: Added a new "Tap Route Segments (beta)" toggle in the advanced settings UI with descriptive text explaining the feature
- **AppState**: Added `enableSegmentTap` published property that persists to UserDefaults, allowing the feature state to be saved across app sessions
- **CongestionMapView**: Added guard checks to only process segment tap callbacks when the feature is enabled
- **MapContainerView**: Added guard checks to only process segment tap callbacks when the feature is enabled
- **HistoricalDataView**: Added guard check to only process segment tap callbacks when the feature is enabled

## Implementation Details
- The feature is marked as beta in the UI to indicate it's still in development
- The toggle uses an orange tint color to match the app's design system
- All segment tap handlers (both route segments and individual segments) are gated behind the `enableSegmentTap` flag
- The feature state is persisted using UserDefaults and restored on app launch
- When disabled, tap interactions are silently ignored via early return guards

https://claude.ai/code/session_01HesQyTN6rTamf7huEzrjDC