### PR TITLE
Include cancelled trains in departures even if expired

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -263,8 +263,13 @@ class DepartureService:
             journey_date_filter,
             # Filter by selected data sources
             TrainJourney.data_source.in_(allowed_sources),
-            # Filter out expired trains (no longer in real-time feed)
-            TrainJourney.is_expired.is_not(True),
+            # Filter out expired trains (no longer in real-time feed),
+            # but keep cancelled trains even if expired — they must remain
+            # visible to match what the congestion endpoint counts.
+            or_(
+                TrainJourney.is_expired.is_not(True),
+                TrainJourney.is_cancelled.is_(True),
+            ),
             # Filter out completed trains (journey finished)
             TrainJourney.is_completed.is_not(True),
             # Filter out stale cancelled trains regardless of hide_departed.

--- a/backend_v2/tests/unit/services/test_departure_filtering.py
+++ b/backend_v2/tests/unit/services/test_departure_filtering.py
@@ -155,6 +155,71 @@ class TestDepartureFiltering:
         assert result.departures[0].train_id == "1234"
 
     @pytest.mark.asyncio
+    async def test_cancelled_expired_trains_included_in_departures(self):
+        """Test that cancelled trains are visible even if also marked expired.
+
+        The congestion endpoint counts cancelled+expired trains in its
+        cancellation_rate. The departures endpoint must also show them so
+        users see the cancelled trains that cause the dashed congestion line.
+        The cancelled train's own 2-hour staleness window still applies.
+        """
+        # Create journeys: one normal, one cancelled+expired
+        normal_journey = self._create_journey("1234", is_expired=False)
+        cancelled_expired = self._create_journey(
+            "5678", is_cancelled=True, is_expired=True
+        )
+
+        mock_session = AsyncMock(spec=AsyncSession)
+
+        mock_result = Mock()
+        mock_scalars = Mock()
+        # Both should be returned: the is_expired filter exempts cancelled trains
+        mock_scalars.unique.return_value.all.return_value = [
+            normal_journey,
+            cancelled_expired,
+        ]
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.scalar = AsyncMock(return_value=None)
+
+        service = DepartureService()
+
+        with patch.object(
+            service, "_maybe_trigger_background_refresh", new_callable=AsyncMock
+        ):
+            with patch.object(
+                service, "_get_path_cutoff_time", new_callable=AsyncMock
+            ) as mock_cutoff:
+                mock_cutoff.return_value = now_et() + timedelta(hours=2)
+
+                with patch.object(
+                    service,
+                    "_calculate_train_position",
+                    return_value=self._mock_train_position(),
+                ):
+                    with patch("trackrat.services.gtfs.GTFSService") as mock_gtfs_class:
+                        mock_gtfs = AsyncMock()
+                        mock_gtfs.get_scheduled_departures = AsyncMock(
+                            return_value=Mock(departures=[])
+                        )
+                        mock_gtfs_class.return_value = mock_gtfs
+
+                        result = await service.get_departures(
+                            db=mock_session,
+                            from_station="TR",
+                            to_station="NY",
+                        )
+
+        # Both trains should be visible
+        assert len(result.departures) == 2
+        train_ids = {d.train_id for d in result.departures}
+        assert train_ids == {"1234", "5678"}
+
+        # The cancelled+expired train should have is_cancelled=True
+        cancelled_dep = next(d for d in result.departures if d.train_id == "5678")
+        assert cancelled_dep.is_cancelled is True
+
+    @pytest.mark.asyncio
     async def test_completed_trains_excluded_from_departures(self):
         """Test that trains with is_completed=True are excluded from departure results."""
         # Create journeys: one normal, one completed


### PR DESCRIPTION
## Summary
Modified the departures endpoint to include cancelled trains even when they are marked as expired, ensuring consistency with the congestion endpoint's cancellation rate calculations.

## Key Changes
- Updated the `get_departures` query filter in `DepartureService` to exempt cancelled trains from the expiration filter
- Changed the `is_expired` filter from a simple exclusion to a conditional `or_()` clause that allows expired trains if they are cancelled
- Added comprehensive test coverage (`test_cancelled_expired_trains_included_in_departures`) to verify cancelled+expired trains are visible with correct metadata

## Implementation Details
The change modifies the database query logic to use SQLAlchemy's `or_()` operator:
- Trains are excluded if expired, **unless** they are also marked as cancelled
- This ensures cancelled trains remain visible to users even after they fall out of the real-time feed
- The cancelled train's own 2-hour staleness window still applies as a separate filter
- This maintains consistency between the departures endpoint and the congestion endpoint, which counts cancelled+expired trains in its cancellation rate

https://claude.ai/code/session_01Axnu6CKep3LQtx3ykbBQrn