### PR TITLE
Add diagnostic logging for Amtrak trains in NJT data without track

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -441,6 +441,13 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                             session, train_id, station_code, track,
                             source="njt_discovery",
                         )
+                    else:
+                        logger.debug(
+                            "amtrak_in_njt_no_track",
+                            train_id=train_id,
+                            station_code=station_code,
+                            track_value=repr(track),
+                        )
                     continue
 
                 # Parse scheduled departure time

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -805,6 +805,13 @@ class DepartureService:
                                         db, train_id, station_code, track,
                                         source="njt_jit",
                                     )
+                                else:
+                                    logger.debug(
+                                        "amtrak_in_njt_jit_no_track",
+                                        train_id=train_id,
+                                        station_code=station_code,
+                                        track_value=repr(track),
+                                    )
                             else:
                                 logger.debug(
                                     "journey_not_found_during_station_refresh",


### PR DESCRIPTION
Cross-reference never fired on staging — need to determine if NJT API returns TRACK data for Amtrak trains or not. Adds debug logging when Amtrak trains are found but have no track value.

https://claude.ai/code/session_01PukW141sXH76MHCsZKiDJ9