### PR TITLE
Remove hardcoded NYC default station fallbacks

### DIFF
--- a/android/app/src/main/java/com/trackrat/android/data/preferences/UserPreferencesRepository.kt
+++ b/android/app/src/main/java/com/trackrat/android/data/preferences/UserPreferencesRepository.kt
@@ -53,7 +53,7 @@ class UserPreferencesRepository @Inject constructor(
      * Data class representing user preferences
      */
     data class UserPreferences(
-        val lastFromStation: String = Constants.StationCodes.NEW_YORK_PENN,
+        val lastFromStation: String? = null,
         val lastToStation: String? = null,
         val autoRefreshEnabled: Boolean = true,
         val hapticFeedbackEnabled: Boolean = true,
@@ -88,8 +88,7 @@ class UserPreferencesRepository @Inject constructor(
         }
         .map { preferences ->
             UserPreferences(
-                lastFromStation = preferences[PreferencesKeys.LAST_FROM_STATION]
-                    ?: Constants.StationCodes.NEW_YORK_PENN,
+                lastFromStation = preferences[PreferencesKeys.LAST_FROM_STATION],
                 lastToStation = preferences[PreferencesKeys.LAST_TO_STATION],
                 autoRefreshEnabled = preferences[PreferencesKeys.AUTO_REFRESH_ENABLED] ?: true,
                 hapticFeedbackEnabled = preferences[PreferencesKeys.HAPTIC_FEEDBACK_ENABLED] ?: true,

--- a/android/app/src/test/java/com/trackrat/android/data/preferences/UserPreferencesRepositoryTest.kt
+++ b/android/app/src/test/java/com/trackrat/android/data/preferences/UserPreferencesRepositoryTest.kt
@@ -48,7 +48,7 @@ class UserPreferencesRepositoryTest {
         val preferences = repository.userPreferencesFlow.first()
         
         // Then: Default values are returned
-        assertEquals(Constants.StationCodes.NEW_YORK_PENN, preferences.lastFromStation)
+        assertNull(preferences.lastFromStation)
         assertNull(preferences.lastToStation)
         assertTrue(preferences.autoRefreshEnabled)
         assertTrue(preferences.hapticFeedbackEnabled)
@@ -184,7 +184,7 @@ class UserPreferencesRepositoryTest {
         
         // Then: All preferences return to defaults
         val preferences = repository.userPreferencesFlow.first()
-        assertEquals(Constants.StationCodes.NEW_YORK_PENN, preferences.lastFromStation)
+        assertNull(preferences.lastFromStation)
         assertNull(preferences.lastToStation)
         assertTrue(preferences.autoRefreshEnabled)
         assertTrue(preferences.hapticFeedbackEnabled)

--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -807,10 +807,6 @@ final class AppState: ObservableObject {
         loadFavoriteStations()
         loadSelectedSystems()
         loadMapSettings()
-
-        // Migrate existing data
-        storageService.migrateRecentDestinations()
-        loadRecentTrips() // Reload after migration
     }
     
     

--- a/ios/TrackRat/Services/StorageService.swift
+++ b/ios/TrackRat/Services/StorageService.swift
@@ -286,11 +286,6 @@ final class StorageService {
             stations.append(FavoriteStation(code: workCode, name: workName))
         }
         
-        // If no stations at all (no stored favorites and no home/work), return NYC as default
-        if stations.isEmpty {
-            stations = [FavoriteStation(code: "NY", name: "New York Penn Station")]
-        }
-        
         return stations.sorted { $0.lastUsed > $1.lastUsed }
     }
     
@@ -341,30 +336,6 @@ final class StorageService {
         userDefaults.set(environment.rawValue, forKey: serverEnvironmentKey)
     }
     
-    // MARK: - Migration
-    func migrateRecentDestinations() {
-        // Get existing destinations from UserDefaults directly (since we removed the method)
-        let existingDestinations = userDefaults.stringArray(forKey: "trackrat.recentDestinations") ?? []
-
-        if !existingDestinations.isEmpty && loadRecentTrips().isEmpty {
-            // Create trip pairs with NY Penn as default departure
-            for destination in existingDestinations {
-                if let destCode = Stations.getStationCode(destination) {
-                    saveTrip(
-                        departureCode: "NY",
-                        departureName: Stations.displayName(for: "New York Penn Station"),
-                        destinationCode: destCode,
-                        destinationName: destination
-                    )
-                }
-            }
-
-            // Clean up old keys after migration
-            userDefaults.removeObject(forKey: "trackrat.recentDestinations")
-            userDefaults.removeObject(forKey: "trackrat.recentDepartures")
-        }
-    }
-
     // MARK: - Completed Trips (Trip History)
 
     func saveCompletedTrip(_ trip: CompletedTrip) {


### PR DESCRIPTION
## Summary
This PR removes hardcoded "New York Penn Station" defaults from the application, allowing the departure/origin station to be truly optional. This change affects both iOS and Android platforms and removes associated migration logic that is no longer needed.

## Key Changes
- **iOS (`StorageService.swift`)**:
  - Removed fallback logic that defaulted to NYC Penn Station when no favorite stations were available
  - Removed the `migrateRecentDestinations()` migration method that converted old recent destinations to trips with NYC as the default departure
  - Removed the migration call from app initialization in `TrackRatApp.swift`

- **Android (`UserPreferencesRepository.kt`)**:
  - Changed `lastFromStation` default from `Constants.StationCodes.NEW_YORK_PENN` to `null`
  - Updated the preferences mapping to return `null` instead of falling back to NYC Penn Station
  - Updated corresponding unit tests to expect `null` instead of the hardcoded station code

## Implementation Details
- The changes allow users to have no default departure station selected, requiring explicit selection before making a trip
- This is a breaking change in behavior but aligns with a more user-centric approach where defaults are not assumed
- All platform-specific implementations (iOS and Android) are updated consistently
- Test expectations have been updated to reflect the new nullable behavior

https://claude.ai/code/session_011kbRSv3hKRT2Ztm8xePeWM