### PR TITLE
Fix congestion API returning bloated response when any provider cache misses

### DIFF
--- a/backend_v2/src/trackrat/services/api_cache.py
+++ b/backend_v2/src/trackrat/services/api_cache.py
@@ -122,13 +122,14 @@ class ApiCacheService:
     ) -> dict[str, Any] | None:
         """Assemble a multi-system congestion response by merging per-provider cached entries.
 
-        Returns the merged response dict, or None if any requested system is missing
-        from the cache (caller should fall back to direct computation).
+        Skips providers whose cache entry is missing or expired and merges whatever
+        is available.  Returns None only when *no* provider had a cache hit.
         """
         merged_individual: list[dict[str, Any]] = []
         merged_aggregated: list[dict[str, Any]] = []
         merged_positions: list[dict[str, Any]] = []
         oldest_generated_at: str | None = None
+        merged_systems: list[str] = []
 
         for system in systems:
             provider_params = {
@@ -146,8 +147,9 @@ class ApiCacheService:
                     time_window_hours=time_window_hours,
                     max_per_segment=max_per_segment,
                 )
-                return None
+                continue
 
+            merged_systems.append(system)
             merged_individual.extend(cached.get("individual_segments", []))
             merged_aggregated.extend(cached.get("aggregated_segments", []))
             merged_positions.extend(cached.get("train_positions", []))
@@ -155,6 +157,9 @@ class ApiCacheService:
             gen_at = cached.get("generated_at")
             if gen_at and (oldest_generated_at is None or gen_at < oldest_generated_at):
                 oldest_generated_at = gen_at
+
+        if not merged_systems:
+            return None
 
         # Build merged metadata
         congestion_levels: dict[str, int] = {
@@ -180,13 +185,13 @@ class ApiCacheService:
                 "total_aggregated_segments": len(merged_aggregated),
                 "congestion_levels": congestion_levels,
                 "total_trains": len(merged_positions),
-                "merged_from_systems": systems,
+                "merged_from_systems": merged_systems,
             },
         }
 
         logger.info(
             "congestion_cache_merged",
-            systems=systems,
+            systems=merged_systems,
             aggregated_count=len(merged_aggregated),
             train_count=len(merged_positions),
         )

--- a/backend_v2/tests/unit/services/test_api_cache.py
+++ b/backend_v2/tests/unit/services/test_api_cache.py
@@ -736,13 +736,28 @@ class TestMergeCongestionFromProviderCaches:
         assert sources == {"NJT", "PATH"}
 
     @pytest.mark.asyncio
-    async def test_merge_returns_none_on_cache_miss(self, cache_service, mock_db):
-        """If any provider is missing from cache, merge returns None (caller falls back)."""
+    async def test_merge_skips_missing_provider(self, cache_service, mock_db):
+        """If a provider is missing from cache, merge skips it and returns available data."""
         njt_resp = self._make_provider_response("NJT")
 
         with patch.object(cache_service, "get_cached_response") as mock_get:
             # NJT hits, PATH misses
             mock_get.side_effect = [njt_resp, None]
+
+            result = await cache_service.merge_congestion_from_provider_caches(
+                mock_db, ["NJT", "PATH"], time_window_hours=2, max_per_segment=100
+            )
+
+        assert result is not None
+        assert len(result["individual_segments"]) == 1
+        assert result["individual_segments"][0]["data_source"] == "NJT"
+        assert result["metadata"]["merged_from_systems"] == ["NJT"]
+
+    @pytest.mark.asyncio
+    async def test_merge_returns_none_when_all_miss(self, cache_service, mock_db):
+        """If all providers are missing from cache, merge returns None."""
+        with patch.object(cache_service, "get_cached_response") as mock_get:
+            mock_get.return_value = None
 
             result = await cache_service.merge_congestion_from_provider_caches(
                 mock_db, ["NJT", "PATH"], time_window_hours=2, max_per_segment=100


### PR DESCRIPTION
The merge function returned None when any single provider had no cache entry,
causing the fallback to query all providers unfiltered. On staging this produced
a 14.7MB response (vs 4.4MB on production) because it included data for 9
providers instead of 3. Now skips missing providers and merges what's available.

https://claude.ai/code/session_01KDKE7WiX4LLCqPGRHgn6vE