### PR TITLE
Add system-wide alert subscriptions support

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -193,12 +193,7 @@ async def evaluate_route_alerts(
                     state_changed = True
                 continue
 
-            # System-wide subscriptions: skip real-time delay/cancellation
-            # evaluation (handled entirely via service alerts in evaluate_service_alerts)
-            if _is_system_wide(sub):
-                continue
-
-            # Build query for relevant journeys (line / station-pair modes)
+            # Build query for relevant journeys (line / station-pair / system-wide modes)
             journeys = await _query_journeys_for_subscription(
                 db, sub, today, one_hour_ago, now
             )
@@ -519,7 +514,7 @@ async def _query_journeys_for_subscription(
 
         return journeys
 
-    else:
+    elif sub.from_station_code and sub.to_station_code:
         # Station-pair mode: match origin/destination or journey stops
         # Eagerly load stops so _is_significantly_delayed can check
         # arrival delay at the destination station.
@@ -571,6 +566,13 @@ async def _query_journeys_for_subscription(
                     TrainJourney.id.in_(subq),
                 )
             )
+        )
+        return list(result.scalars().all())
+
+    else:
+        # System-wide mode: all journeys for this data source
+        result = await db.execute(
+            select(TrainJourney).where(and_(*base_conditions))
         )
         return list(result.scalars().all())
 
@@ -646,13 +648,14 @@ async def _query_baseline_train_count(
         if not route:
             return None
         base_conditions.append(TrainJourney.line_code.in_(list(route.line_codes)))
-    else:
+    elif sub.from_station_code and sub.to_station_code:
         base_conditions.extend(
             [
                 TrainJourney.origin_station_code == sub.from_station_code,
                 TrainJourney.terminal_station_code == sub.to_station_code,
             ]
         )
+    # else: system-wide — no additional filtering, all journeys for data_source
 
     # Count trains per day, then average across days
     per_day = (
@@ -1064,7 +1067,11 @@ async def _generate_digest_summary(
                 train_id=sub.train_id,
             )
         else:
-            return None
+            # System-wide: use network summary for the data source
+            result = await summary_service.get_network_summary(
+                db,
+                data_source=sub.data_source,
+            )
 
         # For push notifications, use body (descriptive) over headline (terse)
         # to avoid redundancy — headline contains stats like "85% on time" or

--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -60,10 +60,14 @@ final class AlertSubscriptionService: ObservableObject {
         saveToDefaults()
     }
 
-    /// Find subscriptions matching a route context (by dataSource + station codes or lineId).
+    /// Find subscriptions matching a route context (by dataSource + station codes, lineId, or system-wide).
     func subscriptions(for context: RouteStatusContext) -> [RouteAlertSubscription] {
         subscriptions.filter { sub in
             guard sub.dataSource == context.dataSource else { return false }
+            // Match system-wide subscriptions when context has no line or stations
+            if sub.isSystemWide && context.lineId == nil && context.fromStationCode == nil {
+                return true
+            }
             // Match line subscriptions
             if let lineId = sub.lineId, lineId == context.lineId {
                 return true

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -79,14 +79,21 @@ struct RouteStatusView: View {
             }
             .task {
                 // Initialize draft subscription for alert config if not yet subscribed
-                if matchingSubscriptions.isEmpty && draftSubscription == nil,
-                   let from = context.fromStationCode, let to = context.toStationCode {
-                    draftSubscription = RouteAlertSubscription(
-                        dataSource: context.dataSource,
-                        fromStationCode: from,
-                        toStationCode: to,
-                        activeDays: 0
-                    )
+                if matchingSubscriptions.isEmpty && draftSubscription == nil {
+                    if let from = context.fromStationCode, let to = context.toStationCode {
+                        draftSubscription = RouteAlertSubscription(
+                            dataSource: context.dataSource,
+                            fromStationCode: from,
+                            toStationCode: to,
+                            activeDays: 0
+                        )
+                    } else if context.lineId == nil {
+                        // System-wide context
+                        draftSubscription = RouteAlertSubscription(
+                            dataSource: context.dataSource,
+                            activeDays: 0
+                        )
+                    }
                 }
                 await viewModel.loadData(initialPeriod: selectedHistoryPeriod)
             }
@@ -119,9 +126,14 @@ struct RouteStatusView: View {
 
     // MARK: - Alert Subscription Section
 
+    /// Whether this context represents a system-wide subscription (no line or stations).
+    private var isSystemWideContext: Bool {
+        context.lineId == nil && context.fromStationCode == nil && context.toStationCode == nil
+    }
+
     @ViewBuilder
     private var alertSubscriptionSection: some View {
-        if context.fromStationCode != nil && context.toStationCode != nil {
+        if context.fromStationCode != nil && context.toStationCode != nil || isSystemWideContext {
             AlertConfigurationSection(subscription: alertConfigBinding)
                 .onChange(of: alertConfigBinding.wrappedValue.activeDays) { _, newDays in
                     handleActiveDaysChange(newDays)
@@ -144,12 +156,18 @@ struct RouteStatusView: View {
             return Binding(
                 get: {
                     // Draft is initialized in .task; fallback should never be needed
-                    draftSubscription ?? RouteAlertSubscription(
-                        dataSource: context.dataSource,
-                        fromStationCode: context.fromStationCode ?? "",
-                        toStationCode: context.toStationCode ?? "",
-                        activeDays: 0
-                    )
+                    if let draft = draftSubscription {
+                        return draft
+                    } else if isSystemWideContext {
+                        return RouteAlertSubscription(dataSource: context.dataSource, activeDays: 0)
+                    } else {
+                        return RouteAlertSubscription(
+                            dataSource: context.dataSource,
+                            fromStationCode: context.fromStationCode ?? "",
+                            toStationCode: context.toStationCode ?? "",
+                            activeDays: 0
+                        )
+                    }
                 },
                 set: { draftSubscription = $0 }
             )
@@ -158,7 +176,12 @@ struct RouteStatusView: View {
 
     /// Handle active days changes: auto-subscribe when going non-zero, auto-unsubscribe when zero.
     private func handleActiveDaysChange(_ newDays: Int) {
-        guard let from = context.fromStationCode, let to = context.toStationCode else { return }
+        let from = context.fromStationCode
+        let to = context.toStationCode
+        let isSystemWide = isSystemWideContext
+
+        // Need either a station pair or system-wide context
+        guard (from != nil && to != nil) || isSystemWide else { return }
 
         if newDays > 0 && !isSubscribed {
             // Check freemium limit before auto-subscribing
@@ -169,30 +192,53 @@ struct RouteStatusView: View {
                 showingPaywall = true
                 return
             }
-            // Auto-subscribe — create single direction matching what user is viewing
-            let template = draftSubscription ?? RouteAlertSubscription(
-                dataSource: context.dataSource,
-                fromStationCode: from,
-                toStationCode: to,
-                activeDays: newDays
-            )
-            let sub = RouteAlertSubscription(
-                dataSource: template.dataSource,
-                fromStationCode: from,
-                toStationCode: to,
-                activeDays: newDays,
-                activeStartMinutes: template.activeStartMinutes,
-                activeEndMinutes: template.activeEndMinutes,
-                timezone: template.timezone,
-                delayThresholdMinutes: template.delayThresholdMinutes,
-                serviceThresholdPct: template.serviceThresholdPct,
-                cancellationThresholdPct: template.cancellationThresholdPct,
-                notifyCancellation: template.notifyCancellation,
-                notifyDelay: template.notifyDelay,
-                notifyRecovery: template.notifyRecovery,
-                digestTimeMinutes: template.digestTimeMinutes,
-                includePlannedWork: template.includePlannedWork
-            )
+            // Auto-subscribe
+            let sub: RouteAlertSubscription
+            if isSystemWide {
+                let template = draftSubscription ?? RouteAlertSubscription(
+                    dataSource: context.dataSource,
+                    activeDays: newDays
+                )
+                sub = RouteAlertSubscription(
+                    dataSource: template.dataSource,
+                    activeDays: newDays,
+                    activeStartMinutes: template.activeStartMinutes,
+                    activeEndMinutes: template.activeEndMinutes,
+                    timezone: template.timezone,
+                    delayThresholdMinutes: template.delayThresholdMinutes,
+                    serviceThresholdPct: template.serviceThresholdPct,
+                    cancellationThresholdPct: template.cancellationThresholdPct,
+                    notifyCancellation: template.notifyCancellation,
+                    notifyDelay: template.notifyDelay,
+                    notifyRecovery: template.notifyRecovery,
+                    digestTimeMinutes: template.digestTimeMinutes,
+                    includePlannedWork: template.includePlannedWork
+                )
+            } else {
+                let template = draftSubscription ?? RouteAlertSubscription(
+                    dataSource: context.dataSource,
+                    fromStationCode: from!,
+                    toStationCode: to!,
+                    activeDays: newDays
+                )
+                sub = RouteAlertSubscription(
+                    dataSource: template.dataSource,
+                    fromStationCode: from!,
+                    toStationCode: to!,
+                    activeDays: newDays,
+                    activeStartMinutes: template.activeStartMinutes,
+                    activeEndMinutes: template.activeEndMinutes,
+                    timezone: template.timezone,
+                    delayThresholdMinutes: template.delayThresholdMinutes,
+                    serviceThresholdPct: template.serviceThresholdPct,
+                    cancellationThresholdPct: template.cancellationThresholdPct,
+                    notifyCancellation: template.notifyCancellation,
+                    notifyDelay: template.notifyDelay,
+                    notifyRecovery: template.notifyRecovery,
+                    digestTimeMinutes: template.digestTimeMinutes,
+                    includePlannedWork: template.includePlannedWork
+                )
+            }
             alertService.addSubscriptions([sub])
             draftSubscription = nil
             alertService.syncIfPossible()
@@ -203,12 +249,19 @@ struct RouteStatusView: View {
                 alertService.removeSubscription(sub)
             }
             editedSubscriptions.removeAll()
-            draftSubscription = RouteAlertSubscription(
-                dataSource: context.dataSource,
-                fromStationCode: from,
-                toStationCode: to,
-                activeDays: 0
-            )
+            if isSystemWide {
+                draftSubscription = RouteAlertSubscription(
+                    dataSource: context.dataSource,
+                    activeDays: 0
+                )
+            } else {
+                draftSubscription = RouteAlertSubscription(
+                    dataSource: context.dataSource,
+                    fromStationCode: from!,
+                    toStationCode: to!,
+                    activeDays: 0
+                )
+            }
             alertService.syncIfPossible()
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         }
@@ -359,7 +412,7 @@ struct RouteStatusView: View {
 
     private var operationsSummarySection: some View {
         OperationsSummaryView(
-            scope: .route,
+            scope: isSystemWideContext ? .network : .route,
             fromStation: context.effectiveFromStation,
             toStation: context.effectiveToStation
         )


### PR DESCRIPTION
## Summary
This PR extends the alert subscription system to support system-wide subscriptions that monitor all routes across a data source, in addition to the existing line-based and station-pair subscriptions.

## Key Changes

**iOS Frontend (RouteStatusView.swift)**
- Added `isSystemWideContext` computed property to identify contexts with no line or station filters
- Extended draft subscription initialization to create system-wide subscriptions when appropriate
- Updated alert subscription section visibility to show for system-wide contexts
- Modified `alertConfigBinding` to handle system-wide subscription creation in fallback cases
- Enhanced `handleActiveDaysChange` to support auto-subscribe/unsubscribe for system-wide contexts with separate logic paths for station-pair vs. system-wide modes
- Changed operations summary scope from `.route` to `.network` for system-wide contexts

**Backend Alert Evaluator (alert_evaluator.py)**
- Removed early skip of system-wide subscriptions in `evaluate_route_alerts` to enable real-time evaluation
- Extended `_query_journeys_for_subscription` to handle system-wide mode by querying all journeys for a data source
- Updated `_query_baseline_train_count` to support system-wide subscriptions without additional filtering
- Modified `_generate_digest_summary` to use network summary for system-wide subscriptions instead of returning None

**Alert Subscription Service (AlertSubscriptionService.swift)**
- Enhanced `subscriptions(for:)` filtering to match system-wide subscriptions when context has no line or station codes

## Implementation Details
- System-wide subscriptions are identified by having no `lineId`, `fromStationCode`, or `toStationCode`
- The backend now evaluates system-wide subscriptions against all journeys for their data source
- Digest summaries for system-wide subscriptions use network-level statistics rather than route-specific data
- The UI properly distinguishes between station-pair and system-wide contexts when creating subscriptions with different parameters

https://claude.ai/code/session_01LvpKAzaEZNpK8i9LHAp6yn