### PR TITLE
Add system-wide alert subscriptions

### DIFF
--- a/backend_v2/src/trackrat/api/alerts.py
+++ b/backend_v2/src/trackrat/api/alerts.py
@@ -61,15 +61,21 @@ class SubscriptionItem(BaseModel):
 
     @model_validator(mode="after")
     def check_subscription_type(self) -> "SubscriptionItem":
-        """Require exactly one of: line_id, both station codes, or train_id."""
+        """Require exactly one of: line_id, both station codes, train_id, or none (system-wide)."""
         has_line = bool(self.line_id)
         has_stations = bool(self.from_station_code and self.to_station_code)
         has_train = bool(self.train_id)
         modes = sum([has_line, has_stations, has_train])
-        if modes != 1:
+        if modes > 1:
             raise ValueError(
-                "Must provide exactly one of: line_id, both from_station_code "
-                "and to_station_code, or train_id"
+                "Must provide at most one of: line_id, both from_station_code "
+                "and to_station_code, or train_id. "
+                "Provide none for a system-wide subscription."
+            )
+        # Reject partial station pairs (one set, the other not)
+        if bool(self.from_station_code) != bool(self.to_station_code):
+            raise ValueError(
+                "Both from_station_code and to_station_code must be provided together"
             )
         return self
 
@@ -123,16 +129,19 @@ def _subscription_identity(
 ) -> tuple[Any, ...]:
     """Return a hashable key uniquely identifying a subscription's logical target.
 
-    Three mutually exclusive subscription types:
+    Four mutually exclusive subscription types:
     - Line-based: (data_source, line_id, direction)
     - Station-pair: (data_source, from_station_code, to_station_code)
     - Train-specific: (data_source, train_id)
+    - System-wide: (data_source,) — all identifiers are NULL
     """
     if row.train_id:
         return ("train", row.data_source, row.train_id)
     if row.from_station_code and row.to_station_code:
         return ("stations", row.data_source, row.from_station_code, row.to_station_code)
-    return ("line", row.data_source, row.line_id, row.direction)
+    if row.line_id:
+        return ("line", row.data_source, row.line_id, row.direction)
+    return ("system", row.data_source)
 
 
 def _subscription_identity_from_item(
@@ -148,7 +157,9 @@ def _subscription_identity_from_item(
             item.from_station_code,
             item.to_station_code,
         )
-    return ("line", item.data_source, item.line_id, item.direction)
+    if item.line_id:
+        return ("line", item.data_source, item.line_id, item.direction)
+    return ("system", item.data_source)
 
 
 # ---------------------------------------------------------------------------

--- a/backend_v2/src/trackrat/db/migrations/versions/20260324_1644-4ae83310c010_allow_system_wide_alert_subscriptions.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260324_1644-4ae83310c010_allow_system_wide_alert_subscriptions.py
@@ -1,0 +1,50 @@
+"""Allow system-wide alert subscriptions.
+
+Relaxes the ck_alert_sub_type check constraint to permit subscriptions
+where all of line_id, from_station_code, to_station_code, and train_id
+are NULL, representing a system-wide subscription keyed only by data_source.
+
+Revision ID: 4ae83310c010
+Revises: b8ca879ae8c5
+Create Date: 2026-03-24 16:44:00.000000+00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4ae83310c010"
+down_revision = "b8ca879ae8c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the old constraint and add the relaxed one
+    op.drop_constraint("ck_alert_sub_type", "route_alert_subscriptions", type_="check")
+    op.create_check_constraint(
+        "ck_alert_sub_type",
+        "route_alert_subscriptions",
+        "(line_id IS NOT NULL) OR "
+        "(from_station_code IS NOT NULL AND to_station_code IS NOT NULL) OR "
+        "(train_id IS NOT NULL) OR "
+        "(line_id IS NULL AND from_station_code IS NULL AND to_station_code IS NULL AND train_id IS NULL)",
+    )
+    # Index for system-wide subscriptions (data_source only, all identifiers NULL)
+    op.create_index(
+        "idx_alert_sub_system_wide",
+        "route_alert_subscriptions",
+        ["data_source"],
+        postgresql_where="line_id IS NULL AND from_station_code IS NULL AND to_station_code IS NULL AND train_id IS NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_alert_sub_system_wide", table_name="route_alert_subscriptions")
+    op.drop_constraint("ck_alert_sub_type", "route_alert_subscriptions", type_="check")
+    op.create_check_constraint(
+        "ck_alert_sub_type",
+        "route_alert_subscriptions",
+        "(line_id IS NOT NULL) OR "
+        "(from_station_code IS NOT NULL AND to_station_code IS NOT NULL) OR "
+        "(train_id IS NOT NULL)",
+    )

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -385,7 +385,9 @@ class RouteAlertSubscription(Base):
         CheckConstraint(
             "(line_id IS NOT NULL) OR "
             "(from_station_code IS NOT NULL AND to_station_code IS NOT NULL) OR "
-            "(train_id IS NOT NULL)",
+            "(train_id IS NOT NULL) OR "
+            "(line_id IS NULL AND from_station_code IS NULL "
+            "AND to_station_code IS NULL AND train_id IS NULL)",
             name="ck_alert_sub_type",
         ),
         Index("idx_alert_sub_device", "device_id"),

--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -91,6 +91,11 @@ def _line_codes_to_gtfs_ids(data_source: str, line_codes: frozenset[str]) -> set
     return gtfs_ids
 
 
+def _is_system_wide(sub: RouteAlertSubscription) -> bool:
+    """Check if a subscription is system-wide (no line, station pair, or train)."""
+    return not sub.line_id and not sub.from_station_code and not sub.to_station_code and not sub.train_id
+
+
 def _get_gtfs_route_ids_for_subscription(
     sub: RouteAlertSubscription,
 ) -> set[str]:
@@ -99,8 +104,12 @@ def _get_gtfs_route_ids_for_subscription(
     Maps our internal route topology to the route IDs used in
     service alert feeds (MTA GTFS route_ids, NJT line codes).
 
-    Supports both line-based subs (direct route lookup) and station-pair
-    subs (finds all routes covering the segment).
+    Supports line-based subs (direct route lookup), station-pair
+    subs (finds all routes covering the segment), and system-wide
+    subs (returns None to match all routes for that data source).
+
+    Returns an empty set if no routes could be resolved (except
+    system-wide, which is handled separately).
     """
     if sub.line_id:
         route = _ROUTES_BY_ID.get(sub.line_id)
@@ -166,6 +175,11 @@ async def evaluate_route_alerts(
                 if sent:
                     alerts_sent += 1
                     state_changed = True
+                continue
+
+            # System-wide subscriptions: skip real-time delay/cancellation
+            # evaluation (handled entirely via service alerts in evaluate_service_alerts)
+            if _is_system_wide(sub):
                 continue
 
             # Build query for relevant journeys (line / station-pair modes)
@@ -765,6 +779,8 @@ async def _send_recovery_notification(
 
 def _get_route_name(sub: RouteAlertSubscription) -> str:
     """Build a human-readable route name for a subscription."""
+    if _is_system_wide(sub):
+        return sub.data_source or "Unknown"
     if sub.line_id:
         route = _ROUTES_BY_ID.get(sub.line_id)
         route_name = route.name if route else sub.line_id
@@ -1102,10 +1118,16 @@ async def evaluate_service_alerts(
             if sub.data_source not in SERVICE_ALERT_SOURCES:
                 continue
 
-            # Get GTFS route_ids this subscription covers
-            gtfs_route_ids = _get_gtfs_route_ids_for_subscription(sub)
-            if not gtfs_route_ids:
-                continue
+            # System-wide subs match ALL alerts for the data source
+            is_sw = _is_system_wide(sub)
+
+            if not is_sw:
+                # Get GTFS route_ids this subscription covers
+                gtfs_route_ids = _get_gtfs_route_ids_for_subscription(sub)
+                if not gtfs_route_ids:
+                    continue
+            else:
+                gtfs_route_ids = None  # sentinel: match all routes
 
             # Find alerts affecting this subscription's routes
             matching_alerts = _find_matching_alerts(
@@ -1176,14 +1198,14 @@ async def evaluate_service_alerts(
 def _find_matching_alerts(
     alerts: list[ServiceAlert],
     data_source: str,
-    gtfs_route_ids: set[str],
+    gtfs_route_ids: set[str] | None,
     now_epoch: int,
 ) -> list[ServiceAlert]:
     """Find service alerts that match a subscription and are currently active.
 
     Returns alerts that:
     1. Are for the same data source
-    2. Affect at least one of the subscription's routes
+    2. Affect at least one of the subscription's routes (or all if gtfs_route_ids is None)
     3. Have at least one active period that is currently active (started and not yet ended)
     """
     matching: list[ServiceAlert] = []
@@ -1192,10 +1214,11 @@ def _find_matching_alerts(
         if alert.data_source != data_source:
             continue
 
-        # Check route overlap
-        alert_routes = set(alert.affected_route_ids or [])
-        if not alert_routes & gtfs_route_ids:
-            continue
+        # Check route overlap (None = system-wide, match all)
+        if gtfs_route_ids is not None:
+            alert_routes = set(alert.affected_route_ids or [])
+            if not alert_routes & gtfs_route_ids:
+                continue
 
         # Check if any active period is currently active
         is_currently_active = False
@@ -1219,6 +1242,8 @@ def _find_matching_alerts(
 
 def _get_route_name_for_subscription(sub: RouteAlertSubscription) -> str:
     """Get a human-readable route name for a subscription."""
+    if _is_system_wide(sub):
+        return sub.data_source or "Unknown"
     if sub.line_id:
         route = _ROUTES_BY_ID.get(sub.line_id)
         return route.name if route else sub.line_id

--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -30,7 +30,11 @@ final class AlertSubscriptionService: ObservableObject {
     func addSubscriptions(_ subs: [RouteAlertSubscription]) {
         for sub in subs {
             let isDuplicate: Bool
-            if let lineId = sub.lineId, let direction = sub.direction {
+            if sub.isSystemWide {
+                isDuplicate = subscriptions.contains {
+                    $0.isSystemWide && $0.dataSource == sub.dataSource
+                }
+            } else if let lineId = sub.lineId, let direction = sub.direction {
                 isDuplicate = subscriptions.contains {
                     $0.lineId == lineId && $0.dataSource == sub.dataSource && $0.direction == direction
                 }
@@ -143,9 +147,17 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
     var digestTimeMinutes: Int?  // Minutes from midnight, nil = disabled
     var includePlannedWork: Bool
 
+    /// Whether this is a system-wide subscription (no line, station pair, or train specified).
+    var isSystemWide: Bool {
+        lineId == nil && fromStationCode == nil && toStationCode == nil && trainId == nil
+    }
+
     /// Human-readable name for this subscription (e.g. "Hoboken to 33rd Street").
     var displayName: String {
-        if let trainName = trainName {
+        if isSystemWide {
+            let system = TrainSystem(rawValue: dataSource)
+            return "\(system?.displayName ?? dataSource) — System Alerts"
+        } else if let trainName = trainName {
             return trainName
         } else if let lineName = lineName {
             guard let direction = direction else { return lineName }
@@ -291,6 +303,39 @@ struct RouteAlertSubscription: Codable, Identifiable, Equatable {
         self.notifyRecovery = notifyRecovery
         self.digestTimeMinutes = digestTimeMinutes
         self.includePlannedWork = false
+    }
+
+    /// System-wide subscription (all alerts for a transit system).
+    init(
+        dataSource: String,
+        activeDays: Int = 127, activeStartMinutes: Int? = nil, activeEndMinutes: Int? = nil,
+        timezone: String? = nil, delayThresholdMinutes: Int? = nil, serviceThresholdPct: Int? = nil,
+        cancellationThresholdPct: Int? = nil,
+        notifyCancellation: Bool = true, notifyDelay: Bool = true,
+        notifyRecovery: Bool = false, digestTimeMinutes: Int? = nil,
+        includePlannedWork: Bool = true
+    ) {
+        self.id = UUID()
+        self.dataSource = dataSource
+        self.lineId = nil
+        self.lineName = nil
+        self.fromStationCode = nil
+        self.toStationCode = nil
+        self.trainId = nil
+        self.trainName = nil
+        self.direction = nil
+        self.activeDays = activeDays
+        self.activeStartMinutes = activeStartMinutes
+        self.activeEndMinutes = activeEndMinutes
+        self.timezone = timezone
+        self.delayThresholdMinutes = delayThresholdMinutes
+        self.serviceThresholdPct = serviceThresholdPct
+        self.cancellationThresholdPct = cancellationThresholdPct
+        self.notifyCancellation = notifyCancellation
+        self.notifyDelay = notifyDelay
+        self.notifyRecovery = notifyRecovery
+        self.digestTimeMinutes = digestTimeMinutes
+        self.includePlannedWork = includePlannedWork
     }
 
     /// Backward-compatible decoding: new fields default to sensible values if missing.

--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -312,7 +312,7 @@ struct AlertConfigurationSection: View {
     private static let plannedWorkSystems: Set<String> = ["SUBWAY", "LIRR", "MNR", "NJT"]
 
     private var showPlannedWork: Bool {
-        (subscription.lineId != nil || subscription.fromStationCode != nil)
+        (subscription.isSystemWide || subscription.lineId != nil || subscription.fromStationCode != nil)
             && Self.plannedWorkSystems.contains(subscription.dataSource)
     }
 

--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -1,10 +1,19 @@
 import SwiftUI
 
+/// Alert mode: route-specific (station pair) or system-wide.
+private enum AlertMode: String, CaseIterable {
+    case route = "Route"
+    case system = "System"
+}
+
 struct AddRouteAlertView: View {
     @EnvironmentObject private var appState: AppState
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var alertService = AlertSubscriptionService.shared
     @ObservedObject private var subscriptionService = SubscriptionService.shared
+
+    // Mode selection
+    @State private var alertMode: AlertMode = .route
 
     // Station-pair state
     @State private var showFromPicker = false
@@ -12,6 +21,10 @@ struct AddRouteAlertView: View {
     @State private var fromStation: Station? = nil
     @State private var toStation: Station? = nil
     @State private var confirmationMessage: String? = nil
+
+    // System-wide state
+    @State private var selectedSystem: TrainSystem? = nil
+    @State private var systemAlertSheetData: DirectionalSheetData? = nil
 
     // Customization sheet state
     @State private var directionalSheetData: DirectionalSheetData? = nil
@@ -23,7 +36,7 @@ struct AddRouteAlertView: View {
 
     var body: some View {
         NavigationStack {
-            stationPairPicker
+            alertContent
                 .navigationTitle("Add Route Alert")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -37,6 +50,11 @@ struct AddRouteAlertView: View {
         .sheet(item: $directionalSheetData) { data in
             DirectionalAlertConfigurationSheet(directions: data.directions) { subs in
                 saveDirectionalSubscriptions(subs)
+            }
+        }
+        .sheet(item: $systemAlertSheetData) { data in
+            DirectionalAlertConfigurationSheet(directions: data.directions) { subs in
+                saveSystemSubscription(subs)
             }
         }
     }
@@ -60,13 +78,130 @@ struct AddRouteAlertView: View {
         }
     }
 
-    // MARK: - Station-Pair Picker
+    private func saveSystemSubscription(_ subs: [RouteAlertSubscription]) {
+        guard !atAlertLimit else { return }
+        alertService.addSubscriptions(subs)
+        alertService.syncIfPossible()
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        systemAlertSheetData = nil
+        withAnimation { selectedSystem = nil }
+    }
 
-    private var stationPairPicker: some View {
+    // MARK: - Alert Content
+
+    private var alertContent: some View {
         VStack(spacing: 16) {
             if alertCapableSystems.isEmpty {
                 noEligibleSystemsView(detail: "Your selected systems are schedule-only and cannot detect delays.")
             } else {
+                Picker("Alert Type", selection: $alertMode) {
+                    ForEach(AlertMode.allCases, id: \.self) { mode in
+                        Text(mode.rawValue).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                switch alertMode {
+                case .route:
+                    routeModePicker
+                case .system:
+                    systemModePicker
+                }
+
+                if let message = confirmationMessage {
+                    HStack(spacing: 6) {
+                        Image(systemName: message.hasPrefix("Alert") ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                            .foregroundColor(message.hasPrefix("Alert") ? .green : .yellow)
+                        Text(message)
+                            .foregroundColor(.white)
+                    }
+                    .font(.subheadline)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+        }
+        .padding(.top)
+    }
+
+    // MARK: - System Mode
+
+    private var systemModePicker: some View {
+        VStack(spacing: 16) {
+            Text("Get notified about service alerts, delays, and planned work across an entire transit system.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            let systems = alertCapableSystems.sorted { $0.displayName < $1.displayName }
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 100), spacing: 10)], spacing: 10) {
+                ForEach(systems, id: \.self) { system in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.15)) {
+                            selectedSystem = selectedSystem == system ? nil : system
+                        }
+                    } label: {
+                        Text(system.displayName)
+                            .font(.subheadline)
+                            .fontWeight(selectedSystem == system ? .semibold : .regular)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(selectedSystem == system ? Color.orange : .ultraThinMaterial)
+                            )
+                            .foregroundColor(selectedSystem == system ? .black : .white)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+
+            if let system = selectedSystem {
+                Button {
+                    let alreadyExists = alertService.subscriptions.contains {
+                        $0.isSystemWide && $0.dataSource == system.rawValue
+                    }
+
+                    if alreadyExists {
+                        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                        showConfirmation("Already subscribed")
+                    } else {
+                        let sub = RouteAlertSubscription(dataSource: system.rawValue)
+                        systemAlertSheetData = DirectionalSheetData(directions: [
+                            DirectionDraft(
+                                label: "\(system.displayName) System Alerts",
+                                subscription: sub,
+                                alreadySubscribed: false
+                            ),
+                        ])
+                    }
+                } label: {
+                    Text("Add Alert")
+                        .font(.headline)
+                        .foregroundColor(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Capsule().fill(.orange))
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Route Mode (Station-Pair Picker)
+
+    private var routeModePicker: some View {
+        VStack(spacing: 16) {
+            Text("Get notified about delays and cancellations between two stations.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.6))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
             // First station
             Button {
                 showFromPicker = true
@@ -158,22 +293,9 @@ struct AddRouteAlertView: View {
                 .padding(.top, 8)
             }
 
-            if let message = confirmationMessage {
-                HStack(spacing: 6) {
-                    Image(systemName: message.hasPrefix("Alert") ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
-                        .foregroundColor(message.hasPrefix("Alert") ? .green : .yellow)
-                    Text(message)
-                        .foregroundColor(.white)
-                }
-                .font(.subheadline)
-                .transition(.opacity.combined(with: .move(edge: .top)))
-                .padding(.top, 8)
-            }
-
             Spacer()
-            } // else alertCapableSystems not empty
         }
-        .padding()
+        .padding(.horizontal)
         .sheet(isPresented: $showFromPicker) {
             StationPickerSheet(
                 selectedStation: $fromStation,


### PR DESCRIPTION
## Summary

- Expands "Add Route Alert" view with a **segmented picker** (Route / System) and descriptive headers for each mode
- **Route mode**: existing station-pair flow, now with a brief description ("Get notified about delays and cancellations between two stations")
- **System mode**: new flow where users select an entire transit system (NJT, Amtrak, PATH, LIRR, MNR, Subway) and subscribe to all service alerts, delays, and planned work for that system
- Backend relaxes the check constraint to allow system-wide subscriptions (all identifier fields NULL, keyed by `data_source` only)
- Alert evaluator skips real-time delay evaluation for system-wide subs (service alerts only — matches all alerts for the data source)
- System-wide subs count toward the free-user limit

## Changes

**iOS (4 files):**
- `AddRouteAlertView.swift` — segmented picker, system selector grid, descriptions for both modes
- `AlertSubscriptionService.swift` — system-wide initializer (`isSystemWide`, `displayName`), dedup logic
- `AlertConfigurationSection.swift` — planned work toggle shown for system-wide subs
- No new files or views

**Backend (4 files):**
- Migration: relax `ck_alert_sub_type` constraint + partial index for system-wide subs
- `alerts.py` — validator accepts system-wide subs, identity functions handle new type
- `alert_evaluator.py` — `_is_system_wide()` helper, skips real-time eval, service alert matching with `None` route IDs
- `database.py` — updated check constraint in model definition

## Test plan

- [ ] Verify Route mode still works identically (station pair → directional config → save)
- [ ] Verify System mode shows all alert-capable systems (excludes PATCO)
- [ ] Select a system → tap Add Alert → customize sheet appears with system name as header
- [ ] Service Alerts toggle defaults to ON for system-wide subs
- [ ] Duplicate system-wide sub shows "Already subscribed" warning
- [ ] Free users limited to 1 total alert (route or system)
- [ ] System-wide sub displays as "NJ Transit — System Alerts" in Settings
- [ ] Backend migration applies cleanly
- [ ] `PUT /alerts/subscriptions` accepts `{"data_source": "SUBWAY"}` with no other identifiers

https://claude.ai/code/session_01ErhJUQPEkswFjRmwLvQzLb