### PR TITLE
Add yearly subscription option to paywall

### DIFF
--- a/ios/TrackRat/Configuration.storekit
+++ b/ios/TrackRat/Configuration.storekit
@@ -99,6 +99,37 @@
           "referenceName" : "TrackRat Pro Monthly",
           "subscriptionGroupID" : "21612118",
           "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "49.99",
+          "familyShareable" : false,
+          "groupNumber" : 2,
+          "internalID" : "6740389183",
+          "introductoryOffer" : {
+            "displayPrice" : "0",
+            "internalID" : "FREE_TRIAL_1_WEEK_YEARLY",
+            "numberOfPeriods" : 1,
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "Full access to all TrackRat Pro features",
+              "displayName" : "TrackRat Pro Yearly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.trackrat.pro.yearly",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "TrackRat Pro Yearly",
+          "subscriptionGroupID" : "21612118",
+          "type" : "RecurringSubscription"
         }
       ]
     }

--- a/ios/TrackRat/Services/SubscriptionService.swift
+++ b/ios/TrackRat/Services/SubscriptionService.swift
@@ -67,7 +67,8 @@ final class SubscriptionService: ObservableObject {
 
     // Product IDs - configure these in App Store Connect
     static let monthlyProductId = "com.trackrat.pro.monthly"
-    private let productIds: Set<String> = [monthlyProductId]
+    static let yearlyProductId = "com.trackrat.pro.yearly"
+    private let productIds: Set<String> = [monthlyProductId, yearlyProductId]
 
     // Free tier limits
     static let freeTrainSystemLimit = 1
@@ -83,6 +84,10 @@ final class SubscriptionService: ObservableObject {
 
     var monthlyProduct: Product? {
         availableProducts.first { $0.id == Self.monthlyProductId }
+    }
+
+    var yearlyProduct: Product? {
+        availableProducts.first { $0.id == Self.yearlyProductId }
     }
 
     // MARK: - Initialization

--- a/ios/TrackRat/Views/Paywall/PaywallView.swift
+++ b/ios/TrackRat/Views/Paywall/PaywallView.swift
@@ -153,6 +153,19 @@ struct PaywallView: View {
                                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                                 }
                             }
+
+                            // Yearly option
+                            if let yearly = subscriptionService.yearlyProduct {
+                                PricingOptionView(
+                                    product: yearly,
+                                    isSelected: selectedProduct?.id == yearly.id,
+                                    subtitle: subscriptionSubtitle(for: yearly),
+                                    badge: subscriptionService.monthlyProduct.flatMap { yearlySavingsText(yearly: yearly, monthly: $0) }
+                                ) {
+                                    selectedProduct = yearly
+                                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                }
+                            }
                         }
                         .padding(.horizontal)
                     }
@@ -307,7 +320,34 @@ struct PaywallView: View {
     /// Format the subscription subtitle with trial info if available
     private func subscriptionSubtitle(for product: Product) -> String {
         let trialPrefix = trialText(for: product)
-        return "\(trialPrefix)\(product.displayPrice)/month"
+        let periodLabel: String
+        if let subscription = product.subscription {
+            switch subscription.subscriptionPeriod.unit {
+            case .year:
+                periodLabel = "/year"
+            case .month:
+                periodLabel = "/month"
+            case .week:
+                periodLabel = "/week"
+            case .day:
+                periodLabel = "/day"
+            @unknown default:
+                periodLabel = ""
+            }
+        } else {
+            periodLabel = ""
+        }
+        return "\(trialPrefix)\(product.displayPrice)\(periodLabel)"
+    }
+
+    /// Calculate the monthly equivalent price for a yearly product and the savings percentage vs monthly
+    private func yearlySavingsText(yearly: Product, monthly: Product) -> String? {
+        let yearlyTotal = yearly.price
+        let monthlyTotal = monthly.price * 12
+        guard monthlyTotal > 0 else { return nil }
+        let savingsPercent = Int(((monthlyTotal - yearlyTotal) / monthlyTotal * 100).rounded())
+        guard savingsPercent > 0 else { return nil }
+        return "Save \(savingsPercent)%"
     }
 
     private func purchase() async {
@@ -373,15 +413,30 @@ private struct PricingOptionView: View {
     let product: Product
     let isSelected: Bool
     let subtitle: String
+    var badge: String? = nil
     let onSelect: () -> Void
 
     var body: some View {
         Button(action: onSelect) {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(product.displayName)
-                        .font(.headline)
-                        .foregroundColor(.white)
+                    HStack(spacing: 8) {
+                        Text(product.displayName)
+                            .font(.headline)
+                            .foregroundColor(.white)
+
+                        if let badge {
+                            Text(badge)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundColor(.orange)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(
+                                    Capsule()
+                                        .fill(.orange.opacity(0.15))
+                                )
+                        }
+                    }
 
                     Text(subtitle)
                         .font(.caption)


### PR DESCRIPTION
## Summary
Added support for yearly subscription plans to the paywall, allowing users to choose between monthly and yearly billing options with automatic savings calculation.

## Key Changes
- **Paywall UI**: Added yearly subscription option display alongside monthly option with selection functionality
- **Pricing Display**: Updated `subscriptionSubtitle()` to dynamically display the correct billing period (/month, /year, /week, /day) based on the product's subscription period
- **Savings Badge**: Implemented `yearlySavingsText()` to calculate and display savings percentage when yearly plan offers better value than monthly
- **PricingOptionView**: Enhanced to support optional badge display (e.g., "Save 20%") with styled capsule design
- **SubscriptionService**: Added `yearlyProduct` property and included yearly product ID in the products set for fetching
- **StoreKit Configuration**: Added yearly subscription product definition (`com.trackrat.pro.yearly`) at $49.99/year with 1-week free trial

## Implementation Details
- Yearly savings calculation compares yearly total price against 12x monthly price
- Savings badge only displays when savings percentage is greater than 0
- Both subscription options use the same selection pattern with haptic feedback
- Yearly product is conditionally rendered only if available in the subscription service

https://claude.ai/code/session_01For7WnsNg8MbGXDiTmi7qT