### PR TITLE
Update TrackRat Pro subscription display name to include billing period

### DIFF
--- a/ios/TrackRat/Configuration.storekit
+++ b/ios/TrackRat/Configuration.storekit
@@ -90,7 +90,7 @@
           "localizations" : [
             {
               "description" : "Full access to all TrackRat Pro features",
-              "displayName" : "TrackRat Pro",
+              "displayName" : "TrackRat Pro Monthly",
               "locale" : "en_US"
             }
           ],


### PR DESCRIPTION
## Summary
Updated the display name for the TrackRat Pro in-app subscription product to clarify the billing period to users.

## Changes
- Changed the `displayName` for the TrackRat Pro subscription from "TrackRat Pro" to "TrackRat Pro Monthly" in the StoreKit configuration file

## Details
This change makes the subscription billing period more explicit to users during the purchase flow, helping them understand that this is a monthly subscription offering rather than a one-time purchase or other billing model.

https://claude.ai/code/session_017WNC5i5B57b9dNvTFJFPPs