### PR TITLE
Replace frequency display with headway format in route status

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -555,10 +555,9 @@ struct RouteStatusView: View {
             HStack(spacing: 12) {
                 statCard(
                     title: "Frequency",
-                    value: formatFrequency(totalTrains: total, hours: hours),
+                    value: formatHeadway(totalTrains: total, hours: hours),
                     color: freqColor
                 )
-                statCard(title: "On Time", value: onTimeValue, color: onTimeColor)
             }
 
             if stats.cancellationRate > 0 {
@@ -637,6 +636,20 @@ struct RouteStatusView: View {
     private func formatDelay(_ minutes: Double) -> String {
         let rounded = Int(round(minutes))
         return "\(rounded)m"
+    }
+
+    /// Format as headway ("Every ~X min") for frequency-first systems.
+    /// Matches CongestionSegment.headwayDisplayText pattern.
+    private func formatHeadway(totalTrains: Int, hours: Double) -> String {
+        guard totalTrains > 0 else { return "N/A" }
+        let perHour = Double(totalTrains) / hours
+        if perHour >= 1 {
+            let minutes = Int(round(60.0 / perHour))
+            return minutes <= 1 ? "Every ~1 min" : "Every ~\(minutes) min"
+        } else {
+            let perDay = perHour * 24
+            return perDay == perDay.rounded() ? "\(Int(perDay))/day" : String(format: "%.1f/day", perDay)
+        }
     }
 
     private func formatFrequency(totalTrains: Int, hours: Double) -> String {


### PR DESCRIPTION
## Summary
Updated the RouteStatusView to display train frequency using a headway-based format ("Every ~X min") instead of the previous frequency format, and removed the "On Time" stat card from the display.

## Key Changes
- Renamed `formatFrequency()` call to `formatHeadway()` in the frequency stat card
- Removed the "On Time" stat card from the HStack display
- Added new `formatHeadway()` function that formats frequency data as:
  - "Every ~X min" for services with 1+ trains per hour
  - "X/day" for less frequent services
  - Matches the existing `CongestionSegment.headwayDisplayText` pattern for consistency

## Implementation Details
- The `formatHeadway()` function calculates minutes between trains (60 / trains per hour)
- For infrequent services (< 1 train/hour), it converts to daily frequency
- Handles edge cases like single-minute headways and rounding for display
- The old `formatFrequency()` function remains in the codebase but is no longer used in this view

https://claude.ai/code/session_01XJHbgYoeeFTroMAm4XScDf