### PR TITLE
Standardize Metra HTTP error logging format

### DIFF
--- a/backend_v2/src/trackrat/collectors/metra/client.py
+++ b/backend_v2/src/trackrat/collectors/metra/client.py
@@ -212,10 +212,7 @@ class MetraClient:
             return arrivals
 
         except httpx.HTTPStatusError as e:
-            logger.error(
-                "metra_gtfs_rt_http_error",
-                status_code=e.response.status_code,
-            )
+            logger.error(f"HTTP error fetching Metra GTFS-RT feed: {e.response.status_code}")
             return self._cache or []
         except httpx.HTTPError as e:
             logger.error(f"HTTP error fetching Metra GTFS-RT feed: {type(e).__name__}")


### PR DESCRIPTION
## Summary
Updated the HTTP status error logging in the Metra GTFS-RT client to use a consistent string formatting approach that matches the existing error handling pattern.

## Key Changes
- Replaced structured logging call for `HTTPStatusError` with f-string formatted message
- Now uses the same logging format as the `HTTPError` handler below it for consistency
- Maintains the same error information (status code) in the log output

## Implementation Details
The change simplifies the error logging by converting from a structured logging format (`logger.error("metra_gtfs_rt_http_error", status_code=...)`) to a more readable f-string format (`logger.error(f"HTTP error fetching Metra GTFS-RT feed: {e.response.status_code}")`). This aligns with the logging pattern used for the generic `HTTPError` exception handler in the same method, improving code consistency and maintainability.

https://claude.ai/code/session_014JUhGt8q8vjqjCfva3FpZo