### PR TITLE
Update docs to reflect recent code changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ TrackRat is an open-source transit tracking framework (Apache 2.0) with:
 - **iOS**: Swift (SwiftUI + ActivityKit) in `ios/`
 - **Android**: Kotlin (Jetpack Compose + Hilt + Retrofit) in `android/`
 - **Web**: React (TypeScript + Vite + Tailwind) in `webpage_v2/` - See `webpage_v2/CLAUDE.md`
+- **Backend docs**: See `backend_v2/CLAUDE.md` for detailed backend architecture
 - **Infrastructure**: Terraform (Google Cloud Platform) in `infra_v2/`
 
 ## USE SUB-AGENTS FOR CONTEXT OPTIMIZATION
@@ -166,6 +167,19 @@ script and provide a narrative summary that highlights:
   congestion_cache are known to be slow). Zero errors is worth calling out.
 - **Scanner noise**: mention probe count but don't dwell on it unless unusual.
 
+**Other Utility Scripts:**
+
+```bash
+# Scrub staging database (remove production PII before testing)
+bash scripts/scrub-staging-db.sh
+
+# Generate subway station data from GTFS
+python3 scripts/generate_subway_data.py
+
+# Create DB backup, restore, and train ML model
+bash scripts/create-and-restore-db-then-train-model.sh
+```
+
 ### Architecture Patterns
 
 **Backend Data Collection (NJT/Amtrak - Multi-Phase):**
@@ -203,6 +217,12 @@ script and provide a narrative summary that highlights:
 - Three alert types: `planned_work`, `alert` (real-time), `elevator` (outages)
 - Upserts into `service_alerts` table; marks missing alerts as inactive
 - Used to send planned work / service change push notifications to subscribed users
+
+**Transit Transfers / Trip Search:**
+- Multi-leg trip search across transit systems via `/api/v2/trips/search`
+- Transfer points defined in `backend_v2/src/trackrat/config/transfer_points.py`
+- Service in `backend_v2/src/trackrat/services/trip_search.py`, API in `backend_v2/src/trackrat/api/trips.py`
+- Supports system-wide alert subscriptions (not just per-route)
 
 **Route Alert Customization:**
 - Per-subscription settings: active days (bitmask), time windows, delay/service thresholds
@@ -279,7 +299,6 @@ poetry run uvicorn trackrat.main:app --reload
 
 # Lint & type check
 poetry run black . && poetry run ruff check . && poetry run mypy src/
-# Or use: make lint
 ```
 
 ### iOS Development
@@ -414,7 +433,8 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - Backend API endpoints: `backend_v2/src/trackrat/api/`
 - Backend models: `backend_v2/src/trackrat/models/`
 - Backend collectors: `backend_v2/src/trackrat/collectors/` (njt, amtrak, path, lirr, mnr, subway, service_alerts, mta_common, mta_extensions)
-- Backend config: `backend_v2/src/trackrat/config/` (stations/ package, route_topology, station_configs, platform_mappings)
+- Backend config: `backend_v2/src/trackrat/config/` (stations/ package, route_topology, station_configs, platform_mappings, transfer_points)
+- Backend utilities: `backend_v2/src/trackrat/utils/` (logging, metrics, request_stats, locks, time, train, sanitize)
 - Backend tests: `backend_v2/tests/`
 - iOS views: `ios/TrackRat/Views/Screens/`, `ios/TrackRat/Views/Components/`
 - iOS services: `ios/TrackRat/Services/`
@@ -447,16 +467,20 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 /api/v2/predictions/delay          # Delay/cancellation forecasts (iOS)
 /api/v2/predictions/supported-stations  # Stations with predictions
 
+# Trip Search
+/api/v2/trips/search               # Multi-leg trip search with transfers
+
 # Route Alerts
 /api/v2/devices/register           # Register APNS device token
 /api/v2/alerts/subscriptions       # Sync route alert subscriptions (PUT)
+/api/v2/alerts/subscriptions/{device_id}  # Get current subscriptions (GET)
 /api/v2/alerts/service             # MTA service alerts (planned work, delays)
 
 # Feedback
 /api/v2/feedback                   # Submit user feedback
 
 # Route Preferences
-/api/v2/route-preferences          # User route preferences
+/api/v2/routes/preferences         # User route preferences (GET/PUT)
 
 # Admin
 /admin/stats                       # Server usage statistics page (HTML)

--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -202,7 +202,7 @@ GET /predictions/supported-stations                   # Stations with prediction
 # Route Alerts
 POST /devices/register                               # Register APNS device token
 PUT  /alerts/subscriptions                           # Sync route alert subscriptions
-GET  /alerts/subscriptions                           # Get current alert subscriptions
+GET  /alerts/subscriptions/{device_id}               # Get current alert subscriptions
 
 # Validation
 GET /validation/status                               # Validation status and recent results
@@ -219,8 +219,12 @@ DELETE /live-activities/{token}   # Unregister Live Activity
 GET /admin/stats              # Server usage statistics (HTML)
 GET /admin/stats.json         # Server usage statistics (JSON)
 
+# Trip Search
+GET /trips/search             # Multi-leg trip search with transfers
+
 # Route Preferences
-GET /route-preferences        # User route preferences
+GET /routes/preferences       # User route preferences
+PUT /routes/preferences       # Update route preferences
 
 # System Health and Metrics
 GET /health                    # Comprehensive health check
@@ -343,7 +347,7 @@ poetry run ruff check .
 poetry run mypy src/
 
 # Run all checks
-make lint
+poetry run black . && poetry run ruff check . && poetry run mypy src/
 ```
 
 ### Testing
@@ -662,6 +666,11 @@ The backend is organized into service classes for better maintainability:
 - **AlertEvaluatorService** (`services/alert_evaluator.py`): Evaluates delay/cancellation conditions for route alert push notifications
 - **AlertsAPI** (`api/alerts.py`): Device registration and alert subscription management endpoints
 
+#### Trip Search & Transfers
+- **TripSearchService** (`services/trip_search.py`): Multi-leg trip search across transit systems
+- **TransferPoints** (`config/transfer_points.py`): Defines transfer connections between transit systems
+- **TripsAPI** (`api/trips.py`): Trip search endpoint
+
 #### Infrastructure
 - **SimpleAPNSService** (`services/apns.py`): Apple Push Notifications for Live Activities and Route Alerts
 - **BackupService** (`services/backup_service.py`): GCS backup management (optional)
@@ -682,6 +691,12 @@ The backend is organized into service classes for better maintainability:
 - ✅ Subscription sync fix preventing notification deduplication state wipe
 - ✅ Fix route segment map showing full route instead of selected segment
 - ✅ Backend instance upgrade from t2d-standard-1 to t2d-standard-2
+- ✅ Multi-leg trip search with transit transfers (`/api/v2/trips/search`)
+- ✅ Transfer points configuration for cross-system connections
+- ✅ System-wide alert subscriptions (not just per-route)
+- ✅ Request stats tracking for API usage metrics
+- ✅ Track assignment push notifications
+- ✅ LIRR Port Washington line code collision fix
 
 ### Recent Improvements (February 2026)
 - ✅ Recurring train alerts: subscribe to specific train numbers for daily commute monitoring


### PR DESCRIPTION
## Summary
- Fix incorrect API endpoint path (`/api/v2/route-preferences` → `/api/v2/routes/preferences`)
- Add missing endpoints: `/api/v2/trips/search`, `/api/v2/alerts/subscriptions/{device_id}` GET
- Add backend_v2/CLAUDE.md reference, utilities directory, and transfer_points to Key File Locations
- Document undocumented scripts (scrub-staging-db, generate_subway_data, create-and-restore-db)
- Add Transit Transfers architecture pattern to root CLAUDE.md
- Remove broken `make lint` reference (no Makefile exists)
- Add Trip Search & Transfers service section and recent March changelog to backend_v2/CLAUDE.md

## Test plan
- [ ] Verify all documented API paths match actual route definitions
- [ ] Verify all referenced file paths exist in the codebase
- [ ] Confirm no broken script references

https://claude.ai/code/session_01Ej1MBmPf2G6kQmkyagmgBC