### PR TITLE
Prioritize favorite stations in search results

### DIFF
--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -118,8 +118,38 @@ struct DestinationPickerView: View {
                         
                         // Search results - take full page when searching
                         if isSearching {
+                            let favoriteCodes = Set(favoriteStations.map(\.id))
+                            let favoriteMatches = searchResults.stations.filter { station in
+                                guard let code = Stations.getStationCode(station) else { return false }
+                                return favoriteCodes.contains(code)
+                            }
+                            let otherMatches = searchResults.stations.filter { station in
+                                guard let code = Stations.getStationCode(station) else { return true }
+                                return !favoriteCodes.contains(code)
+                            }
+
                             VStack(spacing: 8) {
-                                ForEach(searchResults.stations, id: \.self) { station in
+                                // Favorite station matches first
+                                if !favoriteMatches.isEmpty {
+                                    Text("Favorites")
+                                        .font(.caption)
+                                        .foregroundColor(.white.opacity(0.5))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.horizontal, 20)
+
+                                    ForEach(favoriteMatches, id: \.self) { station in
+                                        Button {
+                                            selectDestination(station)
+                                        } label: {
+                                            destinationSearchRow(station: station)
+                                        }
+                                        .buttonStyle(.plain)
+                                        .padding(.horizontal)
+                                    }
+                                }
+
+                                // Remaining station matches
+                                ForEach(otherMatches, id: \.self) { station in
                                     Button {
                                         selectDestination(station)
                                     } label: {

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -228,13 +228,45 @@ struct TripSelectionView: View {
                     
                     // Search results
                     if isSearching {
+                        let favoriteCodes = Set(appState.favoriteStations.map(\.id))
+                        let favoriteMatches = searchResults.stations.filter { station in
+                            guard let code = Stations.getStationCode(station) else { return false }
+                            return favoriteCodes.contains(code)
+                        }
+                        let otherMatches = searchResults.stations.filter { station in
+                            guard let code = Stations.getStationCode(station) else { return true }
+                            return !favoriteCodes.contains(code)
+                        }
+
                         VStack(spacing: 8) {
                             // Train number results (support for multiple trains)
                             ForEach(searchResults.trainNumbers, id: \.self) { trainNumber in
                                 trainSearchCard(for: trainNumber)
                             }
 
-                            ForEach(searchResults.stations.prefix(5), id: \.self) { station in
+                            // Favorite station matches first
+                            if !favoriteMatches.isEmpty {
+                                Text("Favorites")
+                                    .font(.caption)
+                                    .foregroundColor(.white.opacity(0.5))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 20)
+
+                                ForEach(favoriteMatches, id: \.self) { station in
+                                    Button {
+                                        if let code = Stations.getStationCode(station) {
+                                            selectOriginStation(name: station, code: code)
+                                        }
+                                    } label: {
+                                        stationSearchRow(station: station)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .padding(.horizontal)
+                                }
+                            }
+
+                            // Remaining station matches
+                            ForEach(otherMatches.prefix(5), id: \.self) { station in
                                 Button {
                                     if let code = Stations.getStationCode(station) {
                                         selectOriginStation(name: station, code: code)


### PR DESCRIPTION
## Summary
Updated search result displays in trip selection and destination picker views to prioritize favorite stations, showing them in a dedicated "Favorites" section at the top of search results.

## Key Changes
- **TripSelectionView**: Modified station search results to separate favorite stations from other matches, displaying favorites first with a "Favorites" label
- **DestinationPickerView**: Applied the same favorite station prioritization logic to the destination search results
- Both views now filter search results into two groups:
  - Favorite stations (displayed first with a section header)
  - Other matching stations (displayed below, limited to 5 in TripSelectionView)

## Implementation Details
- Favorite stations are identified by comparing station codes against `appState.favoriteStations` (or `favoriteStations` in DestinationPickerView)
- Favorite matches are displayed with a subtle "Favorites" caption header
- The filtering logic handles edge cases where station codes may not be available
- UI styling remains consistent with existing search result presentation

https://claude.ai/code/session_01R58urywyPbVy8gTb6jHHDh