### PR TITLE
Fix intermediate stations selection to prefer shortest routes

### DIFF
--- a/ios/TrackRat/Shared/RouteTopology.swift
+++ b/ios/TrackRat/Shared/RouteTopology.swift
@@ -979,19 +979,28 @@ struct RouteTopology {
 
     /// Returns all station codes (inclusive) between two stations on a matching route.
     /// Handles both forward and reverse direction. Returns nil if no route contains both stations.
+    /// Picks the route with the fewest intermediate stations to avoid cross-route contamination
+    /// (e.g., local stops inserted when following an express train).
     static func getIntermediateStations(from: String, to: String, dataSource: String) -> [String]? {
+        var bestResult: [String]?
+        var bestDistance = Int.max
+
         for route in allRoutes where route.dataSource == dataSource {
             guard let fromIndex = route.stationCodes.firstIndex(of: from),
                   let toIndex = route.stationCodes.firstIndex(of: to) else {
                 continue
             }
-            if fromIndex <= toIndex {
-                return Array(route.stationCodes[fromIndex...toIndex])
-            } else {
-                return Array(route.stationCodes[toIndex...fromIndex].reversed())
+            let distance = abs(toIndex - fromIndex)
+            if distance < bestDistance {
+                bestDistance = distance
+                if fromIndex <= toIndex {
+                    bestResult = Array(route.stationCodes[fromIndex...toIndex])
+                } else {
+                    bestResult = Array(route.stationCodes[toIndex...fromIndex].reversed())
+                }
             }
         }
-        return nil
+        return bestResult
     }
 
     /// Expands a list of station codes to include all intermediate stations from route topology.


### PR DESCRIPTION
## Summary
Updated `getIntermediateStations` to select the route with the fewest intermediate stations between two stops, preventing cross-route contamination when multiple routes contain the same station pair.

## Key Changes
- Modified the function to iterate through all matching routes instead of returning immediately on the first match
- Added distance tracking to identify the route with the shortest path between the two stations
- Returns the result from the route with the minimum number of intermediate stops

## Implementation Details
- Introduced `bestResult` and `bestDistance` variables to track the optimal route found so far
- Calculates distance as the absolute difference between station indices for each matching route
- Updates the best result only when a shorter distance is found
- This prevents issues where local stops inserted when following an express train would contaminate the intermediate station list

https://claude.ai/code/session_01RrLU7H3EPSoDfE4geqxCFg