### PR TITLE
Simplify train details action buttons and update labels

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -100,32 +100,7 @@ struct TrainDetailsView: View {
             // Action buttons row
             if let train = viewModel.train {
                 HStack(spacing: 12) {
-                    // Alerts button
-                    if let fromCode = appState.departureStationCode,
-                       let toCode = appState.destinationStationCode {
-                        Button {
-                            appState.pendingRouteStatus = RouteStatusContext(
-                                dataSource: train.dataSource,
-                                lineId: train.line.code,
-                                fromStationCode: fromCode,
-                                toStationCode: toCode
-                            )
-                        } label: {
-                            HStack(spacing: 6) {
-                                Image(systemName: "bell.badge")
-                                    .font(.subheadline)
-                                Text("Alerts")
-                                    .font(.subheadline)
-                            }
-                            .foregroundColor(.white.opacity(0.8))
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 8)
-                            .background(Capsule().fill(Color.white.opacity(0.12)))
-                        }
-                        .buttonStyle(.plain)
-                    }
-
-                    // Watch button (Live Activity)
+                    // Get Updates button (Live Activity)
                     if let originCode = appState.departureStationCode,
                        !originCode.isEmpty {
                         TrackTrainInlineButton(
@@ -134,8 +109,8 @@ struct TrainDetailsView: View {
                             destinationCode: appState.destinationStationCode ?? "",
                             destinationName: appState.selectedDestination,
                             textColor: .white.opacity(0.8),
-                            activeLabel: "Unwatch",
-                            inactiveLabel: "Watch",
+                            activeLabel: "Stop Updates",
+                            inactiveLabel: "Get Updates",
                             font: .subheadline
                         )
                         .padding(.horizontal, 14)


### PR DESCRIPTION
## Summary
Removed the "Alerts" button from the TrainDetailsView and updated the "Watch" button labels to better reflect the Live Activity functionality.

## Key Changes
- Removed the "Alerts" button that was conditionally displayed when both departure and destination station codes were available
- Renamed "Watch"/"Unwatch" button labels to "Get Updates"/"Stop Updates" for clearer user intent
- Updated the button comment from "Watch button (Live Activity)" to "Get Updates button (Live Activity)"
- Simplified the action buttons row by removing the conditional alerts button logic

## Implementation Details
The changes streamline the UI by consolidating functionality into a single "Get Updates" button that manages Live Activity subscriptions. The new label terminology better communicates to users that they are subscribing to real-time updates rather than simply "watching" a train.

https://claude.ai/code/session_01XR7zZVSidDPpu5DxCznwhC