### PR TITLE
Clip route station codes to from/to segment when specified

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -595,6 +595,14 @@ struct RouteStatusContext: Identifiable, Equatable {
     var stationCodes: [String] {
         if let lineId = lineId,
            let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
+            // When from/to are specified, clip to just that segment of the route
+            if let from = fromStationCode, let to = toStationCode,
+               let fromIdx = route.stationCodes.firstIndex(of: from),
+               let toIdx = route.stationCodes.firstIndex(of: to) {
+                let lower = min(fromIdx, toIdx)
+                let upper = max(fromIdx, toIdx)
+                return Array(route.stationCodes[lower...upper])
+            }
             return route.stationCodes
         }
         if let from = fromStationCode, let to = toStationCode {


### PR DESCRIPTION
## Summary
Updated the `stationCodes` computed property in `RouteStatusContext` to return only the relevant segment of a route when both `fromStationCode` and `toStationCode` are specified.

## Key Changes
- Added logic to detect when both `from` and `to` station codes are present on a valid route
- Clips the returned station codes array to only include stations between the from and to stations (inclusive)
- Handles bidirectional routes by using `min`/`max` to determine the correct segment regardless of direction
- Maintains backward compatibility by falling back to the full route station codes when from/to are not specified

## Implementation Details
- The clipping logic uses `firstIndex(of:)` to locate the from and to stations within the route
- Array slicing (`route.stationCodes[lower...upper]`) is used to extract the segment, then converted back to an Array
- This optimization reduces the number of stations processed when working with a specific route segment

https://claude.ai/code/session_01Tt5XnD3vkwtFzqb9MQMjGX