### PR TITLE
Fix Alembic migration cycle crashing staging

### DIFF
--- a/backend_v2/src/trackrat/db/migrations/versions/20260323_1200-5a14a873c3f9_add_track_notified_at.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260323_1200-5a14a873c3f9_add_track_notified_at.py
@@ -1,7 +1,7 @@
 """add_track_notified_at
 
-Revision ID: a1b2c3d4e5f6
-Revises: c3d4e5f6a7b8
+Revision ID: 5a14a873c3f9
+Revises: b8ca879ae8c5
 Create Date: 2026-03-23 12:00:00.000000
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
-down_revision = "c3d4e5f6a7b8"
+revision = "5a14a873c3f9"
+down_revision = "b8ca879ae8c5"
 branch_labels = None
 depends_on = None
 

--- a/backend_v2/src/trackrat/db/migrations/versions/20260324_1644-4ae83310c010_allow_system_wide_alert_subscriptions.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260324_1644-4ae83310c010_allow_system_wide_alert_subscriptions.py
@@ -5,7 +5,7 @@ where all of line_id, from_station_code, to_station_code, and train_id
 are NULL, representing a system-wide subscription keyed only by data_source.
 
 Revision ID: 4ae83310c010
-Revises: b8ca879ae8c5
+Revises: 5a14a873c3f9
 Create Date: 2026-03-24 16:44:00.000000+00:00
 """
 
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "4ae83310c010"
-down_revision = "b8ca879ae8c5"
+down_revision = "5a14a873c3f9"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

- **Staging is in a crash loop** — the app restarts every ~10 seconds and never serves requests (HTTP 502)
- Root cause: migration `20260323_1200_add_track_notified_at` reused revision ID `a1b2c3d4e5f6` (already assigned to the `20251202` scaling indexes migration), creating a dependency cycle across 23 revisions
- Fix: assign unique revision ID `5a14a873c3f9`, repoint to `b8ca879ae8c5` for linear chain, update downstream migration `4ae83310c010`

## Test plan

- [x] Verified migration chain: 44 migrations, single head, zero cycles
- [ ] Staging should recover automatically once this merges and deploys
- [ ] Run `bash scripts/validate-staging.sh --no-wait` after deploy to confirm

https://claude.ai/code/session_01F3hMZwG41c24Hvxd1CBmP7