### PR TITLE
Improve alert configuration section layout and labeling

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -373,15 +373,16 @@ struct AlertConfigurationSection: View {
                         .tint(.orange)
                     }
 
-                    // Recovery (only when at least one alert type is active)
+                    // Recovery & daily summary
                     if subscription.notifyCancellation || subscription.notifyDelay {
+                        Text("Also...")
+                            .font(.subheadline)
+                            .foregroundColor(.white.opacity(0.6))
                         Toggle(isOn: $subscription.notifyRecovery) {
                             Text("Notify on Recovery")
                         }
                         .tint(.orange)
                     }
-
-                    Divider().opacity(0.3)
 
                     // Daily status summary
                     Toggle(isOn: digestEnabled) {


### PR DESCRIPTION
## Summary
Enhanced the alert configuration UI by improving the visual hierarchy and organization of notification settings, particularly around recovery and daily summary options.

## Key Changes
- Added a subheading label ("Also...") above the recovery notification toggle to better organize related settings
- Removed the divider that previously separated recovery and daily summary sections for a cleaner, more cohesive layout
- Updated the section comment to reflect that both recovery and daily summary options are grouped together

## Implementation Details
- The "Also..." subheading uses `.subheadline` font styling with reduced opacity (0.6) to create visual hierarchy without being too prominent
- The recovery toggle now only appears when at least one alert type (cancellation or delay) is active, maintaining the existing conditional logic
- The removal of the divider creates a tighter visual grouping between the recovery and daily summary toggles, suggesting they are related options

https://claude.ai/code/session_017gfoYrPo8binBaNbwmdfE1