### PR TITLE
Reorder sections in RouteStatusView for better UX

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -56,9 +56,9 @@ struct RouteStatusView: View {
                     }
                     operationsSummarySection
                     historySections
-                    alertSubscriptionSection
                     upcomingTrainsSection
                     serviceAlertsSection
+                    alertSubscriptionSection
                 }
                 .padding()
                 .animation(.easeInOut(duration: 0.3), value: viewModel.filterLoaded)


### PR DESCRIPTION
## Summary
Reorganized the layout of sections in RouteStatusView to improve the information hierarchy and user experience.

## Changes
- Moved `alertSubscriptionSection` from its position before `upcomingTrainsSection` to after `serviceAlertsSection`
- This reordering places the alert subscription controls after the service alerts are displayed, creating a more logical flow where users see alerts before being prompted to manage their subscriptions

## Details
The new section order is now:
1. Operations summary
2. History sections
3. Upcoming trains
4. Service alerts
5. Alert subscription

This change improves the UX by grouping alert-related sections together (service alerts followed by subscription management) rather than separating them.

https://claude.ai/code/session_01BUuHrTPQNkxTaTC5MxGFkQ