### PR TITLE
Add missing "Frequency" labels to transit stats cards

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -575,7 +575,7 @@ struct RouteStatusView: View {
             // Frequency-focused stats for rapid transit (PATH, Subway, PATCO)
             HStack(spacing: 12) {
                 statCard(
-                    title: "",
+                    title: "Frequency",
                     value: formatHeadway(totalTrains: total, hours: hours),
                     color: freqColor
                 )
@@ -600,7 +600,7 @@ struct RouteStatusView: View {
                     color: stats.cancellationRate <= 5 ? .green : .red
                 )
                 statCard(
-                    title: "",
+                    title: "Frequency",
                     value: formatFrequency(totalTrains: total, hours: hours),
                     color: freqColor
                 )


### PR DESCRIPTION
## Summary
Fixed missing titles on frequency statistic cards in the RouteStatusView by adding the "Frequency" label to two stat cards that were displaying empty strings.

## Changes
- Added "Frequency" title to the headway stat card for rapid transit routes (PATH, Subway, PATCO)
- Added "Frequency" title to the frequency stat card in the secondary stats section

## Details
Two `statCard` components were initialized with empty string titles (`title: ""`), which resulted in unlabeled statistics being displayed to users. These have been updated to display "Frequency" as the card title, making the UI more informative and consistent with the data being presented (headway and frequency calculations for transit routes).

https://claude.ai/code/session_01H7t1PEinxiTwRQumAhF6JX