### PR TITLE
Cache multi-system congestion by merging per-provider entries

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
 from sqlalchemy import and_, exists, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
@@ -622,7 +623,7 @@ async def _calculate_baseline_train_count(
         return None
 
 
-@router.get("/congestion", response_model=CongestionMapResponse)
+@router.get("/congestion")
 @handle_errors
 async def get_route_congestion(
     time_window_hours: int = Query(1, ge=1, le=24, description="Hours to look back"),
@@ -634,73 +635,90 @@ async def get_route_congestion(
     ),
     data_source: str | None = Query(
         None,
-        description="Filter by data source (NJT, AMTRAK, PATH, PATCO, LIRR, MNR, SUBWAY, METRA, WMATA, MBTA)",
+        description="Filter by single data source (NJT, AMTRAK, PATH, etc). Mutually exclusive with systems.",
+    ),
+    systems: str | None = Query(
+        None,
+        description="Comma-separated list of systems to include (e.g. NJT,PATH,AMTRAK). "
+        "Omit for all systems. Mutually exclusive with data_source.",
     ),
     force_refresh: bool = Query(False, description="Force bypass cache and recompute"),
     db: AsyncSession = Depends(get_db),
-) -> CongestionMapResponse:
+) -> Response:
     """Get network congestion levels based on recent train performance.
 
     Analyzes train journeys within a lookback window (minimum 2 hours) and returns
     per-segment congestion factors, aggregated congestion levels, and live train
     positions. Results are cached for 10 minutes.
+
+    Use ``systems`` to request a subset of providers (e.g. ``systems=NJT,PATH``).
+    When omitted, all systems are returned by merging per-provider caches.
+    The legacy ``data_source`` parameter still works for single-provider requests.
     """
 
     # Enforce minimum 2-hour window for meaningful congestion data across all systems
     effective_time_window = max(time_window_hours, 2)
 
-    # Cache key uses effective values so precomputed entries match
-    cache_params = {
-        "time_window_hours": effective_time_window,
-        "max_per_segment": max_per_segment,
-        "data_source": data_source,
-    }
+    # Parse systems parameter
+    requested_systems: list[str] | None = None
+    if systems:
+        requested_systems = [s.strip().upper() for s in systems.split(",") if s.strip()]
+    elif data_source:
+        # Legacy single data_source is equivalent to systems=<data_source>
+        requested_systems = [data_source.upper()]
 
-    # Try to serve from cache first (unless force_refresh is requested)
+    # --- Cache lookup ---
     if not force_refresh:
-        from trackrat.services.api_cache import ApiCacheService
-
         cache_service = ApiCacheService()
-        cached_response = await cache_service.get_cached_response(
-            db=db,
-            endpoint="/api/v2/routes/congestion",
-            params=cache_params,
-        )
 
-        if cached_response:
-            try:
-                # Return cached response directly - it's already in the correct format
-                return CongestionMapResponse(**cached_response)
-            except (TypeError, ValueError) as e:
-                logger.warning(
-                    "cache_deserialization_failed",
-                    endpoint="/api/v2/routes/congestion",
-                    params=cache_params,
-                    error=str(e),
-                    error_type=type(e).__name__,
+        if requested_systems and len(requested_systems) == 1:
+            # Single-provider: direct cache lookup (fast path)
+            cache_params = {
+                "time_window_hours": effective_time_window,
+                "max_per_segment": max_per_segment,
+                "data_source": requested_systems[0],
+            }
+            cached = await cache_service.get_cached_response(
+                db, "/api/v2/routes/congestion", cache_params
+            )
+            if cached:
+                return Response(
+                    content=json_mod.dumps(cached),
+                    media_type="application/json",
                 )
-                # Invalidate corrupted cache entry
-                await cache_service.invalidate_cache_entry(
-                    db,
-                    "/api/v2/routes/congestion",
-                    cache_params,
+
+        else:
+            # Multi-provider or all: merge per-provider caches
+            from trackrat.services.api_cache import CONGESTION_PROVIDERS
+
+            merge_systems = requested_systems or CONGESTION_PROVIDERS
+            merged = await cache_service.merge_congestion_from_provider_caches(
+                db, merge_systems, effective_time_window, max_per_segment
+            )
+            if merged:
+                return Response(
+                    content=json_mod.dumps(merged),
+                    media_type="application/json",
                 )
+
+    # --- Cache miss: compute directly ---
+    # For single-provider requests, query that provider.
+    # For multi/all, use data_source=None which queries everything.
+    query_data_source = requested_systems[0] if (requested_systems and len(requested_systems) == 1) else None
 
     analyzer = CongestionAnalyzer()
     try:
         aggregated_segments, journeys, individual_segments = (
             await analyzer.get_network_congestion_with_trains(
-                db, effective_time_window, max_per_segment, data_source
+                db, effective_time_window, max_per_segment, query_data_source
             )
         )
     except Exception as e:
-        # Statement timeout or other DB error on live computation path.
-        # The precompute job will populate the cache on next run.
         error_name = type(e).__name__
         if "QueryCanceled" in error_name or "statement timeout" in str(e).lower():
             logger.warning(
                 "congestion_query_timeout",
-                data_source=data_source,
+                data_source=query_data_source,
                 time_window_hours=effective_time_window,
             )
             raise HTTPException(
@@ -710,9 +728,7 @@ async def get_route_congestion(
             ) from None
         raise
 
-    # Filter out segments containing "SAN" station code - collision between
-    # San Diego Santa Fe Depot (Pacific Surfliner) and Sanford, FL (Silver Service)
-    # causes cross-country lines on the map. TODO: Proper disambiguation in Amtrak collector.
+    # Filter out SAN station code collision (Amtrak disambiguation TODO)
     aggregated_segments = [
         s
         for s in aggregated_segments
@@ -724,24 +740,31 @@ async def get_route_congestion(
         if s.from_station != "SAN" and s.to_station != "SAN"
     ]
 
+    # If multi-system was requested but we queried all, filter to requested systems
+    if requested_systems and len(requested_systems) > 1:
+        systems_set = set(requested_systems)
+        aggregated_segments = [
+            s for s in aggregated_segments if s.data_source in systems_set
+        ]
+        individual_segments = [
+            s for s in individual_segments if s.data_source in systems_set
+        ]
+        journeys = [j for j in journeys if j.data_source in systems_set]
+
     # Extract train positions from journeys
     departure_service = DepartureService()
     train_positions = []
 
     for journey in journeys:
-        # Skip cancelled trains
         if journey.is_cancelled:
             continue
 
-        # Calculate train position
         position = departure_service._calculate_train_position(journey)
 
-        # Get journey progress if available
         journey_percent = None
         if journey.progress:
             journey_percent = journey.progress.journey_percent
 
-        # Create train location data
         location_data = TrainLocationData(
             train_id=journey.train_id,
             line=journey.line_code,
@@ -752,11 +775,6 @@ async def get_route_congestion(
             between_stations=position.between_stations,
             journey_percent=journey_percent,
         )
-
-        # Add GPS data for Amtrak trains if available
-        # TODO: This will need to be fetched from Amtrak API snapshot data
-        # For now, we'll just include the station-based position
-
         train_positions.append(location_data)
 
     # Convert aggregated segments to API models
@@ -776,7 +794,6 @@ async def get_route_congestion(
             current_average_minutes=segment.avg_transit_minutes,
             cancellation_count=segment.cancellation_count,
             cancellation_rate=segment.cancellation_rate,
-            # Frequency/health metrics
             train_count=segment.train_count,
             baseline_train_count=segment.baseline_train_count,
             frequency_factor=segment.frequency_factor,
@@ -797,55 +814,42 @@ async def get_route_congestion(
             "total_aggregated_segments": len(aggregated_api_segments),
             "congestion_levels": {
                 "normal": len(
-                    [
-                        s
-                        for s in aggregated_api_segments
-                        if s.congestion_level == "normal"
-                    ]
+                    [s for s in aggregated_api_segments if s.congestion_level == "normal"]
                 ),
                 "moderate": len(
-                    [
-                        s
-                        for s in aggregated_api_segments
-                        if s.congestion_level == "moderate"
-                    ]
+                    [s for s in aggregated_api_segments if s.congestion_level == "moderate"]
                 ),
                 "heavy": len(
-                    [
-                        s
-                        for s in aggregated_api_segments
-                        if s.congestion_level == "heavy"
-                    ]
+                    [s for s in aggregated_api_segments if s.congestion_level == "heavy"]
                 ),
                 "severe": len(
-                    [
-                        s
-                        for s in aggregated_api_segments
-                        if s.congestion_level == "severe"
-                    ]
+                    [s for s in aggregated_api_segments if s.congestion_level == "severe"]
                 ),
             },
             "total_trains": len(train_positions),
         },
     )
+    response_dict = response.model_dump(mode="json")
 
-    # Store in cache for future requests (also update cache on force_refresh)
+    # Store in cache for future requests
     try:
-        from trackrat.services.api_cache import ApiCacheService
-
+        cache_params = {
+            "time_window_hours": effective_time_window,
+            "max_per_segment": max_per_segment,
+            "data_source": query_data_source,
+        }
         cache_service = ApiCacheService()
         await cache_service.store_cached_response(
             db=db,
             endpoint="/api/v2/routes/congestion",
             params=cache_params,
-            response=response.model_dump(mode="json"),
-            ttl_seconds=600,  # 10 minutes (longer than 15-min refresh to avoid gaps)
+            response=response_dict,
+            ttl_seconds=600,
         )
     except Exception as e:
-        # Don't let cache storage failure affect the API response
         logger.warning("cache_storage_failed", error=str(e))
 
-    return response
+    return Response(content=json_mod.dumps(response_dict), media_type="application/json")
 
 
 @router.get(

--- a/backend_v2/src/trackrat/services/api_cache.py
+++ b/backend_v2/src/trackrat/services/api_cache.py
@@ -23,6 +23,20 @@ from trackrat.utils.time import now_et
 
 logger = get_logger(__name__)
 
+# Providers that have per-provider congestion cache entries pre-computed.
+# Keep in sync with the param_sets in precompute_congestion_responses().
+CONGESTION_PROVIDERS = [
+    "NJT",
+    "PATH",
+    "AMTRAK",
+    "LIRR",
+    "MNR",
+    "SUBWAY",
+    "WMATA",
+    "PATCO",
+    "METRA",
+]
+
 
 class ApiCacheService:
     """Service for pre-computing and caching expensive API responses."""
@@ -97,6 +111,86 @@ class ApiCacheService:
             )
         return deleted
 
+    async def merge_congestion_from_provider_caches(
+        self,
+        db: AsyncSession,
+        systems: list[str],
+        time_window_hours: int,
+        max_per_segment: int,
+    ) -> dict[str, Any] | None:
+        """Assemble a multi-system congestion response by merging per-provider cached entries.
+
+        Returns the merged response dict, or None if any requested system is missing
+        from the cache (caller should fall back to direct computation).
+        """
+        merged_individual: list[dict[str, Any]] = []
+        merged_aggregated: list[dict[str, Any]] = []
+        merged_positions: list[dict[str, Any]] = []
+        oldest_generated_at: str | None = None
+
+        for system in systems:
+            provider_params = {
+                "time_window_hours": time_window_hours,
+                "max_per_segment": max_per_segment,
+                "data_source": system,
+            }
+            cached = await self.get_cached_response(
+                db, "/api/v2/routes/congestion", provider_params
+            )
+            if cached is None:
+                logger.debug(
+                    "merge_cache_miss",
+                    missing_system=system,
+                    time_window_hours=time_window_hours,
+                    max_per_segment=max_per_segment,
+                )
+                return None
+
+            merged_individual.extend(cached.get("individual_segments", []))
+            merged_aggregated.extend(cached.get("aggregated_segments", []))
+            merged_positions.extend(cached.get("train_positions", []))
+
+            gen_at = cached.get("generated_at")
+            if gen_at and (oldest_generated_at is None or gen_at < oldest_generated_at):
+                oldest_generated_at = gen_at
+
+        # Build merged metadata
+        congestion_levels: dict[str, int] = {
+            "normal": 0,
+            "moderate": 0,
+            "heavy": 0,
+            "severe": 0,
+        }
+        for seg in merged_aggregated:
+            level = seg.get("congestion_level", "normal")
+            if level in congestion_levels:
+                congestion_levels[level] += 1
+
+        merged_response = {
+            "individual_segments": merged_individual,
+            "aggregated_segments": merged_aggregated,
+            "train_positions": merged_positions,
+            "generated_at": oldest_generated_at or now_et().isoformat(),
+            "time_window_hours": time_window_hours,
+            "max_per_segment": max_per_segment,
+            "metadata": {
+                "total_individual_segments": len(merged_individual),
+                "total_aggregated_segments": len(merged_aggregated),
+                "congestion_levels": congestion_levels,
+                "total_trains": len(merged_positions),
+                "merged_from_systems": systems,
+            },
+        }
+
+        logger.info(
+            "congestion_cache_merged",
+            systems=systems,
+            aggregated_count=len(merged_aggregated),
+            train_count=len(merged_positions),
+        )
+
+        return merged_response
+
     async def store_cached_response(
         self,
         db: AsyncSession,
@@ -145,30 +239,22 @@ class ApiCacheService:
     async def precompute_congestion_responses(self, db: AsyncSession) -> None:
         """Pre-compute congestion responses for common parameter combinations used by iOS app."""
 
-        # Parameter combinations based on iOS app usage analysis
-        # Cache keys use effective time window (minimum 2h enforced by API endpoint)
-        param_sets: list[dict[str, Any]] = [
-            # iOS summary mode (default): timeWindowHours=1 -> effective 2, maxPerSegment=0
-            {"time_window_hours": 2, "max_per_segment": 0, "data_source": None},
-            # iOS trains mode: timeWindowHours=1 -> effective 2, maxPerSegment=100
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": None},
-            # Longer window views
-            {"time_window_hours": 3, "max_per_segment": 100, "data_source": None},
-            {"time_window_hours": 3, "max_per_segment": 0, "data_source": None},
-            # Per-provider filtering (iOS RouteStatusView uses timeWindowHours=1 -> effective 2, maxPerSegment=100)
-            {"time_window_hours": 2, "max_per_segment": 0, "data_source": "NJT"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "NJT"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "PATH"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "AMTRAK"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "LIRR"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "MNR"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "SUBWAY"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "WMATA"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "PATCO"},
-            {"time_window_hours": 2, "max_per_segment": 100, "data_source": "METRA"},
-            # Longer window views with NJT
-            {"time_window_hours": 3, "max_per_segment": 100, "data_source": "NJT"},
-        ]
+        # Per-provider cache entries only. "All systems" requests are assembled
+        # by merging per-provider caches at query time (see merge_congestion_from_provider_caches),
+        # which avoids the expensive unfiltered SQL queries.
+        param_sets: list[dict[str, Any]] = []
+        for provider in CONGESTION_PROVIDERS:
+            # Both summary (maxPerSegment=0) and trains (maxPerSegment=100) modes
+            param_sets.append(
+                {"time_window_hours": 2, "max_per_segment": 0, "data_source": provider}
+            )
+            param_sets.append(
+                {"time_window_hours": 2, "max_per_segment": 100, "data_source": provider}
+            )
+        # Longer window views for NJT (commonly used)
+        param_sets.append(
+            {"time_window_hours": 3, "max_per_segment": 100, "data_source": "NJT"}
+        )
 
         logger.info("precomputing_congestion_responses", param_count=len(param_sets))
 

--- a/backend_v2/tests/unit/services/test_api_cache.py
+++ b/backend_v2/tests/unit/services/test_api_cache.py
@@ -13,7 +13,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from trackrat.models.database import CachedApiResponse
-from trackrat.services.api_cache import ApiCacheService
+from trackrat.services.api_cache import CONGESTION_PROVIDERS, ApiCacheService
 
 
 class TestApiCacheService:
@@ -245,8 +245,11 @@ class TestApiCacheService:
 
     @pytest.mark.asyncio
     async def test_precompute_congestion_responses(self, cache_service, mock_db):
-        """Test pre-computation of congestion responses."""
-        # Mock the compute method to return a simple response
+        """Test pre-computation of congestion responses.
+
+        Only per-provider entries are pre-computed (no all-sources queries).
+        9 providers x 2 modes (summary + trains) + 1 NJT/3hr = 19 param sets.
+        """
         mock_response = {
             "aggregated_segments": [],
             "individual_segments": [],
@@ -260,120 +263,53 @@ class TestApiCacheService:
             with patch.object(cache_service, "store_cached_response") as mock_store:
                 await cache_service.precompute_congestion_responses(mock_db)
 
-                # Should compute for 15 default parameter combinations
-                assert mock_compute.call_count == 15
+                # 9 providers x 2 modes + 1 NJT/3hr = 19
+                expected_count = len(CONGESTION_PROVIDERS) * 2 + 1
+                assert mock_compute.call_count == expected_count
+                assert mock_store.call_count == expected_count
 
-                # Should store each computed response
-                assert mock_store.call_count == 15
+                # Build expected params: each provider gets max_per_segment=0 and 100
+                expected_params = []
+                for provider in CONGESTION_PROVIDERS:
+                    expected_params.append(
+                        {"time_window_hours": 2, "max_per_segment": 0, "data_source": provider}
+                    )
+                    expected_params.append(
+                        {"time_window_hours": 2, "max_per_segment": 100, "data_source": provider}
+                    )
+                expected_params.append(
+                    {"time_window_hours": 3, "max_per_segment": 100, "data_source": "NJT"}
+                )
 
-                # Verify the parameter combinations
-                expected_params = [
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 0,
-                        "data_source": None,
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": None,
-                    },
-                    {
-                        "time_window_hours": 3,
-                        "max_per_segment": 100,
-                        "data_source": None,
-                    },
-                    {
-                        "time_window_hours": 3,
-                        "max_per_segment": 0,
-                        "data_source": None,
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 0,
-                        "data_source": "NJT",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "NJT",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "PATH",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "AMTRAK",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "LIRR",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "MNR",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "SUBWAY",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "WMATA",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "PATCO",
-                    },
-                    {
-                        "time_window_hours": 2,
-                        "max_per_segment": 100,
-                        "data_source": "METRA",
-                    },
-                    {
-                        "time_window_hours": 3,
-                        "max_per_segment": 100,
-                        "data_source": "NJT",
-                    },
-                ]
-
+                # No all-sources (data_source=None) entries should exist
                 for i, expected_param in enumerate(expected_params):
                     actual_params = mock_compute.call_args_list[i][0][1]
                     assert actual_params == expected_param
+                    assert actual_params["data_source"] is not None, (
+                        f"param set {i} has data_source=None — all-sources queries should not be pre-computed"
+                    )
 
-                    # Verify store was called with correct endpoint and TTL
                     store_call = mock_store.call_args_list[i]
                     assert store_call.kwargs["endpoint"] == "/api/v2/routes/congestion"
                     assert store_call.kwargs["params"] == expected_param
-                    assert store_call.kwargs["ttl_seconds"] == 600  # 10 minutes
+                    assert store_call.kwargs["ttl_seconds"] == 600
 
     @pytest.mark.asyncio
     async def test_precompute_handles_computation_errors(self, cache_service, mock_db):
         """Test that pre-computation continues even if some computations fail."""
-        # Make compute fail on first call, succeed on others
+        expected_count = len(CONGESTION_PROVIDERS) * 2 + 1  # 19
         with patch.object(
             cache_service, "_compute_congestion_response"
         ) as mock_compute:
             mock_compute.side_effect = [
                 Exception("Computation failed"),
-            ] + [{"data": f"response{i}"} for i in range(2, 16)]
+            ] + [{"data": f"response{i}"} for i in range(2, expected_count + 1)]
 
             with patch.object(cache_service, "store_cached_response") as mock_store:
                 await cache_service.precompute_congestion_responses(mock_db)
 
-                # Should try to compute all 15
-                assert mock_compute.call_count == 15
-
-                # Should only store the 14 successful ones
-                assert mock_store.call_count == 14
+                assert mock_compute.call_count == expected_count
+                assert mock_store.call_count == expected_count - 1
 
     @pytest.mark.asyncio
     async def test_compute_congestion_response(self, cache_service, mock_db):
@@ -718,6 +654,160 @@ class TestApiCacheService:
 
         assert len(result["departures"]) == 2
         assert result["metadata"]["to_station"] is None
+
+
+class TestMergeCongestionFromProviderCaches:
+    """Tests for assembling multi-system congestion responses from per-provider caches."""
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock(spec=AsyncSession)
+        db.execute = AsyncMock()
+        db.commit = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def cache_service(self):
+        return ApiCacheService()
+
+    def _make_provider_response(self, provider: str) -> dict:
+        """Build a minimal but complete cached congestion response for a single provider."""
+        return {
+            "individual_segments": [
+                {
+                    "from_station": f"{provider}_A",
+                    "to_station": f"{provider}_B",
+                    "data_source": provider,
+                    "congestion_factor": 1.0,
+                }
+            ],
+            "aggregated_segments": [
+                {
+                    "from_station": f"{provider}_A",
+                    "to_station": f"{provider}_B",
+                    "data_source": provider,
+                    "congestion_level": "normal",
+                    "congestion_factor": 1.0,
+                }
+            ],
+            "train_positions": [
+                {"train_id": f"{provider}_1", "data_source": provider}
+            ],
+            "generated_at": "2025-01-01T12:00:00-05:00",
+            "time_window_hours": 2,
+            "max_per_segment": 100,
+            "metadata": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_merge_two_providers(self, cache_service, mock_db):
+        """Merging NJT + PATH should concatenate segments and positions from both."""
+        njt_resp = self._make_provider_response("NJT")
+        path_resp = self._make_provider_response("PATH")
+
+        with patch.object(cache_service, "get_cached_response") as mock_get:
+            mock_get.side_effect = [njt_resp, path_resp]
+
+            result = await cache_service.merge_congestion_from_provider_caches(
+                mock_db, ["NJT", "PATH"], time_window_hours=2, max_per_segment=100
+            )
+
+        assert result is not None
+        assert len(result["individual_segments"]) == 2
+        assert len(result["aggregated_segments"]) == 2
+        assert len(result["train_positions"]) == 2
+        assert result["metadata"]["merged_from_systems"] == ["NJT", "PATH"]
+        assert result["metadata"]["total_trains"] == 2
+        assert result["time_window_hours"] == 2
+        assert result["max_per_segment"] == 100
+
+        # Verify data sources present
+        sources = {s["data_source"] for s in result["aggregated_segments"]}
+        assert sources == {"NJT", "PATH"}
+
+    @pytest.mark.asyncio
+    async def test_merge_returns_none_on_cache_miss(self, cache_service, mock_db):
+        """If any provider is missing from cache, merge returns None (caller falls back)."""
+        njt_resp = self._make_provider_response("NJT")
+
+        with patch.object(cache_service, "get_cached_response") as mock_get:
+            # NJT hits, PATH misses
+            mock_get.side_effect = [njt_resp, None]
+
+            result = await cache_service.merge_congestion_from_provider_caches(
+                mock_db, ["NJT", "PATH"], time_window_hours=2, max_per_segment=100
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_merge_all_providers(self, cache_service, mock_db):
+        """Merging all CONGESTION_PROVIDERS should produce combined response."""
+        responses = [self._make_provider_response(p) for p in CONGESTION_PROVIDERS]
+
+        with patch.object(cache_service, "get_cached_response") as mock_get:
+            mock_get.side_effect = responses
+
+            result = await cache_service.merge_congestion_from_provider_caches(
+                mock_db, CONGESTION_PROVIDERS, time_window_hours=2, max_per_segment=100
+            )
+
+        assert result is not None
+        assert len(result["individual_segments"]) == len(CONGESTION_PROVIDERS)
+        assert len(result["aggregated_segments"]) == len(CONGESTION_PROVIDERS)
+        assert len(result["train_positions"]) == len(CONGESTION_PROVIDERS)
+
+    @pytest.mark.asyncio
+    async def test_merge_uses_oldest_generated_at(self, cache_service, mock_db):
+        """The merged response should use the oldest generated_at from providers."""
+        resp_old = self._make_provider_response("NJT")
+        resp_old["generated_at"] = "2025-01-01T11:50:00-05:00"
+        resp_new = self._make_provider_response("PATH")
+        resp_new["generated_at"] = "2025-01-01T12:00:00-05:00"
+
+        with patch.object(cache_service, "get_cached_response") as mock_get:
+            mock_get.side_effect = [resp_old, resp_new]
+
+            result = await cache_service.merge_congestion_from_provider_caches(
+                mock_db, ["NJT", "PATH"], time_window_hours=2, max_per_segment=100
+            )
+
+        assert result is not None
+        assert result["generated_at"] == "2025-01-01T11:50:00-05:00"
+
+    @pytest.mark.asyncio
+    async def test_merge_metadata_congestion_levels(self, cache_service, mock_db):
+        """Merged metadata should tally congestion levels across all providers."""
+        njt_resp = self._make_provider_response("NJT")
+        njt_resp["aggregated_segments"][0]["congestion_level"] = "heavy"
+        path_resp = self._make_provider_response("PATH")
+        path_resp["aggregated_segments"][0]["congestion_level"] = "normal"
+
+        with patch.object(cache_service, "get_cached_response") as mock_get:
+            mock_get.side_effect = [njt_resp, path_resp]
+
+            result = await cache_service.merge_congestion_from_provider_caches(
+                mock_db, ["NJT", "PATH"], time_window_hours=2, max_per_segment=100
+            )
+
+        assert result["metadata"]["congestion_levels"]["heavy"] == 1
+        assert result["metadata"]["congestion_levels"]["normal"] == 1
+        assert result["metadata"]["congestion_levels"]["moderate"] == 0
+
+    @pytest.mark.asyncio
+    async def test_merge_passes_correct_cache_params(self, cache_service, mock_db):
+        """Merge should look up each provider with the correct cache key structure."""
+        with patch.object(cache_service, "get_cached_response", return_value=None) as mock_get:
+            await cache_service.merge_congestion_from_provider_caches(
+                mock_db, ["NJT"], time_window_hours=3, max_per_segment=0
+            )
+
+            # Should call with provider-specific params
+            mock_get.assert_called_once_with(
+                mock_db,
+                "/api/v2/routes/congestion",
+                {"time_window_hours": 3, "max_per_segment": 0, "data_source": "NJT"},
+            )
 
 
 class TestApiCacheIntegration:


### PR DESCRIPTION
## Summary
Refactors the congestion caching strategy to pre-compute and cache only per-provider responses, then assemble multi-system responses at query time by merging individual provider caches. This avoids expensive unfiltered SQL queries and enables efficient serving of both single-provider and multi-system requests.

## Key Changes

- **New `CONGESTION_PROVIDERS` constant** in `api_cache.py`: Defines the 9 providers with pre-computed cache entries (NJT, PATH, AMTRAK, LIRR, MNR, SUBWAY, WMATA, PATCO, METRA).

- **New `merge_congestion_from_provider_caches()` method**: Assembles multi-system congestion responses by fetching and merging per-provider cached entries. Returns `None` if any requested system is missing from cache, allowing the caller to fall back to direct computation.

- **Simplified `precompute_congestion_responses()`**: Now only pre-computes per-provider entries (9 providers × 2 modes + 1 NJT/3hr = 19 param sets), eliminating expensive all-sources queries. Removed hardcoded parameter lists in favor of iterating over `CONGESTION_PROVIDERS`.

- **Updated `/routes/congestion` endpoint**:
  - Added new `systems` query parameter for requesting multiple providers (e.g., `systems=NJT,PATH,AMTRAK`)
  - Kept legacy `data_source` parameter for backward compatibility (single-provider requests)
  - Implements two-tier cache lookup: direct cache hit for single-provider, merge for multi-provider
  - Falls back to direct computation only when cache misses occur
  - Filters results to requested systems when computing all systems

- **Updated test suite**:
  - Modified `test_precompute_congestion_responses` to use `CONGESTION_PROVIDERS` constant and verify 19 param sets
  - Added comprehensive `TestMergeCongestionFromProviderCaches` test class with 6 test cases covering merge logic, cache misses, metadata aggregation, and parameter passing

## Implementation Details

- The merge operation concatenates segments and train positions from all requested providers, uses the oldest `generated_at` timestamp, and tallies congestion levels across all providers in metadata.
- Single-provider requests use the fast path (direct cache lookup), while multi-provider requests merge per-provider caches.
- The endpoint now returns `Response` with JSON serialization instead of relying on Pydantic model serialization, providing more control over the response format.
- Removed verbose comments and simplified code clarity throughout the endpoint implementation.

https://claude.ai/code/session_01WtZ263aQifHLv8BN4nh1Y5