### PR TITLE
Add line_codes filter to route performance stats

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -66,6 +66,10 @@ async def get_route_history(
         description="Hours lookback (overrides days when provided)",
     ),
     highlight_train: str | None = Query(None, description="Train ID to highlight"),
+    lines: str | None = Query(
+        None,
+        description="Comma-separated line codes to filter (e.g. 'A,1,7')",
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> RouteHistoryResponse:
     """Get aggregate historical performance for all trains on a route.
@@ -77,6 +81,9 @@ async def get_route_history(
     When `hours` is provided, filters by actual departure time at the origin station
     instead of journey date, enabling sub-day time windows (e.g. past hour).
     """
+    # Parse line codes filter
+    line_codes = [lc.strip() for lc in lines.split(",") if lc.strip()] if lines else None
+
     logger.info(
         "get_route_history_request",
         from_station=from_station,
@@ -85,6 +92,7 @@ async def get_route_history(
         days=days,
         hours=hours,
         highlight_train=highlight_train,
+        lines=line_codes,
     )
 
     # Validate data_source
@@ -104,6 +112,7 @@ async def get_route_history(
             "data_source": data_source,
             "days": days,
             "hours": hours,
+            "lines": lines,
         }
         cached_response = await cache_service.get_cached_response(
             db=db,
@@ -138,7 +147,8 @@ async def get_route_history(
 
     # Compute aggregate stats via SQL
     aggregate_stats = await _calculate_route_stats_sql(
-        db, data_source, start_date, end_date, from_codes, to_codes, cutoff_time, now
+        db, data_source, start_date, end_date, from_codes, to_codes, cutoff_time, now,
+        line_codes=line_codes,
     )
 
     # Compute highlighted train stats if specified
@@ -154,6 +164,7 @@ async def get_route_history(
             cutoff_time,
             now,
             train_id_filter=highlight_train,
+            line_codes=line_codes,
         )
         if highlighted_stats["total_journeys"] > 0:
             hl_breakdown = highlighted_stats["delay_breakdown"]
@@ -172,7 +183,7 @@ async def get_route_history(
 
     # Calculate baseline train count for frequency comparison
     baseline_train_count = await _calculate_baseline_train_count(
-        db, data_source, from_codes, to_codes, hours, now
+        db, data_source, from_codes, to_codes, hours, now, line_codes=line_codes,
     )
 
     response = RouteHistoryResponse(
@@ -226,6 +237,7 @@ async def _calculate_route_stats_sql(
     cutoff_time: datetime | None,
     now: datetime,
     train_id_filter: str | None = None,
+    line_codes: list[str] | None = None,
 ) -> dict[str, Any]:
     """Calculate route statistics using SQL aggregation instead of loading ORM objects."""
 
@@ -253,6 +265,10 @@ async def _calculate_route_stats_sql(
     if train_id_filter:
         train_filter = "AND tj.train_id = :train_id"
 
+    line_filter = ""
+    if line_codes:
+        line_filter = "AND tj.line_code = ANY(:line_codes)"
+
     # Build the route_journeys CTE SQL (reused by stats and track queries)
     route_journeys_cte = f"""
         SELECT tj.id AS journey_id, tj.is_cancelled
@@ -261,6 +277,7 @@ async def _calculate_route_stats_sql(
           AND tj.journey_date >= :start_date
           AND tj.journey_date <= :end_date
           {train_filter}
+          {line_filter}
           AND EXISTS (
               SELECT 1 FROM journey_stops fs
               WHERE fs.journey_id = tj.id
@@ -378,6 +395,8 @@ async def _calculate_route_stats_sql(
         params["now_time"] = now
     if train_id_filter:
         params["train_id"] = train_id_filter
+    if line_codes:
+        params["line_codes"] = line_codes
 
     result = await db.execute(sql, params)
     row = result.mappings().first()
@@ -443,6 +462,7 @@ async def _calculate_baseline_train_count(
     to_codes: list[str],
     hours: int | None,
     now: datetime,
+    line_codes: list[str] | None = None,
 ) -> float | None:
     """Calculate expected train count for frequency baseline comparison.
 
@@ -463,6 +483,10 @@ async def _calculate_baseline_train_count(
     is_weekend = now_eastern.weekday() >= 5  # Saturday=5, Sunday=6
 
     # Build filters based on time window
+    baseline_line_filter = ""
+    if line_codes:
+        baseline_line_filter = "AND stt.line_code = ANY(:line_codes)"
+
     hour_filter = ""
     day_filter = ""
 
@@ -492,6 +516,7 @@ async def _calculate_baseline_train_count(
             WHERE stt.departure_time >= :baseline_start
               AND stt.from_station_code = ANY(:from_codes)
               AND stt.data_source = :data_source
+              {baseline_line_filter}
               {hour_filter}
               {day_filter}
               AND EXISTS (
@@ -521,6 +546,8 @@ async def _calculate_baseline_train_count(
         params["current_hour"] = current_hour
     if day_filter:
         params["is_weekend"] = is_weekend
+    if line_codes:
+        params["line_codes"] = line_codes
 
     try:
         result = await db.execute(sql, params)

--- a/backend_v2/tests/unit/api/test_route_history.py
+++ b/backend_v2/tests/unit/api/test_route_history.py
@@ -31,13 +31,15 @@ async def _create_journey(
     stops: list[dict],
     is_cancelled: bool = False,
     data_source: str = "NJT",
+    line_code: str = "NE",
+    line_name: str = "Northeast Corridor",
 ) -> TrainJourney:
     """Create a real TrainJourney with JourneyStop records in the database."""
     journey = TrainJourney(
         train_id=train_id,
         journey_date=BASE_DATE,
-        line_code="NE",
-        line_name="Northeast Corridor",
+        line_code=line_code,
+        line_name=line_name,
         destination="Trenton",
         origin_station_code=stops[0]["station_code"],
         terminal_station_code=stops[-1]["station_code"],
@@ -78,6 +80,7 @@ async def _run_stats(
     from_codes: list[str] | None = None,
     to_codes: list[str] | None = None,
     train_id_filter: str | None = None,
+    line_codes: list[str] | None = None,
 ) -> dict:
     """Helper to call _calculate_route_stats_sql with common defaults."""
     return await _calculate_route_stats_sql(
@@ -90,6 +93,7 @@ async def _run_stats(
         cutoff_time=None,
         now=BASE_TIME + timedelta(hours=2),
         train_id_filter=train_id_filter,
+        line_codes=line_codes,
     )
 
 
@@ -1229,3 +1233,241 @@ class TestCutoffTimeFiltersByArrival:
         # No cutoff = all journeys included (the _run_stats default)
         result = await _run_stats(db_session)
         assert result["total_journeys"] == 3
+
+
+def _make_stops(
+    delay_minutes: float = 0,
+    from_code: str = "NY",
+    to_code: str = "TR",
+) -> list[dict]:
+    """Helper to create a simple 2-stop journey with optional delay."""
+    return [
+        {
+            "station_code": from_code,
+            "stop_sequence": 0,
+            "scheduled_departure": BASE_TIME,
+            "actual_departure": BASE_TIME,
+        },
+        {
+            "station_code": to_code,
+            "stop_sequence": 1,
+            "scheduled_arrival": BASE_TIME + timedelta(hours=1),
+            "actual_arrival": BASE_TIME
+            + timedelta(hours=1, minutes=delay_minutes),
+            "arrival_source": "api_observed",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+class TestLineCodesFilter:
+    """Verify that the line_codes parameter correctly filters route stats.
+
+    This tests the fix for the bug where Route Performance showed aggregate
+    stats for ALL subway lines even when only some lines were enabled in
+    Route Settings.
+    """
+
+    async def test_line_codes_filter_includes_matching_line(
+        self, db_session: AsyncSession
+    ):
+        """Journeys with a matching line_code are included."""
+        await _create_journey(
+            db_session,
+            train_id="A_train_1",
+            stops=_make_stops(),
+            data_source="SUBWAY",
+            line_code="A",
+            line_name="A Train",
+        )
+        await db_session.commit()
+
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=["A"],
+        )
+        assert result["total_journeys"] == 1, (
+            f"Expected 1 journey for line A, got {result['total_journeys']}"
+        )
+
+    async def test_line_codes_filter_excludes_non_matching_line(
+        self, db_session: AsyncSession
+    ):
+        """Journeys with a non-matching line_code are excluded."""
+        await _create_journey(
+            db_session,
+            train_id="A_train_2",
+            stops=_make_stops(),
+            data_source="SUBWAY",
+            line_code="A",
+            line_name="A Train",
+        )
+        await db_session.commit()
+
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=["1"],
+        )
+        assert result["total_journeys"] == 0, (
+            f"Expected 0 journeys when filtering for line 1 but only line A exists, "
+            f"got {result['total_journeys']}"
+        )
+
+    async def test_line_codes_filter_multiple_lines(
+        self, db_session: AsyncSession
+    ):
+        """Multiple line codes filter includes all matching, excludes non-matching."""
+        # Create journeys on 3 different lines
+        for line_code, line_name in [("A", "A Train"), ("1", "1 Train"), ("7", "7 Train")]:
+            await _create_journey(
+                db_session,
+                train_id=f"{line_code}_train",
+                stops=_make_stops(),
+                data_source="SUBWAY",
+                line_code=line_code,
+                line_name=line_name,
+            )
+        await db_session.commit()
+
+        # Filter for A and 1 only — should exclude 7
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=["A", "1"],
+        )
+        assert result["total_journeys"] == 2, (
+            f"Expected 2 journeys for lines A and 1, got {result['total_journeys']}. "
+            "Line 7 should be excluded."
+        )
+
+    async def test_line_codes_none_returns_all(
+        self, db_session: AsyncSession
+    ):
+        """When line_codes is None, all lines are included (backwards compatible)."""
+        for line_code, line_name in [("A", "A Train"), ("1", "1 Train")]:
+            await _create_journey(
+                db_session,
+                train_id=f"{line_code}_train_all",
+                stops=_make_stops(),
+                data_source="SUBWAY",
+                line_code=line_code,
+                line_name=line_name,
+            )
+        await db_session.commit()
+
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=None,
+        )
+        assert result["total_journeys"] == 2, (
+            f"Expected 2 journeys with no line filter (all lines), "
+            f"got {result['total_journeys']}"
+        )
+
+    async def test_line_codes_filter_affects_stats_accuracy(
+        self, db_session: AsyncSession
+    ):
+        """Stats are computed only from filtered lines, not polluted by others.
+
+        Creates a delayed line A train (10 min late) and an on-time line 1 train.
+        Filtering for line A only should show ~100% late, not ~50%.
+        """
+        # Line A: 10 min delayed
+        await _create_journey(
+            db_session,
+            train_id="A_delayed",
+            stops=_make_stops(delay_minutes=10),
+            data_source="SUBWAY",
+            line_code="A",
+            line_name="A Train",
+        )
+        # Line 1: on time
+        await _create_journey(
+            db_session,
+            train_id="1_ontime",
+            stops=_make_stops(delay_minutes=0),
+            data_source="SUBWAY",
+            line_code="1",
+            line_name="1 Train",
+        )
+        await db_session.commit()
+
+        # Unfiltered: 50% on-time (1 of 2 trains on time)
+        all_result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=None,
+        )
+        assert all_result["total_journeys"] == 2
+        assert all_result["on_time_percentage"] == pytest.approx(50.0, abs=1), (
+            f"Expected ~50% on-time with both lines, got {all_result['on_time_percentage']}"
+        )
+
+        # Filtered to line A only: 0% on-time (the A train is 10min late)
+        a_result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=["A"],
+        )
+        assert a_result["total_journeys"] == 1
+        assert a_result["on_time_percentage"] == pytest.approx(0.0, abs=1), (
+            f"Expected 0% on-time for line A (10min delayed), "
+            f"got {a_result['on_time_percentage']}"
+        )
+
+        # Filtered to line 1 only: 100% on-time
+        one_result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="SUBWAY",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["TR"],
+            cutoff_time=None,
+            now=BASE_TIME + timedelta(hours=2),
+            line_codes=["1"],
+        )
+        assert one_result["total_journeys"] == 1
+        assert one_result["on_time_percentage"] == pytest.approx(100.0, abs=1), (
+            f"Expected 100% on-time for line 1 (on time), "
+            f"got {one_result['on_time_percentage']}"
+        )

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -439,7 +439,8 @@ final class APIService: ObservableObject {
         dataSource: String,
         highlightTrain: String? = nil,
         days: Int = 365,
-        hours: Int? = nil
+        hours: Int? = nil,
+        lines: [String]? = nil
     ) async throws -> RouteHistoricalData {
         var urlComponents = URLComponents(string: "\(baseURL)/v2/routes/history")!
         urlComponents.queryItems = [
@@ -455,6 +456,10 @@ final class APIService: ObservableObject {
 
         if let highlightTrain = highlightTrain {
             urlComponents.queryItems?.append(URLQueryItem(name: "highlight_train", value: highlightTrain))
+        }
+
+        if let lines = lines, !lines.isEmpty {
+            urlComponents.queryItems?.append(URLQueryItem(name: "lines", value: lines.joined(separator: ",")))
         }
         
         guard let url = urlComponents.url else {

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -1361,14 +1361,30 @@ final class RouteStatusViewModel: ObservableObject {
             )
         }
 
+        // Extract per-system line codes from enabledLineIds for filtering
+        // When enabledLineIds is empty (all enabled), pass nil to skip filtering
+        let linesBySystem: [String: [String]?] = {
+            if enabledLineIds.isEmpty { return [:] }
+            var result: [String: [String]] = [:]
+            for id in enabledLineIds {
+                let parts = id.split(separator: ":")
+                guard parts.count == 2 else { continue }
+                let system = String(parts[0])
+                let lineCode = String(parts[1])
+                result[system, default: []].append(lineCode)
+            }
+            return result
+        }()
+
         // Fetch all periods for all systems in parallel
         await withTaskGroup(of: Void.self) { group in
             for system in systemsToFetch {
+                let systemLines = linesBySystem[system] ?? nil
                 // Past hour
                 group.addTask {
                     do {
                         let data = try await APIService.shared.fetchRouteHistoricalData(
-                            from: from, to: to, dataSource: system, hours: 1
+                            from: from, to: to, dataSource: system, hours: 1, lines: systemLines
                         )
                         await MainActor.run {
                             self.historyBySystem[system]?.pastHour = data
@@ -1385,7 +1401,7 @@ final class RouteStatusViewModel: ObservableObject {
                 group.addTask {
                     do {
                         let data = try await APIService.shared.fetchRouteHistoricalData(
-                            from: from, to: to, dataSource: system, hours: 24
+                            from: from, to: to, dataSource: system, hours: 24, lines: systemLines
                         )
                         await MainActor.run {
                             self.historyBySystem[system]?.past24Hours = data
@@ -1402,7 +1418,7 @@ final class RouteStatusViewModel: ObservableObject {
                 group.addTask {
                     do {
                         let data = try await APIService.shared.fetchRouteHistoricalData(
-                            from: from, to: to, dataSource: system, days: 7
+                            from: from, to: to, dataSource: system, days: 7, lines: systemLines
                         )
                         await MainActor.run {
                             self.historyBySystem[system]?.past7Days = data


### PR DESCRIPTION
## Summary
This PR adds support for filtering route performance statistics by specific transit lines, fixing a bug where Route Performance showed aggregate stats for ALL lines even when only some lines were enabled in Route Settings.

## Key Changes

**Backend (Python/FastAPI)**
- Added `line_codes` optional parameter to `_calculate_route_stats_sql()` to filter journeys by line code
- Added `line_codes` optional parameter to `_calculate_baseline_train_count()` for consistent filtering
- Updated `get_route_history()` endpoint to accept a `lines` query parameter (comma-separated line codes)
- Implemented SQL filtering using `AND tj.line_code = ANY(:line_codes)` in the route_journeys CTE
- Made `_create_journey()` test helper accept configurable `line_code` and `line_name` parameters
- Added comprehensive test suite (`TestLineCodesFilter`) with 5 test cases covering:
  - Single line filtering (inclusion and exclusion)
  - Multiple line filtering
  - Backwards compatibility (None returns all lines)
  - Stats accuracy verification (ensuring filtered stats aren't polluted by other lines)

**iOS Client (Swift)**
- Updated `fetchRouteHistoricalData()` in `APIService` to accept optional `lines` parameter
- Modified `RouteStatusViewModel` to extract per-system line codes from `enabledLineIds`
- Pass filtered line codes to all three historical data fetch calls (past hour, 24 hours, 7 days)
- When `enabledLineIds` is empty (all enabled), passes `nil` to skip filtering on backend

## Implementation Details
- The filter is optional and backwards compatible—when `line_codes` is `None`, all lines are included
- Line filtering is applied at the SQL level in the route_journeys CTE for efficiency
- The iOS client intelligently maps the global `enabledLineIds` (format: "system:lineCode") to per-system line code lists
- Test coverage includes edge cases like stats accuracy to ensure filtering doesn't cause data pollution

https://claude.ai/code/session_01TFedYviSpE1qimV8ZKF6mn