### PR TITLE
Make METRA API token retrieval non-fatal in trackrat startup

### DIFF
--- a/infra_v2/terraform/compute.tf
+++ b/infra_v2/terraform/compute.tf
@@ -168,7 +168,7 @@ resource "google_compute_instance_template" "trackrat" {
       WMATA_API_KEY=$(toolbox --quiet gcloud secrets versions access latest \
         --secret=trackrat-wmata-api-key --project="$PROJECT_ID" 2>/dev/null)
       METRA_API_TOKEN=$(toolbox --quiet gcloud secrets versions access latest \
-        --secret=trackrat-metra-api-token --project="$PROJECT_ID" 2>/dev/null)
+        --secret=trackrat-metra-api-token --project="$PROJECT_ID" 2>/dev/null) || true
       echo "Secrets fetched successfully"
 
       # ===========================================


### PR DESCRIPTION
## Summary
Added error handling to the METRA API token retrieval in the trackrat instance template startup script to prevent initialization failures when the secret is unavailable.

## Key Changes
- Added `|| true` to the METRA_API_TOKEN secret retrieval command to make it non-fatal if the secret fetch fails
- This allows the instance to continue startup even if the METRA API token cannot be retrieved, matching the error handling pattern for other optional secrets

## Implementation Details
The change makes the METRA API token retrieval consistent with graceful degradation principles. If the secret is unavailable (e.g., during initial setup or in certain environments), the startup process will continue rather than failing completely. The `2>/dev/null` already suppresses error output, and the `|| true` ensures the command always exits successfully.

https://claude.ai/code/session_01FcoLhd2AG35bo7aUvprVNP