### PR TITLE
Adjust feedback button spacing in SettingsView

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -532,7 +532,7 @@ struct SettingsSection: View {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
                 showingFeedbackSheet = true
             } label: {
-                HStack(spacing: 10) {
+                HStack(spacing: 16) {
                     Image(systemName: "exclamationmark.bubble.fill")
                         .font(.title2)
                         .foregroundColor(.orange)


### PR DESCRIPTION
## Summary
Updated the horizontal spacing of the feedback button in the Settings view to improve visual consistency and alignment with the app's design system.

## Changes
- Increased `HStack` spacing from 10 to 16 points in the feedback button layout
- This adjustment affects the spacing between the exclamation mark icon and the button label

## Details
The spacing change aligns the feedback button with standard spacing conventions used elsewhere in the app, providing better visual hierarchy and improved touch target sizing.

https://claude.ai/code/session_011oE4eeAA3q9M6j3TbW8Luy