### PR TITLE
Simplify morning digest notification titles

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -956,7 +956,7 @@ async def evaluate_morning_digests(
             if not summary or not device.apns_token:
                 continue
 
-            title = f"Morning Update: {route_name}"
+            title = route_name
             custom_data = {
                 "route_alert": {
                     "data_source": sub.data_source,
@@ -968,8 +968,9 @@ async def evaluate_morning_digests(
                     "alert_type": "digest",
                 }
             }
+            body = f"Daily digest: {summary}"
             sent = await apns_service.send_alert_notification(
-                device.apns_token, title, summary, custom_data=custom_data
+                device.apns_token, title, body, custom_data=custom_data
             )
 
             if sent:


### PR DESCRIPTION
## Summary
Updated the morning digest notification formatting to use a cleaner title structure and explicit body parameter.

## Key Changes
- Changed notification title from `"Morning Update: {route_name}"` to just `route_name` for a simpler, more concise presentation
- Introduced explicit `body` variable with format `"Daily digest: {summary}"` to clearly separate title and body content
- Updated `send_alert_notification()` call to pass the new `body` variable instead of using `summary` directly

## Implementation Details
This change improves the notification UX by:
- Reducing redundancy in the title (removing the "Morning Update:" prefix)
- Making the code more explicit about what constitutes the notification body
- Maintaining the same information content while improving clarity

https://claude.ai/code/session_01YULaxvtB2GSJPj4mca5BTL