### PR TITLE
Add system metrics (disk, memory, CPU) to stats and health endpoints

### DIFF
--- a/backend_v2/src/trackrat/api/admin.py
+++ b/backend_v2/src/trackrat/api/admin.py
@@ -29,6 +29,7 @@ from trackrat.models.database import (
 from trackrat.services.scheduler import get_scheduler
 from trackrat.settings import Settings, get_settings
 from trackrat.utils.request_stats import get_request_stats
+from trackrat.utils.system_stats import get_system_stats
 from trackrat.utils.time import now_et
 
 router = APIRouter(tags=["admin"])
@@ -212,6 +213,59 @@ def _build_filter_links(
     )
 
 
+def _render_system_section(system_stats: dict[str, Any]) -> str:
+    """Render the system metrics section for the HTML page."""
+    if not system_stats:
+        return ""
+
+    rows = ""
+    disk = system_stats.get("disk")
+    if disk:
+        pct = disk["usage_percent"]
+        cls = "ok" if pct < 80 else ("warn" if pct < 90 else "err")
+        rows += (
+            f"<tr><td>Disk</td>"
+            f"<td class='num {cls}'>{pct}%</td>"
+            f"<td class='num'>{disk['used_gb']} / {disk['total_gb']} GB</td>"
+            f"<td class='num'>{disk['free_gb']} GB free</td></tr>"
+        )
+
+    memory = system_stats.get("memory")
+    if memory:
+        pct = memory["usage_percent"]
+        cls = "ok" if pct < 80 else ("warn" if pct < 90 else "err")
+        rows += (
+            f"<tr><td>Memory</td>"
+            f"<td class='num {cls}'>{pct}%</td>"
+            f"<td class='num'>{memory['used_gb']} / {memory['total_gb']} GB</td>"
+            f"<td class='num'>{memory['available_gb']} GB avail</td></tr>"
+        )
+
+    cpu = system_stats.get("cpu")
+    if cpu:
+        rows += (
+            f"<tr><td>CPU Load</td>"
+            f"<td class='num'>{cpu['load_1m']}</td>"
+            f"<td class='num'>{cpu['load_5m']}</td>"
+            f"<td class='num'>{cpu['load_15m']}</td></tr>"
+        )
+
+    if not rows:
+        return ""
+
+    # Header row adapts to what's available
+    header = "<tr><th>Metric</th><th class='num'>Usage</th><th class='num'>Used / Total</th><th class='num'>Detail</th></tr>"
+    if cpu and not disk and not memory:
+        header = "<tr><th>Metric</th><th class='num'>1m</th><th class='num'>5m</th><th class='num'>15m</th></tr>"
+
+    return f"""
+<h2>System</h2>
+<table>
+{header}
+{rows}
+</table>"""
+
+
 def _render_html(
     request_stats: dict[str, Any],
     db_stats: dict[str, Any],
@@ -220,6 +274,7 @@ def _render_html(
     *,
     hours: int | None = None,
     ios_only: bool = False,
+    system_stats: dict[str, Any] | None = None,
 ) -> str:
     """Render the stats page as self-contained HTML."""
     now = now_et()
@@ -443,6 +498,7 @@ def _render_html(
 {provider_rows if provider_rows else "<tr><td colspan='5'>No data</td></tr>"}
 </table>
 {ip_section}
+{_render_system_section(system_stats or {}) }
 </div>
 </div>
 
@@ -473,6 +529,7 @@ async def stats_page(
     request_data = get_request_stats().snapshot(hours=hours, ios_only=ios_only)
     db_data = await _db_stats(db)
     scheduler_jobs = _scheduler_stats()
+    system_data = get_system_stats()
     html = _render_html(
         request_data,
         db_data,
@@ -480,6 +537,7 @@ async def stats_page(
         settings,
         hours=hours,
         ios_only=ios_only,
+        system_stats=system_data,
     )
     return HTMLResponse(content=html)
 
@@ -514,8 +572,9 @@ async def stats_json(
     }
     request_data["route_searches"] = route_searches
 
-    # Include scheduler jobs (JSON parity with HTML)
+    # Include scheduler jobs and system metrics (JSON parity with HTML)
     request_data["scheduler_jobs"] = scheduler_jobs
+    request_data["system"] = get_system_stats()
 
     train_detail_views = {
         f"{entry['train_id']} ({get_station_name(entry['from'])} -> {get_station_name(entry['to'])})": entry[

--- a/backend_v2/src/trackrat/api/health.py
+++ b/backend_v2/src/trackrat/api/health.py
@@ -15,6 +15,7 @@ from trackrat.db.engine import get_db
 from trackrat.models.database import DiscoveryRun, TrainJourney
 from trackrat.services.scheduler import get_scheduler
 from trackrat.settings import Settings, get_settings
+from trackrat.utils.system_stats import get_disk_usage, get_memory_usage
 from trackrat.utils.time import now_et
 
 logger = get_logger(__name__)
@@ -122,6 +123,34 @@ async def health_check(
         }
     except Exception as e:
         health_status["checks"]["discovery"] = {"status": "unhealthy", "error": str(e)}
+
+    # Disk space check
+    disk = get_disk_usage("/")
+    if disk:
+        pct = disk["usage_percent"]
+        if pct >= 95:
+            disk_status = "unhealthy"
+        elif pct >= 90:
+            disk_status = "warning"
+        else:
+            disk_status = "healthy"
+        health_status["checks"]["disk"] = {
+            "status": disk_status,
+            **disk,
+        }
+
+    # Memory check
+    memory = get_memory_usage()
+    if memory:
+        pct = memory["usage_percent"]
+        if pct >= 95:
+            mem_status = "warning"
+        else:
+            mem_status = "healthy"
+        health_status["checks"]["memory"] = {
+            "status": mem_status,
+            **memory,
+        }
 
     # PostgreSQL with Cloud SQL provides automated backups
     health_status["checks"]["backup"] = {

--- a/backend_v2/src/trackrat/main.py
+++ b/backend_v2/src/trackrat/main.py
@@ -317,6 +317,9 @@ if settings.enable_metrics:
 
     @app.get("/metrics", include_in_schema=False)
     async def metrics() -> Response:
+        from trackrat.utils.metrics import update_system_metrics
+
+        update_system_metrics()
         return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 

--- a/backend_v2/src/trackrat/utils/metrics.py
+++ b/backend_v2/src/trackrat/utils/metrics.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 from structlog import get_logger
 
 logger = get_logger(__name__)
@@ -60,6 +60,46 @@ train_validation_runs = Counter(
     "Total validation runs",
     ["status"],  # success or failure
 )
+
+
+# System resource gauges
+system_disk_usage_percent = Gauge(
+    "system_disk_usage_percent",
+    "Disk usage percentage",
+)
+
+system_disk_free_bytes = Gauge(
+    "system_disk_free_bytes",
+    "Disk free space in bytes",
+)
+
+system_memory_usage_percent = Gauge(
+    "system_memory_usage_percent",
+    "Memory usage percentage",
+)
+
+system_cpu_load_1m = Gauge(
+    "system_cpu_load_1m",
+    "CPU load average (1 minute)",
+)
+
+
+def update_system_metrics() -> None:
+    """Update system resource Prometheus gauges from /proc and shutil."""
+    from trackrat.utils.system_stats import get_cpu_load, get_disk_usage, get_memory_usage
+
+    disk = get_disk_usage("/")
+    if disk:
+        system_disk_usage_percent.set(disk["usage_percent"])
+        system_disk_free_bytes.set(disk["free_gb"] * 1024**3)
+
+    memory = get_memory_usage()
+    if memory:
+        system_memory_usage_percent.set(memory["usage_percent"])
+
+    cpu = get_cpu_load()
+    if cpu:
+        system_cpu_load_1m.set(cpu["load_1m"])
 
 
 def track_api_call(

--- a/backend_v2/src/trackrat/utils/system_stats.py
+++ b/backend_v2/src/trackrat/utils/system_stats.py
@@ -1,0 +1,103 @@
+"""
+System-level metrics: disk usage, memory, and CPU load.
+
+Uses stdlib and /proc filesystem — no external dependencies.
+All functions degrade gracefully if /proc is unavailable.
+"""
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def get_disk_usage(path: str = "/") -> dict[str, Any]:
+    """Get disk usage for the given mount point.
+
+    Returns dict with total_gb, used_gb, free_gb, usage_percent.
+    """
+    try:
+        usage = shutil.disk_usage(path)
+        total_gb = round(usage.total / (1024**3), 2)
+        used_gb = round(usage.used / (1024**3), 2)
+        free_gb = round(usage.free / (1024**3), 2)
+        usage_percent = round(usage.used / usage.total * 100, 1) if usage.total > 0 else 0
+        return {
+            "total_gb": total_gb,
+            "used_gb": used_gb,
+            "free_gb": free_gb,
+            "usage_percent": usage_percent,
+        }
+    except OSError:
+        return {}
+
+
+def get_memory_usage() -> dict[str, Any]:
+    """Get memory usage from /proc/meminfo.
+
+    Returns dict with total_gb, available_gb, usage_percent.
+    """
+    try:
+        meminfo: dict[str, int] = {}
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                key = parts[0].rstrip(":")
+                # Values in /proc/meminfo are in kB
+                meminfo[key] = int(parts[1])
+
+        total_kb = meminfo.get("MemTotal", 0)
+        available_kb = meminfo.get("MemAvailable", 0)
+        if total_kb == 0:
+            return {}
+
+        total_gb = round(total_kb / (1024**2), 2)
+        available_gb = round(available_kb / (1024**2), 2)
+        used_gb = round((total_kb - available_kb) / (1024**2), 2)
+        usage_percent = round((total_kb - available_kb) / total_kb * 100, 1)
+        return {
+            "total_gb": total_gb,
+            "used_gb": used_gb,
+            "available_gb": available_gb,
+            "usage_percent": usage_percent,
+        }
+    except (OSError, ValueError, KeyError):
+        return {}
+
+
+def get_cpu_load() -> dict[str, Any]:
+    """Get CPU load averages from /proc/loadavg.
+
+    Returns dict with load_1m, load_5m, load_15m.
+    """
+    try:
+        parts = Path("/proc/loadavg").read_text().split()
+        return {
+            "load_1m": float(parts[0]),
+            "load_5m": float(parts[1]),
+            "load_15m": float(parts[2]),
+        }
+    except (OSError, ValueError, IndexError):
+        return {}
+
+
+def get_system_stats() -> dict[str, Any]:
+    """Collect all system-level metrics.
+
+    Returns a dict with disk, memory, and cpu sections.
+    Only includes sections that could be read successfully.
+    """
+    stats: dict[str, Any] = {}
+
+    disk = get_disk_usage("/")
+    if disk:
+        stats["disk"] = disk
+
+    memory = get_memory_usage()
+    if memory:
+        stats["memory"] = memory
+
+    cpu = get_cpu_load()
+    if cpu:
+        stats["cpu"] = cpu
+
+    return stats

--- a/backend_v2/tests/unit/test_system_stats.py
+++ b/backend_v2/tests/unit/test_system_stats.py
@@ -1,0 +1,184 @@
+"""Tests for system_stats utility module.
+
+Validates disk, memory, and CPU metric collection from stdlib/procfs.
+Tests both real system reads and graceful degradation when sources are unavailable.
+"""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from trackrat.utils.system_stats import (
+    get_cpu_load,
+    get_disk_usage,
+    get_memory_usage,
+    get_system_stats,
+)
+
+
+class TestGetDiskUsage:
+    """Tests for get_disk_usage()."""
+
+    def test_returns_real_disk_stats(self) -> None:
+        """Should return real disk usage for root filesystem."""
+        result = get_disk_usage("/")
+        assert result, "Expected non-empty dict from real filesystem"
+        assert "total_gb" in result
+        assert "used_gb" in result
+        assert "free_gb" in result
+        assert "usage_percent" in result
+
+        # Sanity: total should be positive, percent in range
+        assert result["total_gb"] > 0, f"total_gb should be positive, got {result['total_gb']}"
+        assert 0 <= result["usage_percent"] <= 100, (
+            f"usage_percent out of range: {result['usage_percent']}"
+        )
+        # used + free <= total (reserved blocks may account for the difference)
+        assert result["used_gb"] + result["free_gb"] <= result["total_gb"] + 0.1, (
+            f"used ({result['used_gb']}) + free ({result['free_gb']}) > "
+            f"total ({result['total_gb']})"
+        )
+
+    def test_matches_shutil_directly(self) -> None:
+        """Values should match shutil.disk_usage output."""
+        result = get_disk_usage("/")
+        raw = shutil.disk_usage("/")
+        expected_pct = round(raw.used / raw.total * 100, 1)
+        assert result["usage_percent"] == expected_pct
+
+    def test_invalid_path_returns_empty(self) -> None:
+        """Should return empty dict for non-existent path."""
+        result = get_disk_usage("/nonexistent/path/that/does/not/exist")
+        assert result == {}
+
+    def test_oserror_returns_empty(self) -> None:
+        """Should return empty dict when shutil raises OSError."""
+        with patch("trackrat.utils.system_stats.shutil.disk_usage", side_effect=OSError("boom")):
+            result = get_disk_usage("/")
+        assert result == {}
+
+
+class TestGetMemoryUsage:
+    """Tests for get_memory_usage()."""
+
+    def test_returns_real_memory_stats(self) -> None:
+        """Should return real memory stats from /proc/meminfo if available."""
+        result = get_memory_usage()
+        if not Path("/proc/meminfo").exists():
+            pytest.skip("/proc/meminfo not available on this platform")
+
+        assert result, "Expected non-empty dict from /proc/meminfo"
+        assert "total_gb" in result
+        assert "used_gb" in result
+        assert "available_gb" in result
+        assert "usage_percent" in result
+
+        assert result["total_gb"] > 0, f"total_gb should be positive, got {result['total_gb']}"
+        assert 0 <= result["usage_percent"] <= 100, (
+            f"usage_percent out of range: {result['usage_percent']}"
+        )
+
+    def test_missing_proc_returns_empty(self) -> None:
+        """Should return empty dict when /proc/meminfo doesn't exist."""
+        with patch.object(Path, "read_text", side_effect=OSError("no /proc")):
+            result = get_memory_usage()
+        assert result == {}
+
+    def test_malformed_meminfo_returns_empty(self) -> None:
+        """Should return empty dict when meminfo content is garbage."""
+        with patch.object(Path, "read_text", return_value="not valid meminfo data\n"):
+            result = get_memory_usage()
+        # MemTotal won't be found, total_kb=0, returns empty
+        assert result == {}
+
+    def test_parses_known_meminfo_format(self) -> None:
+        """Should correctly parse a known /proc/meminfo snippet."""
+        fake_meminfo = (
+            "MemTotal:        8000000 kB\n"
+            "MemFree:         1000000 kB\n"
+            "MemAvailable:    3000000 kB\n"
+            "Buffers:          500000 kB\n"
+        )
+        with patch.object(Path, "read_text", return_value=fake_meminfo):
+            result = get_memory_usage()
+
+        assert result["total_gb"] == round(8000000 / (1024**2), 2)
+        assert result["available_gb"] == round(3000000 / (1024**2), 2)
+        assert result["used_gb"] == round(5000000 / (1024**2), 2)
+        assert result["usage_percent"] == round(5000000 / 8000000 * 100, 1)
+
+
+class TestGetCpuLoad:
+    """Tests for get_cpu_load()."""
+
+    def test_returns_real_cpu_load(self) -> None:
+        """Should return real load averages from /proc/loadavg if available."""
+        result = get_cpu_load()
+        if not Path("/proc/loadavg").exists():
+            pytest.skip("/proc/loadavg not available on this platform")
+
+        assert result, "Expected non-empty dict from /proc/loadavg"
+        assert "load_1m" in result
+        assert "load_5m" in result
+        assert "load_15m" in result
+
+        # Load averages should be non-negative
+        assert result["load_1m"] >= 0
+        assert result["load_5m"] >= 0
+        assert result["load_15m"] >= 0
+
+    def test_missing_proc_returns_empty(self) -> None:
+        """Should return empty dict when /proc/loadavg doesn't exist."""
+        with patch.object(Path, "read_text", side_effect=OSError("no /proc")):
+            result = get_cpu_load()
+        assert result == {}
+
+    def test_parses_known_loadavg_format(self) -> None:
+        """Should correctly parse a known /proc/loadavg line."""
+        with patch.object(Path, "read_text", return_value="1.23 4.56 7.89 2/300 12345\n"):
+            result = get_cpu_load()
+
+        assert result["load_1m"] == 1.23
+        assert result["load_5m"] == 4.56
+        assert result["load_15m"] == 7.89
+
+
+class TestGetSystemStats:
+    """Tests for the aggregate get_system_stats()."""
+
+    def test_returns_all_sections_on_linux(self) -> None:
+        """On Linux, should return disk, memory, and cpu sections."""
+        result = get_system_stats()
+        # Disk should always work (shutil is cross-platform)
+        assert "disk" in result, f"Missing disk section. Got keys: {list(result.keys())}"
+
+        if Path("/proc/meminfo").exists():
+            assert "memory" in result, "Missing memory section on Linux"
+        if Path("/proc/loadavg").exists():
+            assert "cpu" in result, "Missing cpu section on Linux"
+
+    def test_omits_empty_sections(self) -> None:
+        """Should not include sections that returned empty dicts."""
+        with (
+            patch("trackrat.utils.system_stats.get_disk_usage", return_value={}),
+            patch("trackrat.utils.system_stats.get_memory_usage", return_value={}),
+            patch("trackrat.utils.system_stats.get_cpu_load", return_value={}),
+        ):
+            result = get_system_stats()
+
+        assert result == {}, f"Expected empty dict when all sources fail, got {result}"
+
+    def test_partial_availability(self) -> None:
+        """Should include only available sections."""
+        with (
+            patch("trackrat.utils.system_stats.get_memory_usage", return_value={}),
+            patch("trackrat.utils.system_stats.get_cpu_load", return_value={}),
+        ):
+            result = get_system_stats()
+
+        # Disk should still be present (real shutil)
+        assert "disk" in result
+        assert "memory" not in result
+        assert "cpu" not in result


### PR DESCRIPTION
## Summary

- Adds disk usage, memory usage, and CPU load to `/admin/stats` (HTML dashboard), `/admin/stats.json` (JSON), and `/health` (health check)
- Disk space check in `/health` flags **warning at 90%** and **unhealthy at 95%** — would have caught the recent disk space outage before it happened
- Prometheus gauges (`system_disk_usage_percent`, `system_disk_free_bytes`, `system_memory_usage_percent`, `system_cpu_load_1m`) updated on each `/metrics` scrape for external alerting

## Implementation

- New `backend_v2/src/trackrat/utils/system_stats.py` — uses only stdlib (`shutil.disk_usage`) and `/proc` filesystem (`/proc/meminfo`, `/proc/loadavg`). No new dependencies.
- Graceful degradation: each metric source is independent; if `/proc` is unavailable (e.g., macOS dev), those sections are simply omitted
- 14 unit tests covering real reads, known-format parsing, and error degradation

## Test plan

- [x] `poetry run pytest tests/unit/test_system_stats.py -v` — 14/14 pass
- [ ] Verify `/admin/stats` shows System section with disk/memory/CPU on staging
- [ ] Verify `/admin/stats.json` includes `system` key
- [ ] Verify `/health` includes `disk` and `memory` checks
- [ ] Verify `/metrics` includes `system_disk_usage_percent` gauge
- [ ] Confirm health endpoint returns `degraded` when disk >90%

https://claude.ai/code/session_01NgQXSBCT3BM3hSDFUrf4La