### PR TITLE
Reorder action buttons in TrainDetailsView

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -100,24 +100,6 @@ struct TrainDetailsView: View {
             // Action buttons row
             if let train = viewModel.train {
                 HStack(spacing: 12) {
-                    // Watch button (Live Activity)
-                    if let originCode = appState.departureStationCode,
-                       !originCode.isEmpty {
-                        TrackTrainInlineButton(
-                            train: train,
-                            originCode: originCode,
-                            destinationCode: appState.destinationStationCode ?? "",
-                            destinationName: appState.selectedDestination,
-                            textColor: .white.opacity(0.8),
-                            activeLabel: "Unwatch",
-                            inactiveLabel: "Watch",
-                            font: .subheadline
-                        )
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .background(Capsule().fill(Color.white.opacity(0.12)))
-                    }
-
                     // Alerts button
                     if let fromCode = appState.departureStationCode,
                        let toCode = appState.destinationStationCode {
@@ -141,6 +123,24 @@ struct TrainDetailsView: View {
                             .background(Capsule().fill(Color.white.opacity(0.12)))
                         }
                         .buttonStyle(.plain)
+                    }
+
+                    // Watch button (Live Activity)
+                    if let originCode = appState.departureStationCode,
+                       !originCode.isEmpty {
+                        TrackTrainInlineButton(
+                            train: train,
+                            originCode: originCode,
+                            destinationCode: appState.destinationStationCode ?? "",
+                            destinationName: appState.selectedDestination,
+                            textColor: .white.opacity(0.8),
+                            activeLabel: "Unwatch",
+                            inactiveLabel: "Watch",
+                            font: .subheadline
+                        )
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Capsule().fill(Color.white.opacity(0.12)))
                     }
 
                 }


### PR DESCRIPTION
## Summary
Reordered the action buttons in the TrainDetailsView to display the Alerts button before the Watch button (Live Activity).

## Changes
- Moved the Watch button (Live Activity) code block to appear after the Alerts button in the action buttons HStack
- No functional changes to the buttons themselves, only their display order

## Details
The buttons now appear in the following order:
1. Alerts button
2. Watch button (Live Activity)

This change improves the UI flow by prioritizing the alerts functionality before the watch/tracking feature.

https://claude.ai/code/session_01F9tbzMKY7Ym8obWhZr1KFq