### PR TITLE
Fix favorite stations leaking home/work designations to storage

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -907,12 +907,9 @@ final class AppState: ObservableObject {
 
     /// Explicitly removes a station from favorites
     func removeFavoriteStation(code: String) {
-        // Remove from the explicit favorites list if present
-        if let station = favoriteStations.first(where: { $0.id == code }) {
-            storageService.toggleFavoriteStation(code: code, name: station.name)
-        }
-        // Always reload — the station may have been a virtual entry (home/work injection)
-        // that was cleared before this call, so we need to refresh regardless
+        // Use dedicated remove (never adds) — safe even if the station was only
+        // present via home/work injection and not in stored favorites
+        storageService.removeFavoriteStation(code: code)
         loadFavoriteStations()
     }
 

--- a/ios/TrackRat/Services/StorageService.swift
+++ b/ios/TrackRat/Services/StorageService.swift
@@ -319,6 +319,16 @@ final class StorageService {
         saveStoredFavorites(stations)
     }
 
+    /// Removes a station from the explicit favorites list (no-op if not present).
+    /// Unlike toggleFavoriteStation, this never adds.
+    func removeFavoriteStation(code: String) {
+        var stations = loadStoredFavorites()
+        if let index = stations.firstIndex(where: { $0.id == code }) {
+            stations.remove(at: index)
+            saveStoredFavorites(stations)
+        }
+    }
+
     func isStationFavorited(code: String) -> Bool {
         let isInStored = loadStoredFavorites().contains { $0.id == code }
         let isHomeStation = RatSenseService.shared.getHomeStation() == code

--- a/ios/TrackRatTests/Services/StorageServiceTests.swift
+++ b/ios/TrackRatTests/Services/StorageServiceTests.swift
@@ -158,6 +158,52 @@ class StorageServiceTests: XCTestCase {
         XCTAssertLessThanOrEqual(favorites.count, 10, "Should cap at 10 explicit favorites")
     }
 
+    func testRemoveFavoriteStation_injectedOnly_doesNotAdd() {
+        // Removing a station that only exists via home/work injection (not in UserDefaults)
+        // must NOT add it to UserDefaults. This was the toggle-direction bug.
+        print("--- testRemoveFavoriteStation_injectedOnly_doesNotAdd ---")
+
+        RatSenseService.shared.setHomeStation("NY")
+        print("  Home set to NY (not explicitly favorited)")
+
+        // Verify NY appears in display list via injection
+        var favorites = storageService.loadFavoriteStations()
+        XCTAssertTrue(favorites.contains { $0.id == "NY" }, "NY should be in display list via injection")
+
+        // Now clear home and call removeFavoriteStation
+        RatSenseService.shared.setHomeStation(nil)
+        storageService.removeFavoriteStation(code: "NY")
+
+        favorites = storageService.loadFavoriteStations()
+        print("  After clearing home + remove: \(favorites.map(\.id))")
+        XCTAssertFalse(favorites.contains { $0.id == "NY" },
+                       "NY should NOT be in favorites — remove must not add an injected-only station")
+        XCTAssertFalse(storageService.isStationFavorited(code: "NY"),
+                       "NY should not report as favorited")
+    }
+
+    func testRemoveFavoriteStation_explicitlyAdded_removes() {
+        // Removing a station that was explicitly added should remove it
+        print("--- testRemoveFavoriteStation_explicitlyAdded_removes ---")
+
+        storageService.toggleFavoriteStation(code: "TR", name: "Trenton")
+        XCTAssertTrue(storageService.isStationFavorited(code: "TR"), "TR should be favorited")
+
+        storageService.removeFavoriteStation(code: "TR")
+        XCTAssertFalse(storageService.isStationFavorited(code: "TR"),
+                       "TR should be removed after explicit remove")
+    }
+
+    func testRemoveFavoriteStation_notPresent_noOp() {
+        // Removing a station that doesn't exist at all should be a safe no-op
+        print("--- testRemoveFavoriteStation_notPresent_noOp ---")
+
+        storageService.removeFavoriteStation(code: "NONEXISTENT")
+        let favorites = storageService.loadFavoriteStations()
+        print("  After removing nonexistent: \(favorites.map(\.id))")
+        XCTAssertTrue(favorites.isEmpty, "Should have no favorites after removing nonexistent station")
+    }
+
     func testIsStationFavorited_homeWorkAndExplicit() {
         print("--- testIsStationFavorited_homeWorkAndExplicit ---")
 


### PR DESCRIPTION
## Summary
This PR fixes a bug where home and work station designations were being persisted to the explicit favorites list in UserDefaults, causing them to remain as favorites even after being cleared.

## Key Changes

- **Separated storage concerns in StorageService**: 
  - Introduced `loadStoredFavorites()` to load only explicitly saved favorites from UserDefaults
  - Introduced `saveStoredFavorites()` to persist only explicit favorites
  - Modified `loadFavoriteStations()` to inject home/work stations at load time (for display) without persisting them
  - Updated `toggleFavoriteStation()` to operate only on stored favorites, preventing home/work stations from leaking into UserDefaults

- **Fixed `isStationFavorited()` logic**:
  - Now checks stored favorites separately from home/work designations
  - Correctly reports favorited status for all three categories (explicit, home, work)

- **Updated AppState methods**:
  - `addFavoriteStation()` now always reloads the display list since home/work injection means the list may change even if a station was already "favorited" via designation
  - `removeFavoriteStation()` now always reloads to handle cases where a station was a virtual entry (home/work injection) that was cleared before removal

- **Enhanced test coverage**:
  - Added comprehensive tests for favorite station functionality
  - Added critical regression test (`testHomeStationNotLeakedToUserDefaults`) to prevent this bug from reoccurring
  - Added tests for home/work station appearance in favorites and removal flows

## Implementation Details
The core fix separates the concept of "stored favorites" (explicit user selections) from "displayed favorites" (stored + home/work injections). This ensures that toggling any station only modifies the explicit list, while home/work stations are dynamically included at load time without being persisted.

https://claude.ai/code/session_011SLicX9ze9ZjUW9xA9vDEk