### PR TITLE
Fix startup crash from duplicate 'Hollywood, FL' key in stationCodes dictionary

### DIFF
--- a/ios/TrackRat/Shared/StationData.swift
+++ b/ios/TrackRat/Shared/StationData.swift
@@ -1936,7 +1936,6 @@ extension Stations {
         "Gainesville, FL": "GNS",
         "Gulfport Amtrak Sta": "GUF",
         "Hattiesburg": "HBG",
-        "Hollywood, FL": "HOL",
         "Jesup GA Alt": "JSP",
         "Lakeland, FL Alt": "LAK",
         "Laurel": "LAU",
@@ -3002,10 +3001,11 @@ extension Stations {
             result[code] = name
         }
         // Map equivalent Amtrak codes to the same station name.
-        // These stations are shared between Amtrak and Metro-North but use
-        // different internal codes. The stationCodes dict uses MNR codes;
-        // these entries ensure Amtrak codes also resolve correctly.
+        // These stations are shared between Amtrak routes or between Amtrak
+        // and Metro-North but use different internal codes. The stationCodes
+        // dict uses one code per station; these ensure alternates resolve.
         let amtrakEquivalents: [(amtrakCode: String, mnrCode: String)] = [
+            ("HOL", "HLW"),    // Hollywood, FL (Sunset Limited vs Silver Service)
             ("YNY", "MYON"),   // Yonkers
             ("CRT", "MCRH"),   // Croton-Harmon
             ("POU", "MPOK"),   // Poughkeepsie


### PR DESCRIPTION
The stationCodes dictionary had two entries for "Hollywood, FL" mapping to
different Amtrak station codes (HLW for Silver Service, HOL for Sunset Limited).
Swift dictionary literals treat duplicate keys as a fatal runtime error, causing
an immediate crash on app launch.

Removed the duplicate entry and added HOL to the amtrakEquivalents list so the
reverse lookup (stationCodeToName) still resolves both codes correctly.

https://claude.ai/code/session_019xTJH7z4vkHApe4Ai1r77f