### PR TITLE
Issue #903: Fix route history timeout DB session corruption

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -4,6 +4,7 @@ Route API endpoints for TrackRat V2.
 Provides route-based historical analysis independent of specific trains.
 """
 
+import asyncio
 import json as json_mod
 from datetime import datetime, timedelta
 from typing import Any
@@ -17,7 +18,7 @@ from structlog import get_logger
 
 from trackrat.api.utils import handle_errors
 from trackrat.config.stations import expand_station_codes, get_station_name
-from trackrat.db.engine import get_db
+from trackrat.db.engine import get_db, get_session
 from trackrat.models.api import (
     AggregateStats,
     CongestionMapResponse,
@@ -147,17 +148,27 @@ async def get_route_history(
                     db, "/api/v2/routes/history", cache_params
                 )
 
-    # Compute route history (shared with pre-warming in api_cache.py)
-    response = await compute_route_history(
-        db,
-        from_station,
-        to_station,
-        data_source,
-        days,
-        hours,
-        lines,
-        highlight_train=highlight_train,
-    )
+    # Compute route history in a dedicated session with a timeout.
+    # Uses a separate session so that if the query exceeds the timeout,
+    # the resulting transaction corruption doesn't poison the request's
+    # main session (which caused HTTP 500 via "Can't reconnect until
+    # invalid transaction is rolled back" for BART/MBTA).
+    # The 45s timeout fires before the 60s command_timeout in engine.py,
+    # giving clean cancellation instead of DB-level abort.
+    async with get_session() as history_db:
+        response = await asyncio.wait_for(
+            compute_route_history(
+                history_db,
+                from_station,
+                to_station,
+                data_source,
+                days,
+                hours,
+                lines,
+                highlight_train=highlight_train,
+            ),
+            timeout=45.0,
+        )
 
     # Store in cache (skip when highlight_train is provided)
     if not highlight_train:

--- a/backend_v2/tests/unit/api/test_route_history_timeout.py
+++ b/backend_v2/tests/unit/api/test_route_history_timeout.py
@@ -1,0 +1,102 @@
+"""
+Tests for route history endpoint timeout behavior.
+
+Verifies the fix for issue #903: route history query timeout leaves DB session
+in broken state, causing BART/MBTA 500s. The fix uses a dedicated session with
+asyncio.wait_for(timeout=45.0) to ensure clean cancellation before the 60s
+command_timeout fires.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_route_history_timeout_returns_504(client):
+    """When compute_route_history exceeds the 45s timeout, return HTTP 504.
+
+    The @handle_errors decorator catches TimeoutError and returns 504.
+    This verifies the timeout wrapper fires and propagates correctly,
+    instead of letting the 60s command_timeout fire and corrupt the session.
+    """
+
+    async def _slow_computation(*args, **kwargs):
+        """Simulate a route history query that takes too long (BART/MBTA)."""
+        await asyncio.sleep(3600)
+
+    # Mock cache miss so we reach compute_route_history
+    mock_cache = MagicMock()
+    mock_cache.get_cached_response = AsyncMock(return_value=None)
+
+    with patch(
+        "trackrat.api.routes.ApiCacheService", return_value=mock_cache
+    ), patch(
+        "trackrat.api.routes.compute_route_history", side_effect=_slow_computation
+    ):
+        # Patch asyncio.wait_for in routes module to use a short timeout for testing
+        original_wait_for = asyncio.wait_for
+
+        async def fast_wait_for(coro, *, timeout):
+            return await original_wait_for(coro, timeout=0.1)
+
+        with patch(
+            "trackrat.api.routes.asyncio.wait_for", side_effect=fast_wait_for
+        ):
+            response = client.get(
+                "/api/v2/routes/history?from_station=NY&to_station=TR&data_source=NJT"
+            )
+
+    # Should get 504 (timeout) — NOT 500 (session corruption)
+    assert response.status_code == 504, (
+        f"Expected 504 (clean timeout via handle_errors), "
+        f"got {response.status_code}: {response.json()}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_history_uses_dedicated_session(client):
+    """Verify that compute_route_history receives a session from get_session(),
+    not the request's main db session from Depends(get_db).
+
+    This isolation prevents transaction corruption from leaking to the
+    request's main session when a query is cancelled mid-execution.
+    """
+    session_from_get_session = AsyncMock()
+    captured_db_arg = []
+
+    async def _capture_db_arg(db, *args, **kwargs):
+        """Record which session object is passed to compute_route_history."""
+        captured_db_arg.append(db)
+        # Raise to short-circuit — we only care about the session identity
+        raise ValueError("captured")
+
+    mock_cache = MagicMock()
+    mock_cache.get_cached_response = AsyncMock(return_value=None)
+
+    # Mock get_session to return a known sentinel session
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=session_from_get_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "trackrat.api.routes.ApiCacheService", return_value=mock_cache
+    ), patch(
+        "trackrat.api.routes.compute_route_history", side_effect=_capture_db_arg
+    ), patch(
+        "trackrat.api.routes.get_session", return_value=mock_ctx
+    ):
+        response = client.get(
+            "/api/v2/routes/history?from_station=NY&to_station=TR&data_source=NJT"
+        )
+
+    # The endpoint will return 500 because compute_route_history raised ValueError,
+    # but we only care that the right session was passed
+    assert len(captured_db_arg) == 1, (
+        "compute_route_history should have been called once"
+    )
+    assert captured_db_arg[0] is session_from_get_session, (
+        "compute_route_history should receive the dedicated session from get_session(), "
+        "not the request's main db session"
+    )


### PR DESCRIPTION
## Summary
- Uses a dedicated session (`get_session()`) for `compute_route_history` instead of the request's shared `Depends(get_db)` session
- Wraps the computation in `asyncio.wait_for(timeout=45.0)` — fires before the 60s `command_timeout` in `engine.py`, giving clean cancellation instead of DB-level query abort
- The `@handle_errors` decorator catches `TimeoutError` and returns HTTP 504 instead of the previous cryptic 500

## Root Cause
When BART/MBTA route history queries exceeded the 60s PostgreSQL `command_timeout`, asyncpg cancelled the query at the DB level, putting the connection in an aborted transaction state. Any subsequent operation on the same session (cache storage) failed with "Can't reconnect until invalid transaction is rolled back."

## Files Modified
- **`backend_v2/src/trackrat/api/routes.py`** — Added `asyncio` import, `get_session` import; replaced `compute_route_history(db, ...)` with `async with get_session() as history_db: await asyncio.wait_for(compute_route_history(history_db, ...), timeout=45.0)`
- **`backend_v2/tests/unit/api/test_route_history_timeout.py`** — New test file with two tests

## Design Decisions
- **45s timeout**: Under the 60s `command_timeout` so the application-level timeout fires first, giving clean cancellation
- **Dedicated session**: Follows the pattern already used for predictions at `trains.py:359-364` — isolates timeout/cancellation from the request's main session
- **No explicit TimeoutError catch**: The existing `@handle_errors` decorator already maps `TimeoutError` → HTTP 504

## Test Coverage
- `test_route_history_timeout_returns_504`: Verifies timeout produces 504 (not 500)
- `test_route_history_uses_dedicated_session`: Verifies `compute_route_history` receives the dedicated session from `get_session()`, not the request's `Depends(get_db)` session

Closes #903

https://claude.ai/code/session_014iJdnj5MNXFzhrFXq9nHjw