### PR TITLE
Support cross-platform transfers via station equivalents

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -598,14 +598,27 @@ struct RouteStatusContext: Identifiable, Equatable {
         return dataSource
     }
 
-    /// Station codes for filtering congestion segments
+    /// Station codes for filtering congestion segments.
+    /// Expands via station equivalents for cross-platform transfers (e.g., G→L at Metropolitan Av).
     var stationCodes: [String] {
         if let lineId = lineId,
            let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
             return route.stationCodes
         }
         if let from = fromStationCode, let to = toStationCode {
-            return RouteTopology.expandStationCodes([from, to], dataSource: dataSource)
+            let direct = RouteTopology.expandStationCodes([from, to], dataSource: dataSource)
+            if direct.count > 2 { return direct }
+
+            // Try station equivalents for cross-platform transfers
+            let fromCodes = Stations.stationEquivalents[from] ?? [from]
+            let toCodes = Stations.stationEquivalents[to] ?? [to]
+            for f in fromCodes {
+                for t in toCodes {
+                    let expanded = RouteTopology.expandStationCodes([f, t], dataSource: dataSource)
+                    if expanded.count > 2 { return expanded }
+                }
+            }
+            return direct
         }
         return []
     }

--- a/ios/TrackRat/Shared/RouteTopology.swift
+++ b/ios/TrackRat/Shared/RouteTopology.swift
@@ -815,26 +815,35 @@ struct RouteTopology {
     /// Finds the route line that contains both station codes for a given data source.
     /// Returns the first matching route, preferring routes where both stations appear
     /// in the correct order (from before to).
+    /// Expands via station equivalents for cross-platform transfers (e.g., G→L at Metropolitan Av).
     static func routeContaining(from: String, to: String, dataSource: String) -> RouteLine? {
         let candidates = allRoutes.filter { $0.dataSource == dataSource }
 
-        // Prefer a route where both stations exist and from appears before to
-        for route in candidates {
-            if let fromIdx = route.stationCodes.firstIndex(of: from),
-               let toIdx = route.stationCodes.firstIndex(of: to),
-               fromIdx < toIdx {
-                return route
+        // Try direct codes first, then expand via station equivalents
+        let fromCodes = Stations.stationEquivalents[from] ?? [from]
+        let toCodes = Stations.stationEquivalents[to] ?? [to]
+        let codePairs = [(from, to)] + fromCodes.flatMap { f in toCodes.compactMap { t in
+            (f == from && t == to) ? nil : (f, t)
+        }}
+
+        for (f, t) in codePairs {
+            // Prefer a route where both stations exist and from appears before to
+            for route in candidates {
+                if let fromIdx = route.stationCodes.firstIndex(of: f),
+                   let toIdx = route.stationCodes.firstIndex(of: t),
+                   fromIdx < toIdx {
+                    return route
+                }
+            }
+
+            // Fall back to any route containing both stations (reverse direction)
+            for route in candidates {
+                if route.stationCodes.contains(f) && route.stationCodes.contains(t) {
+                    return route
+                }
             }
         }
 
-        // Fall back to any route containing both stations (reverse direction)
-        for route in candidates {
-            if route.stationCodes.contains(from) && route.stationCodes.contains(to) {
-                return route
-            }
-        }
-
-        // Last resort: any route containing at least one of the stations
-        return candidates.first { $0.stationCodes.contains(from) || $0.stationCodes.contains(to) }
+        return nil
     }
 }

--- a/ios/TrackRatTests/Models/RouteStatusContextTests.swift
+++ b/ios/TrackRatTests/Models/RouteStatusContextTests.swift
@@ -159,6 +159,41 @@ class RouteStatusContextTests: XCTestCase {
         XCTAssertTrue(context.gtfsRouteIds.isEmpty, "Unknown LIRR line should return empty set")
     }
 
+    // MARK: - stationCodes: cross-platform transfers
+
+    func testStationCodes_crossPlatformTransfer_resolvesViaEquivalents() {
+        // SG29 (G platform) → S635 (4/5/6 platform) should expand via equivalents
+        // to find L line intermediate stations (SL10→SL03)
+        let context = RouteStatusContext(dataSource: "SUBWAY", lineId: nil, fromStationCode: "SG29", toStationCode: "S635")
+        let codes = context.stationCodes
+        XCTAssertGreaterThan(codes.count, 2, "Should expand cross-platform route via equivalents, got only \(codes.count) stations: \(codes)")
+        // Should contain L line stations between Metropolitan Av and 14 St-Union Sq
+        XCTAssertTrue(codes.contains("SL10") || codes.contains("SL03"),
+                       "Expanded codes should include L line station codes, got: \(codes)")
+    }
+
+    func testStationCodes_sameLine_expandsDirectly() {
+        // SM01 and SM14 are both on the M line, should expand directly without needing equivalents
+        let context = RouteStatusContext(dataSource: "SUBWAY", lineId: nil, fromStationCode: "SM01", toStationCode: "SM14")
+        let codes = context.stationCodes
+        XCTAssertGreaterThan(codes.count, 2, "Same-line stations should expand to intermediate stations")
+    }
+
+    func testStationCodes_withLineId_returnsFullRoute() {
+        // When lineId matches a RouteTopology route, return all station codes for that route
+        let context = RouteStatusContext(dataSource: "SUBWAY", lineId: "subway-l", fromStationCode: nil, toStationCode: nil)
+        let codes = context.stationCodes
+        XCTAssertGreaterThan(codes.count, 10, "L line should have many stations")
+        XCTAssertTrue(codes.contains("SL10"), "L line should contain Metropolitan Av (SL10)")
+        XCTAssertTrue(codes.contains("SL03"), "L line should contain 14 St-Union Sq (SL03)")
+    }
+
+    func testStationCodes_unknownStations_returnsRawPair() {
+        let context = RouteStatusContext(dataSource: "SUBWAY", lineId: nil, fromStationCode: "FAKE1", toStationCode: "FAKE2")
+        let codes = context.stationCodes
+        XCTAssertEqual(codes, ["FAKE1", "FAKE2"], "Unknown stations should return raw pair as fallback")
+    }
+
     // MARK: - resolveGtfsRouteIds consistency
 
     func testGtfsRouteIds_allLirrBranches_topologyAndCodeAgree() {

--- a/ios/TrackRatTests/Models/RouteTopologyTests.swift
+++ b/ios/TrackRatTests/Models/RouteTopologyTests.swift
@@ -56,13 +56,25 @@ class RouteTopologyTests: XCTestCase {
         XCTAssertEqual(route?.dataSource, "PATH")
     }
 
-    func testRouteContainingFallsBackToPartialMatch() {
-        // Test that a station on only one end still returns a route (last resort)
+    func testRouteContainingReturnsNilForPartialMatch() {
+        // When only one station matches, return nil rather than a misleading partial match
         let route = RouteTopology.routeContaining(from: "NY", to: "NONEXISTENT", dataSource: "NJT")
-        XCTAssertNotNil(route, "Should fall back to route containing at least one station")
-        guard let route = route else { return }
-        XCTAssertEqual(route.dataSource, "NJT")
-        XCTAssertTrue(route.stationCodes.contains("NY"), "Fallback route should contain the known station")
+        XCTAssertNil(route, "Should return nil when only one station matches (no last-resort fallback)")
+    }
+
+    func testRouteContainingResolvesCrossPlatformViaEquivalents() {
+        // SG29 (Metropolitan Av, G line) and S635 (14 St-Union Sq, 4/5/6)
+        // Neither is on the L line, but their equivalents are: SG29↔SL10, S635↔SL03
+        let route = RouteTopology.routeContaining(from: "SG29", to: "S635", dataSource: "SUBWAY")
+        XCTAssertNotNil(route, "Should find L line via station equivalents for SG29→S635")
+        XCTAssertEqual(route?.id, "subway-l", "Cross-platform transfer SG29→S635 should resolve to the L line")
+    }
+
+    func testRouteContainingResolvesCrossPlatformReverse() {
+        // Same as above but reversed direction
+        let route = RouteTopology.routeContaining(from: "S635", to: "SG29", dataSource: "SUBWAY")
+        XCTAssertNotNil(route, "Should find L line via equivalents in reverse direction")
+        XCTAssertEqual(route?.id, "subway-l", "Reverse cross-platform transfer should also resolve to L line")
     }
 
     // MARK: - allRoutes Validation


### PR DESCRIPTION
## Summary
This PR enhances route finding and station code expansion to support cross-platform transfers by leveraging station equivalents. This allows the app to correctly handle transfers between different lines at the same physical station (e.g., G line at Metropolitan Av to 4/5/6 lines at 14 St-Union Sq via the L line).

## Key Changes

- **RouteTopology.routeContaining()**: Modified to expand station codes via `Stations.stationEquivalents` before searching for routes. This enables finding intermediate routes when direct station codes don't exist on a single line but their equivalents do.
  - Tries direct codes first, then expands via equivalents
  - Removes the "last resort" fallback that returned partial matches, now returns `nil` for unmatchable pairs
  - Maintains preference for routes where stations appear in correct order

- **RouteStatusContext.stationCodes**: Enhanced to attempt cross-platform transfer resolution when direct expansion yields insufficient results (≤2 stations).
  - First tries direct expansion between provided stations
  - Falls back to expanding via station equivalents if needed
  - Returns raw station pair as final fallback for unknown stations

- **Test Coverage**: Added comprehensive tests for cross-platform transfer scenarios:
  - `testRouteContainingResolvesCrossPlatformViaEquivalents()`: Validates SG29→S635 resolves to L line
  - `testRouteContainingResolvesCrossPlatformReverse()`: Validates reverse direction works
  - `testStationCodes_crossPlatformTransfer_resolvesViaEquivalents()`: Validates station code expansion for transfers
  - `testStationCodes_sameLine_expandsDirectly()`: Validates same-line expansion still works
  - Updated `testRouteContainingFallsBackToPartialMatch()` to reflect new behavior (returns nil instead of partial match)

## Implementation Details

The solution prioritizes direct matches but gracefully expands to equivalent stations when needed. This maintains performance for common same-line transfers while enabling complex cross-platform scenarios. The removal of the "last resort" fallback prevents returning misleading partial routes that don't actually connect the requested stations.

https://claude.ai/code/session_01SKVdiFFMHZv7Ts2YypYNGt