### PR TITLE
Remove OutlinedPolylineRenderer to fix dark shadow compounding on congestion map

### DIFF
--- a/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
+++ b/ios/TrackRat/Views/Components/JourneyCongestionMapView.swift
@@ -475,7 +475,7 @@ struct CongestionMapKitView: UIViewRepresentable {
         // MARK: - Polyline Rendering
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
             if let polyline = overlay as? CongestionPolyline {
-                let renderer = OutlinedPolylineRenderer(polyline: polyline)
+                let renderer = MKPolylineRenderer(polyline: polyline)
                 if let segment = polyline.segment {
                     renderer.strokeColor = colorForSegment(segment)
                     renderer.lineWidth = 6.0

--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -1332,7 +1332,7 @@ struct SystemCongestionMapView: UIViewRepresentable {
 
             // Handle aggregated segment polylines
             if let polyline = overlay as? SystemCongestionPolyline {
-                let renderer = OutlinedPolylineRenderer(polyline: polyline)
+                let renderer = MKPolylineRenderer(polyline: polyline)
 
                 if let segment = polyline.segment {
                     // Base color from delay/frequency metrics
@@ -1809,56 +1809,6 @@ private func createSingleSegmentOverlay(_ segment: CongestionSegment, isDimmed: 
     polyline.segments = [segment]
     polyline.isDimmed = isDimmed
     return polyline
-}
-
-// MARK: - Outlined Polyline Renderer
-
-/// Draws a dark border stroke behind the colored fill stroke for better contrast on any map background.
-/// The border uses a darkened version of the stroke color for a cohesive look.
-/// At low zoom levels, the border fades out to prevent overlapping borders from compounding into dark blobs.
-class OutlinedPolylineRenderer: MKPolylineRenderer {
-    /// Width of the border around each side of the stroke. Total rendered width = lineWidth + 2 * borderWidth.
-    var borderWidth: CGFloat = 1.5
-
-    override func draw(_ mapRect: MKMapRect, zoomScale: MKZoomScale, in context: CGContext) {
-        // Butt caps prevent the wider border stroke from protruding beyond the fill at endpoints.
-        // Round joins keep bends smooth along curves.
-        lineCap = .butt
-        lineJoin = .round
-
-        // Scale border with zoom: road width gives a stable reference across zoom levels.
-        // At low zoom, overlapping segment borders compound into dark blobs — fade them out.
-        let roadWidth = MKRoadWidthAtZoomScale(zoomScale)
-        let borderFactor = min(1.0, max(0.0, (roadWidth - 2.0) / 8.0))
-        let effectiveBorderWidth = borderWidth * CGFloat(borderFactor)
-
-        guard effectiveBorderWidth > 0.25 else {
-            // At low zoom, skip the border entirely — just draw the fill
-            super.draw(mapRect, zoomScale: zoomScale, in: context)
-            return
-        }
-
-        let originalColor = strokeColor
-        let originalWidth = lineWidth
-        let originalAlpha = alpha
-
-        // Draw border: darkened version of the stroke color with reduced opacity to limit compounding
-        var hue: CGFloat = 0, sat: CGFloat = 0, bri: CGFloat = 0, a: CGFloat = 0
-        if let color = originalColor, color.getHue(&hue, saturation: &sat, brightness: &bri, alpha: &a) {
-            strokeColor = UIColor(hue: hue, saturation: sat, brightness: bri * 0.5, alpha: a)
-        } else {
-            strokeColor = UIColor.black.withAlphaComponent(0.4)
-        }
-        lineWidth = originalWidth + effectiveBorderWidth * 2
-        alpha = originalAlpha * CGFloat(borderFactor)
-        super.draw(mapRect, zoomScale: zoomScale, in: context)
-
-        // Draw fill on top
-        strokeColor = originalColor
-        lineWidth = originalWidth
-        alpha = originalAlpha
-        super.draw(mapRect, zoomScale: zoomScale, in: context)
-    }
 }
 
 // MARK: - Custom Polyline Classes


### PR DESCRIPTION
The custom renderer drew a darkened border behind each polyline for contrast,
but overlapping segments compound these borders into large opaque black regions.
Previous threshold-based mitigations were insufficient. Plain MKPolylineRenderer
eliminates the issue entirely — individual and topology polylines already used it.

https://claude.ai/code/session_01X1kFZdqhdFNxnJi4Bq47iB