### PR TITLE
Issue #900: Fix PATH collector unconditional flush after exception

### DIFF
--- a/backend_v2/src/trackrat/collectors/path/collector.py
+++ b/backend_v2/src/trackrat/collectors/path/collector.py
@@ -28,7 +28,7 @@ from trackrat.config.stations import (
     get_path_route_and_stops,
     get_station_name,
 )
-from trackrat.db.engine import get_session
+from trackrat.db.engine import get_session, _is_postgresql_concurrency_error
 from trackrat.models.database import JourneySnapshot, JourneyStop, TrainJourney
 from trackrat.services.transit_analyzer import TransitAnalyzer
 from trackrat.utils.locks import with_train_lock
@@ -1459,6 +1459,10 @@ class PathCollector:
             await session.flush()
 
         except Exception as e:
+            # Re-raise DB concurrency errors (deadlocks, serialization failures)
+            # so retry_on_deadlock in the JIT flow can catch and retry them.
+            if _is_postgresql_concurrency_error(e):
+                raise
             logger.error(
                 "path_journey_update_failed",
                 train_id=journey.train_id,

--- a/backend_v2/tests/unit/collectors/path/test_collector.py
+++ b/backend_v2/tests/unit/collectors/path/test_collector.py
@@ -2870,7 +2870,7 @@ class TestCollectJourneyDetailsFlushHandling:
 
         collector._get_journey_stops = AsyncMock(return_value=[])
         collector._update_stops_from_arrivals = AsyncMock(
-            side_effect=Exception("serialization failure")
+            side_effect=Exception("some API failure")
         )
 
         await collector._collect_journey_details_impl(session, journey)
@@ -2880,20 +2880,60 @@ class TestCollectJourneyDetailsFlushHandling:
 
     @pytest.mark.asyncio
     async def test_journey_expired_after_three_errors(self):
-        """Journey is marked expired after 3 consecutive errors."""
+        """Journey is marked expired after 3 consecutive non-DB errors."""
         collector = self._make_collector()
         session = AsyncMock(spec=AsyncSession)
         journey = self._make_journey(api_error_count=2)
 
         collector._get_journey_stops = AsyncMock(return_value=[])
         collector._update_stops_from_arrivals = AsyncMock(
-            side_effect=Exception("deadlock detected")
+            side_effect=Exception("API returned invalid response")
         )
 
         await collector._collect_journey_details_impl(session, journey)
 
         assert journey.api_error_count == 3
         assert journey.is_expired is True
+
+    @pytest.mark.asyncio
+    async def test_deadlock_error_propagates_for_retry(self):
+        """DB deadlock errors re-raise so retry_on_deadlock in JIT can retry them.
+
+        Codex Review feedback: the broad except must not swallow retriable DB
+        concurrency errors (deadlocks, serialization failures), because the JIT
+        flow wraps this in retry_on_deadlock which needs to see the exception.
+        """
+        collector = self._make_collector()
+        session = AsyncMock(spec=AsyncSession)
+        journey = self._make_journey()
+
+        collector._get_journey_stops = AsyncMock(return_value=[])
+        collector._update_stops_from_arrivals = AsyncMock(
+            side_effect=Exception("deadlock detected")
+        )
+
+        with pytest.raises(Exception, match="deadlock detected"):
+            await collector._collect_journey_details_impl(session, journey)
+
+        # Error count should NOT be incremented — this is a DB issue, not an API error
+        assert journey.api_error_count == 0
+
+    @pytest.mark.asyncio
+    async def test_serialization_error_propagates_for_retry(self):
+        """DB serialization failures also re-raise for retry_on_deadlock."""
+        collector = self._make_collector()
+        session = AsyncMock(spec=AsyncSession)
+        journey = self._make_journey()
+
+        collector._get_journey_stops = AsyncMock(return_value=[])
+        # Simulate flush raising a serialization error
+        session.flush = AsyncMock(
+            side_effect=Exception("could not serialize access due to concurrent update")
+        )
+        collector._update_stops_from_arrivals = AsyncMock()
+
+        with pytest.raises(Exception, match="could not serialize access"):
+            await collector._collect_journey_details_impl(session, journey)
 
     @pytest.mark.asyncio
     async def test_error_tracking_flush_failure_handled(self):


### PR DESCRIPTION
## Summary

- Move `session.flush()` inside the `try` block so it only runs on the happy path
- In the `except` block, `rollback()` the failed transaction before persisting error-tracking fields (`api_error_count`, `last_updated_at`, `is_expired`), then `flush()` in a separate try
- If the error-tracking flush also fails, log and continue — no cascading error that masks the original failure

## Root cause

`await session.flush()` at line 1471 was outside the try/except block, executing unconditionally. When `_update_stops_from_arrivals` raised a DB exception (constraint violation, serialization failure), the session entered a failed transaction state, and the unconditional flush produced "Can't reconnect until invalid transaction is rolled back" errors.

## Files modified

- `backend_v2/src/trackrat/collectors/path/collector.py` — Restructured `_collect_journey_details_impl` error handling
- `backend_v2/tests/unit/collectors/path/test_collector.py` — 5 new tests: success flush, poisoned session handling, error count increment, expiry after 3 errors, graceful handling of error-tracking flush failure

## Test coverage

All 5 new tests pass. Existing PATH collector tests unaffected.

Closes #900

https://claude.ai/code/session_01K58Z3ePHiSwfxhhX3PuCb3