### PR TITLE
Update health check configuration for trackrat service

### DIFF
--- a/infra_v2/terraform/compute.tf
+++ b/infra_v2/terraform/compute.tf
@@ -270,13 +270,13 @@ resource "google_compute_health_check" "trackrat" {
 
   http_health_check {
     port         = 8000
-    request_path = "/health/live"
+    request_path = "/health/ready"
   }
 
   check_interval_sec  = 30
   timeout_sec         = 10
   healthy_threshold   = 2
-  unhealthy_threshold = 3
+  unhealthy_threshold = 5
 
   depends_on = [google_project_service.apis]
 }


### PR DESCRIPTION
## Summary
Updated the Google Compute health check configuration for the trackrat service to use a readiness probe instead of a liveness probe and increased the unhealthy threshold tolerance.

## Key Changes
- Changed health check endpoint from `/health/live` to `/health/ready` to align with readiness probe semantics
- Increased `unhealthy_threshold` from 3 to 5 to reduce false positives and provide more tolerance for transient failures before marking an instance as unhealthy

## Implementation Details
These changes improve the stability of the health check by:
1. Using the readiness endpoint which better reflects whether the service is ready to accept traffic
2. Allowing more consecutive failed health checks (5 instead of 3) before removing an instance from the load balancer, reducing unnecessary instance churn during temporary service disruptions

https://claude.ai/code/session_01MEqX8d42KBT2WDZpR8tS8q