### PR TITLE
Increase auto-advance delay in onboarding from 0.5s to 1.0s

### DIFF
--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -168,7 +168,7 @@ struct OnboardingView: View {
                                 UIImpactFeedbackGenerator(style: .medium).impactOccurred()
                             }
                             pendingAutoAdvance = workItem
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: workItem)
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
                         }
                     )
                 }


### PR DESCRIPTION
## Summary
Increased the delay for automatic screen advancement in the onboarding flow from 500ms to 1000ms to provide users with more time to perceive the haptic feedback and transition between screens.

## Changes
- Increased `DispatchQueue.main.asyncAfter` deadline from `0.5` seconds to `1.0` seconds in the onboarding auto-advance logic
- This gives users a more comfortable experience by allowing the medium impact haptic feedback to settle before advancing to the next screen

## Details
The change affects the timing of automatic progression through onboarding screens. The longer delay ensures that the haptic feedback (medium impact) is fully perceived before the view transitions, improving the overall user experience during the onboarding process.

https://claude.ai/code/session_01BNgPg5w3woARyzXFt7tCxq