### PR TITLE
Change Amtrak-in-NJT diagnostic logging from debug to info level

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -442,7 +442,7 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                             source="njt_discovery",
                         )
                     else:
-                        logger.debug(
+                        logger.info(
                             "amtrak_in_njt_no_track",
                             train_id=train_id,
                             station_code=station_code,

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -806,7 +806,7 @@ class DepartureService:
                                         source="njt_jit",
                                     )
                                 else:
-                                    logger.debug(
+                                    logger.info(
                                         "amtrak_in_njt_jit_no_track",
                                         train_id=train_id,
                                         station_code=station_code,


### PR DESCRIPTION
Debug-level logs are filtered out on staging. Upgrade to info so we can see whether NJT API returns TRACK data for Amtrak trains.

https://claude.ai/code/session_01PukW141sXH76MHCsZKiDJ9