### PR TITLE
Upgrade default VM machine type from t2d-standard-1 to t2d-standard-2

### DIFF
--- a/infra_v2/README.md
+++ b/infra_v2/README.md
@@ -120,7 +120,7 @@ gcloud builds submit --config=cloudbuild.yaml .
 | `project_id` | trackrat-v2 | GCP project |
 | `region` | us-east4 | GCP region |
 | `zone` | us-east4-a | GCP zone |
-| `machine_type` | t2d-standard-1 | VM machine type |
+| `machine_type` | t2d-standard-2 | VM machine type |
 | `disk_size_gb` | 10 | Persistent disk size |
 | `snapshot_retention_days` | 35 | Snapshot retention period |
 

--- a/infra_v2/terraform/variables.tf
+++ b/infra_v2/terraform/variables.tf
@@ -36,7 +36,7 @@ variable "domain" {
 variable "machine_type" {
   description = "GCE machine type"
   type        = string
-  default     = "t2d-standard-1"
+  default     = "t2d-standard-2"
 }
 
 variable "disk_size_gb" {


### PR DESCRIPTION
## Summary
This PR upgrades the default GCP Compute Engine machine type from `t2d-standard-1` to `t2d-standard-2` to provide improved performance and resource capacity for the infrastructure.

## Changes
- Updated default `machine_type` variable from `t2d-standard-1` to `t2d-standard-2` in `infra_v2/terraform/variables.tf`
- Updated corresponding documentation in `infra_v2/README.md` to reflect the new default machine type

## Details
The machine type change upgrades from a single vCPU configuration to a dual vCPU configuration, providing better performance for workloads while maintaining the same machine family (t2d - AMD-based). This change affects the default infrastructure deployment unless explicitly overridden during Terraform apply.

https://claude.ai/code/session_01HHTi2WSwFWQ7foQC3yfshb