### PR TITLE
Remove enable_metra variable and make Metra integration always available

### DIFF
--- a/infra_v2/terraform/secrets.tf
+++ b/infra_v2/terraform/secrets.tf
@@ -47,7 +47,6 @@ data "google_secret_manager_secret" "wmata_api_key" {
 }
 
 data "google_secret_manager_secret" "metra_api_token" {
-  count      = var.enable_metra ? 1 : 0
   secret_id  = "trackrat-metra-api-token"
   depends_on = [google_project_service.apis]
 }
@@ -79,8 +78,7 @@ resource "google_secret_manager_secret_iam_member" "wmata_api_key" {
 }
 
 resource "google_secret_manager_secret_iam_member" "metra_api_token" {
-  count     = var.enable_metra ? 1 : 0
-  secret_id = data.google_secret_manager_secret.metra_api_token[0].secret_id
+  secret_id = data.google_secret_manager_secret.metra_api_token.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.trackrat.email}"
 }

--- a/infra_v2/terraform/variables.tf
+++ b/infra_v2/terraform/variables.tf
@@ -51,12 +51,6 @@ variable "snapshot_retention_days" {
   default     = 35
 }
 
-variable "enable_metra" {
-  description = "Enable Metra GTFS-RT integration (requires trackrat-metra-api-token secret in Secret Manager)"
-  type        = bool
-  default     = false
-}
-
 variable "alert_email" {
   description = "Email address for uptime monitoring alerts"
   type        = string


### PR DESCRIPTION
## Summary
This PR removes the `enable_metra` feature flag variable and makes Metra GTFS-RT integration always available in the infrastructure. The conditional logic that gated access to the Metra API token secret has been removed.

## Key Changes
- Removed `enable_metra` boolean variable from `variables.tf` that previously controlled Metra integration availability
- Removed conditional count logic (`count = var.enable_metra ? 1 : 0`) from the Metra API token secret data source in `secrets.tf`
- Removed conditional count logic from the Metra API token IAM role binding resource
- Updated IAM role binding to directly reference the Metra secret without array indexing (changed from `[0]` accessor to direct reference)

## Implementation Details
The Metra API token secret (`trackrat-metra-api-token`) is now always expected to exist in Secret Manager and will always be accessible to the trackrat service account. This simplifies the infrastructure configuration by removing the need to conditionally manage this integration.

https://claude.ai/code/session_01XMWFPX6vyyvC1BaB3anLKo