### PR TITLE
Preserve notification state during subscription sync

### DIFF
--- a/backend_v2/src/trackrat/api/alerts.py
+++ b/backend_v2/src/trackrat/api/alerts.py
@@ -6,6 +6,8 @@ alert subscriptions for delay/cancellation events, and query
 active MTA service alerts (planned work, delays).
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, model_validator
 from sqlalchemy import ColumnElement, delete, select
@@ -112,6 +114,44 @@ class GetSubscriptionsResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _subscription_identity(
+    row: RouteAlertSubscription,
+) -> tuple[Any, ...]:
+    """Return a hashable key uniquely identifying a subscription's logical target.
+
+    Three mutually exclusive subscription types:
+    - Line-based: (data_source, line_id, direction)
+    - Station-pair: (data_source, from_station_code, to_station_code)
+    - Train-specific: (data_source, train_id)
+    """
+    if row.train_id:
+        return ("train", row.data_source, row.train_id)
+    if row.from_station_code and row.to_station_code:
+        return ("stations", row.data_source, row.from_station_code, row.to_station_code)
+    return ("line", row.data_source, row.line_id, row.direction)
+
+
+def _subscription_identity_from_item(
+    device_id: str, item: SubscriptionItem
+) -> tuple[Any, ...]:
+    """Same identity key as ``_subscription_identity`` but from request data."""
+    if item.train_id:
+        return ("train", item.data_source, item.train_id)
+    if item.from_station_code and item.to_station_code:
+        return (
+            "stations",
+            item.data_source,
+            item.from_station_code,
+            item.to_station_code,
+        )
+    return ("line", item.data_source, item.line_id, item.direction)
+
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -145,13 +185,35 @@ async def register_device(
 async def sync_subscriptions(
     request: SyncSubscriptionsRequest, db: AsyncSession = Depends(get_db)
 ) -> SyncSubscriptionsResponse:
-    """Full-replace all alert subscriptions for a device."""
+    """Full-replace all alert subscriptions for a device.
+
+    Preserves server-side notification state (last_alerted_at, last_alert_hash,
+    last_digest_at, last_service_alert_ids) when a subscription's logical
+    identity matches an existing row, preventing duplicate notifications on
+    re-sync.
+    """
     # Verify device exists
     existing = await db.execute(
         select(DeviceToken).where(DeviceToken.device_id == request.device_id)
     )
     if not existing.scalar_one_or_none():
         raise HTTPException(status_code=404, detail="Device not registered")
+
+    # Read existing subscriptions and build state map keyed by logical identity
+    old_rows = await db.execute(
+        select(RouteAlertSubscription).where(
+            RouteAlertSubscription.device_id == request.device_id
+        )
+    )
+    state_map: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for row in old_rows.scalars():
+        key = _subscription_identity(row)
+        state_map[key] = {
+            "last_alerted_at": row.last_alerted_at,
+            "last_alert_hash": row.last_alert_hash,
+            "last_digest_at": row.last_digest_at,
+            "last_service_alert_ids": row.last_service_alert_ids,
+        }
 
     # Delete existing subscriptions
     await db.execute(
@@ -160,7 +222,7 @@ async def sync_subscriptions(
         )
     )
 
-    # Insert new subscriptions
+    # Insert new subscriptions, restoring state for matching identities
     for item in request.subscriptions:
         sub = RouteAlertSubscription(
             device_id=request.device_id,
@@ -183,6 +245,13 @@ async def sync_subscriptions(
             digest_time_minutes=item.digest_time_minutes,
             include_planned_work=item.include_planned_work,
         )
+        key = _subscription_identity(sub)
+        preserved = state_map.get(key)
+        if preserved:
+            sub.last_alerted_at = preserved["last_alerted_at"]
+            sub.last_alert_hash = preserved["last_alert_hash"]
+            sub.last_digest_at = preserved["last_digest_at"]
+            sub.last_service_alert_ids = preserved["last_service_alert_ids"]
         db.add(sub)
 
     await db.commit()
@@ -191,6 +260,11 @@ async def sync_subscriptions(
         "subscriptions_synced",
         device_id=request.device_id,
         count=len(request.subscriptions),
+        preserved=sum(
+            1
+            for item in request.subscriptions
+            if _subscription_identity_from_item(request.device_id, item) in state_map
+        ),
     )
     return SyncSubscriptionsResponse(count=len(request.subscriptions))
 

--- a/backend_v2/tests/unit/api/test_alerts.py
+++ b/backend_v2/tests/unit/api/test_alerts.py
@@ -4,8 +4,17 @@ Tests for the route alert subscription API endpoints.
 Uses the e2e_client fixture for real database integration.
 """
 
-import pytest
+from datetime import UTC, datetime
+
+from sqlalchemy import select
 from starlette.testclient import TestClient
+
+from trackrat.api.alerts import (
+    SubscriptionItem,
+    _subscription_identity,
+    _subscription_identity_from_item,
+)
+from trackrat.models.database import RouteAlertSubscription
 
 
 class TestDeviceRegistration:
@@ -685,7 +694,7 @@ class TestCancellationThreshold:
         # All: 90%
         assert by_line["subway-L"]["notify_cancellation"] is True
         assert by_line["subway-L"]["cancellation_threshold_pct"] == 90
-        print(f"  All three sensitivity levels verified")
+        print("  All three sensitivity levels verified")
 
 
 class TestServiceAlertsEndpoint:
@@ -810,3 +819,417 @@ class TestNotifyTypeToggleSubscriptions:
         assert subs[0]["notify_cancellation"] is True
         assert subs[0]["notify_delay"] is False
         print("  Verified: mixed toggle values round-trip independently")
+
+
+class TestSubscriptionIdentityHelpers:
+    """Unit tests for _subscription_identity and _subscription_identity_from_item."""
+
+    def test_line_identity(self):
+        """Line-based subscription identity uses data_source, line_id, direction."""
+        row = RouteAlertSubscription(
+            device_id="d1",
+            data_source="NJT",
+            line_id="njt-nec",
+            direction="TR",
+        )
+        assert _subscription_identity(row) == ("line", "NJT", "njt-nec", "TR")
+
+    def test_station_pair_identity(self):
+        """Station-pair subscription identity uses data_source + station codes."""
+        row = RouteAlertSubscription(
+            device_id="d1",
+            data_source="NJT",
+            from_station_code="NY",
+            to_station_code="TR",
+        )
+        assert _subscription_identity(row) == ("stations", "NJT", "NY", "TR")
+
+    def test_train_identity(self):
+        """Train-specific subscription identity uses data_source + train_id."""
+        row = RouteAlertSubscription(
+            device_id="d1",
+            data_source="NJT",
+            train_id="3254",
+        )
+        assert _subscription_identity(row) == ("train", "NJT", "3254")
+
+    def test_item_matches_row_identity(self):
+        """_subscription_identity_from_item produces the same key as _subscription_identity."""
+        cases = [
+            (
+                {"data_source": "NJT", "line_id": "njt-nec", "direction": "TR"},
+                RouteAlertSubscription(
+                    device_id="d1",
+                    data_source="NJT",
+                    line_id="njt-nec",
+                    direction="TR",
+                ),
+            ),
+            (
+                {
+                    "data_source": "NJT",
+                    "from_station_code": "NY",
+                    "to_station_code": "TR",
+                },
+                RouteAlertSubscription(
+                    device_id="d1",
+                    data_source="NJT",
+                    from_station_code="NY",
+                    to_station_code="TR",
+                ),
+            ),
+            (
+                {"data_source": "NJT", "train_id": "3254"},
+                RouteAlertSubscription(
+                    device_id="d1", data_source="NJT", train_id="3254"
+                ),
+            ),
+        ]
+        for item_kwargs, row in cases:
+            item = SubscriptionItem(**item_kwargs)
+            item_key = _subscription_identity_from_item("d1", item)
+            row_key = _subscription_identity(row)
+            assert item_key == row_key, (
+                f"Mismatch for {item_kwargs}: item={item_key}, row={row_key}"
+            )
+            print(f"  Matched: {row_key}")
+
+    def test_line_null_direction_identity(self):
+        """Line subscription with direction=None has distinct identity from direction='TR'."""
+        row_null = RouteAlertSubscription(
+            device_id="d1", data_source="NJT", line_id="njt-nec", direction=None
+        )
+        row_tr = RouteAlertSubscription(
+            device_id="d1", data_source="NJT", line_id="njt-nec", direction="TR"
+        )
+        assert _subscription_identity(row_null) != _subscription_identity(row_tr)
+        print(
+            f"  null={_subscription_identity(row_null)}, TR={_subscription_identity(row_tr)}"
+        )
+
+
+class TestSyncPreservesNotificationState:
+    """Verify that re-syncing subscriptions preserves server-side dedup state.
+
+    This is the core regression test for the duplicate notification bug:
+    the old delete-all-then-recreate pattern wiped last_alerted_at,
+    last_alert_hash, last_digest_at, and last_service_alert_ids on every sync.
+    """
+
+    def _set_state_on_subscriptions(
+        self, sync_session, device_id: str
+    ) -> dict[str, dict]:
+        """Directly set notification state columns on DB rows.
+
+        Returns a map of line_id/train_id -> state dict for later assertion.
+        """
+        rows = (
+            sync_session.execute(
+                select(RouteAlertSubscription).where(
+                    RouteAlertSubscription.device_id == device_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+        state_by_key = {}
+        now = datetime.now(UTC)
+        for i, row in enumerate(rows):
+            state = {
+                "last_alerted_at": now,
+                "last_alert_hash": f"hash-{i}",
+                "last_digest_at": now,
+                "last_service_alert_ids": [f"alert-{i}-a", f"alert-{i}-b"],
+            }
+            row.last_alerted_at = state["last_alerted_at"]
+            row.last_alert_hash = state["last_alert_hash"]
+            row.last_digest_at = state["last_digest_at"]
+            row.last_service_alert_ids = state["last_service_alert_ids"]
+            # Key by whichever identity field is set
+            key = row.line_id or row.train_id or f"{row.from_station_code}-{row.to_station_code}"
+            state_by_key[key] = state
+        sync_session.commit()
+        return state_by_key
+
+    def _get_state_from_db(self, sync_session, device_id: str) -> dict[str, dict]:
+        """Read notification state columns from DB rows after a sync."""
+        rows = (
+            sync_session.execute(
+                select(RouteAlertSubscription).where(
+                    RouteAlertSubscription.device_id == device_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+        result = {}
+        for row in rows:
+            key = row.line_id or row.train_id or f"{row.from_station_code}-{row.to_station_code}"
+            result[key] = {
+                "last_alerted_at": row.last_alerted_at,
+                "last_alert_hash": row.last_alert_hash,
+                "last_digest_at": row.last_digest_at,
+                "last_service_alert_ids": row.last_service_alert_ids,
+            }
+        return result
+
+    def test_resync_identical_line_subs_preserves_state(
+        self, e2e_client: TestClient, sync_session
+    ):
+        """Re-syncing the same line subscriptions preserves all four state columns."""
+        device_id = "dev-state-line"
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": device_id, "apns_token": "tok-state-line"},
+        )
+
+        subs_payload = [
+            {"data_source": "NJT", "line_id": "njt-nec", "direction": "TR"},
+            {"data_source": "SUBWAY", "line_id": "subway-G"},
+        ]
+
+        # Initial sync
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={"device_id": device_id, "subscriptions": subs_payload},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 2
+
+        # Set notification state directly in DB
+        original_state = self._set_state_on_subscriptions(sync_session, device_id)
+        print(f"  Set state on {len(original_state)} subscriptions")
+        assert len(original_state) == 2
+
+        # Re-sync with identical subscriptions (simulates app launch)
+        resp2 = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={"device_id": device_id, "subscriptions": subs_payload},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["count"] == 2
+
+        # Verify state was preserved
+        sync_session.expire_all()
+        after_state = self._get_state_from_db(sync_session, device_id)
+        for key, orig in original_state.items():
+            after = after_state[key]
+            assert after["last_alerted_at"] is not None, (
+                f"{key}: last_alerted_at was wiped"
+            )
+            assert after["last_alert_hash"] == orig["last_alert_hash"], (
+                f"{key}: last_alert_hash was wiped"
+            )
+            assert after["last_digest_at"] is not None, (
+                f"{key}: last_digest_at was wiped"
+            )
+            assert after["last_service_alert_ids"] == orig["last_service_alert_ids"], (
+                f"{key}: last_service_alert_ids was wiped"
+            )
+            print(f"  {key}: all state columns preserved")
+
+    def test_resync_identical_station_pair_preserves_state(
+        self, e2e_client: TestClient, sync_session
+    ):
+        """Re-syncing station-pair subscriptions preserves state."""
+        device_id = "dev-state-stn"
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": device_id, "apns_token": "tok-state-stn"},
+        )
+
+        subs_payload = [
+            {"data_source": "NJT", "from_station_code": "NY", "to_station_code": "TR"},
+        ]
+
+        e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={"device_id": device_id, "subscriptions": subs_payload},
+        )
+        original_state = self._set_state_on_subscriptions(sync_session, device_id)
+
+        # Re-sync
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={"device_id": device_id, "subscriptions": subs_payload},
+        )
+        assert resp.status_code == 200
+
+        sync_session.expire_all()
+        after_state = self._get_state_from_db(sync_session, device_id)
+        key = "NY-TR"
+        assert after_state[key]["last_alert_hash"] == original_state[key]["last_alert_hash"]
+        assert after_state[key]["last_service_alert_ids"] == original_state[key]["last_service_alert_ids"]
+        print(f"  Station-pair state preserved: {key}")
+
+    def test_resync_identical_train_sub_preserves_state(
+        self, e2e_client: TestClient, sync_session
+    ):
+        """Re-syncing train subscriptions preserves state."""
+        device_id = "dev-state-train"
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": device_id, "apns_token": "tok-state-train"},
+        )
+
+        subs_payload = [
+            {"data_source": "NJT", "train_id": "3254", "active_days": 31},
+        ]
+
+        e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={"device_id": device_id, "subscriptions": subs_payload},
+        )
+        original_state = self._set_state_on_subscriptions(sync_session, device_id)
+
+        # Re-sync
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={"device_id": device_id, "subscriptions": subs_payload},
+        )
+        assert resp.status_code == 200
+
+        sync_session.expire_all()
+        after_state = self._get_state_from_db(sync_session, device_id)
+        assert after_state["3254"]["last_alert_hash"] == original_state["3254"]["last_alert_hash"]
+        assert after_state["3254"]["last_service_alert_ids"] == original_state["3254"]["last_service_alert_ids"]
+        print("  Train subscription state preserved")
+
+    def test_new_subscription_gets_null_state(
+        self, e2e_client: TestClient, sync_session
+    ):
+        """A genuinely new subscription added during sync starts with NULL state."""
+        device_id = "dev-state-new"
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": device_id, "apns_token": "tok-state-new"},
+        )
+
+        # Initial sync with one sub
+        e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": device_id,
+                "subscriptions": [
+                    {"data_source": "NJT", "line_id": "njt-nec"},
+                ],
+            },
+        )
+        self._set_state_on_subscriptions(sync_session, device_id)
+
+        # Re-sync with original + one new subscription
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": device_id,
+                "subscriptions": [
+                    {"data_source": "NJT", "line_id": "njt-nec"},
+                    {"data_source": "SUBWAY", "line_id": "subway-G"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+
+        sync_session.expire_all()
+        after_state = self._get_state_from_db(sync_session, device_id)
+
+        # Existing sub should have preserved state
+        assert after_state["njt-nec"]["last_alert_hash"] is not None
+        print("  Existing sub preserved state")
+
+        # New sub should have NULL state
+        assert after_state["subway-G"]["last_alerted_at"] is None
+        assert after_state["subway-G"]["last_alert_hash"] is None
+        assert after_state["subway-G"]["last_digest_at"] is None
+        assert after_state["subway-G"]["last_service_alert_ids"] is None
+        print("  New sub has NULL state (correct)")
+
+    def test_removed_subscription_state_not_carried_to_different_sub(
+        self, e2e_client: TestClient, sync_session
+    ):
+        """Removing a subscription and adding a different one doesn't leak state."""
+        device_id = "dev-state-remove"
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": device_id, "apns_token": "tok-state-remove"},
+        )
+
+        # Initial sync
+        e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": device_id,
+                "subscriptions": [
+                    {"data_source": "NJT", "line_id": "njt-nec"},
+                ],
+            },
+        )
+        self._set_state_on_subscriptions(sync_session, device_id)
+
+        # Re-sync replacing the sub entirely
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": device_id,
+                "subscriptions": [
+                    {"data_source": "SUBWAY", "line_id": "subway-G"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+
+        sync_session.expire_all()
+        after_state = self._get_state_from_db(sync_session, device_id)
+        assert "njt-nec" not in after_state, "Old subscription should be gone"
+        assert after_state["subway-G"]["last_alert_hash"] is None, (
+            "New subscription should not inherit old state"
+        )
+        print("  No state leakage between different subscriptions")
+
+    def test_config_change_preserves_state(
+        self, e2e_client: TestClient, sync_session
+    ):
+        """Changing config fields (e.g. delay_threshold) preserves notification state."""
+        device_id = "dev-state-cfg"
+        e2e_client.post(
+            "/api/v2/devices/register",
+            json={"device_id": device_id, "apns_token": "tok-state-cfg"},
+        )
+
+        # Initial sync
+        e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": device_id,
+                "subscriptions": [
+                    {
+                        "data_source": "NJT",
+                        "line_id": "njt-nec",
+                        "delay_threshold_minutes": 5,
+                    },
+                ],
+            },
+        )
+        original_state = self._set_state_on_subscriptions(sync_session, device_id)
+
+        # Re-sync with changed config
+        resp = e2e_client.put(
+            "/api/v2/alerts/subscriptions",
+            json={
+                "device_id": device_id,
+                "subscriptions": [
+                    {
+                        "data_source": "NJT",
+                        "line_id": "njt-nec",
+                        "delay_threshold_minutes": 10,
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 200
+
+        sync_session.expire_all()
+        after_state = self._get_state_from_db(sync_session, device_id)
+        assert after_state["njt-nec"]["last_alert_hash"] == original_state["njt-nec"]["last_alert_hash"]
+        assert after_state["njt-nec"]["last_service_alert_ids"] == original_state["njt-nec"]["last_service_alert_ids"]
+        print("  Config change preserved notification state")


### PR DESCRIPTION
## Summary
Fix a duplicate notification bug where re-syncing alert subscriptions would wipe server-side deduplication state (last_alerted_at, last_alert_hash, last_digest_at, last_service_alert_ids), causing duplicate alerts to be sent on app launch or reconnection.

## Key Changes
- **Added subscription identity helpers** (`_subscription_identity` and `_subscription_identity_from_item`): These functions generate a hashable key that uniquely identifies a subscription's logical target, supporting three subscription types:
  - Line-based: (data_source, line_id, direction)
  - Station-pair: (data_source, from_station_code, to_station_code)
  - Train-specific: (data_source, train_id)

- **Modified sync_subscriptions endpoint**: Changed from a simple delete-all-then-recreate pattern to a state-preserving approach:
  - Reads existing subscriptions before deletion and builds a state map keyed by logical identity
  - After inserting new subscriptions, restores notification state for any matching identities
  - Logs the count of preserved subscriptions for observability

- **Added comprehensive test coverage** (`TestSubscriptionIdentityHelpers` and `TestSyncPreservesNotificationState`):
  - Unit tests for identity key generation across all subscription types
  - Integration tests verifying state preservation for line, station-pair, and train subscriptions
  - Tests confirming new subscriptions start with NULL state
  - Tests ensuring state doesn't leak between different subscriptions
  - Tests validating that config changes preserve state

## Implementation Details
- The identity key includes a type prefix ("line", "stations", "train") to prevent collisions between different subscription types
- Direction is included in line-based identity keys, allowing direction=NULL to be distinct from specific directions
- State preservation only occurs when the logical identity matches; genuinely new subscriptions correctly start with NULL state
- The sync endpoint now tracks and reports how many subscriptions had their state preserved

https://claude.ai/code/session_01HvVDdebaHL42X5T3wQEish