### PR TITLE
Remove feedback URL constant from LandingPage

### DIFF
--- a/webpage_v2/src/pages/LandingPage.tsx
+++ b/webpage_v2/src/pages/LandingPage.tsx
@@ -8,7 +8,6 @@ const APP_STORE_URL = 'https://apps.apple.com/us/app/trackrat/id6746423610';
 const GITHUB_URL = 'https://github.com/trackrat-dev/TrackRat';
 const YOUTUBE_URL = 'https://www.youtube.com/@TrackRat-App/shorts';
 const INSTAGRAM_URL = 'https://www.instagram.com/trackratapp/';
-const FEEDBACK_URL = 'https://trackrat.nolt.io/';
 const API_DOCS_URL = 'https://apiv2.trackrat.net/docs';
 const SUPPORT_EMAIL = 'mailto:trackrat@andymartin.cc';
 


### PR DESCRIPTION
## Summary
Removed the unused `FEEDBACK_URL` constant that pointed to the Nolt feedback platform from the LandingPage component.

## Changes
- Removed the `FEEDBACK_URL` constant (`https://trackrat.nolt.io/`) from the LandingPage configuration

## Notes
This constant was not being referenced anywhere in the component, so removing it cleans up unused code and reduces maintenance burden.

https://claude.ai/code/session_014SVw7S3wYxcM9Y2hVmgnhR