### PR TITLE
Close feature gaps between web and iOS app

### DIFF
--- a/webpage_v2/src/components/SimilarTrainsPanel.tsx
+++ b/webpage_v2/src/components/SimilarTrainsPanel.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import { OperationsSummaryResponse } from '../types';
+import { apiService } from '../services/api';
+import { TrainDistributionChart } from './TrainDistributionChart';
+
+interface Props {
+  trainId: string;
+  from: string;
+  to: string;
+  dataSource?: string;
+}
+
+export function SimilarTrainsPanel({ trainId, from, to, dataSource }: Props) {
+  const [summary, setSummary] = useState<OperationsSummaryResponse | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    apiService.getTrainSummary(trainId, from, to).then(setSummary);
+  }, [trainId, from, to]);
+
+  if (!summary) return null;
+
+  const hasChart = summary.metrics?.trains_by_category || summary.metrics?.trains_by_headway;
+
+  return (
+    <div className="mb-6">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full bg-surface/50 backdrop-blur-xl border border-text-muted/20 rounded-xl p-4 text-left transition-all hover:bg-surface"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center justify-between">
+          <div className="text-sm font-medium text-text-primary">{summary.headline}</div>
+          <span className="text-text-muted text-xs ml-2">{expanded ? '▲' : '▼'}</span>
+        </div>
+        {expanded && (
+          <>
+            <div className="mt-3 text-sm text-text-muted whitespace-pre-line">{summary.body}</div>
+            {hasChart && (
+              <TrainDistributionChart
+                trainsByCategory={summary.metrics!.trains_by_category}
+                trainsByHeadway={summary.metrics!.trains_by_headway}
+                dataSource={dataSource}
+                from={from}
+                to={to}
+              />
+            )}
+            {summary.metrics && (
+              <div className="grid grid-cols-3 gap-2 mt-3">
+                {summary.metrics.on_time_percentage != null && (
+                  <div className="text-center">
+                    <div className={`text-sm font-bold ${summary.metrics.on_time_percentage >= 80 ? 'text-success' : summary.metrics.on_time_percentage >= 60 ? 'text-warning' : 'text-error'}`}>
+                      {Math.round(summary.metrics.on_time_percentage)}%
+                    </div>
+                    <div className="text-[10px] text-text-muted">On time</div>
+                  </div>
+                )}
+                {summary.metrics.average_delay_minutes != null && (
+                  <div className="text-center">
+                    <div className="text-sm font-bold text-text-primary">
+                      {summary.metrics.average_delay_minutes.toFixed(1)}m
+                    </div>
+                    <div className="text-[10px] text-text-muted">Avg delay</div>
+                  </div>
+                )}
+                {summary.metrics.train_count != null && (
+                  <div className="text-center">
+                    <div className="text-sm font-bold text-text-primary">
+                      {summary.metrics.train_count}
+                    </div>
+                    <div className="text-[10px] text-text-muted">Similar trains</div>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/webpage_v2/src/components/StationPicker.tsx
+++ b/webpage_v2/src/components/StationPicker.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Station } from '../types';
-import { searchStations, getGroupedPrimaryStations } from '../data/stations';
+import { searchStations, getGroupedPrimaryStations, SYSTEM_ORDER, SYSTEM_NAMES } from '../data/stations';
+import { useAppStore } from '../store/appStore';
 
 interface StationPickerProps {
   title: string;
@@ -11,22 +12,36 @@ interface StationPickerProps {
 export function StationPicker({ title, onSelect, onClose }: StationPickerProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Station[]>([]);
+  const { preferredSystems, toggleSystem, loadPreferredSystems } = useAppStore();
+
+  useEffect(() => {
+    loadPreferredSystems();
+  }, [loadPreferredSystems]);
+
+  const activeFilter = preferredSystems.length > 0 ? preferredSystems : undefined;
 
   const handleSearch = (value: string) => {
     setQuery(value);
     if (value.trim()) {
-      setResults(searchStations(value));
+      setResults(searchStations(value, activeFilter));
     } else {
       setResults([]);
     }
   };
+
+  // Re-run search when filter changes
+  useEffect(() => {
+    if (query.trim()) {
+      setResults(searchStations(query, activeFilter));
+    }
+  }, [preferredSystems]);
 
   const handleSelect = (station: Station) => {
     onSelect(station);
     onClose();
   };
 
-  const groupedStations = getGroupedPrimaryStations();
+  const groupedStations = getGroupedPrimaryStations(activeFilter);
   const isSearching = query.trim().length > 0;
 
   return (
@@ -49,8 +64,27 @@ export function StationPicker({ title, onSelect, onClose }: StationPickerProps) 
             onChange={(e) => handleSearch(e.target.value)}
             placeholder="Search stations..."
             autoFocus
-            className="w-full px-4 py-3 bg-background border border-text-muted/30 rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent"
+            className="w-full px-4 py-3 bg-background border border-text-muted/30 rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent mb-3"
           />
+          {/* System filter chips */}
+          <div className="flex gap-1.5 overflow-x-auto pb-1 -mb-1 scrollbar-hide">
+            {SYSTEM_ORDER.map(system => {
+              const active = preferredSystems.includes(system);
+              return (
+                <button
+                  key={system}
+                  onClick={() => toggleSystem(system)}
+                  className={`flex-shrink-0 px-2.5 py-1 rounded-full text-[11px] font-semibold transition-colors ${
+                    active
+                      ? 'bg-accent text-white'
+                      : 'bg-surface/80 border border-text-muted/20 text-text-muted hover:text-text-secondary'
+                  }`}
+                >
+                  {SYSTEM_NAMES[system]}
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto">

--- a/webpage_v2/src/components/TrainDistributionChart.tsx
+++ b/webpage_v2/src/components/TrainDistributionChart.tsx
@@ -1,0 +1,129 @@
+import { Link } from 'react-router-dom';
+import { TrainDelaySummary } from '../types';
+
+const DELAY_CATEGORIES = [
+  { key: 'on_time', label: 'On time', color: 'bg-success', textColor: 'text-success' },
+  { key: 'slight_delay', label: '5-15m', color: 'bg-warning/70', textColor: 'text-warning' },
+  { key: 'delayed', label: '15m+', color: 'bg-warning', textColor: 'text-warning' },
+  { key: 'cancelled', label: 'Cancelled', color: 'bg-text-muted', textColor: 'text-text-muted' },
+] as const;
+
+const HEADWAY_CATEGORIES = [
+  { key: '0-5', label: '0-5m', color: 'bg-success', textColor: 'text-success' },
+  { key: '5-10', label: '5-10m', color: 'bg-success/70', textColor: 'text-success' },
+  { key: '10-20', label: '10-20m', color: 'bg-warning/70', textColor: 'text-warning' },
+  { key: '20+', label: '20m+', color: 'bg-error/70', textColor: 'text-error' },
+] as const;
+
+const MAX_PILLS = 5;
+
+// Systems that use headway-based frequency charts
+const FREQUENCY_SYSTEMS = new Set(['PATH', 'SUBWAY', 'PATCO', 'BART', 'MBTA']);
+
+interface Props {
+  trainsByCategory: Record<string, TrainDelaySummary[]> | null;
+  trainsByHeadway: Record<string, TrainDelaySummary[]> | null;
+  dataSource?: string;
+  from?: string;
+  to?: string;
+}
+
+export function TrainDistributionChart({ trainsByCategory, trainsByHeadway, dataSource, from, to }: Props) {
+  const useFrequency = dataSource && FREQUENCY_SYSTEMS.has(dataSource) && trainsByHeadway;
+  const categories = useFrequency ? HEADWAY_CATEGORIES : DELAY_CATEGORIES;
+  const data = useFrequency ? trainsByHeadway! : trainsByCategory;
+
+  if (!data) return null;
+
+  const totalTrains = Object.values(data).reduce((sum, trains) => sum + trains.length, 0);
+  if (totalTrains === 0) return null;
+
+  return (
+    <div className="mt-3">
+      {/* Bar chart */}
+      <div className="flex h-3 rounded-full overflow-hidden mb-3">
+        {categories.map(cat => {
+          const trains = data[cat.key] || [];
+          const pct = (trains.length / totalTrains) * 100;
+          if (pct === 0) return null;
+          return (
+            <div
+              key={cat.key}
+              className={cat.color}
+              style={{ width: `${pct}%` }}
+              title={`${cat.label}: ${trains.length} trains (${Math.round(pct)}%)`}
+            />
+          );
+        })}
+      </div>
+
+      {/* Columns with train pills */}
+      <div className="grid grid-cols-4 gap-2">
+        {categories.map(cat => {
+          const trains = data[cat.key] || [];
+          if (trains.length === 0) {
+            return (
+              <div key={cat.key} className="text-center">
+                <div className="text-[10px] text-text-muted mb-1">{cat.label}</div>
+                <div className="text-xs text-text-muted">—</div>
+              </div>
+            );
+          }
+          const overflow = trains.length - MAX_PILLS;
+          return (
+            <div key={cat.key} className="text-center">
+              <div className="text-[10px] text-text-muted mb-1">
+                {cat.label} ({trains.length})
+              </div>
+              <div className="flex flex-col gap-1 items-center">
+                {trains.slice(0, MAX_PILLS).map(train => (
+                  <TrainPill
+                    key={train.train_id}
+                    train={train}
+                    textColor={cat.textColor}
+                    from={from}
+                    to={to}
+                  />
+                ))}
+                {overflow > 0 && (
+                  <span className="text-[10px] text-text-muted">+{overflow} more</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TrainPill({ train, textColor, from, to }: {
+  train: TrainDelaySummary;
+  textColor: string;
+  from?: string;
+  to?: string;
+}) {
+  const label = formatTrainLabel(train.train_id);
+  const href = from && to
+    ? `/train/${encodeURIComponent(train.train_id)}/${from}/${to}`
+    : `/train/${encodeURIComponent(train.train_id)}`;
+
+  return (
+    <Link
+      to={href}
+      className={`text-[10px] font-medium ${textColor} bg-surface/80 border border-text-muted/15 rounded-full px-2 py-0.5 hover:bg-surface transition-colors truncate max-w-full`}
+      title={`${train.train_id} — ${train.delay_minutes.toFixed(0)}m delay`}
+    >
+      {label}
+    </Link>
+  );
+}
+
+function formatTrainLabel(trainId: string): string {
+  // Truncate long IDs (subway, PATH, etc.) to last meaningful segment
+  if (trainId.length > 10) {
+    const parts = trainId.split('_');
+    return parts.length > 1 ? parts[parts.length - 1].slice(0, 8) : trainId.slice(0, 8);
+  }
+  return trainId;
+}

--- a/webpage_v2/src/components/UpcomingTrains.tsx
+++ b/webpage_v2/src/components/UpcomingTrains.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { Train, TripOption } from '../types';
+import { apiService } from '../services/api';
+import { formatTime, getDelayMinutes } from '../utils/date';
+
+interface Props {
+  from: string;
+  to: string;
+}
+
+const MAX_TRAINS = 3;
+
+export function UpcomingTrains({ from, to }: Props) {
+  const [trains, setTrains] = useState<Train[]>([]);
+
+  useEffect(() => {
+    apiService.searchTrips(from, to, 10)
+      .then(response => {
+        const direct = response.trips
+          .filter(t => t.is_direct)
+          .map(tripToTrain)
+          .filter(t => !t.is_cancelled && !hasTrainDeparted(t))
+          .slice(0, MAX_TRAINS);
+        setTrains(direct);
+      })
+      .catch(() => {}); // Fail silently
+  }, [from, to]);
+
+  if (trains.length === 0) return null;
+
+  return (
+    <div className="mb-4 bg-surface/70 backdrop-blur-xl border border-text-muted/20 rounded-2xl p-4">
+      <h4 className="text-sm font-semibold text-text-primary mb-3">Upcoming Trains</h4>
+      <div className="space-y-2">
+        {trains.map(train => {
+          const delayMins = getDelayMinutes(
+            train.departure.scheduled_time,
+            train.departure.updated_time || train.departure.actual_time || undefined
+          );
+          return (
+            <Link
+              key={train.train_id}
+              to={`/train/${encodeURIComponent(train.train_id)}/${from}/${to}`}
+              className="flex items-center gap-3 p-2 rounded-lg hover:bg-surface/50 transition-colors"
+            >
+              {/* Line color dot */}
+              <div
+                className="w-2 h-8 rounded-full flex-shrink-0"
+                style={{ backgroundColor: train.line.color || '#CC5500' }}
+              />
+              {/* Train info */}
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-text-primary truncate">
+                  {train.line.name}
+                </div>
+                {train.departure.track && (
+                  <div className="text-[10px] text-text-muted">Track {train.departure.track}</div>
+                )}
+              </div>
+              {/* Time + delay */}
+              <div className="text-right flex-shrink-0">
+                <div className="text-sm font-medium text-text-primary">
+                  {formatTime(train.departure.scheduled_time)}
+                </div>
+                {delayMins > 0 && (
+                  <div className="text-[10px] text-warning font-medium">{delayMins}m late</div>
+                )}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+      <Link
+        to={`/trains/${from}/${to}`}
+        className="block mt-3 text-xs text-accent hover:text-accent/80 font-medium text-center"
+      >
+        View All Departures →
+      </Link>
+    </div>
+  );
+}
+
+function tripToTrain(trip: TripOption): Train {
+  const leg = trip.legs[0];
+  return {
+    train_id: leg.train_id,
+    journey_date: leg.journey_date,
+    line: leg.line,
+    destination: leg.destination,
+    departure: leg.boarding,
+    arrival: leg.alighting,
+    train_position: leg.train_position,
+    data_freshness: { last_updated: '', age_seconds: 0, update_count: 0, collection_method: null },
+    data_source: leg.data_source,
+    observation_type: (leg.observation_type as 'OBSERVED' | 'SCHEDULED') || 'OBSERVED',
+    is_cancelled: leg.is_cancelled,
+  };
+}
+
+function hasTrainDeparted(train: Train): boolean {
+  const timeStr = train.departure.actual_time || train.departure.updated_time || train.departure.scheduled_time;
+  if (!timeStr) return false;
+  return new Date(timeStr).getTime() + 60000 < Date.now();
+}

--- a/webpage_v2/src/data/stations.ts
+++ b/webpage_v2/src/data/stations.ts
@@ -1637,19 +1637,22 @@ export function getStationByCode(code: string): Station | undefined {
   return STATIONS.find(s => s.code === code);
 }
 
-export function searchStations(query: string): Station[] {
+export function searchStations(query: string, systems?: TransitSystem[]): Station[] {
   if (!query) return [];
   const q = query.toLowerCase();
+  const hasFilter = systems && systems.length > 0;
   return STATIONS
     .filter(s =>
-      s.name.toLowerCase().includes(q) ||
-      s.code.toLowerCase().includes(q)
+      (s.name.toLowerCase().includes(q) || s.code.toLowerCase().includes(q)) &&
+      (!hasFilter || (s.system && systems!.includes(s.system)))
     )
     .slice(0, 15);
 }
 
-export function getGroupedPrimaryStations(): { system: TransitSystem; name: string; stations: Station[] }[] {
-  return SYSTEM_ORDER.map(system => ({
+export function getGroupedPrimaryStations(systems?: TransitSystem[]): { system: TransitSystem; name: string; stations: Station[] }[] {
+  const hasFilter = systems && systems.length > 0;
+  const order = hasFilter ? SYSTEM_ORDER.filter(s => systems!.includes(s)) : SYSTEM_ORDER;
+  return order.map(system => ({
     system,
     name: SYSTEM_NAMES[system],
     stations: PRIMARY_STATIONS[system]

--- a/webpage_v2/src/pages/RouteStatusPage.tsx
+++ b/webpage_v2/src/pages/RouteStatusPage.tsx
@@ -6,8 +6,35 @@ import { getStationByCode } from '../data/stations';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { ErrorMessage } from '../components/ErrorMessage';
 import { ServiceAlertBanner } from '../components/ServiceAlertBanner';
+import { UpcomingTrains } from '../components/UpcomingTrains';
 
-type Period = '7' | '30' | '90';
+type Period = '1h' | '6h' | '24h' | '7d' | '30d' | '90d';
+
+const PERIODS: { value: Period; label: string }[] = [
+  { value: '1h', label: '1h' },
+  { value: '6h', label: '6h' },
+  { value: '24h', label: '24h' },
+  { value: '7d', label: '7d' },
+  { value: '30d', label: '30d' },
+  { value: '90d', label: '90d' },
+];
+
+function periodToApiParams(period: Period): { days?: number; hours?: number } {
+  switch (period) {
+    case '1h': return { hours: 1 };
+    case '6h': return { hours: 6 };
+    case '24h': return { hours: 24 };
+    case '7d': return { days: 7 };
+    case '30d': return { days: 30 };
+    case '90d': return { days: 90 };
+  }
+}
+
+function periodLabel(period: Period): string {
+  const p = periodToApiParams(period);
+  if (p.hours) return `${p.hours} hour${p.hours > 1 ? 's' : ''}`;
+  return `${p.days} days`;
+}
 
 export function RouteStatusPage() {
   const { from, to } = useParams<{ from: string; to: string }>();
@@ -15,7 +42,7 @@ export function RouteStatusPage() {
 
   const [history, setHistory] = useState<RouteHistoryResponse | null>(null);
   const [summary, setSummary] = useState<OperationsSummaryResponse | null>(null);
-  const [period, setPeriod] = useState<Period>('30');
+  const [period, setPeriod] = useState<Period>('24h');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,8 +56,9 @@ export function RouteStatusPage() {
     setLoading(true);
     setError(null);
 
+    const { days, hours } = periodToApiParams(period);
     Promise.all([
-      apiService.getRouteHistory(from, to, dataSource, Number(period)),
+      apiService.getRouteHistory(from, to, dataSource, days, hours),
       apiService.getRouteSummary(from, to),
     ])
       .then(([historyRes, summaryRes]) => {
@@ -78,19 +106,22 @@ export function RouteStatusPage() {
         </div>
       )}
 
+      {/* Upcoming trains */}
+      <UpcomingTrains from={from} to={to} />
+
       {/* Period selector */}
-      <div className="flex gap-2 mb-4">
-        {(['7', '30', '90'] as Period[]).map(p => (
+      <div className="flex gap-1.5 mb-4">
+        {PERIODS.map(p => (
           <button
-            key={p}
-            onClick={() => setPeriod(p)}
-            className={`flex-1 py-2 rounded-xl text-sm font-semibold transition-colors ${
-              period === p
+            key={p.value}
+            onClick={() => setPeriod(p.value)}
+            className={`flex-1 py-2 rounded-xl text-xs font-semibold transition-colors ${
+              period === p.value
                 ? 'bg-accent text-white'
                 : 'bg-surface/50 border border-text-muted/20 text-text-secondary hover:bg-surface'
             }`}
           >
-            {p}d
+            {p.label}
           </button>
         ))}
       </div>
@@ -171,7 +202,7 @@ export function RouteStatusPage() {
 
           {/* Data info */}
           <div className="text-xs text-text-muted text-center mt-2">
-            {history?.route.total_trains} trains over {period} days
+            {history?.route.total_trains} trains over {periodLabel(period)}
           </div>
         </div>
       ) : (

--- a/webpage_v2/src/pages/TrainDetailsPage.tsx
+++ b/webpage_v2/src/pages/TrainDetailsPage.tsx
@@ -10,6 +10,7 @@ import { ShareButton } from '../components/ShareButton';
 import { DelayForecastCard } from '../components/DelayForecastCard';
 import { ServiceAlertBanner } from '../components/ServiceAlertBanner';
 import { HistoricalPerformance } from '../components/HistoricalPerformance';
+import { SimilarTrainsPanel } from '../components/SimilarTrainsPanel';
 import { getTodayDateString, formatTimeAgo, isToday, formatDate } from '../utils/date';
 import { buildTrainShareData } from '../utils/share';
 
@@ -230,6 +231,16 @@ export function TrainDetailsPage() {
             journeyDate={train.journey_date}
           />
         </div>
+      )}
+
+      {/* Similar trains panel — only before departure from user's origin */}
+      {from && to && !predictionStop?.has_departed_station && (
+        <SimilarTrainsPanel
+          trainId={train.train_id}
+          from={from.toUpperCase()}
+          to={to.toUpperCase()}
+          dataSource={train.data_source}
+        />
       )}
 
       <h3 className="text-xl font-semibold mb-4 text-text-primary">Stops</h3>

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -8,6 +8,7 @@ import { ErrorMessage } from '../components/ErrorMessage';
 import { TrainCard } from '../components/TrainCard';
 import { TransferTripCard } from '../components/TransferTripCard';
 import { ServiceAlertBanner } from '../components/ServiceAlertBanner';
+import { TrainDistributionChart } from '../components/TrainDistributionChart';
 import { getStationByCode } from '../data/stations';
 import { formatTimeAgo, getTodayDateString } from '../utils/date';
 
@@ -183,7 +184,18 @@ export function TrainListPage() {
             <span className="text-text-muted text-xs ml-2">{summaryExpanded ? '▲' : '▼'}</span>
           </div>
           {summaryExpanded && (
-            <div className="mt-3 text-sm text-text-muted whitespace-pre-line">{summary.body}</div>
+            <>
+              <div className="mt-3 text-sm text-text-muted whitespace-pre-line">{summary.body}</div>
+              {summary.metrics && (
+                <TrainDistributionChart
+                  trainsByCategory={summary.metrics.trains_by_category}
+                  trainsByHeadway={summary.metrics.trains_by_headway}
+                  dataSource={fromStation?.system}
+                  from={from}
+                  to={to}
+                />
+              )}
+            </>
           )}
         </button>
       )}

--- a/webpage_v2/src/pages/TripSelectionPage.tsx
+++ b/webpage_v2/src/pages/TripSelectionPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../store/appStore';
 import { StationPicker } from '../components/StationPicker';
 import { getStationByCode } from '../data/stations';
+import { storageService } from '../services/storage';
 
 export function TripSelectionPage() {
   const navigate = useNavigate();
@@ -83,12 +84,11 @@ export function TripSelectionPage() {
               <button
                 key={trip.id}
                 onClick={() => {
-                  const from = getStationByCode(trip.departureCode);
-                  const to = getStationByCode(trip.destinationCode);
-                  if (from && to) {
-                    setDeparture(from);
-                    setDestination(to);
-                  }
+                  storageService.saveLastRoute(
+                    { code: trip.departureCode, name: trip.departureName },
+                    { code: trip.destinationCode, name: trip.destinationName }
+                  );
+                  navigate(`/trains/${trip.departureCode}/${trip.destinationCode}`);
                 }}
                 className="w-full bg-surface/50 backdrop-blur-xl border border-text-muted/20 rounded-xl p-4 text-left hover:bg-surface transition-all"
               >

--- a/webpage_v2/src/services/api.ts
+++ b/webpage_v2/src/services/api.ts
@@ -117,14 +117,27 @@ export class APIService {
     }
   }
 
-  async getRouteHistory(from: string, to: string, dataSource: string, days = 30): Promise<RouteHistoryResponse | null> {
+  async getTrainSummary(trainId: string, from: string, to: string): Promise<OperationsSummaryResponse | null> {
+    try {
+      const url = `${BASE_URL}/routes/summary?scope=train&train_id=${encodeURIComponent(trainId)}&from_station=${encodeURIComponent(from)}&to_station=${encodeURIComponent(to)}`;
+      return await this.fetch<OperationsSummaryResponse>(url);
+    } catch {
+      return null;
+    }
+  }
+
+  async getRouteHistory(from: string, to: string, dataSource: string, days = 30, hours?: number): Promise<RouteHistoryResponse | null> {
     try {
       const params = new URLSearchParams({
         from_station: from,
         to_station: to,
         data_source: dataSource,
-        days: days.toString(),
       });
+      if (hours !== undefined) {
+        params.set('hours', hours.toString());
+      } else {
+        params.set('days', days.toString());
+      }
       const url = `${BASE_URL}/routes/history?${params.toString()}`;
       return await this.fetch<RouteHistoryResponse>(url);
     } catch {

--- a/webpage_v2/src/services/storage.ts
+++ b/webpage_v2/src/services/storage.ts
@@ -1,8 +1,9 @@
-import { TripPair, FavoriteStation } from '../types';
+import { TripPair, FavoriteStation, TransitSystem } from '../types';
 
 const RECENT_TRIPS_KEY = 'trackrat:recentTrips';
 const FAVORITES_KEY = 'trackrat:favorites';
 const LAST_ROUTE_KEY = 'trackrat:lastRoute';
+const SYSTEMS_KEY = 'trackrat:systems';
 
 const MAX_RECENT_TRIPS = 10;
 
@@ -103,6 +104,20 @@ class StorageService {
 
   saveLastRoute(from: { code: string; name: string }, to: { code: string; name: string }): void {
     localStorage.setItem(LAST_ROUTE_KEY, JSON.stringify({ from, to }));
+  }
+
+  // Preferred Transit Systems
+  getPreferredSystems(): TransitSystem[] {
+    try {
+      const data = localStorage.getItem(SYSTEMS_KEY);
+      return data ? JSON.parse(data) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  savePreferredSystems(systems: TransitSystem[]): void {
+    localStorage.setItem(SYSTEMS_KEY, JSON.stringify(systems));
   }
 }
 

--- a/webpage_v2/src/store/appStore.ts
+++ b/webpage_v2/src/store/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Station, TripPair, FavoriteStation } from '../types';
+import { Station, TripPair, FavoriteStation, TransitSystem } from '../types';
 import { storageService } from '../services/storage';
 
 interface AppState {
@@ -10,6 +10,7 @@ interface AppState {
   // User Preferences
   recentTrips: TripPair[];
   favoriteStations: FavoriteStation[];
+  preferredSystems: TransitSystem[];
 
   // Actions
   setDeparture: (station: Station | null) => void;
@@ -24,6 +25,10 @@ interface AppState {
   addFavorite: (station: Station) => void;
   removeFavorite: (stationId: string) => void;
   loadFavorites: () => void;
+
+  // System Preferences
+  toggleSystem: (system: TransitSystem) => void;
+  loadPreferredSystems: () => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -32,6 +37,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectedDestination: null,
   recentTrips: [],
   favoriteStations: [],
+  preferredSystems: [],
 
   // Actions
   setDeparture: (station) => {
@@ -103,5 +109,20 @@ export const useAppStore = create<AppState>((set, get) => ({
   loadFavorites: () => {
     const favorites = storageService.getFavoriteStations();
     set({ favoriteStations: favorites });
+  },
+
+  // System Preferences
+  toggleSystem: (system) => {
+    const current = get().preferredSystems;
+    const updated = current.includes(system)
+      ? current.filter(s => s !== system)
+      : [...current, system];
+    set({ preferredSystems: updated });
+    storageService.savePreferredSystems(updated);
+  },
+
+  loadPreferredSystems: () => {
+    const systems = storageService.getPreferredSystems();
+    set({ preferredSystems: systems });
   },
 }));

--- a/webpage_v2/src/types/index.ts
+++ b/webpage_v2/src/types/index.ts
@@ -139,6 +139,22 @@ export interface DataFreshness {
 
 // Operations Summary Types
 
+export interface TrainDelaySummary {
+  train_id: string;
+  delay_minutes: number;
+  category: 'on_time' | 'slight_delay' | 'delayed' | 'cancelled';
+  scheduled_departure: string;
+}
+
+export interface SummaryMetrics {
+  on_time_percentage: number | null;
+  average_delay_minutes: number | null;
+  cancellation_count: number | null;
+  train_count: number | null;
+  trains_by_category: Record<string, TrainDelaySummary[]> | null;
+  trains_by_headway: Record<string, TrainDelaySummary[]> | null;
+}
+
 export interface OperationsSummaryResponse {
   headline: string;
   body: string;
@@ -146,6 +162,7 @@ export interface OperationsSummaryResponse {
   time_window_minutes: number;
   data_freshness_seconds: number;
   generated_at: string;
+  metrics: SummaryMetrics | null;
 }
 
 // Track Prediction Types


### PR DESCRIPTION
- Auto-navigate on recent trip click (skip extra "Search Trains" tap)
- Rich operations summary with train distribution chart and tappable pills
- Similar trains panel on train details (pre-departure analysis)
- Route Status: 1h/6h/24h/7d/30d/90d time periods (was 7d/30d/90d only)
- Route Status: upcoming trains section with next 3 departures
- System filtering in station picker via persistent filter chips
- New types: SummaryMetrics, TrainDelaySummary on OperationsSummaryResponse
- New API: getTrainSummary (scope=train), getRouteHistory hours param

https://claude.ai/code/session_01Fk7ciYm5HU2DpfMLPQxDHW