### PR TITLE
Add section labels to alert configuration UI

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -334,6 +334,9 @@ struct AlertConfigurationSection: View {
                 .font(.headline)
 
                 // Day selection (top — controls subscribe/unsubscribe)
+                Text("Send me notifications...")
+                    .font(.subheadline)
+                    .foregroundColor(.white.opacity(0.6))
                 dayPresetRow
 
                 if isCustomDays || showCustomDays {
@@ -343,6 +346,9 @@ struct AlertConfigurationSection: View {
 
                 if hasDaysSelected {
                     // Time window presets
+                    Text("At...")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.6))
                     timePresetRow
 
                     if activeTimePreset == .custom || showCustomTime {
@@ -353,6 +359,9 @@ struct AlertConfigurationSection: View {
                     Divider().opacity(0.3)
 
                     // Alert types
+                    Text("When there are...")
+                        .font(.subheadline)
+                        .foregroundColor(.white.opacity(0.6))
                     sensitivityRow(label: "Cancellations", sensitivity: cancellationSensitivity)
                     sensitivityRow(
                         label: isFrequencyBased ? "Fewer Trains" : "Delays",


### PR DESCRIPTION
## Summary
Added descriptive section labels to the AlertConfigurationSection to improve UI clarity and guide users through the notification configuration process.

## Key Changes
- Added "Send me notifications..." label above the day selection preset row
- Added "At..." label above the time window preset row
- Added "When there are..." label above the alert type sensitivity options
- All labels use `.subheadline` font with 60% white opacity for visual hierarchy

## Implementation Details
The labels are positioned as section headers within the existing conditional layout structure, appearing immediately before their corresponding configuration controls. This provides better visual organization and helps users understand the purpose of each configuration section without requiring additional documentation.

https://claude.ai/code/session_01WUZqt8haS13A3ZpodQ92mL