### PR TITLE
Remove beta status from subway train system

### DIFF
--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -76,10 +76,7 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
 
     /// Whether this system is in beta (shown as label in UI)
     var isBeta: Bool {
-        switch self {
-        case .subway: return true
-        default: return false
-        }
+        return false
     }
 
     /// Preferred health indicator for this system.


### PR DESCRIPTION
## Summary
Removed the beta designation from the subway train system by simplifying the `isBeta` computed property to always return `false`.

## Changes
- Simplified the `isBeta` property in `TrainSystem` enum from a switch statement that returned `true` for `.subway` to a constant `false` return value
- This removes the beta label that was previously shown in the UI for the subway system

## Details
The `isBeta` computed property previously used a switch statement to conditionally mark the subway system as beta. This change consolidates all train systems to have non-beta status by removing the special case handling.

https://claude.ai/code/session_01JNQk4cCyC1rtEJMR3mphjF