### PR TITLE
Issue #891: Unify station picker with inactive system tips

### DIFF
--- a/ios/TrackRat/Views/Components/StationPickerSheet.swift
+++ b/ios/TrackRat/Views/Components/StationPickerSheet.swift
@@ -12,6 +12,8 @@ struct StationPickerSheet: View {
     @Binding var selectedStation: Station?
     let disabledStation: Station?  // Station that should be shown as disabled
     var selectedSystems: Set<TrainSystem>? = nil  // Optional: filter stations by selected systems
+    var showsInactiveSystemTips: Bool = false
+    var onInactiveStationSelected: ((Station) -> Void)? = nil
     let onStationSelected: (Station) -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -34,9 +36,20 @@ struct StationPickerSheet: View {
         return allStations
     }
 
-    /// Search results using ranked search (prefix > substring).
-    private var searchResults: [Station] {
-        guard !searchText.isEmpty else { return [] }
+    /// Search results grouped by whether the station belongs to an active system.
+    private var searchResults: (active: [Station], inactive: [Station]) {
+        guard !searchText.isEmpty else { return ([], []) }
+
+        if showsInactiveSystemTips,
+           let systems = selectedSystems,
+           !systems.isEmpty {
+            let grouped = Stations.searchGrouped(searchText, selectedSystems: systems)
+            return (
+                grouped.primary.compactMap { station(named: $0) },
+                grouped.other.compactMap { station(named: $0) }
+            )
+        }
+
         let q = searchText.lowercased()
         let stations = visibleStations
         let prefixMatches = stations.filter { $0.name.lowercased().hasPrefix(q) }
@@ -46,8 +59,9 @@ struct StationPickerSheet: View {
             ($0.name.localizedCaseInsensitiveContains(searchText) ||
              $0.code.localizedCaseInsensitiveContains(searchText))
         }
-            .sorted { $0.name < $1.name }
-        return Array((prefixMatches + substringMatches).prefix(20))
+        .sorted { $0.name < $1.name }
+
+        return (Array((prefixMatches + substringMatches).prefix(20)), [])
     }
 
     /// Stations grouped by system for the browse view (when search is empty).
@@ -114,6 +128,46 @@ struct StationPickerSheet: View {
         .listRowBackground(Color.clear)
     }
 
+    @ViewBuilder
+    private func inactiveSystemStationRow(_ station: Station) -> some View {
+        Button {
+            onInactiveStationSelected?(station)
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        Text(station.name)
+                            .font(.headline)
+                            .foregroundColor(.white.opacity(0.7))
+
+                        if let system = Stations.primarySystem(forStationCode: station.code) {
+                            SystemBadge(system: system)
+                        }
+                    }
+
+                    Text("Edit your train systems to use this station")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.5))
+                }
+
+                Spacer()
+
+                if onInactiveStationSelected != nil {
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.white.opacity(0.35))
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+        .listRowBackground(Color.clear)
+    }
+
+    private func station(named name: String) -> Station? {
+        guard let code = Stations.getStationCode(name) else { return nil }
+        return Station(code: code, name: name)
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -156,8 +210,27 @@ struct StationPickerSheet: View {
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
                 } else {
-                    List(searchResults) { station in
-                        stationRow(station)
+                    List {
+                        ForEach(searchResults.active) { station in
+                            stationRow(station)
+                        }
+
+                        if !searchResults.inactive.isEmpty {
+                            Section {
+                                ForEach(searchResults.inactive) { station in
+                                    inactiveSystemStationRow(station)
+                                }
+                            } header: {
+                                Text("Other systems")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundColor(.white.opacity(0.6))
+                                    .textCase(nil)
+                            } footer: {
+                                Text("Edit your train systems to use these stations.")
+                                    .font(.caption2)
+                                    .foregroundColor(.white.opacity(0.45))
+                            }
+                        }
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -303,9 +303,11 @@ struct DeparturePickerView: View {
                     }
                 }
                 .onSubmit {
-                    if let firstResult = searchResults.stations.first ?? searchResults.otherSystemStations.first,
+                    if let firstResult = searchResults.stations.first,
                        let code = Stations.getStationCode(firstResult) {
                         selectDeparture(name: firstResult, code: code)
+                    } else if !searchResults.otherSystemStations.isEmpty {
+                        showSettingsForTrainSystems = true
                     }
                 }
             }

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -7,13 +7,15 @@ struct DestinationPickerView: View {
     @FocusState private var searchFieldFocused: Bool
     @State private var navigationBarVisible = false
     @State private var searchTask: Task<Void, Never>?
+    @State private var showSettingsForTrainSystems = false
 
-    private var searchResults: [String] {
-        let results = Stations.search(searchText)
-        // Filter out the current departure station — show all systems for cross-system transfers
-        return results.filter { stationName in
-            stationName != appState.selectedDeparture
-        }
+    private var searchResults: (stations: [String], otherSystemStations: [String]) {
+        let grouped = Stations.searchGrouped(searchText, selectedSystems: appState.selectedSystems)
+
+        return (
+            grouped.primary.filter { $0 != appState.selectedDeparture },
+            grouped.other.filter { $0 != appState.selectedDeparture }
+        )
     }
 
     // Favorite stations — always visible, excluding departure station
@@ -96,8 +98,10 @@ struct DestinationPickerView: View {
                                         }
                                     }
                                     .onSubmit {
-                                        if let firstResult = searchResults.first {
+                                        if let firstResult = searchResults.stations.first {
                                             selectDestination(firstResult)
+                                        } else if !searchResults.otherSystemStations.isEmpty {
+                                            showSettingsForTrainSystems = true
                                         }
                                     }
                             }
@@ -118,11 +122,11 @@ struct DestinationPickerView: View {
                         // Search results - take full page when searching
                         if isSearching {
                             let favoriteCodes = Set(favoriteStations.map(\.id))
-                            let favoriteMatches = searchResults.filter { station in
+                            let favoriteMatches = searchResults.stations.filter { station in
                                 guard let code = Stations.getStationCode(station) else { return false }
                                 return favoriteCodes.contains(code)
                             }
-                            let otherMatches = searchResults.filter { station in
+                            let otherMatches = searchResults.stations.filter { station in
                                 guard let code = Stations.getStationCode(station) else { return true }
                                 return !favoriteCodes.contains(code)
                             }
@@ -157,6 +161,25 @@ struct DestinationPickerView: View {
                                     .buttonStyle(.plain)
                                     .padding(.horizontal)
                                 }
+
+                                if !searchResults.otherSystemStations.isEmpty {
+                                    Text("Other systems — edit your train systems to use")
+                                        .font(.caption)
+                                        .foregroundColor(.white.opacity(0.5))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.horizontal, 20)
+                                        .padding(.top, 4)
+
+                                    ForEach(searchResults.otherSystemStations, id: \.self) { station in
+                                        Button {
+                                            showSettingsForTrainSystems = true
+                                        } label: {
+                                            otherSystemDestinationSearchRow(station: station)
+                                        }
+                                        .buttonStyle(.plain)
+                                        .padding(.horizontal)
+                                    }
+                                }
                             }
                             .transition(.opacity.combined(with: .move(edge: .top)))
                         }
@@ -186,6 +209,11 @@ struct DestinationPickerView: View {
         .onAppear {
             // Load favorite stations when view appears
             appState.loadFavoriteStations()
+        }
+        .sheet(isPresented: $showSettingsForTrainSystems) {
+            SettingsView(editTrainSystems: true)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
     
@@ -222,6 +250,47 @@ struct DestinationPickerView: View {
                 .overlay(
                     RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.md)
                         .stroke(TrackRatTheme.Colors.border, lineWidth: 1)
+                )
+        )
+    }
+
+    @ViewBuilder
+    private func otherSystemDestinationSearchRow(station: String) -> some View {
+        HStack {
+            HStack {
+                Text(Stations.displayName(for: station))
+                    .font(.body)
+                    .foregroundColor(.white.opacity(0.7))
+                    .textProtected()
+
+                if let code = Stations.getStationCode(station),
+                   let system = Stations.primarySystem(forStationCode: code) {
+                    SystemBadge(system: system)
+                }
+
+                Spacer()
+            }
+
+            if let code = Stations.getStationCode(station) {
+                StationIconView(
+                    stationCode: code,
+                    isStationFavorited: appState.isStationFavorited(code: code)
+                ) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        appState.toggleFavoriteStation(code: code, name: station)
+                    }
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }
+                .padding(.leading, 8)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.md)
+                .fill(TrackRatTheme.Colors.surfaceCard.opacity(0.6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: TrackRatTheme.CornerRadius.md)
+                        .stroke(TrackRatTheme.Colors.border.opacity(0.6), lineWidth: 1)
                 )
         )
     }

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -19,6 +19,7 @@ struct OnboardingView: View {
     @State private var showSystemSelection = true
     @State private var showBetaSystems = false
     @State private var showingPaywall = false
+    @State private var showingTrainSystemSettings = false
     @State private var showConfetti = false
     @State private var welcomeTextScale: CGFloat = 0.8
 
@@ -118,6 +119,16 @@ struct OnboardingView: View {
                 selectedStation: binding(for: stationBeingEdited),
                 disabledStation: disabledStation(for: stationBeingEdited),
                 selectedSystems: appState.selectedSystems,
+                showsInactiveSystemTips: true,
+                onInactiveStationSelected: { _ in
+                    showStationPicker = false
+
+                    if isRepeating {
+                        showingTrainSystemSettings = true
+                    } else {
+                        showSystemSelection = true
+                    }
+                },
                 onStationSelected: { station in
                     // Explicitly handle station assignment with proper state update
                     DispatchQueue.main.async {
@@ -140,6 +151,11 @@ struct OnboardingView: View {
         }
         .sheet(isPresented: $showingPaywall) {
             PaywallView(context: .trainSystems)
+        }
+        .sheet(isPresented: $showingTrainSystemSettings) {
+            SettingsView(editTrainSystems: true)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
     }
 

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -668,7 +668,11 @@ struct SettingsSection: View {
             StationPickerSheet(
                 selectedStation: $pickerStation,
                 disabledStation: nil,
-                selectedSystems: appState.selectedSystems
+                selectedSystems: appState.selectedSystems,
+                showsInactiveSystemTips: true,
+                onInactiveStationSelected: { _ in
+                    showStationPicker = false
+                }
             ) { station in
                 switch stationPickerRole {
                 case .home:

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -196,9 +196,11 @@ struct TripSelectionView: View {
                                 // Native sheet automatically handles expansion when keyboard appears
                             }
                             .onSubmit {
-                                if let firstResult = searchResults.stations.first ?? searchResults.otherSystemStations.first,
+                                if let firstResult = searchResults.stations.first,
                                    let code = Stations.getStationCode(firstResult) {
                                     selectOriginStation(name: firstResult, code: code)
+                                } else if !searchResults.otherSystemStations.isEmpty {
+                                    showSettingsForTrainSystems = true
                                 }
                             }
                         


### PR DESCRIPTION
## Summary
- Brings consistency across all station picker views by adding inactive system station tips
- `StationPickerSheet`: adds grouped search with `showsInactiveSystemTips` and `onInactiveStationSelected` params; inactive stations show in dimmed "Other systems" section
- `DestinationPickerView`: switches from flat `Stations.search()` to `Stations.searchGrouped()`, matching `DeparturePickerView`/`TripSelectionView`
- `DeparturePickerView`/`TripSelectionView`: fixes `onSubmit` to not auto-select other-system stations; shows train system settings instead
- `OnboardingView`/`SettingsView`: pass new `StationPickerSheet` params

## Files Modified
| File | Change |
|------|--------|
| `StationPickerSheet.swift` | Grouped search, inactive system rows, new params |
| `DestinationPickerView.swift` | Switch to `searchGrouped`, add other-systems UI |
| `DeparturePickerView.swift` | Fix `onSubmit` keyboard return behavior |
| `TripSelectionView.swift` | Fix `onSubmit` keyboard return behavior |
| `OnboardingView.swift` | Pass inactive system tip params |
| `SettingsView.swift` | Pass inactive system tip params |

## Test Plan
- [ ] Search for a station from a non-selected system in each picker (departure, destination, trip selection, onboarding, settings)
- [ ] Verify it appears in dimmed "Other systems" section
- [ ] Tap inactive station → verify settings sheet opens
- [ ] Press keyboard return when only other-system results exist → verify settings opens (not station selection)
- [ ] Verify normal station selection still works for active systems

Cherry-picked from `codex-unify-station-picker` branch, excluding unrelated license/version changes.

Closes #891

https://claude.ai/code/session_01EU8G38uQnyCdBrcH6yxhdF