### PR TITLE
Fix NWK-WTC headsign override and add ground truth validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ bash scripts/validate-staging.sh --no-wait              # Skip 30s stabilization
 bash scripts/validate-staging.sh --no-random             # Skip Phase 2 random routes
 bash scripts/validate-staging.sh --skip-logs             # Skip GCP log check (no creds needed)
 bash scripts/validate-staging.sh --no-wait --no-random   # Fast: health + fixed routes only
+bash scripts/validate-staging.sh --ground-truth           # Include ground truth validation (all providers)
 
 # Against production:
 bash scripts/validate-staging.sh https://apiv2.trackrat.net
@@ -123,9 +124,12 @@ poetry run python3 ../scripts/ground-truth-validate.py --provider MNR --verbose
 
 # SUBWAY (no auth needed)
 poetry run python3 ../scripts/ground-truth-validate.py --provider SUBWAY --verbose
+
+# All providers at once
+poetry run python3 ../scripts/ground-truth-validate.py --all --verbose
 ```
 
-Options: `--tolerance N` (minutes, default 2.0; supports decimals e.g. 2.0 = 120s), `--far-future N` (minutes, default 12; GT arrivals beyond this are WARN not FAIL), `--verbose` (show raw GT/TR data and nearest-match on FAILs).
+Options: `--all` (run all providers sequentially), `--tolerance N` (minutes, default 2.0; supports decimals e.g. 2.0 = 120s), `--far-future N` (minutes, default 12; GT arrivals beyond this are WARN not FAIL), `--verbose` (show raw GT/TR data and nearest-match on FAILs).
 Default target is staging; pass a URL as first positional arg for production.
 
 The NJT API token can be set via `NJT_TOKEN` env var, `TRACKRAT_NJT_API_TOKEN` env var,

--- a/backend_v2/src/trackrat/collectors/path/collector.py
+++ b/backend_v2/src/trackrat/collectors/path/collector.py
@@ -74,6 +74,16 @@ HEADSIGN_TO_LINE_INFO: dict[str, tuple[str, str, str]] = {
     "jsq": ("JSQ-33", "Journal Square - 33rd Street", "#ff9900"),
 }
 
+# NWK-WTC line color is exclusive — no other PATH route uses it.
+# The RidePATH API shows intermediate stops as headsigns at NWK-WTC terminus
+# stations (e.g., "Harrison" at NWK instead of "World Trade Center"), causing
+# truncated journeys and duplicates. Use color + direction to override.
+NWK_WTC_COLOR = "#d93a30"
+NWK_WTC_TERMINUS: dict[str, tuple[str, str]] = {
+    "ToNY": ("PWC", "World Trade Center"),
+    "ToNJ": ("PNK", "Newark"),
+}
+
 
 # =============================================================================
 # HELPER FUNCTIONS
@@ -507,6 +517,24 @@ class PathCollector:
                 headsign=destination_headsign,
             )
             return False
+
+        # Override destination for NWK-WTC trains with misleading headsigns.
+        # The RidePATH API shows intermediate stops (e.g., "Harrison" at NWK,
+        # "Journal Square" at WTC) instead of the true final destination.
+        if arrival.line_color:
+            normalized_color = _normalize_line_color(arrival.line_color)
+            terminus = NWK_WTC_TERMINUS.get(arrival.direction)
+            if normalized_color == NWK_WTC_COLOR and terminus:
+                correct_dest, correct_headsign = terminus
+                if destination_station != correct_dest:
+                    logger.debug(
+                        "path_nwk_wtc_headsign_override",
+                        station=discovered_at_station,
+                        original_headsign=destination_headsign,
+                        corrected_destination=correct_dest,
+                    )
+                    destination_station = correct_dest
+                    destination_headsign = correct_headsign
 
         # Infer the true origin station (may be different if discovered mid-route)
         # Pass line_color to disambiguate overlapping routes (e.g., HOB-33 vs JSQ-33H)

--- a/backend_v2/tests/unit/collectors/path/test_collector.py
+++ b/backend_v2/tests/unit/collectors/path/test_collector.py
@@ -985,6 +985,219 @@ class TestPathCollectorDiscovery:
 
 
 # =============================================================================
+# NWK-WTC HEADSIGN OVERRIDE TESTS
+# =============================================================================
+
+
+class TestNwkWtcHeadsignOverride:
+    """Tests for NWK-WTC color-based destination override.
+
+    The RidePATH API shows intermediate stops as headsigns at NWK-WTC terminus
+    stations (e.g., "Harrison" at NWK instead of "World Trade Center"). The
+    collector uses the exclusive NWK-WTC line color (D93A30) to detect and
+    correct these misleading headsigns.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        client = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def collector(self, mock_client):
+        return PathCollector(client=mock_client)
+
+    @pytest.fixture
+    def mock_session(self):
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value=None)
+        mock_scalars_obj = MagicMock()
+        mock_scalars_obj.all.return_value = []
+        session.scalars = AsyncMock(return_value=mock_scalars_obj)
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_nwk_harrison_headsign_overridden_to_wtc(
+        self, collector, mock_session
+    ):
+        """At NWK, headsign 'Harrison' with NWK-WTC color should create full
+        PNK->PWC journey, not truncated PNK->PHR."""
+        arrival = PathArrival(
+            station_code="PNK",
+            headsign="Harrison",
+            direction="ToNY",
+            minutes_away=0,
+            arrival_time=datetime(2026, 3, 22, 10, 0, 0),
+            line_color="D93A30",
+            last_updated=None,
+        )
+
+        await collector._process_arrival_for_discovery(mock_session, arrival, {})
+
+        assert mock_session.add.called, "Journey should have been created"
+        journey = mock_session.add.call_args_list[0][0][0]
+        assert journey.origin_station_code == "PNK", (
+            f"Origin should be PNK (Newark), got {journey.origin_station_code}"
+        )
+        assert journey.terminal_station_code == "PWC", (
+            f"Terminal should be PWC (World Trade Center), got {journey.terminal_station_code}"
+        )
+        assert journey.destination == "World Trade Center", (
+            f"Destination should be 'World Trade Center', got '{journey.destination}'"
+        )
+        assert journey.line_code == "NWK-WTC", (
+            f"Line code should be NWK-WTC, got {journey.line_code}"
+        )
+        assert journey.stops_count == 6, (
+            f"Full NWK-WTC route has 6 stops, got {journey.stops_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wtc_journal_square_headsign_overridden_to_newark(
+        self, collector, mock_session
+    ):
+        """At WTC, headsign 'Journal Square' with NWK-WTC color should create
+        full PWC->PNK journey, not truncated PWC->PJS."""
+        arrival = PathArrival(
+            station_code="PWC",
+            headsign="Journal Square",
+            direction="ToNJ",
+            minutes_away=0,
+            arrival_time=datetime(2026, 3, 22, 10, 0, 0),
+            line_color="D93A30",
+            last_updated=None,
+        )
+
+        await collector._process_arrival_for_discovery(mock_session, arrival, {})
+
+        assert mock_session.add.called, "Journey should have been created"
+        journey = mock_session.add.call_args_list[0][0][0]
+        assert journey.origin_station_code == "PWC", (
+            f"Origin should be PWC (WTC), got {journey.origin_station_code}"
+        )
+        assert journey.terminal_station_code == "PNK", (
+            f"Terminal should be PNK (Newark), got {journey.terminal_station_code}"
+        )
+        assert journey.destination == "Newark", (
+            f"Destination should be 'Newark', got '{journey.destination}'"
+        )
+        assert journey.stops_count == 6, (
+            f"Full NWK-WTC route has 6 stops, got {journey.stops_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_correct_headsign_not_overridden(
+        self, collector, mock_session
+    ):
+        """At JSQ, headsign 'World Trade Center' with NWK-WTC color should NOT
+        be overridden — it's already correct."""
+        arrival = PathArrival(
+            station_code="PJS",
+            headsign="World Trade Center",
+            direction="ToNY",
+            minutes_away=5,
+            arrival_time=datetime(2026, 3, 22, 10, 5, 0),
+            line_color="D93A30",
+            last_updated=None,
+        )
+
+        await collector._process_arrival_for_discovery(mock_session, arrival, {})
+
+        assert mock_session.add.called, "Journey should have been created"
+        journey = mock_session.add.call_args_list[0][0][0]
+        assert journey.terminal_station_code == "PWC", (
+            f"Terminal should be PWC, got {journey.terminal_station_code}"
+        )
+        assert journey.destination == "World Trade Center", (
+            f"Destination should remain 'World Trade Center', got '{journey.destination}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_nwk_wtc_color_not_overridden(
+        self, collector, mock_session
+    ):
+        """JSQ-33 trains (orange #FF9900) showing 'Journal Square' headsign at
+        P33 should NOT be overridden — only NWK-WTC color triggers override."""
+        arrival = PathArrival(
+            station_code="P33",
+            headsign="Journal Square",
+            direction="ToNJ",
+            minutes_away=3,
+            arrival_time=datetime(2026, 3, 22, 10, 3, 0),
+            line_color="FF9900",
+            last_updated=None,
+        )
+
+        await collector._process_arrival_for_discovery(mock_session, arrival, {})
+
+        assert mock_session.add.called, "Journey should have been created"
+        journey = mock_session.add.call_args_list[0][0][0]
+        # Should resolve to PJS (Journal Square), not be overridden to PNK
+        assert journey.terminal_station_code == "PJS", (
+            f"Non-NWK-WTC train should NOT be overridden. "
+            f"Terminal should be PJS, got {journey.terminal_station_code}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_nwk_and_jsq_discover_same_train_with_same_id(
+        self, collector, mock_session
+    ):
+        """A train discovered at NWK with 'Harrison' headsign and the same train
+        discovered at JSQ with 'World Trade Center' headsign should produce the
+        same train_id (both resolve to origin=PNK, dest='World Trade Center')."""
+        base_time = datetime(2026, 3, 22, 10, 0, 0)
+
+        # Train at NWK (origin) with misleading headsign
+        nwk_arrival = PathArrival(
+            station_code="PNK",
+            headsign="Harrison",
+            direction="ToNY",
+            minutes_away=0,
+            arrival_time=base_time,
+            line_color="D93A30",
+            last_updated=None,
+        )
+
+        await collector._process_arrival_for_discovery(mock_session, nwk_arrival, {})
+        assert mock_session.add.called
+        nwk_journey = mock_session.add.call_args_list[0][0][0]
+        nwk_train_id = nwk_journey.train_id
+
+        mock_session.reset_mock()
+
+        # Same train at JSQ (3 stops later) with correct headsign
+        # arrival_time is later since the train has traveled from NWK to JSQ
+        jsq_arrival = PathArrival(
+            station_code="PJS",
+            headsign="World Trade Center",
+            direction="ToNY",
+            minutes_away=5,
+            arrival_time=base_time + timedelta(minutes=10),
+            line_color="D93A30",
+            last_updated=None,
+        )
+
+        await collector._process_arrival_for_discovery(mock_session, jsq_arrival, {})
+        assert mock_session.add.called
+        jsq_journey = mock_session.add.call_args_list[0][0][0]
+        jsq_train_id = jsq_journey.train_id
+
+        # Both should use "World Trade Center" as destination in their train IDs
+        # (headsign is truncated to 10 chars in train ID: "WorldTrad" -> "worldtrad")
+        assert "worldtrad" in nwk_train_id.lower(), (
+            f"NWK train ID should use 'worldtrad' (overridden), got: {nwk_train_id}"
+        )
+        assert "worldtrad" in jsq_train_id.lower(), (
+            f"JSQ train ID should use 'worldtrad', got: {jsq_train_id}"
+        )
+        # Both should have same origin
+        assert nwk_journey.origin_station_code == jsq_journey.origin_station_code == "PNK"
+
+
+# =============================================================================
 # UPDATE PHASE TESTS
 # =============================================================================
 

--- a/scripts/ground-truth-validate.py
+++ b/scripts/ground-truth-validate.py
@@ -2,7 +2,7 @@
 """Ground truth validation: compare TrackRat departures against raw transit provider data.
 
 Run from the repo root using the backend poetry environment:
-    cd backend_v2 && poetry run python3 ../scripts/ground-truth-validate.py [base_url] [--provider PATH] [--tolerance 1.5]
+    cd backend_v2 && poetry run python3 ../scripts/ground-truth-validate.py [base_url] [--provider PATH] [--all] [--tolerance 1.5]
 """
 
 import argparse
@@ -1187,6 +1187,11 @@ def main() -> None:
         help="Transit provider to validate (default: PATH)",
     )
     parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Validate all providers sequentially (overrides --provider)",
+    )
+    parser.add_argument(
         "--tolerance",
         type=float,
         default=2.0,
@@ -1220,12 +1225,19 @@ def main() -> None:
         "SUBWAY": run_subway_validation,
     }
 
-    runner = runners.get(args.provider)
-    if runner:
-        runner(args.base_url, args.tolerance, verbose=args.verbose, gt_window=args.window, far_future=args.far_future)
+    if args.all:
+        for provider, runner in runners.items():
+            print(f"\n{BOLD}{'='*60}")
+            print(f" {provider}")
+            print(f"{'='*60}{NC}\n")
+            runner(args.base_url, args.tolerance, verbose=args.verbose, gt_window=args.window, far_future=args.far_future)
     else:
-        print(f"{RED}FAIL{NC} Unsupported provider: {args.provider}")
-        sys.exit(1)
+        runner = runners.get(args.provider)
+        if runner:
+            runner(args.base_url, args.tolerance, verbose=args.verbose, gt_window=args.window, far_future=args.far_future)
+        else:
+            print(f"{RED}FAIL{NC} Unsupported provider: {args.provider}")
+            sys.exit(1)
 
     sys.exit(1 if FAIL_COUNT > 0 else 0)
 

--- a/scripts/validate-staging.sh
+++ b/scripts/validate-staging.sh
@@ -8,11 +8,12 @@
 #
 # Automatically installs Python dependencies for step 3 if missing.
 #
-# Usage: ./scripts/validate-staging.sh [base_url] [--no-wait] [--no-random] [--skip-logs]
-#   base_url     defaults to https://staging.apiv2.trackrat.net
-#   --no-wait    skip the stabilization sleep in step 1
-#   --no-random  skip random route generation in step 2
-#   --skip-logs  skip the GCP log check (step 3)
+# Usage: ./scripts/validate-staging.sh [base_url] [--no-wait] [--no-random] [--skip-logs] [--ground-truth]
+#   base_url        defaults to https://staging.apiv2.trackrat.net
+#   --no-wait       skip the stabilization sleep in step 1
+#   --no-random     skip random route generation in step 2
+#   --skip-logs     skip the GCP log check (step 3)
+#   --ground-truth  run ground truth validation against all providers (step 4)
 
 set -euo pipefail
 
@@ -22,14 +23,16 @@ BASE_URL="https://staging.apiv2.trackrat.net"
 NO_WAIT=false
 NO_RANDOM=false
 SKIP_LOGS=false
+GROUND_TRUTH=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --no-wait)   NO_WAIT=true; shift ;;
-    --no-random) NO_RANDOM=true; shift ;;
-    --skip-logs) SKIP_LOGS=true; shift ;;
+    --no-wait)       NO_WAIT=true; shift ;;
+    --no-random)     NO_RANDOM=true; shift ;;
+    --skip-logs)     SKIP_LOGS=true; shift ;;
+    --ground-truth)  GROUND_TRUTH=true; shift ;;
     --help|-h)
-      echo "Usage: $0 [base_url] [--no-wait] [--no-random] [--skip-logs]"
+      echo "Usage: $0 [base_url] [--no-wait] [--no-random] [--skip-logs] [--ground-truth]"
       exit 0
       ;;
     *) BASE_URL="$1"; shift ;;
@@ -98,6 +101,18 @@ else
     step_pass "3 (logs)"
   else
     step_fail "3 (logs)"
+  fi
+fi
+
+# ---------- Step 4: Ground truth validation (optional) ----------
+
+if [[ "$GROUND_TRUTH" == "true" ]]; then
+  echo -e "${BOLD}===== Step 4: Ground Truth Validation (all providers) =====${NC}"
+
+  if (cd "$REPO_ROOT/backend_v2" && poetry run python3 ../scripts/ground-truth-validate.py "$BASE_URL" --all); then
+    step_pass "4 (ground truth)"
+  else
+    step_fail "4 (ground truth)"
   fi
 fi
 


### PR DESCRIPTION
## Summary
This PR addresses misleading headsigns in the PATH collector for NWK-WTC trains and enhances the ground truth validation tooling.

## Key Changes

### PATH Collector - NWK-WTC Headsign Override
- **Problem**: The RidePATH API shows intermediate stops as headsigns at NWK-WTC terminus stations (e.g., "Harrison" at Newark instead of "World Trade Center"), causing truncated journeys and duplicate train IDs.
- **Solution**: Added color-based detection using the exclusive NWK-WTC line color (`#d93a30`) to override misleading headsigns with correct terminus destinations:
  - At Newark (PNK) with direction "ToNY": override to "World Trade Center" (PWC)
  - At World Trade Center (PWC) with direction "ToNJ": override to "Newark" (PNK)
- **Implementation**: 
  - Added `NWK_WTC_COLOR` constant and `NWK_WTC_TERMINUS` mapping in `collector.py`
  - Integrated override logic in `_process_arrival_for_discovery()` method
  - Ensures trains discovered at different stations with the same line produce consistent train IDs
- **Testing**: Added comprehensive test suite (`TestNwkWtcHeadsignOverride`) with 5 test cases covering:
  - Headsign override at Newark and WTC
  - Non-override for already-correct headsigns
  - Non-override for non-NWK-WTC colored trains
  - Train ID consistency across discovery points

### Ground Truth Validation Enhancement
- **Added `--all` flag** to `ground-truth-validate.py` to validate all providers sequentially in a single run
- **Updated `validate-staging.sh`** with optional `--ground-truth` flag to run ground truth validation as step 4
- **Documentation**: Updated CLAUDE.md with examples of new validation workflows

## Implementation Details
- The headsign override is applied before origin station inference, ensuring the corrected destination is used for all downstream logic
- Color normalization is applied to handle case variations in line color values
- Debug logging captures when overrides occur for troubleshooting
- The solution is specific to NWK-WTC (no other PATH route uses that color), minimizing false positives

https://claude.ai/code/session_01JNDxH3nxZb2PdgHtCdStFW