### PR TITLE
Add staging environment for TrackRat webpage with environment-specific API URLs

### DIFF
--- a/infra_v2/cloudbuild-webpage-staging.yaml
+++ b/infra_v2/cloudbuild-webpage-staging.yaml
@@ -1,0 +1,61 @@
+# TrackRat Webpage Staging Deployment
+# Triggered by push to 'main' branch (path filter: webpage_v2/**)
+# Builds the React app pointing at staging API, deploys to staging GCS bucket
+
+substitutions:
+  _WEBPAGE_BUCKET: trackrat-webpage-staging
+  _API_BASE_URL: 'https://staging.apiv2.trackrat.net/api/v2'
+
+steps:
+  # Install dependencies
+  - name: 'node:22'
+    id: 'install'
+    dir: 'webpage_v2'
+    entrypoint: 'npm'
+    args: ['ci', '--silent']
+
+  # Build with staging API URL
+  - name: 'node:22'
+    id: 'build'
+    dir: 'webpage_v2'
+    entrypoint: 'npm'
+    args: ['run', 'build']
+    env:
+      - 'VITE_API_BASE_URL=${_API_BASE_URL}'
+    waitFor: ['install']
+
+  # Sync build output to staging GCS bucket
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: 'sync'
+    args: ['-m', 'rsync', '-r', '-d', 'webpage_v2/dist', 'gs://${_WEBPAGE_BUCKET}']
+    waitFor: ['build']
+
+  # Set no-cache on HTML and service worker files
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: 'cache-html'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" \
+          "gs://${_WEBPAGE_BUCKET}/index.html"
+        gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" \
+          "gs://${_WEBPAGE_BUCKET}/sw.js" 2>/dev/null || true
+        gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" \
+          "gs://${_WEBPAGE_BUCKET}/registerSW.js" 2>/dev/null || true
+    waitFor: ['sync']
+
+  # Set long cache on hashed assets
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: 'cache-assets'
+    args: ['-m', 'setmeta', '-h', 'Cache-Control:public, max-age=31536000, immutable',
+           'gs://${_WEBPAGE_BUCKET}/assets/**']
+    waitFor: ['sync']
+
+tags:
+  - 'trackrat'
+  - 'webpage'
+  - 'staging'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/infra_v2/cloudbuild-webpage.yaml
+++ b/infra_v2/cloudbuild-webpage.yaml
@@ -1,0 +1,61 @@
+# TrackRat Webpage Production Deployment
+# Triggered by push to 'production' branch (path filter: webpage_v2/**)
+# Builds the React app pointing at production API, deploys to production GCS bucket
+
+substitutions:
+  _WEBPAGE_BUCKET: trackrat-links-2caf78c68fded156
+  _API_BASE_URL: 'https://apiv2.trackrat.net/api/v2'
+
+steps:
+  # Install dependencies
+  - name: 'node:22'
+    id: 'install'
+    dir: 'webpage_v2'
+    entrypoint: 'npm'
+    args: ['ci', '--silent']
+
+  # Build with production API URL
+  - name: 'node:22'
+    id: 'build'
+    dir: 'webpage_v2'
+    entrypoint: 'npm'
+    args: ['run', 'build']
+    env:
+      - 'VITE_API_BASE_URL=${_API_BASE_URL}'
+    waitFor: ['install']
+
+  # Sync build output to production GCS bucket
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: 'sync'
+    args: ['-m', 'rsync', '-r', '-d', 'webpage_v2/dist', 'gs://${_WEBPAGE_BUCKET}']
+    waitFor: ['build']
+
+  # Set no-cache on HTML and service worker files
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: 'cache-html'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" \
+          "gs://${_WEBPAGE_BUCKET}/index.html"
+        gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" \
+          "gs://${_WEBPAGE_BUCKET}/sw.js" 2>/dev/null || true
+        gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" \
+          "gs://${_WEBPAGE_BUCKET}/registerSW.js" 2>/dev/null || true
+    waitFor: ['sync']
+
+  # Set long cache on hashed assets
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: 'cache-assets'
+    args: ['-m', 'setmeta', '-h', 'Cache-Control:public, max-age=31536000, immutable',
+           'gs://${_WEBPAGE_BUCKET}/assets/**']
+    waitFor: ['sync']
+
+tags:
+  - 'trackrat'
+  - 'webpage'
+  - 'production'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/scripts/deploy-webpage.sh
+++ b/scripts/deploy-webpage.sh
@@ -1,31 +1,55 @@
 #!/bin/bash
 # Build and deploy webpage_v2 to GCS
 #
-# Usage: ./scripts/deploy-webpage.sh [--dry-run]
+# Usage: ./scripts/deploy-webpage.sh [staging|production] [--dry-run]
 #
+# Defaults to production if no environment specified.
 # Prerequisites: gsutil authenticated, npm installed
 
 set -e
 
-BUCKET="gs://trackrat-links-2caf78c68fded156"
+PROD_BUCKET="gs://trackrat-links-2caf78c68fded156"
+STAGING_BUCKET="gs://trackrat-webpage-staging"
+PROD_API_URL="https://apiv2.trackrat.net/api/v2"
+STAGING_API_URL="https://staging.apiv2.trackrat.net/api/v2"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 WEB_DIR="$PROJECT_DIR/webpage_v2"
 DIST_DIR="$WEB_DIR/dist"
 DRY_RUN=false
+ENVIRONMENT="production"
 
 for arg in "$@"; do
     case $arg in
         --dry-run)
             DRY_RUN=true
             ;;
+        staging)
+            ENVIRONMENT="staging"
+            ;;
+        production)
+            ENVIRONMENT="production"
+            ;;
         *)
             echo "❌ Unknown argument: $arg"
-            echo "Usage: $0 [--dry-run]"
+            echo "Usage: $0 [staging|production] [--dry-run]"
             exit 1
             ;;
     esac
 done
+
+if [[ "$ENVIRONMENT" == "staging" ]]; then
+    BUCKET="$STAGING_BUCKET"
+    API_URL="$STAGING_API_URL"
+else
+    BUCKET="$PROD_BUCKET"
+    API_URL="$PROD_API_URL"
+fi
+
+echo "Environment: $ENVIRONMENT"
+echo "Bucket: $BUCKET"
+echo "API URL: $API_URL"
 
 # Check prerequisites
 if ! command -v gsutil &>/dev/null; then
@@ -39,10 +63,10 @@ if ! command -v npm &>/dev/null; then
 fi
 
 # Build
-echo "📦 Building webpage_v2..."
+echo "📦 Building webpage_v2 ($ENVIRONMENT)..."
 cd "$WEB_DIR"
 npm ci --silent
-npm run build
+VITE_API_BASE_URL="$API_URL" npm run build
 
 if [[ ! -d "$DIST_DIR" ]]; then
     echo "❌ Build failed: dist/ directory not created"
@@ -70,5 +94,5 @@ else
     gsutil setmeta -h "Cache-Control:no-cache, no-store, must-revalidate" "$BUCKET/registerSW.js" 2>/dev/null || true
     gsutil -m setmeta -h "Cache-Control:public, max-age=31536000, immutable" "$BUCKET/assets/**" 2>/dev/null || true
 
-    echo "✅ Deploy complete"
+    echo "✅ Deploy complete ($ENVIRONMENT)"
 fi

--- a/universal-links-deployment/gcs-simple-setup.tf
+++ b/universal-links-deployment/gcs-simple-setup.tf
@@ -1,5 +1,6 @@
-# Simplified GCS + Load Balancer setup for Universal Links
-# This version focuses on getting the core functionality working
+# GCS + Load Balancer setup for TrackRat webpage
+# Production: trackrat.net (existing)
+# Staging: staging.trackrat.net (new)
 
 terraform {
   required_providers {
@@ -47,7 +48,7 @@ resource "google_storage_bucket" "universal_links" {
   
   website {
     main_page_suffix = "index.html"
-    not_found_page   = "train-fallback.html"
+    not_found_page   = "index.html"  # SPA fallback — all routes handled by React Router
   }
 
   cors {
@@ -186,4 +187,122 @@ output "test_urls" {
     train_domain = "https://trackrat.net/train-fallback.html"
   }
   description = "URLs to test (direct = immediate, domain = after DNS setup)"
+}
+
+# ============================================
+# Staging webpage infrastructure
+# ============================================
+
+# GCS bucket for staging webpage
+resource "google_storage_bucket" "webpage_staging" {
+  name          = "trackrat-webpage-staging"
+  location      = "US"
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "index.html"  # SPA fallback
+  }
+
+  cors {
+    origin          = ["*"]
+    method          = ["GET", "HEAD"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+}
+
+# Make staging bucket publicly readable
+resource "google_storage_bucket_iam_member" "staging_public_access" {
+  bucket = google_storage_bucket.webpage_staging.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# CDN backend bucket for staging
+resource "google_compute_backend_bucket" "webpage_staging_backend" {
+  name        = "trackrat-webpage-staging-backend"
+  description = "Backend bucket for TrackRat staging webpage"
+  bucket_name = google_storage_bucket.webpage_staging.name
+  enable_cdn  = true
+
+  cdn_policy {
+    cache_mode        = "CACHE_ALL_STATIC"
+    default_ttl       = 300   # 5 min (shorter for staging)
+    max_ttl           = 3600  # 1 hour
+    client_ttl        = 300
+    negative_caching  = true
+  }
+}
+
+# URL map for staging
+resource "google_compute_url_map" "webpage_staging" {
+  name            = "trackrat-webpage-staging-map"
+  description     = "URL map for TrackRat staging webpage"
+  default_service = google_compute_backend_bucket.webpage_staging_backend.id
+}
+
+# SSL certificate for staging.trackrat.net
+resource "google_compute_managed_ssl_certificate" "webpage_staging_cert" {
+  name = "trackrat-webpage-staging-cert"
+
+  managed {
+    domains = ["staging.trackrat.net"]
+  }
+}
+
+# Global static IP for staging
+resource "google_compute_global_address" "webpage_staging_ip" {
+  name = "trackrat-webpage-staging-ip"
+}
+
+# HTTPS proxy for staging
+resource "google_compute_target_https_proxy" "webpage_staging_proxy" {
+  name             = "trackrat-webpage-staging-https-proxy"
+  url_map          = google_compute_url_map.webpage_staging.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.webpage_staging_cert.id]
+}
+
+# HTTPS forwarding rule for staging
+resource "google_compute_global_forwarding_rule" "webpage_staging_https" {
+  name       = "trackrat-webpage-staging-https"
+  target     = google_compute_target_https_proxy.webpage_staging_proxy.id
+  port_range = "443"
+  ip_address = google_compute_global_address.webpage_staging_ip.address
+}
+
+# HTTP to HTTPS redirect for staging
+resource "google_compute_url_map" "webpage_staging_https_redirect" {
+  name = "trackrat-webpage-staging-https-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "PERMANENT_REDIRECT"
+    strip_query            = false
+  }
+}
+
+resource "google_compute_target_http_proxy" "webpage_staging_http_proxy" {
+  name    = "trackrat-webpage-staging-http-proxy"
+  url_map = google_compute_url_map.webpage_staging_https_redirect.id
+}
+
+resource "google_compute_global_forwarding_rule" "webpage_staging_http" {
+  name       = "trackrat-webpage-staging-http"
+  target     = google_compute_target_http_proxy.webpage_staging_http_proxy.id
+  port_range = "80"
+  ip_address = google_compute_global_address.webpage_staging_ip.address
+}
+
+# Staging outputs
+output "staging_ip" {
+  value       = google_compute_global_address.webpage_staging_ip.address
+  description = "Point staging.trackrat.net DNS A record to this IP"
+}
+
+output "staging_bucket_name" {
+  value       = google_storage_bucket.webpage_staging.name
+  description = "Staging GCS bucket name"
 }

--- a/webpage_v2/src/services/api.ts
+++ b/webpage_v2/src/services/api.ts
@@ -1,6 +1,6 @@
 import { DeparturesResponse, TrainDetailsResponse, PlatformPrediction, OperationsSummaryResponse, TripSearchResponse } from '../types';
 
-const BASE_URL = 'https://apiv2.trackrat.net/api/v2';
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://apiv2.trackrat.net/api/v2';
 const CACHE_DURATION = 120000; // 2 minutes in milliseconds
 
 interface CacheEntry<T> {

--- a/webpage_v2/src/vite-env.d.ts
+++ b/webpage_v2/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/webpage_v2/vite.config.ts
+++ b/webpage_v2/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,svg,png,jpg,jpeg,gif,webp,woff,woff2}'],
         runtimeCaching: [
           {
-            urlPattern: /^https:\/\/apiv2\.trackrat\.net\/api\/v2\/.*/i,
+            urlPattern: /^https:\/\/(apiv2|staging\.apiv2)\.trackrat\.net\/api\/v2\/.*/i,
             handler: 'NetworkFirst',
             options: {
               cacheName: 'trackrat-api-cache',


### PR DESCRIPTION
## Summary
This PR adds a complete staging environment for the TrackRat webpage alongside the existing production setup. The staging environment uses a separate GCS bucket, CDN backend, and SSL certificate, with automatic deployment pipelines for both environments.

## Key Changes

- **Terraform Infrastructure**: Added staging webpage infrastructure (GCS bucket, CDN backend, URL map, SSL certificate, load balancer rules) mirroring the production setup
- **Environment-Specific API URLs**: Modified the API client to use environment variables (`VITE_API_BASE_URL`) instead of hardcoded production URLs, allowing staging to point to `staging.apiv2.trackrat.net` and production to `apiv2.trackrat.net`
- **Cloud Build Pipelines**: Added two new Cloud Build configurations:
  - `cloudbuild-webpage.yaml`: Triggered on `production` branch, builds with production API URL
  - `cloudbuild-webpage-staging.yaml`: Triggered on `main` branch, builds with staging API URL
- **Deployment Script Enhancement**: Updated `deploy-webpage.sh` to support both `staging` and `production` environments with appropriate bucket and API URL selection
- **SPA Fallback Fix**: Changed 404 fallback from `train-fallback.html` to `index.html` to properly support React Router in single-page application
- **Vite Configuration**: Updated service worker caching rules to handle both production and staging API domains

## Implementation Details

- Staging bucket: `trackrat-webpage-staging` with shorter cache TTLs (5 min default) for faster iteration
- Production bucket: `trackrat-links-2caf78c68fded156` with standard cache settings
- Both environments use identical infrastructure patterns for consistency and maintainability
- Cache control headers are properly configured: no-cache for HTML/service workers, immutable long-cache for hashed assets
- DNS records for `staging.trackrat.net` will point to the staging load balancer IP

https://claude.ai/code/session_015tmf9VmWF8aanjwtPUxSrt