### PR TITLE
Add collapsible beta systems section to onboarding

### DIFF
--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -17,6 +17,7 @@ struct OnboardingView: View {
     @State private var isCompletingOnboarding = false
     @State private var hasClearedPreviousData = false
     @State private var showSystemSelection = true
+    @State private var showBetaSystems = false
     @State private var showingPaywall = false
     @State private var showConfetti = false
     @State private var welcomeTextScale: CGFloat = 0.8
@@ -161,7 +162,11 @@ struct OnboardingView: View {
 
             // System selection cards
             VStack(spacing: 12) {
-                ForEach(TrainSystem.allCases.sorted { $0.displayName < $1.displayName }, id: \.self) { system in
+                let sortedSystems = TrainSystem.allCases.sorted { $0.displayName < $1.displayName }
+                let mainSystems = sortedSystems.filter { !$0.isBeta }
+                let betaSystems = sortedSystems.filter { $0.isBeta }
+
+                ForEach(mainSystems, id: \.self) { system in
                     SystemSelectionCard(
                         system: system,
                         isSelected: false,
@@ -176,6 +181,41 @@ struct OnboardingView: View {
                         }
                     )
                 }
+
+                // Collapsible beta systems section
+                DisclosureGroup(isExpanded: $showBetaSystems) {
+                    ForEach(betaSystems, id: \.self) { system in
+                        SystemSelectionCard(
+                            system: system,
+                            isSelected: false,
+                            showCheckmark: false,
+                            onTap: {
+                                appState.selectSystem(system)
+                                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+
+                                withAnimation(.easeInOut(duration: 0.3)) {
+                                    showSystemSelection = false
+                                }
+                            }
+                        )
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Text("Additional Systems")
+                            .font(.headline)
+                            .foregroundColor(.white.opacity(0.7))
+                        Text("beta")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.orange)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule().fill(.orange.opacity(0.2))
+                            )
+                    }
+                }
+                .tint(.white.opacity(0.5))
             }
             .padding(.horizontal, 20)
 


### PR DESCRIPTION
## Summary
Added a collapsible "Additional Systems" section to the onboarding flow that displays beta train systems separately from stable systems, improving the user experience by reducing visual clutter while still providing access to experimental transit systems.

## Key Changes
- Added `showBetaSystems` state variable to track the expansion state of the beta systems section
- Separated train systems into two categories: main systems and beta systems based on their `isBeta` property
- Implemented a `DisclosureGroup` (collapsible section) for beta systems with:
  - "Additional Systems" label with an orange "beta" badge
  - Same selection functionality as main systems
  - Consistent styling and haptic feedback
  - Smooth animation when collapsing/expanding

## Implementation Details
- Beta systems are filtered from the sorted list and displayed in a separate collapsible group
- The beta badge uses orange accent color with reduced opacity background for visual distinction
- The disclosure group tint is set to a subtle white opacity to maintain design consistency
- All beta system cards maintain the same interaction patterns as main systems (haptic feedback, animation, system selection)

https://claude.ai/code/session_0112q8T78s9h7rWXdLUBTUWf