### PR TITLE
Remove Newark PATH station from station data

### DIFF
--- a/ios/TrackRat/Shared/StationData.swift
+++ b/ios/TrackRat/Shared/StationData.swift
@@ -74,7 +74,7 @@ extension Stations {
         "Avenel", "Jersey Avenue",
 
         // PATH Stations
-        "Newark PATH", "Harrison PATH", "Journal Square",
+        "Harrison PATH", "Journal Square",
         "Grove Street", "Exchange Place", "Newport",
         "Hoboken PATH", "Christopher Street", "9th Street",
         "14th Street", "23rd Street", "33rd Street",

--- a/ios/TrackRat/Shared/StationDepartures.swift
+++ b/ios/TrackRat/Shared/StationDepartures.swift
@@ -11,7 +11,6 @@ extension Stations {
         ("World Trade Center", "PWC"),
         ("33rd Street", "P33"),
         ("Journal Square", "PJS"),
-        ("Newark PATH", "PNK"),
         ("Metropark", "MP"),
         ("Princeton Junction", "PJ"),
         ("Hamilton", "HL"),

--- a/webpage_v2/src/data/stations.ts
+++ b/webpage_v2/src/data/stations.ts
@@ -279,7 +279,6 @@ export const STATIONS = ([
 
 
   // PATH
-  { code: 'PNK', name: 'Newark PATH', system: 'PATH' },
   { code: 'PHR', name: 'Harrison PATH', system: 'PATH' },
   { code: 'PJS', name: 'Journal Square', system: 'PATH' },
   { code: 'PGR', name: 'Grove Street', system: 'PATH' },
@@ -1045,7 +1044,7 @@ export const STATIONS = ([
 export const PRIMARY_STATIONS: Record<TransitSystem, string[]> = {
   NJT: ['NY', 'NP', 'HB', 'SE', 'MP', 'PJ', 'HL', 'TR', 'LB', 'PF', 'DN', 'RA'],
   AMTRAK: ['NY', 'PH', 'WI', 'BL', 'WS', 'BOS', 'RVR', 'CLT', 'RGH', 'ATL'],
-  PATH: ['PNK', 'PHO', 'PWC', 'PJS', 'P33', 'PGR', 'PEX', 'PNP'],
+  PATH: ['NP', 'PHO', 'PWC', 'PJS', 'P33', 'PGR', 'PEX', 'PNP'],
   PATCO: ['LND', 'FFL', 'CTH', 'HDF'],
   LIRR: ['JAM', 'GCT', 'LAT', 'BTA', 'LHUN', 'RON', 'PJN', 'LBH', 'PWS', 'LHVL'],
   MNR: ['GCT', 'M125', 'MWPL', 'MCRH', 'MPOK', 'MBRS', 'MSTM', 'MNHV'],


### PR DESCRIPTION
## Summary
This PR removes the Newark PATH station (code: PNK) from the station database across all platforms. The station is being replaced with the existing Newark station (code: NP) in the primary stations list for the PATH system.

## Key Changes
- Removed Newark PATH station entry from the TypeScript stations data file
- Updated PATH system's primary stations list to use 'NP' (Newark) instead of 'PNK' (Newark PATH)
- Removed "Newark PATH" from the iOS station names list
- Removed the Newark PATH station mapping from iOS station departures data

## Implementation Details
The changes maintain consistency across the web and iOS codebases by removing all references to the PNK station code while preserving the Newark station (NP) as the primary PATH station for that location. This consolidation simplifies the station database and eliminates duplicate entries for the same physical location.

https://claude.ai/code/session_01XWxH9ef6QmQq4V7cvBCF5g