### PR TITLE
Remove hardcoded popular stations pinning logic

### DIFF
--- a/ios/TrackRat/Shared/StationDepartures.swift
+++ b/ios/TrackRat/Shared/StationDepartures.swift
@@ -68,9 +68,4 @@ extension Stations {
         ("Flushing-Main St", "S701"),
         ("59 St-Columbus Circle (1/2)", "S125")
     ]
-    
-    // Popular destination stations - kept in sync with departure stations
-    static var popularDestinations: [(name: String, code: String)] {
-        return departureStations
-    }
 }

--- a/ios/TrackRat/Views/Components/StationPickerSheet.swift
+++ b/ios/TrackRat/Views/Components/StationPickerSheet.swift
@@ -64,18 +64,10 @@ struct StationPickerSheet: View {
         let stations = visibleStations
         var groups: [(system: String, stations: [Station])] = []
 
-        // Pinned section first
-        let pinnedCodes = ["NY", "GCT", "PWC", "HB", "S127", "JAM"]
-        let pinned = pinnedCodes.compactMap { code in stations.first { $0.code == code } }
-        if !pinned.isEmpty {
-            groups.append((system: "Popular", stations: pinned))
-        }
-
-        // Group remaining by system
-        let pinnedSet = Set(pinnedCodes)
+        // Group by system
         for (raw, label) in systemOrder {
             let systemStations = stations
-                .filter { !pinnedSet.contains($0.code) && Stations.systemStringsForStation($0.code).contains(raw) }
+                .filter { Stations.systemStringsForStation($0.code).contains(raw) }
                 .sorted { $0.name < $1.name }
             if !systemStations.isEmpty {
                 groups.append((system: label, stations: systemStations))

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -327,7 +327,7 @@ struct DeparturePickerView: View {
         if isSearching {
             searchResultsSection
         } else {
-            popularStationsSection
+            stationsSection
         }
     }
     
@@ -453,9 +453,9 @@ struct DeparturePickerView: View {
     }
 
     @ViewBuilder
-    private var popularStationsSection: some View {
+    private var stationsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Popular Stations")
+            Text("Stations")
                 .trackRatSectionHeader()
                 .padding(.horizontal)
             


### PR DESCRIPTION
## Summary
This PR removes the hardcoded "Popular" stations section that was manually pinned to the top of station lists. Instead, all stations are now grouped uniformly by their transit system, simplifying the station picker UI and data model.

## Key Changes
- **StationPickerSheet.swift**: Removed the hardcoded pinned stations list (`["NY", "GCT", "PWC", "HB", "S127", "JAM"]`) and the logic that created a separate "Popular" section. All stations are now grouped by system in a consistent manner.
- **DeparturePickerView.swift**: Renamed `popularStationsSection` to `stationsSection` and updated the section header from "Popular Stations" to "Stations" to reflect the removal of special pinning logic.
- **StationDepartures.swift**: Removed the unused `popularDestinations` computed property that was kept in sync with `departureStations`.

## Implementation Details
- The filtering logic in StationPickerSheet now only groups by system without excluding any stations from the pinned set
- All stations are presented in a single, system-based grouping structure
- This change simplifies the codebase by removing duplicate data and special-case handling

https://claude.ai/code/session_019Badt8FisMLNK4oPF6D2hS