### PR TITLE
Track Amtrak trains separately in NJT station discovery

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -214,10 +214,16 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
 
             # Track ALL train IDs for batch collection
             all_train_ids = []
+            amtrak_train_ids = []
             for train_data in trains_data:
                 train_id = train_data.get("TRAIN_ID", "").strip()
                 if train_id:
                     all_train_ids.append(train_id)
+                    if is_amtrak_train(train_id):
+                        track = train_data.get("TRACK", "")
+                        amtrak_train_ids.append(
+                            f"{train_id}[track={track or 'none'}]"
+                        )
 
             # Process discovered trains (creates/updates journey records)
             new_train_ids = await self.process_discovered_trains(
@@ -239,6 +245,8 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                 station_code=station_code,
                 trains_discovered=len(trains_data),
                 new_trains=len(new_train_ids),
+                amtrak_trains=len(amtrak_train_ids),
+                amtrak_detail=amtrak_train_ids if amtrak_train_ids else None,
                 duration_ms=duration_ms,
             )
 


### PR DESCRIPTION
## Summary
Enhanced the NJT station discovery process to separately track and report Amtrak trains discovered at stations, including their track assignments.

## Key Changes
- Added `amtrak_train_ids` list to collect Amtrak trains identified during station discovery
- Implemented filtering logic using `is_amtrak_train()` to identify Amtrak trains from the full train list
- Captured track information for each Amtrak train in the format `{train_id}[track={track}]`
- Extended discovery metrics to include:
  - `amtrak_trains`: count of Amtrak trains discovered
  - `amtrak_detail`: list of Amtrak train IDs with track assignments (only included if trains found)

## Implementation Details
- Amtrak trains are identified during the existing train data iteration loop, avoiding additional database queries
- Track information defaults to 'none' if not available in the train data
- The `amtrak_detail` field is conditionally included in metrics only when Amtrak trains are present, keeping the output clean when none are found

https://claude.ai/code/session_018q4oLtAnP9vt7BUZbow1xH