### PR TITLE
Fix migration revision IDs and dependency chain

### DIFF
--- a/backend_v2/src/trackrat/db/migrations/versions/20260314_1200-b8c9d0e1f2a3_add_on_delete_cascade_to_fks.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260314_1200-b8c9d0e1f2a3_add_on_delete_cascade_to_fks.py
@@ -1,7 +1,7 @@
 """add_on_delete_cascade_to_fks
 
 Revision ID: b8c9d0e1f2a3
-Revises: f7a8b9c0d1e2
+Revises: e6f7a8b9c0d1
 Create Date: 2026-03-14 12:00:00.000000
 
 """

--- a/backend_v2/src/trackrat/db/migrations/versions/20260319_1400-b8ca879ae8c5_add_segment_baseline_index.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260319_1400-b8ca879ae8c5_add_segment_baseline_index.py
@@ -5,7 +5,7 @@ data_source, from_station_code, hour_of_day, and departure_time. The existing
 idx_segment_lookup does not cover hour_of_day, forcing sequential scans on
 large tables. This index accelerates those queries.
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: b8ca879ae8c5
 Revises: f9a8b7c6d5e4
 Create Date: 2026-03-19T14:00:00Z
 
@@ -14,7 +14,7 @@ Create Date: 2026-03-19T14:00:00Z
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "b8ca879ae8c5"
 down_revision = "f9a8b7c6d5e4"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
This PR corrects migration revision identifiers and updates the dependency chain in the database migrations to ensure proper sequencing and consistency.

## Key Changes
- Updated the segment baseline index migration revision ID from `a1b2c3d4e5f6` to `b8ca879ae8c5` to match the actual filename and maintain consistency
- Fixed the `Revises` reference in the cascade foreign keys migration from `f7a8b9c0d1e2` to `e6f7a8b9c0d1` to correct the migration dependency chain

## Details
These changes ensure that:
1. Migration revision identifiers are consistent with their filenames
2. The migration dependency chain is properly ordered and references the correct parent migrations
3. Alembic can correctly track and apply migrations in the proper sequence

https://claude.ai/code/session_013S7YDnCL9Y5vyzewDis8rg