### PR TITLE
Fix staging issues: greenlet errors, congestion timeouts, slow subway

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -674,11 +674,28 @@ async def get_route_congestion(
                 )
 
     analyzer = CongestionAnalyzer()
-    aggregated_segments, journeys, individual_segments = (
-        await analyzer.get_network_congestion_with_trains(
-            db, effective_time_window, max_per_segment, data_source
+    try:
+        aggregated_segments, journeys, individual_segments = (
+            await analyzer.get_network_congestion_with_trains(
+                db, effective_time_window, max_per_segment, data_source
+            )
         )
-    )
+    except Exception as e:
+        # Statement timeout or other DB error on live computation path.
+        # The precompute job will populate the cache on next run.
+        error_name = type(e).__name__
+        if "QueryCanceled" in error_name or "statement timeout" in str(e).lower():
+            logger.warning(
+                "congestion_query_timeout",
+                data_source=data_source,
+                time_window_hours=effective_time_window,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Congestion data is temporarily unavailable. Please retry shortly.",
+                headers={"Retry-After": "60"},
+            )
+        raise
 
     # Filter out segments containing "SAN" station code - collision between
     # San Diego Santa Fe Depot (Pacific Surfliner) and Sanford, FL (Silver Service)

--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -261,7 +261,15 @@ class LIRRCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "LIRR",
             )
-            .options(selectinload(TrainJourney.stops))
+            .options(
+                selectinload(TrainJourney.stops),
+                # Load all delete-orphan collections to prevent
+                # greenlet_spawn errors during flush orphan checks
+                selectinload(TrainJourney.snapshots),
+                selectinload(TrainJourney.segment_times),
+                selectinload(TrainJourney.dwell_times),
+                selectinload(TrainJourney.progress_snapshots),
+            )
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -249,7 +249,15 @@ class MNRCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "MNR",
             )
-            .options(selectinload(TrainJourney.stops))
+            .options(
+                selectinload(TrainJourney.stops),
+                # Load all delete-orphan collections to prevent
+                # greenlet_spawn errors during flush orphan checks
+                selectinload(TrainJourney.snapshots),
+                selectinload(TrainJourney.segment_times),
+                selectinload(TrainJourney.dwell_times),
+                selectinload(TrainJourney.progress_snapshots),
+            )
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -243,7 +243,15 @@ class SubwayCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "SUBWAY",
             )
-            .options(selectinload(TrainJourney.stops))
+            .options(
+                selectinload(TrainJourney.stops),
+                # Load all delete-orphan collections to prevent
+                # greenlet_spawn errors during flush orphan checks
+                selectinload(TrainJourney.snapshots),
+                selectinload(TrainJourney.segment_times),
+                selectinload(TrainJourney.dwell_times),
+                selectinload(TrainJourney.progress_snapshots),
+            )
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/db/migrations/versions/20260325_1334-a1b2c3d4e5f6_improve_segment_baseline_index.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260325_1334-a1b2c3d4e5f6_improve_segment_baseline_index.py
@@ -1,0 +1,42 @@
+"""Improve segment_transit_times baseline index for congestion queries.
+
+The historical_baseline CTE in congestion.py filters on (data_source,
+hour_of_day, day_of_week) then scans departure_time for the 30-day range.
+The existing idx_segment_baseline has from_station_code in position 2,
+which is a GROUP BY column not a WHERE filter, forcing extra scanning.
+
+Replace with (data_source, hour_of_day, day_of_week, departure_time) to
+match the actual query predicate order and eliminate unnecessary scans
+for high-volume providers like SUBWAY.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 4ae83310c010
+Create Date: 2026-03-25T13:34:00Z
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "4ae83310c010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("idx_segment_baseline", table_name="segment_transit_times")
+    op.create_index(
+        "idx_segment_baseline",
+        "segment_transit_times",
+        ["data_source", "hour_of_day", "day_of_week", "departure_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_segment_baseline", table_name="segment_transit_times")
+    op.create_index(
+        "idx_segment_baseline",
+        "segment_transit_times",
+        ["data_source", "from_station_code", "hour_of_day", "departure_time"],
+    )

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -485,8 +485,8 @@ class SegmentTransitTime(Base):
         Index(
             "idx_segment_baseline",
             "data_source",
-            "from_station_code",
             "hour_of_day",
+            "day_of_week",
             "departure_time",
         ),
     )

--- a/backend_v2/src/trackrat/services/api_cache.py
+++ b/backend_v2/src/trackrat/services/api_cache.py
@@ -356,6 +356,16 @@ class ApiCacheService:
             {"from_station": "PHO", "to_station": None},
             {"from_station": "PNK", "to_station": None},
             {"from_station": "PWC", "to_station": None},
+            # Subway terminals — uncached subway queries are expensive due to
+            # high stop counts and large GTFS static datasets
+            {"from_station": "S101", "to_station": None},  # South Ferry (1)
+            {"from_station": "S142", "to_station": None},  # 242 St (1)
+            {"from_station": "SL29", "to_station": None},  # 8 Av (L)
+            {"from_station": "SL01", "to_station": None},  # Canarsie (L)
+            {"from_station": "S701", "to_station": None},  # Hudson Yards (7)
+            {"from_station": "S726", "to_station": None},  # Flushing (7)
+            {"from_station": "SR01", "to_station": None},  # Coney Island (N)
+            {"from_station": "SD43", "to_station": None},  # Ditmars Blvd (N)
         ]
 
         # Generate both hide_departed variants for each route

--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -539,6 +539,10 @@ class CongestionAnalyzer:
         if data_source:
             params["data_source"] = data_source
 
+        # Guard against runaway queries (especially for high-volume providers
+        # like SUBWAY). SET LOCAL is transaction-scoped and auto-resets.
+        await db.execute(text("SET LOCAL statement_timeout = '30000'"))
+
         query_start = now_et()
         result = await db.execute(query, params)
         rows = result.fetchall()

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -776,7 +776,15 @@ class DepartureService:
                                 TrainJourney.data_source == "NJT",
                             )
                         )
-                        .options(selectinload(TrainJourney.stops))
+                        .options(
+                            selectinload(TrainJourney.stops),
+                            # Load all delete-orphan collections to prevent
+                            # greenlet_spawn errors during flush orphan checks
+                            selectinload(TrainJourney.snapshots),
+                            selectinload(TrainJourney.segment_times),
+                            selectinload(TrainJourney.dwell_times),
+                            selectinload(TrainJourney.progress_snapshots),
+                        )
                         .order_by(TrainJourney.id)
                     )
                     result = await db.execute(stmt)

--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -1300,6 +1300,10 @@ class GTFSService:
                 )
             )
             .order_by(GTFSStopTime.departure_time)
+            # Cap results to avoid fetching hundreds of trips for high-volume
+            # providers like SUBWAY. Callers apply their own limit (typically
+            # 50-200) after merge/filter, so 250 provides ample headroom.
+            .limit(250)
         )
 
         trips_data = result.all()

--- a/backend_v2/src/trackrat/services/jit.py
+++ b/backend_v2/src/trackrat/services/jit.py
@@ -198,6 +198,11 @@ class JustInTimeUpdateService:
             .where(and_(*conditions))
             .options(
                 selectinload(TrainJourney.stops),
+                # Load all delete-orphan collections to prevent
+                # greenlet_spawn errors during flush orphan checks
+                selectinload(TrainJourney.snapshots),
+                selectinload(TrainJourney.segment_times),
+                selectinload(TrainJourney.dwell_times),
                 selectinload(TrainJourney.progress_snapshots),
             )
         )

--- a/backend_v2/tests/unit/services/test_api_cache.py
+++ b/backend_v2/tests/unit/services/test_api_cache.py
@@ -594,11 +594,11 @@ class TestApiCacheService:
             with patch.object(cache_service, "store_cached_response") as mock_store:
                 await cache_service.precompute_departure_responses(mock_db)
 
-                # 14 routes × 2 hide_departed variants = 28 calls
-                # (8 with destination + 6 origin-only)
-                assert mock_compute.call_count == 28
+                # 22 routes × 2 hide_departed variants = 44 calls
+                # (8 with destination + 6 origin-only + 8 subway terminals)
+                assert mock_compute.call_count == 44
 
-                assert mock_store.call_count == 28
+                assert mock_store.call_count == 44
 
                 # Verify first few routes have correct structure including data_sources key
                 first_call_params = mock_compute.call_args_list[0][0][1]
@@ -612,7 +612,7 @@ class TestApiCacheService:
                 }
 
                 # Verify all calls include the data_sources key
-                for i in range(28):
+                for i in range(44):
                     actual_params = mock_compute.call_args_list[i][0][1]
                     assert (
                         "data_sources" in actual_params
@@ -626,20 +626,20 @@ class TestApiCacheService:
     async def test_precompute_departure_handles_errors(self, cache_service, mock_db):
         """Test that departure pre-computation continues even if some computations fail."""
         with patch.object(cache_service, "_compute_departure_response") as mock_compute:
-            # 28 calls: first fails, rest succeed
-            # (14 routes × 2 hide_departed variants = 28)
+            # 44 calls: first fails, rest succeed
+            # (22 routes × 2 hide_departed variants = 44)
             mock_compute.side_effect = [
                 Exception("Computation failed"),
-            ] + [{"departures": []}] * 27
+            ] + [{"departures": []}] * 43
 
             with patch.object(cache_service, "store_cached_response") as mock_store:
                 await cache_service.precompute_departure_responses(mock_db)
 
-                # 14 routes × 2 hide_departed variants = 28 calls
-                assert mock_compute.call_count == 28
+                # 22 routes × 2 hide_departed variants = 44 calls
+                assert mock_compute.call_count == 44
 
-                # Only 27 successful (first one failed)
-                assert mock_store.call_count == 27
+                # Only 43 successful (first one failed)
+                assert mock_store.call_count == 43
 
     @pytest.mark.asyncio
     async def test_compute_departure_response(self, cache_service, mock_db):


### PR DESCRIPTION
## Summary

Fixes three issues identified during staging validation on 2026-03-25:

- **greenlet_spawn async errors** (3x/day `station_refresh_failed`): Add missing `selectinload` options for delete-orphan cascade collections to 5 query locations missed when the fix was originally applied to `departure.py`'s individual refresh path
- **Congestion endpoint timeouts** (PATH/SUBWAY/PATCO provider-filtered requests): Add 30s statement_timeout, 503 fallback on timeout, and improve the `idx_segment_baseline` index to match the historical_baseline CTE's actual predicate order
- **Slow Subway departure responses** (13s for Subway N): Add 8 subway terminal stations to the departure cache precompute list and cap GTFS static trip queries at 250 rows

## Details

### 1. greenlet_spawn fix (5 files)

The Feb 2026 greenlet lazy-load fix was applied to `departure.py:936-944` (individual refresh) but missed the bulk refresh path at line 779, `jit.py:196-203`, and the three MTA collectors (LIRR/MNR/Subway). During `db.commit()`, SQLAlchemy validates orphan state on unloaded `delete-orphan` cascade relationships (`snapshots`, `segment_times`, `dwell_times`, `progress_snapshots`), which raises `MissingGreenlet` since they have `lazy="raise_on_sql"`.

### 2. Congestion timeout fix (3 files + migration)

- `congestion.py`: `SET LOCAL statement_timeout = '30000'` before the expensive CTE query
- `routes.py`: Catch `QueryCanceled`/statement timeout and return 503 with `Retry-After: 60`
- `database.py` + migration: Replace `idx_segment_baseline` index from `(data_source, from_station_code, hour_of_day, departure_time)` to `(data_source, hour_of_day, day_of_week, departure_time)` — matches the WHERE clause filters, not the GROUP BY columns

### 3. Slow Subway fix (2 files)

- `api_cache.py`: Add 8 subway terminal stations (1/L/7/N line endpoints) to departure precompute list
- `gtfs.py`: Add `.limit(250)` to `_query_departures_for_source` — callers never use more than 200, but SUBWAY can return 500+ trips

## Test plan

- [x] All 1633 non-DB unit tests pass (0 failures)
- [x] `test_api_cache.py` updated for new precompute count (22 routes × 2 = 44)
- [ ] Deploy to staging and re-run `bash scripts/validate-staging.sh`
- [ ] Verify no `greenlet_spawn` / `station_refresh_failed` errors in staging logs over 24h
- [ ] Verify congestion endpoint returns data for PATH/SUBWAY/PATCO (no timeouts)
- [ ] Verify Subway N departures respond in <5s

https://claude.ai/code/session_01NvwTm5pZispsSrEig1rW7i