### PR TITLE
Make Metra GTFS-RT integration optional via feature flag

### DIFF
--- a/infra_v2/terraform/secrets.tf
+++ b/infra_v2/terraform/secrets.tf
@@ -47,6 +47,7 @@ data "google_secret_manager_secret" "wmata_api_key" {
 }
 
 data "google_secret_manager_secret" "metra_api_token" {
+  count      = var.enable_metra ? 1 : 0
   secret_id  = "trackrat-metra-api-token"
   depends_on = [google_project_service.apis]
 }
@@ -78,7 +79,8 @@ resource "google_secret_manager_secret_iam_member" "wmata_api_key" {
 }
 
 resource "google_secret_manager_secret_iam_member" "metra_api_token" {
-  secret_id = data.google_secret_manager_secret.metra_api_token.secret_id
+  count     = var.enable_metra ? 1 : 0
+  secret_id = data.google_secret_manager_secret.metra_api_token[0].secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.trackrat.email}"
 }

--- a/infra_v2/terraform/variables.tf
+++ b/infra_v2/terraform/variables.tf
@@ -51,6 +51,12 @@ variable "snapshot_retention_days" {
   default     = 35
 }
 
+variable "enable_metra" {
+  description = "Enable Metra GTFS-RT integration (requires trackrat-metra-api-token secret in Secret Manager)"
+  type        = bool
+  default     = false
+}
+
 variable "alert_email" {
   description = "Email address for uptime monitoring alerts"
   type        = string


### PR DESCRIPTION
## Summary
This change makes the Metra GTFS-RT integration optional by introducing a feature flag that controls whether the Metra API token secret is accessed and configured in the infrastructure.

## Key Changes
- Added `enable_metra` boolean variable (default: `false`) to allow conditional enablement of Metra integration
- Made the Metra API token secret data source conditional using `count` - only fetched when `enable_metra` is `true`
- Made the Metra API token IAM role binding conditional using `count` - only created when `enable_metra` is `true`
- Updated the IAM binding to reference the conditional secret using index notation `[0]`

## Implementation Details
The implementation uses Terraform's `count` meta-argument to conditionally create resources only when the feature is enabled. This prevents errors when the Metra API token secret doesn't exist in Secret Manager for deployments that don't need Metra integration. The default value of `false` ensures backward compatibility and opt-in behavior for this integration.

https://claude.ai/code/session_01GqrfmvLmZREPcyjMhbTPSX