### PR TITLE
Fix ground truth validation to handle premature dep times

### DIFF
--- a/scripts/ground-truth-validate.py
+++ b/scripts/ground-truth-validate.py
@@ -388,8 +388,25 @@ def fetch_amtrak_ground_truth() -> list[GroundTruthArrival]:
                     if internal_code == dest_code and stop == stations[-1]:
                         continue
 
-                    # Use actual departure > scheduled departure
-                    time_str = stop.dep or stop.schDep
+                    # Use actual departure only if the station has been departed.
+                    # The Amtraker API may prematurely set dep=arr for stations
+                    # the train hasn't left yet (e.g. layover stops).
+                    if stop.status == "Departed" and stop.dep:
+                        time_str = stop.dep
+                        # Clamp actual dep to scheduled if earlier (same as
+                        # production collector logic in journey.py)
+                        if stop.schDep:
+                            try:
+                                dep_raw = stop.dep.replace("Z", "+00:00") if "Z" in stop.dep else stop.dep
+                                sch_raw = stop.schDep.replace("Z", "+00:00") if "Z" in stop.schDep else stop.schDep
+                                dep_dt = datetime.fromisoformat(dep_raw)
+                                sch_dt = datetime.fromisoformat(sch_raw)
+                                if dep_dt < sch_dt:
+                                    time_str = stop.schDep
+                            except ValueError:
+                                pass
+                    else:
+                        time_str = stop.schDep
                     if not time_str:
                         continue
 


### PR DESCRIPTION
## Summary
Updated the ground truth validation script to more accurately handle departure times from the Amtraker API, which may prematurely set `dep=arr` for stations the train hasn't actually departed from yet (e.g., during layover stops).

## Key Changes
- Added a check for `stop.status == "Departed"` before using actual departure time (`stop.dep`)
- Falls back to scheduled departure time (`stop.schDep`) when the train hasn't departed or actual departure is not available
- Implemented clamping logic to ensure actual departure times don't fall before scheduled departure times, matching the production collector logic in `journey.py`
- Added ISO 8601 datetime parsing with timezone normalization (converting "Z" to "+00:00") to safely compare departure times

## Implementation Details
- The fix prevents using unreliable actual departure times for stops where the train is still present
- When actual departure is available and the train has departed, it's validated against the scheduled time and clamped if necessary
- Gracefully handles datetime parsing errors by falling back to the original behavior

https://claude.ai/code/session_01D1bCwKpWY3q4JTM27xuzJr