### PR TITLE
Add "Report an Issue" button to Settings screen

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -144,6 +144,7 @@ struct SettingsSection: View {
     @State private var showAddRouteAlert = false
     @State private var selectedSubscription: RouteAlertSubscription?
     @ObservedObject private var alertService = AlertSubscriptionService.shared
+    @State private var showingFeedbackSheet = false
 
     private enum FavoriteStationRole {
         case home, work, other
@@ -520,6 +521,41 @@ struct SettingsSection: View {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(.ultraThinMaterial)
             )
+
+            // Report an Issue
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                showingFeedbackSheet = true
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "exclamationmark.bubble")
+                        .font(.title2)
+                        .foregroundColor(.orange)
+                        .frame(width: 24, height: 24)
+
+                    Text("Report an Issue")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+
+                    Spacer()
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(.ultraThinMaterial)
+                )
+            }
+            .buttonStyle(.plain)
+            .sheet(isPresented: $showingFeedbackSheet) {
+                FeedbackSheet(
+                    screen: "settings",
+                    trainId: nil,
+                    originCode: nil,
+                    destinationCode: nil
+                )
+            }
 
             // YouTube & Instagram
             HStack(spacing: 12) {


### PR DESCRIPTION
## Summary
Added a new "Report an Issue" button to the Settings screen that allows users to submit feedback about problems they encounter in the app.

## Key Changes
- Added `showingFeedbackSheet` state variable to track the feedback sheet presentation state
- Implemented a new "Report an Issue" button with:
  - Orange exclamation mark bubble icon
  - Haptic feedback (light impact) on tap
  - Consistent styling matching other settings buttons (rounded rectangle with ultra-thin material background)
  - Sheet presentation that opens the `FeedbackSheet` component
- The feedback sheet is initialized with the "settings" screen context and nil values for train/route-specific data

## Implementation Details
- Button uses `.plain` button style to maintain custom styling
- Haptic feedback provides tactile confirmation of user interaction
- The `FeedbackSheet` is configured for general settings feedback without specific transit route context

https://claude.ai/code/session_01B8LXBtRKekNT8PCc3xbLEd