### PR TITLE
Weekly documentation audit: fix stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Web App](https://img.shields.io/badge/Web_App-Live-orange)](https://trackrat.net)
 [![License](https://img.shields.io/badge/License-GPLv3-green.svg)](LICENSE)
 
-TrackRat tracks trains across eleven transit systems in real time, predicts platform assignments, and forecasts delays — all from a unified interface. It runs on iOS, Android (NOT FINISHED), the web (NOT FINISHED), and the backend is written in Python.
+TrackRat tracks trains across eleven transit systems in real time, predicts platform assignments, and forecasts delays — all from a unified interface. It runs on iOS, Android (NOT FINISHED), the [web](https://trackrat.net), and the backend is written in Python.
 
 ## Supported Transit Systems
 

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -159,7 +159,7 @@ GET /api/v2/trains/departures?from=NY&to=TR&limit=50&data_source=ALL&hide_depart
 Get trains between stations with filtering:
 - `from`/`to`: Station codes (works for any segment)
 - `limit`: Max results (default: 50)
-- `data_source`: NJT, AMTRAK, PATH, PATCO, LIRR, MNR, or ALL
+- `data_source`: NJT, AMTRAK, PATH, PATCO, LIRR, MNR, SUBWAY, BART, MBTA, METRA, WMATA, or ALL
 - `hide_departed`: Skip trains that have already departed (default: false). When true, also skips expensive past-train refresh for better performance.
 - Returns both SCHEDULED and OBSERVED trains
 
@@ -372,7 +372,7 @@ Current test coverage:
 - ✅ **Core functionality**: Configuration, time utilities, database models
 - ✅ **Basic API functionality**: Health endpoints, app startup/shutdown
 - ⚠️ **Integration tests**: Require live database setup (some may need fixes)
-- 📝 **Note**: 4/4 critical tests pass, ensuring core system reliability
+- 📝 **Note**: Core test suite passes, ensuring system reliability
 
 ### Database Management
 ```bash

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,6 +1,6 @@
 # TrackRat iOS App 🚂
 
-A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, PATCO, LIRR, Metro-North, and NYC Subway trains with Live Activities, real-time updates, intelligent track predictions, route alerts, and innovative navigation features.
+A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, and WMATA (DC Metro) trains with Live Activities, real-time updates, intelligent track predictions, route alerts, and innovative navigation features.
 
 ## 🎯 Key Features
 
@@ -19,8 +19,12 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, PATCO, LIRR, Metr
 - **LIRR**: All branches via MTA GTFS-RT
 - **Metro-North**: All branches via MTA GTFS-RT
 - **NYC Subway**: 36 routes, 472 stations via MTA GTFS-RT
-- **Total Coverage**: 1,000+ stations across the Eastern United States
-- **Train Services**: NJ Transit, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway
+- **BART**: All lines via BART GTFS-RT
+- **MBTA**: Commuter Rail via MBTA GTFS-RT
+- **Metra**: All lines (Chicago) via Metra GTFS-RT
+- **WMATA (DC Metro)**: All 6 lines, 98 stations via WMATA REST API
+- **Total Coverage**: 1,500+ stations across the United States
+- **Train Services**: NJ Transit, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, WMATA
 
 ### Route Alerts
 - **Push Notifications**: Get alerted when subscribed routes experience delays or cancellations
@@ -94,7 +98,8 @@ TrackRat/
 ├── Models/                      # Data layer
 │   ├── TrainV2.swift           # Pure data model with context-aware calculations
 │   ├── V2APIModels.swift       # Backend V2 API models
-│   ├── TrainSystem.swift       # Train system enum (NJT, Amtrak, PATH, PATCO, LIRR, MNR, Subway)
+│   ├── TrainSystem.swift       # Train system enum (NJT, Amtrak, PATH, PATCO, LIRR, MNR, Subway, BART, MBTA, Metra, WMATA)
+│   ├── TripOption.swift        # Trip search result model
 │   ├── CompletedTrip.swift     # Completed trip model for trip history
 │   ├── DeepLink.swift          # URL scheme handling
 │   └── Train.swift             # Legacy compatibility model
@@ -116,14 +121,16 @@ TrackRat/
 │   └── StaticTrackDistributionService.swift # Track analytics
 │
 ├── Views/                       # UI layer
-│   ├── Screens/                # Full-screen views (14 screens)
+│   ├── Screens/                # Full-screen views (16 screens)
 │   │   ├── TripSelectionView.swift      # Home screen with search
 │   │   ├── DeparturePickerView.swift    # Origin station selection
 │   │   ├── DestinationPickerView.swift  # Destination selection
 │   │   ├── TrainListView.swift          # Departure board
 │   │   ├── TrainDetailsView.swift       # Train journey details
+│   │   ├── TripDetailsView.swift        # Multi-leg trip details
 │   │   ├── CongestionMapView.swift      # Network congestion
 │   │   ├── HistoricalDataView.swift     # Performance analytics
+│   │   ├── PennStationGuideView.swift   # Penn Station boarding guide
 │   │   ├── SettingsView.swift           # User settings (inline favorites & route alerts)
 │   │   ├── MapContainerView.swift       # Primary map interface
 │   │   ├── OnboardingView.swift         # User onboarding
@@ -167,7 +174,8 @@ TrackRat/
 │   ├── StationCoordinates.swift # Station GPS coordinates
 │   ├── StationDepartures.swift # Station departure configuration
 │   ├── LiveActivityModels.swift # Widget shared types
-│   └── RouteTopology.swift      # Route definitions for map layers
+│   ├── RouteTopology.swift      # Route definitions for map layers
+│   └── RouteShapes.swift        # Route shape coordinates for map rendering
 │
 ├── Theme/                       # Visual design
 │   └── TrackRatTheme.swift     # Colors and styles

--- a/webpage_v2/CLAUDE.md
+++ b/webpage_v2/CLAUDE.md
@@ -8,7 +8,7 @@
 - **Build Tool**: Vite 8.0 (fast dev server, optimized builds)
 - **Styling**: Tailwind CSS 4.2 (utility-first, custom design system)
 - **State Management**: Zustand 5.0 (lightweight, no boilerplate)
-- **Routing**: React Router DOM 7.13
+- **Routing**: React Router DOM 7.14
 - **Date Handling**: date-fns 4.1
 - **HTTP Client**: Native `fetch` (no axios)
 - **Deployment**: GCS static hosting (`scripts/deploy-webpage.sh`)


### PR DESCRIPTION
## Summary

Weekly documentation audit against current codebase. Fixes stale references across 4 files.

- **README.md**: Remove stale "NOT FINISHED" label for web app (now live at trackrat.net)
- **ios/README.md**: Add missing BART/MBTA/Metra/WMATA to title, coverage, and TrainSystem enum; update station count 1000→1500+; update screen count 14→16 (add TripDetailsView, PennStationGuideView); add TripOption.swift and RouteShapes.swift to project structure
- **backend_v2/README.md**: Add missing transit systems to `data_source` parameter docs; fix stale "4/4 critical tests" claim
- **webpage_v2/CLAUDE.md**: Update React Router DOM version 7.13→7.14

## Test plan

- [ ] Verify all listed file paths in ios/README.md still exist
- [ ] Verify `data_source` parameter accepts all listed values
- [ ] Spot-check station count claim (~1500+)

https://claude.ai/code/session_017wLGoDyQ4oVxeNuX7xnXzL