### PR TITLE
Prevent dismissing settings without selecting train systems

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -67,11 +67,15 @@ struct SettingsView: View {
 
                 // Close button
                 Button {
-                    dismiss()
+                    if appState.selectedSystems.isEmpty {
+                        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                    } else {
+                        dismiss()
+                    }
                 } label: {
                     Image(systemName: "xmark")
                         .font(TrackRatTheme.IconSize.small)
-                        .foregroundColor(.white)
+                        .foregroundColor(appState.selectedSystems.isEmpty ? .gray : .white)
                         .frame(minWidth: 44, minHeight: 44)
                 }
                 }
@@ -145,6 +149,7 @@ struct SettingsView: View {
                 Text(error)
             }
         }
+        .interactiveDismissDisabled(appState.selectedSystems.isEmpty)
     }
 
     /// Shows debug sections in DEBUG builds or TestFlight (but not App Store releases)
@@ -189,6 +194,11 @@ struct SettingsSection: View {
             // Train Systems
             VStack(spacing: 0) {
                 Button {
+                    // Block closing edit mode when no systems selected
+                    if isEditingTrainSystems && appState.selectedSystems.isEmpty {
+                        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                        return
+                    }
                     withAnimation(.easeInOut(duration: 0.2)) {
                         isEditingTrainSystems.toggle()
                     }
@@ -209,7 +219,7 @@ struct SettingsSection: View {
 
                         Text(isEditingTrainSystems ? "Done" : "Edit")
                             .font(.subheadline)
-                            .foregroundColor(.orange)
+                            .foregroundColor(isEditingTrainSystems && appState.selectedSystems.isEmpty ? .gray : .orange)
                     }
                 }
                 .padding()
@@ -217,6 +227,14 @@ struct SettingsSection: View {
                 if isEditingTrainSystems {
                     Divider()
                         .background(Color.white.opacity(0.1))
+
+                    if appState.selectedSystems.isEmpty {
+                        Text("Select at least one train system")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                            .padding(.horizontal)
+                            .padding(.vertical, 8)
+                    }
 
                     let sortedSystems = TrainSystem.allCases.sorted { $0.displayName < $1.displayName }
                     ForEach(sortedSystems, id: \.self) { system in
@@ -234,7 +252,7 @@ struct SettingsSection: View {
                                 paywallContext = .trainSystems
                                 showingPaywall = true
                             } else {
-                                appState.toggleSystem(system)
+                                appState.toggleSystem(system, allowEmpty: true)
                             }
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
                         }
@@ -729,7 +747,7 @@ struct SettingsSection: View {
             }
         }
         .onAppear {
-            if initialEditTrainSystems {
+            if initialEditTrainSystems || appState.selectedSystems.isEmpty {
                 isEditingTrainSystems = true
             }
         }


### PR DESCRIPTION
## Summary
This PR adds validation to prevent users from closing the Settings view without selecting at least one train system. The changes include visual feedback, disabled dismissal gestures, and warning haptics when attempting to exit without a selection.

## Key Changes
- **Close button validation**: The X button in the Settings header now triggers a warning haptic and prevents dismissal if no train systems are selected. The button color changes to gray when disabled.
- **Swipe-to-dismiss prevention**: Added `.interactiveDismissDisabled()` modifier to prevent closing the sheet via swipe gesture when no systems are selected.
- **Edit mode toggle protection**: The "Edit" button in the Train Systems section now prevents toggling edit mode and shows a warning haptic if attempting to exit edit mode with no systems selected.
- **Visual feedback**: 
  - Edit button color changes to gray when disabled (no systems selected while editing)
  - Added a caption message "Select at least one train system" displayed when the list is empty
- **Auto-open edit mode**: The Train Systems edit mode now automatically opens on view appearance if no systems are selected, guiding users to make a selection.
- **API update**: Modified `toggleSystem()` call to use `allowEmpty: true` parameter to allow the toggle operation during validation.

## Implementation Details
- Uses `UINotificationFeedbackGenerator` with `.warning` style for haptic feedback when users attempt invalid actions
- Color state management tied to `appState.selectedSystems.isEmpty` for consistent visual feedback
- Edit mode auto-opening combined with the validation creates a guided user experience that prevents accidental empty states

https://claude.ai/code/session_01GQoBrHjjPemKKe8PiHoZ17