### PR TITLE
Redesign landing page with improved messaging and features

### DIFF
--- a/webpage_v2/src/pages/LandingPage.tsx
+++ b/webpage_v2/src/pages/LandingPage.tsx
@@ -20,7 +20,7 @@ const features = [
     image: `${BASE}images/1.webp`,
   },
   {
-    title: 'All your trains, one screen',
+    title: 'All your train systems, one screen',
     description:
       'NJ Transit, Amtrak, PATH, LIRR, Metro-North — browse combined schedules for any route.',
     image: `${BASE}images/2.webp`,
@@ -44,6 +44,7 @@ const unifiedFeature = {
   images: [
     `${BASE}images/mtn.webp`,
     `${BASE}images/5.webp`,
+    `${BASE}images/subway.webp`,
     `${BASE}images/lirr.webp`,
   ],
 };
@@ -229,15 +230,12 @@ export function LandingPage() {
               </li>
             </ul>
           </div>
-          <div className="shrink-0">
-            <div className="w-64 md:w-72 bg-surface/80 backdrop-blur-xl border border-text-muted/20 rounded-2xl p-8 text-center shadow-lg">
-              <svg className="w-16 h-16 mx-auto mb-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
-              </svg>
-              <p className="text-text-primary font-semibold text-lg">Route Alerts</p>
-              <p className="text-text-muted text-sm mt-1">Available on iOS</p>
-            </div>
-          </div>
+          <img
+            src={`${BASE}images/alerts.webp`}
+            alt="Route Alerts"
+            className="w-64 md:w-72 rounded-2xl shadow-lg shrink-0"
+            loading="lazy"
+          />
         </div>
       </section>
 
@@ -248,13 +246,13 @@ export function LandingPage() {
             {unifiedFeature.title}
           </h2>
         </div>
-        <div className="flex justify-center gap-3 md:gap-6">
+        <div className="flex justify-center gap-2 md:gap-4">
           {unifiedFeature.images.map((src) => (
             <img
               key={src}
               src={src}
               alt={unifiedFeature.title}
-              className="w-44 md:w-56 rounded-2xl shadow-lg"
+              className="w-36 md:w-48 rounded-2xl shadow-lg"
               loading="lazy"
             />
           ))}


### PR DESCRIPTION
## Summary
Redesigned the landing page to better showcase TrackRat's core features, improve messaging clarity, and enhance the overall user experience with better visual hierarchy and content organization.

## Key Changes

**Content & Messaging**
- Updated hero section headline from "TrackRat" to "Your commute, under control" with more descriptive tagline
- Added feature descriptions to all four main feature cards for better context
- Rewrote feature titles for clarity (e.g., "Browse NJ Transit and Amtrak schedules, together" → "All your train systems, one screen")
- Added new "Route Alerts" section highlighting notification capabilities with custom thresholds and MTA service alerts

**Navigation & Links**
- Added GitHub repository link (`GITHUB_URL` constant) and integrated it throughout the page
- Changed primary CTA from "Try the Web App" link to direct "Download for iOS" button with App Store link
- Reorganized social/external links in hero section with GitHub now featured prominently

**Transit Systems Display**
- Reorganized transit systems list to group by region (Northeast, New York, DC, Boston, Chicago, Bay Area)
- Replaced `beta` property with `region` property for better categorization
- Removed beta badges from individual system cards

**Layout & Styling**
- Increased feature showcase spacing and image sizes (w-48 → w-64 md:w-72)
- Reorganized "More Resources" section into a 3-column grid layout with cards for Web App, Open Source, and REST API
- Added new "Multi-system Showcase" section with improved image gallery layout
- Updated various spacing, padding, and responsive breakpoints for better visual balance
- Changed text color classes for improved contrast (text-muted → text-secondary where appropriate)

**Footer**
- Added GitHub link to footer navigation
- Updated copyright text to include "Open Source (Apache 2.0)" attribution

## Notable Details
- Maintained all existing functionality while improving visual presentation
- Preserved responsive design patterns across all screen sizes
- Added subway.webp image to the multi-system showcase
- Improved semantic HTML with proper link elements replacing router links where external URLs are needed

https://claude.ai/code/session_01LiGd5j6eFEMnpV1ceQ8s8J