### PR TITLE
Remove lookahead window for service alerts, only notify on active alerts

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -1050,25 +1050,19 @@ async def _generate_digest_summary(
 # Service alert (planned work) evaluation
 # ---------------------------------------------------------------------------
 
-# Notify about planned work starting within this window
-PLANNED_WORK_LOOKAHEAD_HOURS = 48
-
-
 async def evaluate_service_alerts(
     db: AsyncSession, apns_service: SimpleAPNSService
 ) -> int:
     """Evaluate planned work alerts for subscriptions with include_planned_work=True.
 
     Checks active service alerts against user subscriptions and sends
-    push notifications for new planned work affecting subscribed routes.
+    push notifications for planned work that is currently active on
+    subscribed routes.
 
     Returns the number of alerts sent.
     """
     now = now_et()
     now_epoch = int(now.timestamp())
-    lookahead_epoch = int(
-        (now + timedelta(hours=PLANNED_WORK_LOOKAHEAD_HOURS)).timestamp()
-    )
 
     # Load devices with subscriptions that opt into planned work
     result = await db.execute(
@@ -1113,7 +1107,6 @@ async def evaluate_service_alerts(
                 sub.data_source,
                 gtfs_route_ids,
                 now_epoch,
-                lookahead_epoch,
             )
 
             if not matching_alerts:
@@ -1179,15 +1172,13 @@ def _find_matching_alerts(
     data_source: str,
     gtfs_route_ids: set[str],
     now_epoch: int,
-    lookahead_epoch: int,
 ) -> list[ServiceAlert]:
-    """Find service alerts that match a subscription and have upcoming active periods.
+    """Find service alerts that match a subscription and are currently active.
 
     Returns alerts that:
     1. Are for the same data source
     2. Affect at least one of the subscription's routes
-    3. Have at least one active period starting within the lookahead window,
-       or are currently active
+    3. Have at least one active period that is currently active (started and not yet ended)
     """
     matching: list[ServiceAlert] = []
 
@@ -1200,8 +1191,8 @@ def _find_matching_alerts(
         if not alert_routes & gtfs_route_ids:
             continue
 
-        # Check if any active period is current or upcoming
-        has_relevant_period = False
+        # Check if any active period is currently active
+        is_currently_active = False
         for period in alert.active_periods or []:
             start = period.get("start")
             end = period.get("end")
@@ -1211,15 +1202,10 @@ def _find_matching_alerts(
 
             # Currently active (started and not yet ended)
             if start <= now_epoch and (end is None or end > now_epoch):
-                has_relevant_period = True
+                is_currently_active = True
                 break
 
-            # Starting within lookahead window
-            if now_epoch < start <= lookahead_epoch:
-                has_relevant_period = True
-                break
-
-        if has_relevant_period:
+        if is_currently_active:
             matching.append(alert)
 
     return matching

--- a/backend_v2/tests/unit/services/test_service_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_service_alert_evaluator.py
@@ -18,7 +18,6 @@ from trackrat.models.database import (
     ServiceAlert,
 )
 from trackrat.services.alert_evaluator import (
-    PLANNED_WORK_LOOKAHEAD_HOURS,
     _build_service_alert_message,
     _find_matching_alerts,
     _get_gtfs_route_ids_for_subscription,
@@ -74,8 +73,8 @@ def _make_service_alert(
     """Create a ServiceAlert record for testing."""
     now_epoch = int(time.time())
     if active_start is None:
-        # Default: starting in 12 hours (within 48h lookahead)
-        active_start = now_epoch + 43200
+        # Default: currently active (started 1 hour ago)
+        active_start = now_epoch - 3600
     if active_end is None:
         active_end = active_start + 86400  # 24h duration
 
@@ -208,7 +207,7 @@ class TestFindMatchingAlerts:
         """Create a ServiceAlert object (not persisted to DB)."""
         now_epoch = int(time.time())
         if active_start is None:
-            active_start = now_epoch + 3600  # 1h from now
+            active_start = now_epoch - 3600  # started 1h ago
         if active_end is None:
             active_end = active_start + 86400
 
@@ -226,27 +225,21 @@ class TestFindMatchingAlerts:
         """Alert matching routes in subscription is returned."""
         now_epoch = int(time.time())
         alert = self._make_alert(route_ids=["G", "F"])
-        result = _find_matching_alerts(
-            [alert], "SUBWAY", {"G"}, now_epoch, now_epoch + 172800
-        )
+        result = _find_matching_alerts([alert], "SUBWAY", {"G"}, now_epoch)
         assert len(result) == 1
 
     def test_no_match_different_routes(self):
         """Alert not matching any subscription routes is excluded."""
         now_epoch = int(time.time())
         alert = self._make_alert(route_ids=["4", "5"])
-        result = _find_matching_alerts(
-            [alert], "SUBWAY", {"G"}, now_epoch, now_epoch + 172800
-        )
+        result = _find_matching_alerts([alert], "SUBWAY", {"G"}, now_epoch)
         assert len(result) == 0
 
     def test_no_match_different_data_source(self):
         """Alert from different data source is excluded."""
         now_epoch = int(time.time())
         alert = self._make_alert(data_source="LIRR", route_ids=["1"])
-        result = _find_matching_alerts(
-            [alert], "SUBWAY", {"G"}, now_epoch, now_epoch + 172800
-        )
+        result = _find_matching_alerts([alert], "SUBWAY", {"G"}, now_epoch)
         assert len(result) == 0
 
     def test_matches_currently_active_alert(self):
@@ -256,9 +249,7 @@ class TestFindMatchingAlerts:
             active_start=now_epoch - 3600,  # started 1h ago
             active_end=now_epoch + 3600,  # ends in 1h
         )
-        result = _find_matching_alerts(
-            [alert], "SUBWAY", {"G"}, now_epoch, now_epoch + 172800
-        )
+        result = _find_matching_alerts([alert], "SUBWAY", {"G"}, now_epoch)
         assert len(result) == 1
 
     def test_excludes_past_alert(self):
@@ -268,33 +259,15 @@ class TestFindMatchingAlerts:
             active_start=now_epoch - 86400,  # started 24h ago
             active_end=now_epoch - 3600,  # ended 1h ago
         )
-        result = _find_matching_alerts(
-            [alert], "SUBWAY", {"G"}, now_epoch, now_epoch + 172800
-        )
+        result = _find_matching_alerts([alert], "SUBWAY", {"G"}, now_epoch)
         assert len(result) == 0
 
-    def test_excludes_far_future_alert(self):
-        """Alert starting beyond the lookahead window is excluded."""
-        now_epoch = int(time.time())
-        far_future = now_epoch + (PLANNED_WORK_LOOKAHEAD_HOURS * 3600) + 7200
-        alert = self._make_alert(active_start=far_future)
-        result = _find_matching_alerts(
-            [alert],
-            "SUBWAY",
-            {"G"},
-            now_epoch,
-            now_epoch + (PLANNED_WORK_LOOKAHEAD_HOURS * 3600),
-        )
-        assert len(result) == 0
-
-    def test_matches_upcoming_within_lookahead(self):
-        """Alert starting within lookahead window is returned."""
+    def test_excludes_future_not_yet_active_alert(self):
+        """Alert starting in the future (not yet active) is excluded."""
         now_epoch = int(time.time())
         alert = self._make_alert(active_start=now_epoch + 7200)  # 2h from now
-        result = _find_matching_alerts(
-            [alert], "SUBWAY", {"G"}, now_epoch, now_epoch + 172800
-        )
-        assert len(result) == 1
+        result = _find_matching_alerts([alert], "SUBWAY", {"G"}, now_epoch)
+        assert len(result) == 0
 
 
 class TestLineCodesToGtfsIds:


### PR DESCRIPTION
## Summary
This change modifies the service alert evaluation logic to only notify users about alerts that are currently active, removing the 48-hour lookahead window for planned work notifications.

## Key Changes
- **Removed lookahead window**: Deleted the `PLANNED_WORK_LOOKAHEAD_HOURS` constant and all related lookahead logic
- **Simplified alert matching**: Updated `_find_matching_alerts()` to only return alerts with active periods that have already started and not yet ended (currently active)
- **Updated function signature**: Removed the `lookahead_epoch` parameter from `_find_matching_alerts()` and its call site
- **Updated test defaults**: Changed test helper methods to create alerts that are currently active (started 1 hour ago) instead of future alerts
- **Updated test cases**: 
  - Removed `test_excludes_far_future_alert()` and `test_matches_upcoming_within_lookahead()` 
  - Added `test_excludes_future_not_yet_active_alert()` to verify future alerts are excluded
  - Simplified all test calls to `_find_matching_alerts()` by removing the lookahead parameter
- **Updated documentation**: Modified docstrings to clarify that only currently active alerts are matched

## Implementation Details
The alert matching logic now uses a simpler condition: an alert is included if any of its active periods satisfy `start <= now_epoch and (end is None or end > now_epoch)`. This ensures users are only notified about service alerts that are actively affecting their routes right now, rather than being notified in advance about future planned work.

https://claude.ai/code/session_01GQnB3dWxZ9hZ3vgC6yjjc4