### PR TITLE
Improve error logging with exception type and fallback repr

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -904,9 +904,15 @@ class DepartureService:
                         TrainJourney.is_cancelled.is_not(True),
                     )
                 )
-                # Eagerly load stops to prevent greenlet errors during
-                # commit's cascade="all, delete-orphan" orphan check
-                .options(selectinload(TrainJourney.stops))
+                # Eagerly load all delete-orphan collections to prevent
+                # greenlet_spawn errors during flush orphan checks
+                .options(
+                    selectinload(TrainJourney.stops),
+                    selectinload(TrainJourney.snapshots),
+                    selectinload(TrainJourney.segment_times),
+                    selectinload(TrainJourney.dwell_times),
+                    selectinload(TrainJourney.progress_snapshots),
+                )
                 .limit(50)
             )
             remaining_stale = list(remaining_stale_result.scalars().unique().all())
@@ -970,7 +976,8 @@ class DepartureService:
                         logger.warning(
                             "stale_train_refresh_failed",
                             train_id=journey.train_id,
-                            error=str(e),
+                            error=str(e) or repr(e),
+                            error_type=type(e).__name__,
                         )
 
                 await db.commit()
@@ -983,7 +990,10 @@ class DepartureService:
 
         except Exception as e:
             logger.error(
-                "station_refresh_failed", station_code=station_code, error=str(e)
+                "station_refresh_failed",
+                station_code=station_code,
+                error=str(e) or repr(e),
+                error_type=type(e).__name__,
             )
             try:
                 await db.rollback()
@@ -1332,5 +1342,6 @@ async def _background_refresh_station(
         logger.warning(
             "background_jit_refresh_failed",
             station_code=station_code,
-            error=str(e),
+            error=str(e) or repr(e),
+            error_type=type(e).__name__,
         )

--- a/backend_v2/src/trackrat/services/jit.py
+++ b/backend_v2/src/trackrat/services/jit.py
@@ -333,7 +333,7 @@ class JustInTimeUpdateService:
                     "failed_to_refresh_journey",
                     train_id=train_id,
                     journey_id=journey.id,
-                    error=str(e),
+                    error=str(e) or repr(e),
                     error_type=type(e).__name__,
                 )
                 # Clear session error state (e.g., PendingRollbackError from failed

--- a/backend_v2/src/trackrat/utils/scheduler_utils.py
+++ b/backend_v2/src/trackrat/utils/scheduler_utils.py
@@ -218,7 +218,8 @@ async def run_with_freshness_check(
             logger.error(
                 "task_execution_failed",
                 task=task_name,
-                error=str(e),
+                error=str(e) or repr(e),
+                error_type=type(e).__name__,
                 instance=instance_id,
                 exc_info=True,
             )
@@ -231,7 +232,8 @@ async def run_with_freshness_check(
         logger.error(
             "task_freshness_check_error",
             task=task_name,
-            error=str(e),
+            error=str(e) or repr(e),
+            error_type=type(e).__name__,
             instance=instance_id,
         )
         # If we can't check freshness, don't run the task (fail safe)


### PR DESCRIPTION
## Summary
Enhanced error logging throughout the codebase to provide more detailed exception information and prevent silent failures when exception string representation is empty.

## Key Changes
- **Error logging improvements**: Updated all error logging calls to include both `error=str(e) or repr(e)` and `error_type=type(e).__name__` for better debugging visibility
  - Modified in `departure.py`: 3 logging calls (stale refresh, station refresh, background refresh)
  - Modified in `scheduler_utils.py`: 2 logging calls (task execution and freshness check)
  - Modified in `jit.py`: 1 logging call (journey refresh)

- **SQLAlchemy eager loading fix**: Expanded eager loading in `_do_bulk_refresh()` to load all delete-orphan relationship collections, not just `stops`
  - Now eagerly loads: `stops`, `snapshots`, `segment_times`, `dwell_times`, and `progress_snapshots`
  - Prevents greenlet_spawn errors during SQLAlchemy's flush orphan checks
  - Updated comment to reflect the broader scope of the fix

## Implementation Details
- The `str(e) or repr(e)` pattern ensures that exceptions with empty `__str__` methods still produce useful error output via their `repr()`
- Adding `error_type` field enables easier filtering and aggregation of errors by exception class in logging systems
- The eager loading change addresses a concurrency issue where lazy-loading relationships during flush operations could cause greenlet errors in async contexts

https://claude.ai/code/session_01QCTiUuQSNUZwtx8DZka2Ch