### PR TITLE
Fix transfer trip search returning zero results for subway-to-subway transfers

### DIFF
--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -289,13 +289,6 @@ async def search_trips(
     # Each transfer point needs leg1 (origin -> transfer) and leg2 (transfer -> dest).
     # Using separate sessions is required because AsyncSession is not concurrency-safe.
     #
-    # Performance trade-off: skip_gtfs_merge=True means transfer legs only match
-    # trains already in the real-time feed, not GTFS-scheduled future trains.
-    # This limits the effective search horizon to ~60 minutes for NJT/Amtrak
-    # (since their real-time data only appears 30-60min before departure).
-    # Acceptable because: (a) most transfer searches are for imminent travel,
-    # (b) the direct-service check in Step 1 already uses GTFS data, and
-    # (c) the latency savings (~22 DB queries per leg) are substantial.
     async def _query_leg(
         leg_from: str,
         leg_to: str,
@@ -317,7 +310,6 @@ async def search_trips(
                 hide_departed=leg_hide_departed,
                 data_sources=leg_data_sources,
                 skip_individual_refresh=True,
-                skip_gtfs_merge=True,
             )
 
     # Build all tasks: for each transfer point, leg1 and leg2


### PR DESCRIPTION
The skip_gtfs_merge=True optimization (added in 0038dd1) prevented transfer
leg queries from including GTFS-scheduled trains. For subway lines during
off-peak hours (or any time real-time GTFS-RT data is sparse), connecting
legs had zero departures, causing the entire transfer search to fail silently.

Removes skip_gtfs_merge=True so transfer legs include both real-time and
scheduled trains, matching the behavior of direct service searches.

https://claude.ai/code/session_01J6GnkYLmpoDdiex1KtCbve