### PR TITLE
Add NJ Transit service alerts support to collector

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/client.py
+++ b/backend_v2/src/trackrat/collectors/njt/client.py
@@ -318,6 +318,45 @@ class NJTransitClient:
             )
             raise NJTransitAPIError(f"Invalid train data format: {str(e)}") from e
 
+    @track_api_call(api_name="njtransit", endpoint="station_messages")
+    async def get_station_messages(
+        self, station: str = "", line: str = ""
+    ) -> list[dict[str, Any]]:
+        """Get station/line service messages via getStationMSG.
+
+        Args:
+            station: Station code (e.g., "NP") or empty for all.
+            line: Line code (e.g., "NE") or empty for all.
+
+        Returns:
+            List of message dicts with MSG_TYPE, MSG_TEXT, MSG_PUBDATE_UTC, etc.
+            Empty list if no messages or API returns None/null.
+        """
+        logger.info(
+            "API QUERY: getting station messages using getStationMSG",
+            station=station or "ALL",
+            line=line or "ALL",
+        )
+
+        response = await self._make_request(
+            "TrainData/getStationMSG", {"station": station, "line": line}
+        )
+
+        # API returns None for bad token, [] for no messages
+        if response is None:
+            logger.warning("station_messages_null_response")
+            return []
+
+        if not isinstance(response, list):
+            logger.warning(
+                "station_messages_unexpected_type",
+                response_type=type(response).__name__,
+            )
+            return []
+
+        logger.info("station_messages_retrieved", count=len(response))
+        return response
+
     @track_api_call(api_name="njtransit", endpoint="station_schedule")
     async def get_station_schedule(
         self, station_code: str | None = None, njt_only: bool = False

--- a/backend_v2/src/trackrat/collectors/service_alerts.py
+++ b/backend_v2/src/trackrat/collectors/service_alerts.py
@@ -1,14 +1,19 @@
 """
-MTA service alerts collector.
+Service alerts collector.
 
-Fetches GTFS-RT service alert feeds for subway, LIRR, and Metro-North,
-and upserts them into the service_alerts table. Supports three alert types:
+Fetches service alerts from multiple sources:
+- MTA (SUBWAY, LIRR, MNR): GTFS-RT service alert feeds
+- NJT: NJ Transit getStationMSG API
+
+Upserts into the service_alerts table. Supports alert types:
 - planned_work: scheduled track work, reroutes, suspensions
 - alert: real-time delays, incidents
 - elevator: elevator/escalator outages
 """
 
+import hashlib
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -17,6 +22,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from trackrat.collectors.njt.client import NJTransitClient, NJTransitAPIError
 from trackrat.config.stations import (
     LIRR_ALERTS_FEED_URL,
     MNR_ALERTS_FEED_URL,
@@ -32,6 +38,30 @@ MTA_ALERT_FEEDS: dict[str, str] = {
     "SUBWAY": SUBWAY_ALERTS_FEED_URL,
     "LIRR": LIRR_ALERTS_FEED_URL,
     "MNR": MNR_ALERTS_FEED_URL,
+}
+
+# NJT MSG_LINE_SCOPE name -> internal line code(s)
+# The API returns names like "*Northeast Corridor Line" in MSG_LINE_SCOPE.
+# Multiple lines are space-delimited with * prefix: "*Main Line *Bergen County Line"
+NJT_LINE_SCOPE_TO_CODES: dict[str, list[str]] = {
+    "Northeast Corridor Line": ["NE"],
+    "Northeast Corrior Line": ["NE"],  # Known typo in NJT API
+    "Northeast Corridor": ["NE"],
+    "North Jersey Coast Line": ["NC"],
+    "ME Line": ["ME", "GL"],  # Morris & Essex covers Morristown + Gladstone
+    "Morris & Essex Line": ["ME", "GL"],
+    "Morris and Essex Line": ["ME", "GL"],
+    "Morristown Line": ["ME"],
+    "Gladstone Branch": ["GL"],
+    "Raritan Valley Line": ["RV"],
+    "Montclair-Boonton Line": ["MO"],
+    "Main Line": ["MA"],
+    "Bergen County Line": ["BE"],
+    "Port Jervis Line": ["PJ"],
+    "Pascack Valley Line": ["PV"],
+    "Atlantic City Line": ["AC"],
+    "Atlantic City Rail Line": ["AC"],
+    "Princeton Branch": ["PR"],
 }
 
 
@@ -159,6 +189,144 @@ async def fetch_and_parse_alerts(
     return alerts
 
 
+def parse_njt_line_scope(line_scope: str) -> list[str]:
+    """Parse NJT MSG_LINE_SCOPE into internal line codes.
+
+    The API uses '*'-prefixed names, space-delimited for multiple lines:
+    - Single: "*North Jersey Coast Line"
+    - Multiple: "*Main Line *Bergen County Line"
+    - None: " " (single space)
+
+    Returns:
+        List of internal line codes (e.g., ["NE", "NC"]).
+    """
+    if not line_scope or line_scope.strip() == "":
+        return []
+
+    # Split on '*' to get individual line names
+    codes: list[str] = []
+    for part in line_scope.split("*"):
+        name = part.strip()
+        if not name:
+            continue
+        mapped = NJT_LINE_SCOPE_TO_CODES.get(name)
+        if mapped:
+            for code in mapped:
+                if code not in codes:
+                    codes.append(code)
+        else:
+            logger.warning("NJT unknown line scope: %s", name)
+    return codes
+
+
+def parse_njt_station_scope(station_scope: str) -> list[str]:
+    """Parse NJT MSG_STATION_SCOPE into station display names.
+
+    The API returns comma-separated station names with '*' prefixes,
+    e.g. "*Newark Penn Station,*Metropark". A single space " " means
+    no station scope.
+
+    Returns:
+        List of station display names (e.g., ["Newark Penn Station", "Metropark"]).
+    """
+    if not station_scope or station_scope.strip() == "":
+        return []
+
+    names: list[str] = []
+    for part in station_scope.split(","):
+        name = part.strip().lstrip("*").strip()
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def parse_njt_message(msg: dict[str, Any]) -> ParsedAlert | None:
+    """Parse a single NJT getStationMSG response into a ParsedAlert.
+
+    Args:
+        msg: A single message dict from the getStationMSG API.
+
+    Returns:
+        ParsedAlert or None if the message has no useful text.
+    """
+    text = (msg.get("MSG_TEXT") or "").strip()
+    if not text:
+        return None
+
+    # Build a stable alert_id from MSG_ID if present, otherwise hash the text
+    msg_id = (msg.get("MSG_ID") or "").strip()
+    if msg_id:
+        alert_id = f"njt-rss-{msg_id}"
+    else:
+        # For non-RSS messages without MSG_ID, use a hash of the text
+        text_hash = hashlib.md5(text.encode()).hexdigest()[:12]
+        alert_id = f"njt-msg-{text_hash}"
+
+    # Classify: RSS source = real-time delay alerts, others = general advisories
+    source = (msg.get("MSG_SOURCE") or "").strip()
+    if source == "RSS_NJTRailAlerts":
+        alert_type = "alert"
+    else:
+        alert_type = "planned_work"
+
+    # Extract affected route IDs from line scope
+    line_scope = msg.get("MSG_LINE_SCOPE") or ""
+    affected_route_ids = parse_njt_line_scope(line_scope)
+
+    # If no line scope, try to include station names in description for context
+    station_scope = msg.get("MSG_STATION_SCOPE") or ""
+    station_names = parse_njt_station_scope(station_scope)
+
+    # Build description with station context if available
+    description = None
+    if station_names:
+        description = f"Stations: {', '.join(station_names)}"
+
+    # Parse publication time as active period
+    active_periods: list[dict[str, int | None]] = []
+    pub_utc = (msg.get("MSG_PUBDATE_UTC") or "").strip()
+    if pub_utc:
+        try:
+            # Format: "12/21/2023 4:13:00 PM"
+            dt = datetime.strptime(pub_utc, "%m/%d/%Y %I:%M:%S %p")
+            dt = dt.replace(tzinfo=timezone.utc)
+            epoch = int(dt.timestamp())
+            active_periods.append({"start": epoch, "end": None})
+        except ValueError:
+            logger.debug("NJT msg unparseable date: %s", pub_utc)
+
+    return ParsedAlert(
+        alert_id=alert_id,
+        alert_type=alert_type,
+        affected_route_ids=affected_route_ids,
+        header_text=text,
+        description_text=description,
+        active_periods=active_periods,
+    )
+
+
+async def fetch_and_parse_njt_alerts() -> list[ParsedAlert]:
+    """Fetch NJT service messages and parse into ParsedAlert objects.
+
+    Calls getStationMSG with no filters to get all active messages.
+    """
+    async with NJTransitClient() as client:
+        messages = await client.get_station_messages()
+
+    alerts: list[ParsedAlert] = []
+    for msg in messages:
+        parsed = parse_njt_message(msg)
+        if parsed:
+            alerts.append(parsed)
+
+    logger.info(
+        "Parsed %d NJT service alerts from %d messages",
+        len(alerts),
+        len(messages),
+    )
+    return alerts
+
+
 async def upsert_service_alerts(
     session: AsyncSession, alerts: list[ParsedAlert], data_source: str
 ) -> dict[str, int]:
@@ -236,14 +404,15 @@ async def upsert_service_alerts(
 
 
 async def collect_service_alerts() -> dict[str, Any]:
-    """Collect service alerts from all MTA feeds.
+    """Collect service alerts from all feeds (MTA + NJT).
 
     This is the main entry point called by the scheduler.
-    Fetches all three feeds, upserts alerts, and returns stats.
+    Fetches all feeds, upserts alerts, and returns stats.
     """
     all_stats: dict[str, Any] = {}
 
     async with get_session() as session:
+        # MTA feeds (GTFS-RT)
         for data_source, feed_url in MTA_ALERT_FEEDS.items():
             try:
                 alerts = await fetch_and_parse_alerts(feed_url, data_source)
@@ -271,6 +440,27 @@ async def collect_service_alerts() -> dict[str, Any]:
                     exc_info=True,
                 )
                 all_stats[data_source] = {"error": str(e)}
+
+        # NJT feed (getStationMSG API)
+        try:
+            njt_alerts = await fetch_and_parse_njt_alerts()
+            async with session.begin_nested():
+                stats = await upsert_service_alerts(session, njt_alerts, "NJT")
+            all_stats["NJT"] = {
+                "total_parsed": len(njt_alerts),
+                **stats,
+            }
+            logger.info("Service alerts collected for NJT: %s", stats)
+        except NJTransitAPIError as e:
+            logger.warning("Failed to fetch NJT service alerts: %s", e)
+            all_stats["NJT"] = {"error": str(e)}
+        except Exception as e:
+            logger.error(
+                "Error collecting NJT service alerts: %s",
+                e,
+                exc_info=True,
+            )
+            all_stats["NJT"] = {"error": str(e)}
 
         await session.commit()
 

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -338,14 +338,14 @@ class SchedulerService:
             misfire_grace_time=300,
         )
 
-        # Schedule MTA service alerts collection (every 15 minutes)
+        # Schedule service alerts collection (every 15 minutes) - MTA + NJT
         self.scheduler.add_job(
             self.run_service_alerts_collection,
             trigger=IntervalTrigger(
                 minutes=15, start_date=now + timedelta(minutes=4), jitter=60
             ),
             id="service_alerts_collection",
-            name="MTA Service Alerts Collection",
+            name="Service Alerts Collection (MTA + NJT)",
             replace_existing=True,
             max_instances=1,
             misfire_grace_time=900,  # 15 minute grace period
@@ -3153,7 +3153,7 @@ class SchedulerService:
                 logger.debug("morning_digest_evaluation_skipped_still_fresh")
 
     async def run_service_alerts_collection(self) -> None:
-        """Collect MTA service alerts from GTFS-RT feeds."""
+        """Collect service alerts from MTA GTFS-RT feeds and NJT API."""
 
         async def do_service_alerts_work() -> None:
             result = await collect_service_alerts()

--- a/backend_v2/tests/unit/collectors/test_service_alerts.py
+++ b/backend_v2/tests/unit/collectors/test_service_alerts.py
@@ -1,5 +1,5 @@
 """
-Tests for MTA service alerts collector.
+Tests for service alerts collector (MTA + NJT).
 
 Tests parsing logic, alert type classification, and database upsert.
 Uses real PostgreSQL via db_session fixture.
@@ -16,6 +16,9 @@ from trackrat.collectors.service_alerts import (
     classify_alert_type,
     extract_english_text,
     parse_alert_entity,
+    parse_njt_line_scope,
+    parse_njt_message,
+    parse_njt_station_scope,
     upsert_service_alerts,
 )
 from trackrat.models.database import ServiceAlert
@@ -341,3 +344,333 @@ class TestUpsertServiceAlerts:
         )
         lirr_row = result.scalar_one()
         assert lirr_row.alert_id == "lmm:planned_work:41"
+
+
+class TestParseNjtLineScope:
+    """Tests for parse_njt_line_scope() NJT line name -> code mapping."""
+
+    def test_single_line(self):
+        """Single line scope maps to correct code."""
+        assert parse_njt_line_scope("*North Jersey Coast Line") == ["NC"]
+
+    def test_me_line_maps_to_morristown_and_gladstone(self):
+        """ME Line maps to both ME and GL codes."""
+        assert parse_njt_line_scope("*ME Line") == ["ME", "GL"]
+
+    def test_multiple_lines_space_separated(self):
+        """Multiple lines are space-delimited with * prefix."""
+        result = parse_njt_line_scope("*Main Line *Bergen County Line")
+        assert result == ["MA", "BE"]
+
+    def test_empty_scope(self):
+        """Single space means no line scope."""
+        assert parse_njt_line_scope(" ") == []
+
+    def test_empty_string(self):
+        """Empty string returns empty list."""
+        assert parse_njt_line_scope("") == []
+
+    def test_none(self):
+        """None returns empty list."""
+        assert parse_njt_line_scope(None) == []  # type: ignore[arg-type]
+
+    def test_all_known_lines(self):
+        """All NJT lines that appear in the API are mapped."""
+        known_scopes = [
+            ("*Northeast Corridor Line", ["NE"]),
+            ("*North Jersey Coast Line", ["NC"]),
+            ("*ME Line", ["ME", "GL"]),
+            ("*Raritan Valley Line", ["RV"]),
+            ("*Montclair-Boonton Line", ["MO"]),
+            ("*Main Line", ["MA"]),
+            ("*Bergen County Line", ["BE"]),
+            ("*Port Jervis Line", ["PJ"]),
+            ("*Pascack Valley Line", ["PV"]),
+            ("*Atlantic City Line", ["AC"]),
+            ("*Princeton Branch", ["PR"]),
+            ("*Gladstone Branch", ["GL"]),
+        ]
+        for scope, expected in known_scopes:
+            result = parse_njt_line_scope(scope)
+            assert result == expected, f"Failed for {scope}: got {result}, expected {expected}"
+
+    def test_deduplicates_codes(self):
+        """Duplicate codes are not repeated."""
+        # If API ever returns "*ME Line *Morris & Essex Line", ME shouldn't appear twice
+        result = parse_njt_line_scope("*ME Line *Morris & Essex Line")
+        assert result.count("ME") == 1
+        assert result.count("GL") == 1
+
+
+class TestParseNjtStationScope:
+    """Tests for parse_njt_station_scope() station name extraction."""
+
+    def test_single_station(self):
+        """Single station is extracted."""
+        assert parse_njt_station_scope("*Newark Penn Station") == ["Newark Penn Station"]
+
+    def test_multiple_stations(self):
+        """Comma-separated stations are extracted."""
+        result = parse_njt_station_scope(
+            "*Newark Penn Station,*Metropark,*Newark Airport"
+        )
+        assert result == ["Newark Penn Station", "Metropark", "Newark Airport"]
+
+    def test_empty_scope(self):
+        """Single space means no station scope."""
+        assert parse_njt_station_scope(" ") == []
+
+    def test_deduplicates(self):
+        """Duplicate station names are not repeated."""
+        result = parse_njt_station_scope("*Newark Penn Station,*Newark Penn Station")
+        assert result == ["Newark Penn Station"]
+
+
+class TestParseNjtMessage:
+    """Tests for parse_njt_message() — full NJT message parsing."""
+
+    def _make_rss_message(
+        self,
+        msg_id: str = "2072532",
+        text: str = "NEC train #3837 is up to 15 min. late.",
+        line_scope: str = "*Northeast Corridor Line",
+        station_scope: str = " ",
+        pub_utc: str = "3/17/2026 12:58:38 AM",
+    ) -> dict:
+        """Build an RSS-sourced NJT message dict (real-time delay alert)."""
+        return {
+            "MSG_TYPE": "banner",
+            "MSG_TEXT": text,
+            "MSG_PUBDATE": "3/16/2026 8:58:38 PM",
+            "MSG_ID": msg_id,
+            "MSG_AGENCY": "NJT",
+            "MSG_SOURCE": "RSS_NJTRailAlerts",
+            "MSG_STATION_SCOPE": station_scope,
+            "MSG_LINE_SCOPE": line_scope,
+            "MSG_PUBDATE_UTC": pub_utc,
+        }
+
+    def _make_system_message(
+        self,
+        text: str = "Service suspended between A and B.",
+        station_scope: str = "*Newark Penn Station",
+        line_scope: str = " ",
+        pub_utc: str = "3/17/2026 1:00:00 AM",
+    ) -> dict:
+        """Build a non-RSS NJT message dict (system/manual advisory)."""
+        return {
+            "MSG_TYPE": "banner",
+            "MSG_TEXT": text,
+            "MSG_PUBDATE": "3/16/2026 9:00:00 PM",
+            "MSG_ID": "",
+            "MSG_AGENCY": "NJT",
+            "MSG_SOURCE": "",
+            "MSG_STATION_SCOPE": station_scope,
+            "MSG_LINE_SCOPE": line_scope,
+            "MSG_PUBDATE_UTC": pub_utc,
+        }
+
+    def test_rss_alert_parses_correctly(self):
+        """RSS-sourced messages become 'alert' type with line codes."""
+        msg = self._make_rss_message()
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.alert_id == "njt-rss-2072532"
+        assert result.alert_type == "alert"
+        assert result.affected_route_ids == ["NE"]
+        assert "train #3837" in result.header_text
+        assert result.description_text is None  # No station scope
+
+    def test_system_message_parses_correctly(self):
+        """Non-RSS messages become 'planned_work' with station description."""
+        msg = self._make_system_message()
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.alert_id.startswith("njt-msg-")
+        assert result.alert_type == "planned_work"
+        assert result.affected_route_ids == []  # No line scope
+        assert result.description_text == "Stations: Newark Penn Station"
+
+    def test_multi_line_scope(self):
+        """Messages with multiple lines map to all codes."""
+        msg = self._make_rss_message(
+            msg_id="999",
+            line_scope="*Main Line *Bergen County Line",
+        )
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.affected_route_ids == ["MA", "BE"]
+
+    def test_empty_text_skipped(self):
+        """Messages with empty text are skipped."""
+        msg = self._make_rss_message(text="")
+        assert parse_njt_message(msg) is None
+
+    def test_whitespace_text_skipped(self):
+        """Messages with whitespace-only text are skipped."""
+        msg = self._make_rss_message(text="   ")
+        assert parse_njt_message(msg) is None
+
+    def test_pub_date_utc_parsed(self):
+        """Publication date is parsed into active_periods epoch."""
+        msg = self._make_rss_message(pub_utc="12/21/2023 4:13:00 PM")
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert len(result.active_periods) == 1
+        assert result.active_periods[0]["start"] == 1703175180
+        assert result.active_periods[0]["end"] is None
+
+    def test_invalid_date_handled(self):
+        """Invalid date format doesn't crash, just skips active period."""
+        msg = self._make_rss_message(pub_utc="not-a-date")
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.active_periods == []
+
+    def test_missing_msg_id_uses_hash(self):
+        """Messages without MSG_ID get a hash-based alert_id."""
+        msg = self._make_system_message(text="Test advisory message")
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.alert_id.startswith("njt-msg-")
+        assert len(result.alert_id) == len("njt-msg-") + 12  # 12-char hex hash
+
+    def test_same_text_same_hash(self):
+        """Same message text produces the same alert_id (idempotent)."""
+        msg1 = self._make_system_message(text="Identical message")
+        msg2 = self._make_system_message(text="Identical message")
+        r1 = parse_njt_message(msg1)
+        r2 = parse_njt_message(msg2)
+
+        assert r1 is not None and r2 is not None
+        assert r1.alert_id == r2.alert_id
+
+    def test_different_text_different_hash(self):
+        """Different message text produces different alert_ids."""
+        msg1 = self._make_system_message(text="Message A")
+        msg2 = self._make_system_message(text="Message B")
+        r1 = parse_njt_message(msg1)
+        r2 = parse_njt_message(msg2)
+
+        assert r1 is not None and r2 is not None
+        assert r1.alert_id != r2.alert_id
+
+    def test_station_scope_in_description(self):
+        """Station scope names appear in description."""
+        msg = self._make_system_message(
+            station_scope="*Brick Church,*Chatham,*Summit"
+        )
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.description_text == "Stations: Brick Church, Chatham, Summit"
+
+    def test_real_me_line_alert(self):
+        """Parse a real ME Line alert from production API."""
+        msg = {
+            "MSG_TYPE": "banner",
+            "MSG_TEXT": "Morris and Essex and Gladstone Branch rail service "
+            "is suspended in both directions between South Orange "
+            "and Millburn due to fire department activity near Maplewood.",
+            "MSG_PUBDATE": "3/16/2026 8:58:38 PM",
+            "MSG_ID": "2072532",
+            "MSG_AGENCY": "NJT",
+            "MSG_SOURCE": "RSS_NJTRailAlerts",
+            "MSG_STATION_SCOPE": " ",
+            "MSG_LINE_SCOPE": "*ME Line",
+            "MSG_PUBDATE_UTC": "3/17/2026 12:58:38 AM",
+        }
+        result = parse_njt_message(msg)
+
+        assert result is not None
+        assert result.alert_id == "njt-rss-2072532"
+        assert result.alert_type == "alert"
+        assert result.affected_route_ids == ["ME", "GL"]
+        assert "suspended" in result.header_text
+        assert "Maplewood" in result.header_text
+
+
+@pytest.mark.asyncio
+class TestNjtUpsertServiceAlerts:
+    """Tests for upserting NJT alerts into the database."""
+
+    async def test_njt_alerts_upsert(self, db_session: AsyncSession):
+        """NJT alerts are inserted with data_source='NJT'."""
+        alerts = [
+            ParsedAlert(
+                alert_id="njt-rss-100",
+                alert_type="alert",
+                affected_route_ids=["NE"],
+                header_text="NEC delay alert",
+                description_text=None,
+                active_periods=[{"start": 1710100000, "end": None}],
+            ),
+            ParsedAlert(
+                alert_id="njt-msg-abc123",
+                alert_type="planned_work",
+                affected_route_ids=[],
+                header_text="System advisory",
+                description_text="Stations: Newark Penn Station",
+                active_periods=[{"start": 1710100000, "end": None}],
+            ),
+        ]
+        stats = await upsert_service_alerts(db_session, alerts, "NJT")
+        await db_session.flush()
+
+        assert stats["inserted"] == 2
+
+        result = await db_session.execute(
+            select(ServiceAlert).where(ServiceAlert.data_source == "NJT")
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 2
+        assert all(r.is_active for r in rows)
+
+        # Verify alert types
+        by_id = {r.alert_id: r for r in rows}
+        assert by_id["njt-rss-100"].alert_type == "alert"
+        assert by_id["njt-msg-abc123"].alert_type == "planned_work"
+
+    async def test_njt_isolation_from_mta(self, db_session: AsyncSession):
+        """NJT alerts don't interfere with MTA alerts."""
+        njt_alert = ParsedAlert(
+            alert_id="njt-rss-200",
+            alert_type="alert",
+            affected_route_ids=["NC"],
+            header_text="NJCL delay",
+            description_text=None,
+            active_periods=[],
+        )
+        mta_alert = ParsedAlert(
+            alert_id="lmm:alert:300",
+            alert_type="alert",
+            affected_route_ids=["G"],
+            header_text="G train delays",
+            description_text=None,
+            active_periods=[],
+        )
+
+        await upsert_service_alerts(db_session, [njt_alert], "NJT")
+        await upsert_service_alerts(db_session, [mta_alert], "SUBWAY")
+        await db_session.flush()
+
+        # Deactivate all NJT alerts
+        stats = await upsert_service_alerts(db_session, [], "NJT")
+        await db_session.flush()
+
+        assert stats["deactivated"] == 1
+
+        # SUBWAY alert untouched
+        result = await db_session.execute(
+            select(ServiceAlert).where(
+                ServiceAlert.data_source == "SUBWAY",
+                ServiceAlert.is_active.is_(True),
+            )
+        )
+        assert result.scalar_one().alert_id == "lmm:alert:300"


### PR DESCRIPTION
## Summary
Extends the service alerts collector to support NJ Transit (NJT) service messages in addition to existing MTA feeds. Adds parsing logic for NJT's getStationMSG API and integrates it into the alert collection pipeline.

## Key Changes

- **NJT Message Parsing**: Added three new parsing functions:
  - `parse_njt_line_scope()`: Maps NJT line names to internal line codes (e.g., "ME Line" → ["ME", "GL"])
  - `parse_njt_station_scope()`: Extracts station names from comma-separated scope strings
  - `parse_njt_message()`: Converts raw NJT API messages into `ParsedAlert` objects with proper classification (RSS-sourced messages as "alert", others as "planned_work")

- **NJT API Integration**: 
  - Added `fetch_and_parse_njt_alerts()` to fetch messages via `NJTransitClient.get_station_messages()`
  - Integrated NJT collection into main `collect_service_alerts()` pipeline with error handling
  - Added `get_station_messages()` method to NJTransitClient for fetching all active messages

- **Alert ID Generation**: Implemented stable ID generation for NJT alerts:
  - RSS-sourced messages use `njt-rss-{MSG_ID}`
  - System messages without MSG_ID use MD5 hash of text for idempotency

- **Line Code Mapping**: Created comprehensive `NJT_LINE_SCOPE_TO_CODES` mapping covering all NJT lines including special cases (ME Line maps to both ME and GL codes for Morris & Essex + Gladstone coverage)

- **Database Isolation**: Ensured NJT alerts are properly isolated by data_source in the database, allowing independent lifecycle management from MTA alerts

## Testing
Added comprehensive test suite covering:
- Line scope parsing with single/multiple lines and edge cases
- Station scope extraction and deduplication
- Full message parsing for both RSS and system messages
- Date/time parsing and active period generation
- Hash-based alert ID generation and idempotency
- Database upsert operations and data source isolation
- Real-world alert examples (e.g., ME Line service suspensions)

## Notable Implementation Details
- NJT messages with empty/whitespace text are filtered out during parsing
- Invalid date formats are handled gracefully without crashing
- Duplicate line codes are deduplicated to prevent redundant route mappings
- Station names appear in description_text when line scope is unavailable, providing context for general advisories

https://claude.ai/code/session_01WJKMaTtAHFU2tWqQWsuz7r