### PR TITLE
Prevent map region reset on view reappear

### DIFF
--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -17,6 +17,7 @@ struct CongestionMapView: View {
     @State private var selectedDataSource: String = "All"
     @State private var showingLayers = false
     @State private var showingPaywall = false
+    @State private var hasSetInitialRegion = false
 
     var body: some View {
         ZStack {
@@ -206,8 +207,11 @@ struct CongestionMapView: View {
             viewModel.setSelectedSystems(appState.selectedSystems)
             viewModel.highlightMode = appState.mapHighlightMode
             viewModel.showStations = appState.showMapStations
-            // Set initial region based on selected systems
-            region = appState.selectedSystems.combinedMapRegion
+            // Set initial region based on selected systems (only on first appear)
+            if !hasSetInitialRegion {
+                region = appState.selectedSystems.combinedMapRegion
+                hasSetInitialRegion = true
+            }
         }
         .onDisappear {
             viewModel.stopAutoRefresh()

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -59,6 +59,7 @@ struct MapContainerView: View {
     @StateObject private var mapRegionVM = MapRegionViewModel()
     @State private var routeStatusContext: RouteStatusContext?
     @State private var selectedIndividualSegment: IndividualJourneySegment?
+    @State private var hasSetInitialRegion = false
     @ObservedObject private var liveActivityService = LiveActivityService.shared
     @ObservedObject private var ratSenseService = RatSenseService.shared
     @ObservedObject private var feedbackService = JourneyFeedbackService.shared
@@ -329,10 +330,13 @@ struct MapContainerView: View {
             print("🗺️ MapContainer: selectedDetent = \(selectedDetent)")
             print("🗺️ MapContainer: Map already initialized by view model - Center: \(mapRegionVM.mapRegion.center.latitude), \(mapRegionVM.mapRegion.center.longitude), Span: \(mapRegionVM.mapRegion.span.latitudeDelta)°")
 
-            // If user has no home/work stations, use selected systems region instead of NY↔NP fallback
-            if RatSenseService.shared.getHomeStation() == nil && RatSenseService.shared.getWorkStation() == nil {
-                mapRegionVM.mapRegion = appState.selectedSystems.combinedMapRegion.adjustedForBottomSheet()
-                print("🗺️ MapContainer: No home/work stations — using selected systems region")
+            // If user has no home/work stations, use selected systems region instead of NY↔NP fallback (only on first appear)
+            if !hasSetInitialRegion {
+                if RatSenseService.shared.getHomeStation() == nil && RatSenseService.shared.getWorkStation() == nil {
+                    mapRegionVM.mapRegion = appState.selectedSystems.combinedMapRegion.adjustedForBottomSheet()
+                    print("🗺️ MapContainer: No home/work stations — using selected systems region")
+                }
+                hasSetInitialRegion = true
             }
 
             // Check for active Live Activity first


### PR DESCRIPTION
## Summary
Fixed an issue where map regions were being reset every time views reappeared, causing the map to jump back to the initial region instead of preserving user navigation.

## Key Changes
- Added `hasSetInitialRegion` state variable to `MapContainerView` to track whether the initial region has been set
- Added `hasSetInitialRegion` state variable to `CongestionMapView` to track whether the initial region has been set
- Wrapped initial region setup logic in both views with a guard condition to only execute on first appearance
- In `MapContainerView`, the fallback to selected systems region (when no home/work stations exist) now only applies on initial load
- In `CongestionMapView`, the region initialization from selected systems now only occurs on first appearance

## Implementation Details
The fix ensures that the `.onAppear` callbacks in both views only set the initial map region once, preventing the map from resetting to the default region every time the view reappears (e.g., when returning from a sheet or navigation). This preserves the user's map navigation state while still providing sensible defaults on first load.

https://claude.ai/code/session_01Bz6YoUMGv5rr7SoTsN8KJb