### PR TITLE
Fix recent trip click not navigating and PWA deep link 404s

### DIFF
--- a/webpage_v2/src/pages/TripSelectionPage.tsx
+++ b/webpage_v2/src/pages/TripSelectionPage.tsx
@@ -84,11 +84,16 @@ export function TripSelectionPage() {
               <button
                 key={trip.id}
                 onClick={() => {
-                  storageService.saveLastRoute(
-                    { code: trip.departureCode, name: trip.departureName },
-                    { code: trip.destinationCode, name: trip.destinationName }
-                  );
-                  navigate(`/trains/${trip.departureCode}/${trip.destinationCode}`);
+                  const url = `/trains/${trip.departureCode}/${trip.destinationCode}`;
+                  try {
+                    storageService.saveLastRoute(
+                      { code: trip.departureCode, name: trip.departureName },
+                      { code: trip.destinationCode, name: trip.destinationName }
+                    );
+                  } catch {
+                    // localStorage may be full or disabled; navigate anyway
+                  }
+                  navigate(url);
                 }}
                 className="w-full bg-surface/50 backdrop-blur-xl border border-text-muted/20 rounded-xl p-4 text-left hover:bg-surface transition-all"
               >

--- a/webpage_v2/src/store/appStore.ts
+++ b/webpage_v2/src/store/appStore.ts
@@ -44,10 +44,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ selectedDeparture: station });
     const dest = get().selectedDestination;
     if (station && dest) {
-      storageService.saveLastRoute(
-        { code: station.code, name: station.name },
-        { code: dest.code, name: dest.name }
-      );
+      try {
+        storageService.saveLastRoute(
+          { code: station.code, name: station.name },
+          { code: dest.code, name: dest.name }
+        );
+      } catch { /* localStorage may be unavailable */ }
     }
   },
 
@@ -55,10 +57,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ selectedDestination: station });
     const dep = get().selectedDeparture;
     if (dep && station) {
-      storageService.saveLastRoute(
-        { code: dep.code, name: dep.name },
-        { code: station.code, name: station.name }
-      );
+      try {
+        storageService.saveLastRoute(
+          { code: dep.code, name: dep.name },
+          { code: station.code, name: station.name }
+        );
+      } catch { /* localStorage may be unavailable */ }
     }
   },
 
@@ -78,12 +82,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Recent Trips
   addRecentTrip: (from, to) => {
-    storageService.saveRecentTrip({
-      departureCode: from.code,
-      departureName: from.name,
-      destinationCode: to.code,
-      destinationName: to.name,
-    });
+    try {
+      storageService.saveRecentTrip({
+        departureCode: from.code,
+        departureName: from.name,
+        destinationCode: to.code,
+        destinationName: to.name,
+      });
+    } catch { /* localStorage may be unavailable */ }
     get().loadRecentTrips();
   },
 

--- a/webpage_v2/vite.config.ts
+++ b/webpage_v2/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
             }
           }
         ],
-        navigateFallback: null // Don't fallback to index.html for API routes
+        navigateFallback: '/index.html' // Serve index.html for SPA client-side routes
       },
       devOptions: {
         enabled: true // Enable PWA in development for testing


### PR DESCRIPTION
Two issues:
1. In TripSelectionPage, storageService.saveLastRoute() was called before
   navigate(). If localStorage throws (quota exceeded, private browsing),
   navigate() never executes and nothing happens. Wrapped in try-catch
   so navigation always fires. Applied same defensive pattern to appStore
   localStorage writes.

2. PWA service worker had navigateFallback: null, meaning deep links like
   /trains/NY/AB would 404 after SW installation. Changed to serve
   /index.html for navigation requests (navigateFallback only applies to
   browser navigation, not fetch/XHR API calls).

https://claude.ai/code/session_01TDbZ35sLv4sTJQPJnFZ2pH