### PR TITLE
Add NJT service alert support

### DIFF
--- a/backend_v2/src/trackrat/collectors/service_alerts.py
+++ b/backend_v2/src/trackrat/collectors/service_alerts.py
@@ -340,11 +340,11 @@ async def upsert_service_alerts(
     """
     stats = {"inserted": 0, "updated": 0, "deactivated": 0}
 
-    # Load existing active alerts for this data source
+    # Load all existing alerts for this data source (including inactive,
+    # so we can reactivate them instead of inserting duplicates)
     result = await session.execute(
         select(ServiceAlert).where(
             ServiceAlert.data_source == data_source,
-            ServiceAlert.is_active.is_(True),
         )
     )
     existing_by_id: dict[str, ServiceAlert] = {
@@ -396,7 +396,7 @@ async def upsert_service_alerts(
 
     # Deactivate alerts no longer in the feed
     for alert_id, existing in existing_by_id.items():
-        if alert_id not in seen_ids:
+        if alert_id not in seen_ids and existing.is_active:
             existing.is_active = False
             stats["deactivated"] += 1
 

--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -53,8 +53,8 @@ REALTIME_SOURCES = {"NJT", "AMTRAK", "PATH", "LIRR", "MNR", "SUBWAY"}
 # Data sources where train_id is stable and represents the same daily service
 STABLE_TRAIN_ID_SOURCES = {"NJT", "AMTRAK", "LIRR", "MNR"}
 
-# Data sources that support service alerts (MTA systems only)
-SERVICE_ALERT_SOURCES = {"SUBWAY", "LIRR", "MNR"}
+# Data sources that support service alerts
+SERVICE_ALERT_SOURCES = {"SUBWAY", "LIRR", "MNR", "NJT"}
 
 # Build route-ID lookup once at import time
 _ROUTES_BY_ID = {route.id: route for route in ALL_ROUTES}
@@ -84,16 +84,20 @@ def _line_codes_to_gtfs_ids(data_source: str, line_codes: frozenset[str]) -> set
             gtfs_id = _MNR_LINE_CODE_TO_GTFS.get(line_code)
             if gtfs_id:
                 gtfs_ids.add(gtfs_id)
+        elif data_source == "NJT":
+            # NJT alert affected_route_ids use the same 2-letter codes
+            # as route topology line_codes (e.g., "NE", "NC", "ME")
+            gtfs_ids.add(line_code)
     return gtfs_ids
 
 
 def _get_gtfs_route_ids_for_subscription(
     sub: RouteAlertSubscription,
 ) -> set[str]:
-    """Get GTFS route_ids that an alert subscription covers.
+    """Get route IDs that an alert subscription covers.
 
-    Maps our internal route topology to the GTFS route_ids used in
-    MTA service alert feeds.
+    Maps our internal route topology to the route IDs used in
+    service alert feeds (MTA GTFS route_ids, NJT line codes).
 
     Supports both line-based subs (direct route lookup) and station-pair
     subs (finds all routes covering the segment).

--- a/backend_v2/tests/unit/collectors/test_service_alerts.py
+++ b/backend_v2/tests/unit/collectors/test_service_alerts.py
@@ -676,3 +676,56 @@ class TestNjtUpsertServiceAlerts:
             )
         )
         assert result.scalar_one().alert_id == "lmm:alert:300"
+
+    async def test_reactivates_previously_deactivated_alert(
+        self, db_session: AsyncSession
+    ):
+        """An alert that was deactivated then reappears is reactivated, not duplicated.
+
+        This is a regression test for a UniqueViolationError that occurred when
+        the upsert only loaded active alerts — a deactivated alert reappearing
+        in the feed would attempt an INSERT and hit the unique constraint.
+        """
+        alert = ParsedAlert(
+            alert_id="lmm:planned_work:reactivate-1",
+            alert_type="planned_work",
+            affected_route_ids=["G"],
+            header_text="G: Weekend service change",
+            description_text="Details",
+            active_periods=[{"start": 1710100000, "end": 1710200000}],
+        )
+
+        # Insert the alert
+        stats = await upsert_service_alerts(db_session, [alert], "SUBWAY")
+        await db_session.flush()
+        assert stats["inserted"] == 1
+
+        # Deactivate it (empty feed)
+        stats = await upsert_service_alerts(db_session, [], "SUBWAY")
+        await db_session.flush()
+        assert stats["deactivated"] == 1
+
+        # Verify it's inactive
+        result = await db_session.execute(
+            select(ServiceAlert).where(
+                ServiceAlert.alert_id == "lmm:planned_work:reactivate-1"
+            )
+        )
+        row = result.scalar_one()
+        assert row.is_active is False
+
+        # Reappear in the feed — should update (reactivate), NOT insert
+        stats = await upsert_service_alerts(db_session, [alert], "SUBWAY")
+        await db_session.flush()
+        assert stats["inserted"] == 0, "Should reactivate, not insert a duplicate"
+        assert stats["updated"] == 1
+
+        # Verify it's active again and there's only one row
+        result = await db_session.execute(
+            select(ServiceAlert).where(
+                ServiceAlert.alert_id == "lmm:planned_work:reactivate-1"
+            )
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 1, f"Expected 1 row, got {len(rows)} (duplicate inserted)"
+        assert rows[0].is_active is True

--- a/backend_v2/tests/unit/services/test_service_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_service_alert_evaluator.py
@@ -179,15 +179,36 @@ class TestGetGtfsRouteIdsForSubscription:
         result = _get_gtfs_route_ids_for_subscription(sub)
         assert result == set()
 
-    def test_non_mta_source_returns_empty(self):
-        """Non-MTA data sources return empty (no GTFS mapping for NJT/Amtrak)."""
+    def test_njt_line_maps_to_line_codes(self):
+        """NJT line IDs map to their 2-letter line codes."""
         sub = RouteAlertSubscription(
             device_id="dev1",
             data_source="NJT",
             line_id="njt-nec",
         )
         result = _get_gtfs_route_ids_for_subscription(sub)
-        # NJT line codes won't match SUBWAY/LIRR/MNR branches
+        assert "NE" in result
+
+    def test_njt_station_pair_finds_matching_routes(self):
+        """NJT station-pair subs find routes covering that segment."""
+        # NY and NP are both on the Northeast Corridor
+        sub = RouteAlertSubscription(
+            device_id="dev1",
+            data_source="NJT",
+            from_station_code="NY",
+            to_station_code="NP",
+        )
+        result = _get_gtfs_route_ids_for_subscription(sub)
+        assert "NE" in result
+
+    def test_unsupported_source_returns_empty(self):
+        """Data sources without alert support return empty."""
+        sub = RouteAlertSubscription(
+            device_id="dev1",
+            data_source="AMTRAK",
+            line_id="amtrak-nec",
+        )
+        result = _get_gtfs_route_ids_for_subscription(sub)
         assert result == set()
 
 
@@ -288,9 +309,14 @@ class TestLineCodesToGtfsIds:
         result = _line_codes_to_gtfs_ids("MNR", frozenset({"MNR-HUD"}))
         assert len(result) > 0
 
+    def test_njt_line_codes_pass_through(self):
+        """NJT line codes pass through directly (same format as alert route IDs)."""
+        result = _line_codes_to_gtfs_ids("NJT", frozenset({"NE", "NC"}))
+        assert result == {"NE", "NC"}
+
     def test_unknown_source_returns_empty(self):
-        """Non-MTA data source returns empty set."""
-        result = _line_codes_to_gtfs_ids("NJT", frozenset({"NEC"}))
+        """Unsupported data source returns empty set."""
+        result = _line_codes_to_gtfs_ids("AMTRAK", frozenset({"NEC"}))
         assert result == set()
 
     def test_empty_line_codes_returns_empty(self):
@@ -485,12 +511,67 @@ class TestEvaluateServiceAlerts:
         count = await evaluate_service_alerts(db_session, apns)
         assert count == 0
 
-    async def test_skips_non_mta_data_source(self, db_session: AsyncSession):
-        """Subscriptions for non-MTA systems are skipped even with planned work opt-in."""
+    async def test_njt_planned_work_sends_notification(self, db_session: AsyncSession):
+        """NJT planned work alert matching a subscription triggers a notification."""
         _make_subscription(
             db_session,
+            device_id="njt-dev",
+            apns_token="njt-token",
             data_source="NJT",
             line_id="njt-nec",
+            include_planned_work=True,
+        )
+        _make_service_alert(
+            db_session,
+            alert_id="njt-msg-abc123",
+            data_source="NJT",
+            alert_type="planned_work",
+            route_ids=["NE"],
+            header="NEC: Weekend track work between Newark and New York",
+        )
+        await db_session.flush()
+
+        apns = _make_apns()
+        count = await evaluate_service_alerts(db_session, apns)
+
+        assert count == 1
+        apns.send_alert_notification.assert_called_once()
+
+        call_args = apns.send_alert_notification.call_args
+        body = call_args.args[2]
+        assert "NEC: Weekend track work" in body
+
+    async def test_njt_realtime_alert_sends_notification(self, db_session: AsyncSession):
+        """NJT real-time alert (RSS) matching a subscription triggers a notification."""
+        _make_subscription(
+            db_session,
+            device_id="njt-rt-dev",
+            apns_token="njt-rt-token",
+            data_source="NJT",
+            line_id="njt-nec",
+            include_planned_work=True,
+        )
+        _make_service_alert(
+            db_session,
+            alert_id="njt-rss-999",
+            data_source="NJT",
+            alert_type="alert",
+            route_ids=["NE"],
+            header="NEC train #3837 is up to 15 min. late.",
+        )
+        await db_session.flush()
+
+        apns = _make_apns()
+        count = await evaluate_service_alerts(db_session, apns)
+
+        assert count == 1
+
+    async def test_skips_unsupported_data_source(self, db_session: AsyncSession):
+        """Subscriptions for unsupported systems are skipped even with planned work opt-in."""
+        _make_subscription(
+            db_session,
+            data_source="AMTRAK",
+            line_id="amtrak-nec",
             include_planned_work=True,
         )
         await db_session.flush()

--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -176,8 +176,8 @@ struct AlertConfigurationSection: View {
         RouteAlertSubscription.frequencyFirstSources.contains(subscription.dataSource)
     }
 
-    /// MTA systems that support planned work notifications.
-    private static let plannedWorkSystems: Set<String> = ["SUBWAY", "LIRR", "MNR"]
+    /// Systems that support planned work notifications.
+    private static let plannedWorkSystems: Set<String> = ["SUBWAY", "LIRR", "MNR", "NJT"]
 
     private var showPlannedWork: Bool {
         (subscription.lineId != nil || subscription.fromStationCode != nil)

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -895,14 +895,14 @@ final class RouteStatusViewModel: ObservableObject {
     @Published var isLoadingMap = false
     @Published var mapError: String?
 
-    // Service alerts (MTA systems only)
+    // Service alerts
     @Published var serviceAlerts: [V2ServiceAlert] = []
 
     // Upcoming trains
     @Published var upcomingTrains: [TrainV2] = []
 
     /// Data sources that have service alert data
-    private static let serviceAlertSystems: Set<String> = ["SUBWAY", "LIRR", "MNR"]
+    private static let serviceAlertSystems: Set<String> = ["SUBWAY", "LIRR", "MNR", "NJT"]
 
     // History state — keyed by system for stacked display
     @Published var historyBySystem: [String: HistoryState] = [:]


### PR DESCRIPTION
## Summary
Extends service alert functionality to support NJT (New Jersey Transit) in addition to existing MTA systems (SUBWAY, LIRR, MNR). This includes alert evaluation, subscription matching, and UI updates.

## Key Changes

**Backend Service Alert Evaluation** (`alert_evaluator.py`):
- Added "NJT" to `SERVICE_ALERT_SOURCES` constant
- Implemented NJT line code mapping in `_line_codes_to_gtfs_ids()` — NJT alert `affected_route_ids` use 2-letter codes (e.g., "NE", "NC") that pass through directly
- Updated docstrings to reflect support for non-MTA systems

**Backend Alert Persistence** (`service_alerts.py`):
- Fixed upsert logic to load all existing alerts (including inactive) instead of only active ones
- Prevents `UniqueViolationError` when a previously deactivated alert reappears in the feed — now correctly reactivates instead of attempting duplicate insert
- Only deactivates alerts that are currently active and no longer in the feed

**Backend Tests** (`test_service_alert_evaluator.py`, `test_service_alerts.py`):
- Replaced generic "non-MTA source" test with specific NJT line mapping test
- Added NJT station-pair subscription test
- Renamed "non-MTA" to "unsupported" for clarity (AMTRAK as example)
- Added NJT planned work and real-time alert integration tests
- Added regression test for alert reactivation scenario

**iOS UI** (`AlertConfigurationSection.swift`, `RouteStatusView.swift`):
- Added "NJT" to `plannedWorkSystems` set
- Added "NJT" to `serviceAlertSystems` set
- Updated comments from "MTA systems only" to "Systems that support..."

## Implementation Details
- NJT line codes in alerts match the internal route topology format, enabling direct pass-through without translation tables
- The upsert fix ensures idempotent behavior: alerts can safely be deactivated and reactivated without database constraint violations
- All changes maintain backward compatibility with existing MTA alert handling

https://claude.ai/code/session_012KcYoL6K1S5gYBMZKN1dsV