### PR TITLE
Add staging notification safety check to prevent production push notifications

### DIFF
--- a/backend_v2/src/trackrat/main.py
+++ b/backend_v2/src/trackrat/main.py
@@ -30,7 +30,7 @@ from trackrat.api import (
     validation,
 )
 from trackrat.db.database import init_database, shutdown_database
-from trackrat.db.engine import close_engine
+from trackrat.db.engine import close_engine, get_session
 from trackrat.services.apns import SimpleAPNSService
 from trackrat.services.scheduler import get_scheduler
 from trackrat.settings import get_settings
@@ -61,6 +61,65 @@ structlog.configure(
 )
 
 
+_STAGING_DEVICE_TOKEN_THRESHOLD = 50
+
+
+async def _check_staging_notification_safety(settings: Any) -> bool:
+    """Check if staging database contains production notification data.
+
+    After cloning production to staging, the scrub script should have cleared
+    device_tokens and live_activity_tokens. If they still contain many rows,
+    it means the scrub was skipped or failed, and the scheduler would send
+    push notifications to real production users.
+
+    Returns True if APNS should be disabled (unsafe token count detected).
+    """
+    from sqlalchemy import func, select
+
+    from trackrat.models.database import DeviceToken, LiveActivityToken
+
+    try:
+        async with get_session() as session:
+            device_count = await session.scalar(
+                select(func.count()).select_from(DeviceToken)
+            )
+            la_count = await session.scalar(
+                select(func.count()).select_from(LiveActivityToken)
+            )
+
+        if (device_count or 0) > _STAGING_DEVICE_TOKEN_THRESHOLD:
+            logger.critical(
+                "staging_notification_safety_warning",
+                message=(
+                    f"Staging database contains {device_count} device tokens and "
+                    f"{la_count} Live Activity tokens. This likely means the "
+                    "post-clone scrub did not run. APNS will be disabled to "
+                    "prevent sending notifications to production users."
+                ),
+                device_tokens=device_count,
+                live_activity_tokens=la_count,
+                threshold=_STAGING_DEVICE_TOKEN_THRESHOLD,
+            )
+            return True
+        elif (device_count or 0) > 0 or (la_count or 0) > 0:
+            logger.info(
+                "staging_notification_tokens_present",
+                device_tokens=device_count,
+                live_activity_tokens=la_count,
+                message="Small number of tokens present — likely from staging testers.",
+            )
+        else:
+            logger.info("staging_notification_safety_ok", message="No production tokens in staging database.")
+    except Exception as e:
+        logger.warning(
+            "staging_notification_safety_check_failed",
+            error=str(e),
+            message="Could not verify staging notification safety. Proceeding with caution.",
+        )
+
+    return False
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Manage application lifecycle events."""
@@ -75,21 +134,35 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await init_database()
     logger.info("database_initialization_complete")
 
+    # Defensive check: warn if staging has production notification data.
+    # If the post-clone scrub was skipped, disable APNS to prevent sending
+    # push notifications to production users.
+    disable_apns = False
+    if settings.environment == "staging":
+        disable_apns = await _check_staging_notification_safety(settings)
+
     # Initialize APNS service
     logger.info("initializing_apns_service")
-    apns_service = SimpleAPNSService()
-    logger.info(
-        "apns_service_initialized",
-        is_configured=apns_service.is_configured,
-        environment=settings.environment,
-        apns_environment=settings.apns_environment,
-        apns_base_url=apns_service.base_url,
-    )
+    if disable_apns:
+        apns_service = None
+        logger.critical(
+            "apns_disabled_for_safety",
+            message="APNS disabled on staging due to unscrubbed production tokens.",
+        )
+    else:
+        apns_service = SimpleAPNSService()
+        logger.info(
+            "apns_service_initialized",
+            is_configured=apns_service.is_configured,
+            environment=settings.environment,
+            apns_environment=settings.apns_environment,
+            apns_base_url=apns_service.base_url,
+        )
 
     # Store APNS service on app state for use by other routers
     app.state.apns_service = apns_service
 
-    # Start scheduler with APNS service
+    # Start scheduler with APNS service (None = no notification jobs)
     logger.info("starting_scheduler_from_lifespan")
     scheduler = get_scheduler(apns_service=apns_service)
     await scheduler.start()

--- a/backend_v2/tests/test_staging_safety.py
+++ b/backend_v2/tests/test_staging_safety.py
@@ -1,0 +1,153 @@
+"""
+Tests for the staging notification safety check.
+
+Verifies that _check_staging_notification_safety correctly detects
+production notification data left in a staging database after a
+production-to-staging disk clone, and returns True to disable APNS
+when the threshold is exceeded.
+"""
+
+import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+from trackrat.main import (
+    _STAGING_DEVICE_TOKEN_THRESHOLD,
+    _check_staging_notification_safety,
+)
+from trackrat.models.database import DeviceToken, LiveActivityToken
+from trackrat.settings import Settings
+
+
+@pytest.fixture
+def staging_settings() -> Settings:
+    """Settings configured as staging environment."""
+    return Settings(
+        environment="staging",
+        database_url="postgresql+asyncpg://trackratuser:password@localhost:5434/trackratdb_test",
+        njt_api_token="test_token",
+    )
+
+
+def _session_context(db_session):
+    """Create a fake async context manager that yields the test db_session."""
+
+    @asynccontextmanager
+    async def fake_get_session():
+        yield db_session
+
+    return fake_get_session
+
+
+@pytest.mark.asyncio
+async def test_safety_check_empty_db_returns_false(db_session, staging_settings, caplog):
+    """With no device tokens, returns False (APNS safe) and logs OK."""
+    with patch("trackrat.main.get_session", _session_context(db_session)):
+        result = await _check_staging_notification_safety(staging_settings)
+
+    assert result is False
+    assert "staging_notification_safety_ok" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safety_check_few_tokens_returns_false(db_session, staging_settings, caplog):
+    """With a few tokens (below threshold), returns False and logs info."""
+    for i in range(3):
+        db_session.add(DeviceToken(
+            device_id=f"test_device_{i:03d}",
+            apns_token=f"test_apns_token_{i:03d}",
+        ))
+    await db_session.commit()
+
+    with patch("trackrat.main.get_session", _session_context(db_session)):
+        result = await _check_staging_notification_safety(staging_settings)
+
+    assert result is False
+    assert "staging_notification_tokens_present" in caplog.text
+    assert "staging testers" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safety_check_many_tokens_returns_true(db_session, staging_settings, caplog):
+    """With many tokens (above threshold), returns True to disable APNS."""
+    count = _STAGING_DEVICE_TOKEN_THRESHOLD + 10
+    for i in range(count):
+        db_session.add(DeviceToken(
+            device_id=f"prod_device_{i:04d}",
+            apns_token=f"prod_apns_token_{i:04d}",
+        ))
+    await db_session.commit()
+
+    with patch("trackrat.main.get_session", _session_context(db_session)):
+        result = await _check_staging_notification_safety(staging_settings)
+
+    assert result is True
+    assert "staging_notification_safety_warning" in caplog.text
+    assert "APNS will be disabled" in caplog.text
+    assert str(count) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safety_check_exactly_at_threshold_returns_false(db_session, staging_settings, caplog):
+    """Exactly at threshold should NOT trigger (only above threshold)."""
+    for i in range(_STAGING_DEVICE_TOKEN_THRESHOLD):
+        db_session.add(DeviceToken(
+            device_id=f"edge_device_{i:04d}",
+            apns_token=f"edge_apns_token_{i:04d}",
+        ))
+    await db_session.commit()
+
+    with patch("trackrat.main.get_session", _session_context(db_session)):
+        result = await _check_staging_notification_safety(staging_settings)
+
+    assert result is False
+    assert "staging_notification_safety_warning" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safety_check_live_activity_tokens_counted(db_session, staging_settings, caplog):
+    """Live Activity token count should appear in the warning message."""
+    from datetime import datetime, timedelta, timezone
+
+    count = _STAGING_DEVICE_TOKEN_THRESHOLD + 5
+    for i in range(count):
+        db_session.add(DeviceToken(
+            device_id=f"la_device_{i:04d}",
+            apns_token=f"la_apns_token_{i:04d}",
+        ))
+
+    la_count = 3
+    for i in range(la_count):
+        db_session.add(LiveActivityToken(
+            push_token=f"la_push_token_{i:03d}",
+            activity_id=f"activity_{i:03d}",
+            train_number=f"100{i}",
+            origin_code="NY",
+            destination_code="TR",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=6),
+        ))
+    await db_session.commit()
+
+    with patch("trackrat.main.get_session", _session_context(db_session)):
+        result = await _check_staging_notification_safety(staging_settings)
+
+    assert result is True
+    assert "staging_notification_safety_warning" in caplog.text
+    assert str(la_count) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safety_check_handles_db_errors_gracefully(staging_settings, caplog):
+    """If the database query fails, returns False (allow startup) with warning."""
+
+    @asynccontextmanager
+    async def failing_get_session():
+        raise ConnectionError("Database unavailable")
+        yield  # pragma: no cover
+
+    with patch("trackrat.main.get_session", failing_get_session):
+        result = await _check_staging_notification_safety(staging_settings)
+
+    assert result is False
+    assert "staging_notification_safety_check_failed" in caplog.text
+    assert "Proceeding with caution" in caplog.text

--- a/infra_v2/terraform/compute.tf
+++ b/infra_v2/terraform/compute.tf
@@ -223,7 +223,56 @@ ENVEOF
       # Pull latest images (DOCKER_CONFIG is exported, so compose uses it)
       $COMPOSE_PATH pull
 
-      # Start containers
+      # ---------------------------------------------------------
+      # 7a. Scrub production user data on staging
+      # ---------------------------------------------------------
+      # When staging boots from a cloned production disk, the database
+      # contains real APNS device tokens and Live Activity tokens.
+      # Without scrubbing, the staging scheduler would send push
+      # notifications to production users within minutes of startup.
+      #
+      # We start only the DB first, run the scrub, then bring up the
+      # full stack so the API never sees production notification data.
+      if [ "$ENVIRONMENT" = "staging" ]; then
+        echo "=== Scrubbing production notification data for staging ==="
+
+        # Start only the database container
+        $COMPOSE_PATH up -d db
+
+        # Wait for PostgreSQL to become healthy
+        echo "Waiting for PostgreSQL to be ready..."
+        for i in $(seq 1 60); do
+          if docker exec trackrat-postgres pg_isready -U trackrat -d trackrat >/dev/null 2>&1; then
+            echo "PostgreSQL is ready"
+            break
+          fi
+          if [ $i -eq 60 ]; then
+            echo "ERROR: PostgreSQL not ready after 60 seconds"
+            exit 1
+          fi
+          sleep 1
+        done
+
+        # Scrub notification-related tables
+        docker exec trackrat-postgres psql -U trackrat -d trackrat -c "
+          -- Count before scrub for logging
+          SELECT 'device_tokens' AS tbl, COUNT(*) AS cnt FROM device_tokens
+          UNION ALL SELECT 'live_activity_tokens', COUNT(*) FROM live_activity_tokens
+          UNION ALL SELECT 'cached_api_responses', COUNT(*) FROM cached_api_responses
+          UNION ALL SELECT 'scheduler_task_runs', COUNT(*) FROM scheduler_task_runs;
+        "
+
+        docker exec trackrat-postgres psql -U trackrat -d trackrat -c "
+          TRUNCATE TABLE device_tokens CASCADE;
+          TRUNCATE TABLE live_activity_tokens;
+          TRUNCATE TABLE cached_api_responses;
+          TRUNCATE TABLE scheduler_task_runs;
+        "
+
+        echo "✅ Staging database scrubbed"
+      fi
+
+      # Start all containers (db is already running on staging, this adds the api)
       $COMPOSE_PATH up -d
 
       echo ""

--- a/scripts/scrub-staging-db.sh
+++ b/scripts/scrub-staging-db.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# scrub-staging-db.sh - Remove production user data from a cloned staging database
+#
+# After cloning a production disk to staging, this script removes device tokens,
+# Live Activity tokens, and other user-specific data that would cause staging to
+# send push notifications to real production users.
+#
+# Usage:
+#   ./scripts/scrub-staging-db.sh [options]
+#
+# Options:
+#   --db-host HOST       PostgreSQL host (default: localhost)
+#   --db-port PORT       PostgreSQL port (default: 5432)
+#   --db-user USER       PostgreSQL user (default: trackrat)
+#   --db-name NAME       Database name (default: trackrat)
+#   --db-password PASS   Database password (or set PGPASSWORD env var)
+#   --docker             Run via docker exec against trackrat-postgres container
+#   --dry-run            Show what would be scrubbed without executing
+#   --help               Show this help message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Defaults
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_USER="trackrat"
+DB_NAME="trackrat"
+DB_PASSWORD=""
+USE_DOCKER=false
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db-host)    DB_HOST="$2"; shift 2 ;;
+    --db-port)    DB_PORT="$2"; shift 2 ;;
+    --db-user)    DB_USER="$2"; shift 2 ;;
+    --db-name)    DB_NAME="$2"; shift 2 ;;
+    --db-password) DB_PASSWORD="$2"; shift 2 ;;
+    --docker)     USE_DOCKER=true; shift ;;
+    --dry-run)    DRY_RUN=true; shift ;;
+    --help|-h)
+      head -20 "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+run_sql() {
+  local sql="$1"
+  if $USE_DOCKER; then
+    docker exec trackrat-postgres psql -U "$DB_USER" -d "$DB_NAME" -c "$sql"
+  else
+    PGPASSWORD="${DB_PASSWORD:-${PGPASSWORD:-}}" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -c "$sql"
+  fi
+}
+
+# Tables to scrub and why:
+#
+# device_tokens (CASCADE → route_alert_subscriptions, route_preferences)
+#   Contains production APNS tokens. If not scrubbed, staging sends real push
+#   notifications to production users' phones within minutes of startup.
+#
+# live_activity_tokens
+#   Contains production APNS Live Activity push tokens. Staging's scheduler
+#   would send Live Activity updates to real users every minute, potentially
+#   showing wrong data or ending their active Live Activities.
+#
+# cached_api_responses
+#   Stale production caches could mask bugs in staging cache generation.
+#
+# scheduler_task_runs
+#   Contains production instance hostnames and last_successful_run timestamps.
+#   If not scrubbed, staging's freshness-check logic may skip scheduled runs
+#   for up to their full interval (thinking tasks already ran recently).
+
+SCRUB_SQL="
+-- Remove all device tokens and cascade to route_alert_subscriptions + route_preferences
+TRUNCATE TABLE device_tokens CASCADE;
+
+-- Remove all Live Activity tokens
+TRUNCATE TABLE live_activity_tokens;
+
+-- Clear stale production caches
+TRUNCATE TABLE cached_api_responses;
+
+-- Reset scheduler state so staging runs collectors immediately
+TRUNCATE TABLE scheduler_task_runs;
+"
+
+COUNT_SQL="
+SELECT 'device_tokens' AS table_name, COUNT(*) AS row_count FROM device_tokens
+UNION ALL
+SELECT 'live_activity_tokens', COUNT(*) FROM live_activity_tokens
+UNION ALL
+SELECT 'cached_api_responses', COUNT(*) FROM cached_api_responses
+UNION ALL
+SELECT 'scheduler_task_runs', COUNT(*) FROM scheduler_task_runs
+UNION ALL
+SELECT 'route_alert_subscriptions', COUNT(*) FROM route_alert_subscriptions
+UNION ALL
+SELECT 'route_preferences', COUNT(*) FROM route_preferences;
+"
+
+echo "=== Staging Database Scrub ==="
+
+if $DRY_RUN; then
+  echo "[DRY RUN] Would scrub the following tables:"
+  echo ""
+  run_sql "$COUNT_SQL"
+  echo ""
+  echo "[DRY RUN] No changes made."
+  exit 0
+fi
+
+echo "Row counts before scrub:"
+run_sql "$COUNT_SQL"
+
+echo ""
+echo "Scrubbing production user data..."
+run_sql "$SCRUB_SQL"
+
+echo ""
+echo "Row counts after scrub:"
+run_sql "$COUNT_SQL"
+
+echo ""
+echo "Staging database scrubbed successfully."


### PR DESCRIPTION
## Summary
Adds a critical safety mechanism to prevent staging environments from sending push notifications to production users after a production-to-staging disk clone. The implementation includes a pre-startup database check, a database scrubbing script, and infrastructure automation to ensure notification tokens are removed before the application starts.

## Key Changes

- **Staging notification safety check** (`_check_staging_notification_safety`): New async function that counts device tokens and Live Activity tokens in the staging database at startup. If the count exceeds a threshold (50 tokens), it disables APNS entirely to prevent accidental notifications to production users.

- **APNS conditional initialization**: Modified the application lifespan to check for unsafe token counts before initializing the APNS service. If the safety check fails, `apns_service` is set to `None` and a critical log is emitted.

- **Database scrubbing script** (`scripts/scrub-staging-db.sh`): New bash utility that removes production user data from a cloned staging database. Scrubs:
  - `device_tokens` (and cascading `route_alert_subscriptions`, `route_preferences`)
  - `live_activity_tokens`
  - `cached_api_responses` (to prevent stale production caches)
  - `scheduler_task_runs` (to reset scheduler state)
  
  Supports both direct PostgreSQL connections and Docker-based execution with dry-run capability.

- **Infrastructure automation** (`compute.tf`): Updated staging boot sequence to:
  1. Start only the database container first
  2. Wait for PostgreSQL to be ready
  3. Run the scrubbing SQL directly via `docker exec`
  4. Then bring up the full application stack
  
  This ensures the API never sees production notification data.

- **Comprehensive test suite** (`test_staging_safety.py`): Tests covering:
  - Empty database (safe)
  - Few tokens below threshold (safe, logged as staging testers)
  - Many tokens above threshold (unsafe, APNS disabled)
  - Exact threshold boundary condition
  - Live Activity token counting
  - Graceful error handling on database failures

## Implementation Details

- The threshold is set to 50 tokens, allowing for a small number of staging testers while catching accidental production clones.
- The safety check is only performed when `settings.environment == "staging"`.
- If the database check fails (connection error, etc.), the function returns `False` to allow startup with a warning, preventing cascading failures.
- The scheduler receives `apns_service=None` when APNS is disabled, preventing any notification jobs from running.
- All logging uses structured logging with relevant context (token counts, threshold, error details).

https://claude.ai/code/session_01KAk8KBuLFJY2kPsCsnPCe9