### PR TITLE
Add Route Alerts button to TrainDetailsView

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -100,6 +100,35 @@ struct TrainDetailsView: View {
             // Action buttons row
             if let train = viewModel.train {
                 HStack(spacing: 12) {
+                    // Route alerts button
+                    if let destCode = appState.destinationStationCode,
+                       !destCode.isEmpty,
+                       let originCode = appState.departureStationCode,
+                       !originCode.isEmpty {
+                        Button {
+                            let ds = train.dataSource
+                            let lineId: String? = ds == "SUBWAY" ? nil : RouteTopology.routeContaining(from: originCode, to: destCode, dataSource: ds)?.id
+                            appState.pendingRouteStatus = RouteStatusContext(
+                                dataSource: ds,
+                                lineId: lineId,
+                                fromStationCode: originCode,
+                                toStationCode: destCode
+                            )
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "bell.badge")
+                                    .font(.subheadline)
+                                Text("Route Alerts")
+                                    .font(.subheadline)
+                            }
+                            .foregroundColor(.white.opacity(0.8))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(Capsule().fill(Color.white.opacity(0.12)))
+                        }
+                        .buttonStyle(.plain)
+                    }
+
                     // Get Updates button (Live Activity)
                     if let originCode = appState.departureStationCode,
                        !originCode.isEmpty {

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -112,7 +112,7 @@ struct TrainListView: View {
                         HStack(spacing: 6) {
                             Image(systemName: "bell.badge")
                                 .font(.subheadline)
-                            Text("Alerts")
+                            Text("Route Alerts")
                                 .font(.subheadline)
                         }
                         .foregroundColor(.white.opacity(0.8))


### PR DESCRIPTION
## Summary
Added a "Route Alerts" button to the TrainDetailsView that allows users to set up alerts for a specific route between their departure and destination stations. Also updated the button label in TrainListView for consistency.

## Key Changes
- **TrainDetailsView**: Added a new "Route Alerts" button in the action buttons row that:
  - Only displays when both departure and destination station codes are available
  - Creates a `RouteStatusContext` with the current train's data source, route line ID (if applicable), and station codes
  - Sets `appState.pendingRouteStatus` to trigger route alert configuration
  - Uses a capsule-styled button with bell.badge icon matching the existing UI design
  - Excludes line ID for SUBWAY data source (set to nil)

- **TrainListView**: Updated button label from "Alerts" to "Route Alerts" for consistency across the app

## Implementation Details
- The Route Alerts button is conditionally rendered only when both `destinationStationCode` and `departureStationCode` are present and non-empty
- For non-SUBWAY routes, the button determines the appropriate line ID using `RouteTopology.routeContaining()`
- Button styling matches existing UI patterns with white text at 80% opacity and a semi-transparent white capsule background
- The button uses `.plain` button style to maintain custom styling

https://claude.ai/code/session_017JsnUF87xL7c934vaV1u8X