### PR TITLE
Weekly documentation audit (Apr 9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,8 @@ Default target is staging; pass a URL as first positional arg for production.
 The NJT API token can be set via `NJT_TOKEN` env var, `TRACKRAT_NJT_API_TOKEN` env var,
 or `.njt-token` file (gitignored) in the repo root. Priority: TRACKRAT_NJT_API_TOKEN > NJT_TOKEN > .njt-token file.
 
-The WMATA API key can be set via `TRACKRAT_WMATA_API_KEY` or `WMATA_API_KEY` env var.
+The WMATA API key is set via `TRACKRAT_WMATA_API_KEY` env var for the backend.
+The ground-truth validation script also accepts `WMATA_API_KEY` as a fallback.
 
 **Server Usage Report:**
 
@@ -229,12 +230,13 @@ bash scripts/create-and-restore-db-then-train-model.sh
 - Uses official GTFS-RT protobuf feeds (no auth required for BART; optional API key for MBTA via `TRACKRAT_MBTA_API_KEY` or `MBTA_API_KEY` env var)
 - Shared logic from `mta_common.py` (stop merging, departure inference, completion detection)
 - BART does not use origin inference (too many terminals per line); MBTA does
+- BART uses Pacific Time (`America/Los_Angeles`)
 - GTFS static schedules backfill stops that GTFS-RT omits
 
 **Backend Data Collection (Metra - Unified GTFS-RT):**
 - Single collector runs every 4 minutes using official Metra GTFS-RT feed
 - Requires `TRACKRAT_METRA_API_TOKEN` env var for API authentication
-- Uses Central Time (only non-Eastern-Time collector)
+- Uses Central Time (BART also uses non-Eastern time; see Pacific Time below)
 - Shared logic from `mta_common.py`
 
 **Backend Data Collection (WMATA / DC Metro - REST API):**
@@ -245,7 +247,7 @@ bash scripts/create-and-restore-db-then-train-model.sh
 - Stop times are estimated using per-segment defaults (no scheduled times from WMATA)
 
 **Backend Data Collection (PATCO - Schedule-only):**
-- Uses GTFS static schedules from SEPTA feed
+- Uses GTFS static schedules from National RTAP feed
 - No real-time API available; times are scheduled only
 
 **MTA Service Alerts Collection:**
@@ -329,7 +331,7 @@ This prevents wasting time editing incorrect files when the user has given clear
 ```bash
 cd backend_v2
 poetry install
-alembic upgrade head
+poetry run alembic upgrade head
 
 # Run locally
 poetry run uvicorn trackrat.main:app --reload
@@ -469,7 +471,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - Backend services: `backend_v2/src/trackrat/services/`
 - Backend API endpoints: `backend_v2/src/trackrat/api/`
 - Backend models: `backend_v2/src/trackrat/models/`
-- Backend collectors: `backend_v2/src/trackrat/collectors/` (njt, amtrak, path, lirr, mnr, subway, bart, mbta, metra, wmata, service_alerts, mta_common, mta_extensions)
+- Backend collectors: `backend_v2/src/trackrat/collectors/` (base, njt, amtrak, path, lirr, mnr, subway, bart, mbta, metra, wmata, service_alerts, mta_common, mta_extensions)
 - Backend config: `backend_v2/src/trackrat/config/` (stations/ package, route_topology, station_configs, platform_mappings, transfer_points)
 - Backend utilities: `backend_v2/src/trackrat/utils/` (logging, metrics, request_stats, locks, time, train, sanitize, scheduler_utils, system_stats)
 - Backend database: `backend_v2/src/trackrat/db/` (database.py, engine.py, migrations_runner.py)
@@ -478,7 +480,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - iOS views: `ios/TrackRat/Views/Screens/`, `ios/TrackRat/Views/Components/`, `ios/TrackRat/Views/Paywall/`
 - iOS services: `ios/TrackRat/Services/`
 - iOS models: `ios/TrackRat/Models/`
-- iOS shared: `ios/TrackRat/Shared/` (LiveActivityModels, Stations, RouteTopology, etc.)
+- iOS shared: `ios/TrackRat/Shared/` (LiveActivityModels, Stations, StationData, StationDepartures, StationCoordinates, RouteTopology, RouteShapes)
 - iOS utilities: `ios/TrackRat/Utilities/` (Extensions, Logger)
 - iOS theme: `ios/TrackRat/Theme/` (TrackRatTheme)
 - iOS Live Activity: `ios/TrainLiveActivityExtension/`
@@ -488,10 +490,14 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - Web components: `webpage_v2/src/components/`
 - Web services: `webpage_v2/src/services/`
 - Web store: `webpage_v2/src/store/appStore.ts`
-- Web tests: `webpage_v2/src/` (colocated `*.test.ts` files, Vitest + React Testing Library)
+- Web data: `webpage_v2/src/data/` (routeTopology, stations)
+- Web utilities: `webpage_v2/src/utils/` (date, share, formatting, routes, ratsense, trainSearch)
+- Web types: `webpage_v2/src/types/`
+- Web tests: `webpage_v2/src/` (colocated `*.test.ts` and `*.test.tsx` files, Vitest + React Testing Library)
 - Test fixtures: `backend_v2/tests/fixtures/` (mock API responses)
 - Infrastructure Terraform: `infra_v2/terraform/`
 - Infrastructure Cloud Build: `infra_v2/cloudbuild*.yaml`
+- Cloud Functions: `infra_v2/functions/` (feedback_notifier, train_follow_notifier)
 - Universal links (AASA): `webpage_v2/public/.well-known/apple-app-site-association`
 - Webpage infrastructure (Terraform): `infra_v2/terraform-webpage/`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,12 @@ collectors/
 ├── lirr/         # LIRR (GTFS-RT)
 ├── mnr/          # Metro-North (GTFS-RT)
 ├── subway/       # NYC Subway (GTFS-RT, 8 feeds)
-├── service_alerts.py  # MTA service alerts collector
+├── bart/         # BART (GTFS-RT)
+├── mbta/         # MBTA Commuter Rail (GTFS-RT)
+├── metra/        # Metra (GTFS-RT, requires API token)
+├── wmata/        # WMATA/DC Metro (REST API)
+├── base.py            # Abstract base classes for collectors
+├── service_alerts.py  # MTA + NJT service alerts collector
 ├── mta_common.py      # Shared MTA logic (stop merging, departure inference)
 └── mta_extensions.py  # MTA extension utilities
 # Note: PATCO uses GTFS static schedules via services/gtfs.py (no dedicated collector)

--- a/README.md
+++ b/README.md
@@ -217,6 +217,6 @@ Copyright 2025-2026 Andrew Martin
 
 - **iOS App:** [App Store](https://apps.apple.com/us/app/trackrat/id6746423610)
 - **Web App:** [trackrat.net](https://trackrat.net)
-- **Feedback:** [trackrat.nolt.io](https://trackrat.nolt.io)
+- **Feedback:** In-app feedback form (iOS, Web) or email below
 - **YouTube:** [@TrackRat-App](https://www.youtube.com/@TrackRat-App/shorts)
 - **Contact:** trackrat@andymartin.cc

--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -53,21 +53,27 @@ android/app/src/main/java/com/trackrat/android/
 ├── TrackRatApp.kt              # Application class with Hilt
 ├── data/
 │   ├── api/                    # Retrofit API interface
+│   ├── mappers/                # TrainMappers
 │   ├── models/                 # Data models (TrainV2, StatusV2, etc.)
 │   ├── preferences/            # DataStore preferences
 │   ├── repository/             # Data repository pattern
-│   └── services/               # TrackPrediction, BackendHealth
+│   ├── services/               # TrackPrediction, BackendHealth
+│   └── Stations.kt             # Station data
 ├── di/                         # Hilt DI modules
-├── services/                   # TrainTrackingService, Notifications
+├── navigation/                 # TrackRatDestinations, Navigator
+├── services/                   # TrainTrackingService, RatSense, Notifications
 ├── ui/
+│   ├── advanced/               # Advanced config screen
 │   ├── components/             # Reusable UI (BottomSheet, Loading, etc.)
-│   ├── theme/                  # Material3 theme, colors, typography
-│   ├── map/                    # MapContainerScreen, congestion
-│   ├── stationselection/       # Origin picker
 │   ├── destinationselection/   # Destination picker
-│   ├── trainlist/              # Departure list
+│   ├── favorites/              # Favorite stations
+│   ├── map/                    # MapContainerScreen, congestion
+│   ├── onboarding/             # Onboarding flow
+│   ├── profile/                # Settings screens
+│   ├── stationselection/       # Origin picker
+│   ├── theme/                  # Material3 theme, colors, typography
 │   ├── traindetail/            # Journey details
-│   └── profile/                # Settings screens
+│   └── trainlist/              # Departure list
 └── utils/                      # Constants, Stations, Helpers
 ```
 
@@ -167,7 +173,6 @@ fun TrainListItem()
 **Not Implemented:**
 - Push notifications (FCM)
 - Home screen widgets
-- Deep linking
 
 ---
 

--- a/android/README.md
+++ b/android/README.md
@@ -78,10 +78,8 @@
 
 1. **Push Notifications** (FCM) - not needed yet
 2. **Route History Screen** - backend endpoint exists, UI not built
-3. **Deep Linking** - not implemented
-4. **Share Functionality** - not implemented
-5. **Home Screen Widgets** (Glance API)
-6. **Offline Mode** - no local caching
+3. **Home Screen Widgets** (Glance API)
+4. **Offline Mode** - no local caching
 
 ## Getting Started - Development Setup
 
@@ -207,16 +205,27 @@ android/
 │       │   │   ├── TrackRatApp.kt         # Application class
 │       │   │   ├── data/
 │       │   │   │   ├── api/              # API service & adapters
+│       │   │   │   ├── mappers/          # TrainMappers
 │       │   │   │   ├── models/           # Data models
 │       │   │   │   ├── preferences/      # User preferences
-│       │   │   │   └── repository/       # Data repositories
+│       │   │   │   ├── repository/       # Data repositories
+│       │   │   │   ├── services/         # TrackPrediction, BackendHealth
+│       │   │   │   └── Stations.kt       # Station data
 │       │   │   ├── di/                   # Dependency injection
+│       │   │   ├── navigation/           # TrackRatDestinations, Navigator
+│       │   │   ├── services/             # TrainTrackingService, RatSense, Notifications
 │       │   │   ├── ui/
+│       │   │   │   ├── advanced/         # Advanced config screen
 │       │   │   │   ├── components/       # Reusable UI components
-│       │   │   │   ├── theme/            # Material3 theming
+│       │   │   │   ├── destinationselection/ # Destination picker
+│       │   │   │   ├── favorites/        # Favorite stations
+│       │   │   │   ├── map/              # MapContainerScreen, congestion
+│       │   │   │   ├── onboarding/       # Onboarding flow
+│       │   │   │   ├── profile/          # Settings screens
 │       │   │   │   ├── stationselection/ # Station selection screen
-│       │   │   │   ├── trainlist/        # Train list screen
-│       │   │   │   └── traindetail/      # Train detail screen
+│       │   │   │   ├── theme/            # Material3 theming
+│       │   │   │   ├── traindetail/      # Train detail screen
+│       │   │   │   └── trainlist/        # Train list screen
 │       │   │   └── utils/                # Utilities & helpers
 │       │   ├── res/                      # Resources (strings, themes)
 │       │   └── AndroidManifest.xml       # App manifest
@@ -232,7 +241,7 @@ android/
 
 1. **Gradle sync fails**
    - File → Invalidate Caches and Restart
-   - Check JDK version (must be 11+)
+   - Check JDK version (must be 17+)
    - Ensure Android SDK 34 is installed
 
 2. **API connection errors**

--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -74,7 +74,7 @@ The V2 backend eliminates the complexity of V1 by:
    - Provides future train visibility beyond 30-60 minute window
 
 2. **Discovery Phase** (Every 30 minutes, configurable)
-   - **NJT**: Polls 7 major stations (NY, NP, PJ, TR, LB, PL, DN) via `getTrainSchedule`
+   - **NJT**: Polls 18 stations (NY, NP, TR, LB, PL, DN, MP, HB, HG, GL, ND, BU, HQ, DV, JA, RA, ST, SV) via `getTrainSchedule`
    - **Amtrak**: Polls major stations for active trains
    - Updates journey records from SCHEDULED to OBSERVED when trains appear
 
@@ -101,8 +101,9 @@ train_journeys (
     id, train_id, journey_date, line_code, line_name, line_color,
     destination, origin_station_code, terminal_station_code,
     data_source (NJT/AMTRAK/PATH/PATCO/LIRR/MNR/SUBWAY/BART/MBTA/METRA/WMATA), observation_type (OBSERVED/SCHEDULED),
+    first_seen_at, last_updated_at, update_count,
     scheduled_departure, scheduled_arrival, actual_departure, actual_arrival,
-    has_complete_journey, stops_count, is_cancelled, is_completed,
+    has_complete_journey, stops_count, is_cancelled, cancellation_reason, is_completed,
     api_error_count, is_expired, discovery_track, discovery_station_code
 
 -- Individual stops with times and tracks
@@ -112,11 +113,14 @@ train_journeys (
 -- Consumers must use max(updated_departure, updated_arrival) for NJT departures.
 -- See database.py JourneyStop model for full documentation.
 journey_stops (
-    journey_id, station_code, stop_sequence,
+    journey_id, station_code, station_name, stop_sequence,
     scheduled_departure, scheduled_arrival,
     updated_departure, updated_arrival,
     actual_departure, actual_arrival,
-    track, status
+    raw_amtrak_status, raw_njt_departed_flag,
+    has_departed_station, departure_source, arrival_source,
+    track, track_assigned_at, pickup_only, dropoff_only,
+    created_at, updated_at
 )
 
 -- Transit time analysis (NEW)
@@ -144,7 +148,9 @@ journey_progress (
 
 -- Historical snapshots for ML training
 journey_snapshots (
-    journey_id, snapshot_type, api_response, created_at
+    journey_id, captured_at, raw_stop_list_data,
+    train_status, delay_minutes, completed_stops, total_stops,
+    track_assignments
 )
 
 -- API response caching
@@ -154,7 +160,9 @@ cached_api_responses (
 
 -- Scheduler coordination (for horizontal scaling)
 scheduler_task_runs (
-    task_name, last_successful_run, run_count, last_run_revision
+    task_name, last_successful_run, last_attempt, run_count,
+    average_duration_ms, last_duration_ms, last_instance_id,
+    created_at, updated_at
 )
 
 -- Live Activity tokens
@@ -165,21 +173,47 @@ live_activity_tokens (
 
 -- Validation results
 validation_results (
-    id, validation_run_id, route, data_source,
-    expected_trains, found_trains, missing_trains,
-    coverage_percent, validation_time
+    id, run_at, route, source,
+    transit_train_count, api_train_count, coverage_percent,
+    missing_trains, extra_trains, details
 )
 
 -- Device tokens for push notifications
 device_tokens (
-    id, device_token, platform, created_at, updated_at
+    id, device_id, apns_token, created_at, updated_at
 )
 
 -- Route alert subscriptions
 route_alert_subscriptions (
-    id, device_token_id, route, data_source,
-    delay_threshold_minutes, notify_cancellations,
-    created_at, updated_at
+    id, device_id, data_source, line_id, from_station_code, to_station_code,
+    train_id, direction, active_days, active_start_minutes, active_end_minutes,
+    timezone, delay_threshold_minutes, service_threshold_pct, cancellation_threshold_pct,
+    notify_cancellation, notify_delay, notify_recovery,
+    digest_time_minutes, include_planned_work,
+    created_at, last_alerted_at, last_alert_hash, last_digest_at, last_service_alert_ids
+)
+
+-- Discovery run tracking
+discovery_runs (
+    id, data_source, station_code, started_at, completed_at,
+    trains_found, trains_created, trains_updated, error
+)
+
+-- MTA service alerts
+service_alerts (
+    id, alert_id, data_source, alert_type, header, description,
+    affected_routes, affected_stops, active_periods, is_active,
+    first_seen_at, last_seen_at, created_at, updated_at
+)
+
+-- GTFS static data tables
+gtfs_feed_info, gtfs_routes, gtfs_trips, gtfs_stop_times,
+gtfs_calendar, gtfs_calendar_dates
+
+-- Route preferences
+route_preferences (
+    id, device_id, from_station_code, to_station_code, data_source,
+    display_order, created_at, updated_at
 )
 ```
 
@@ -222,8 +256,8 @@ POST /feedback                                       # Submit user feedback
 POST /live-activities/register    # Register Live Activity
 DELETE /live-activities/{token}   # Unregister Live Activity
 
-# Admin
-GET /admin/stats              # Server usage statistics (HTML)
+# Admin (NOT under /api/v2/ prefix)
+GET /admin/stats              # Server usage statistics (HTML, supports ?hours=N&ios_only=true)
 GET /admin/stats.json         # Server usage statistics (JSON)
 
 # Trip Search
@@ -244,8 +278,10 @@ GET /metrics                  # Prometheus metrics
 ### 4. Background Scheduler (Horizontally Scalable)
 
 The APScheduler runs in-process and handles:
-- **Daily at 4 AM ET**: NJT schedule collection (27-hour schedules)
-- **Daily at 4:30 AM ET**: Amtrak pattern-based schedule generation
+- **Daily at 12:30 AM ET**: NJT schedule collection (27-hour schedules)
+- **Daily at 12:45 AM ET**: Amtrak pattern-based schedule generation
+- **Daily at 1:00 AM ET**: Lock manager cleanup
+- **Daily at 3:00 AM ET**: GTFS static schedule refresh
 - **Every 30 min**: NJT and Amtrak train discovery from major stations
 - **Every 4 min**: PATH collection (unified, RidePATH API)
 - **Every 4 min**: LIRR collection (unified, MTA GTFS-RT)
@@ -256,11 +292,15 @@ The APScheduler runs in-process and handles:
 - **Every 4 min**: Metra collection (unified, GTFS-RT, requires API token)
 - **Every 3 min**: WMATA/DC Metro collection (REST API, requires API key)
 - **Every 5 min**: Journey update checks for active trains
-- **Every 15 min**: Individual journey collection updates
-- **Every 15 min**: API cache pre-computation for congestion endpoints
-- **Hourly at :05**: Train validation across key routes
-- **Every 30 min**: Live Activity push notification updates
+- **Every 90 sec**: Departure cache pre-computation
+- **Every 5 min**: Route history cache pre-computation
+- **Every 15 min**: Congestion cache pre-computation
+- **Every 15 min**: Service alerts collection (MTA + NJT)
+- **Every 1 min**: Live Activity push notification updates
+- **Hourly**: Live Activity token cleanup
+- **Hourly**: Train validation across key routes
 - **Every 5 min**: Route alert evaluation and push notifications
+- **Every 5 min**: Morning digest evaluation
 - **Automatic startup**: Begins when FastAPI app starts
 
 **Horizontal Scaling Support:**
@@ -511,7 +551,7 @@ alembic history
 
 ```python
 # Enable debug logging
-LOG_LEVEL=DEBUG poetry run uvicorn trackrat.main:app
+TRACKRAT_LOG_LEVEL=DEBUG poetry run uvicorn trackrat.main:app
 
 # Use interactive debugger
 import ipdb; ipdb.set_trace()
@@ -580,7 +620,7 @@ docker run -p 8000:8000 \
 
 ```bash
 # Check database connectivity
-poetry run python -c "from trackrat.db.engine import test_connection; import asyncio; asyncio.run(test_connection())"
+poetry run python -c "from trackrat.db.engine import get_engine; print('DB engine:', get_engine())"
 
 # Verify NJ Transit API connectivity
 curl -s http://localhost:8000/health | jq .data_freshness
@@ -791,7 +831,7 @@ The backend is organized into service classes for better maintainability:
 
 ### Performance Characteristics
 - API response time: <100ms (p95) with caching
-- Discovery completion: ~30 seconds for 7 stations
+- Discovery completion: ~30 seconds for 18 stations
 - Schedule generation: <60 seconds for all NJT trains
 - Cache hit rate: ~80% for popular routes
 - Database queries: <10ms for indexed queries

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -2,7 +2,7 @@
 
 A simplified, efficient train tracking system for NJ Transit, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, and WMATA built with FastAPI, PostgreSQL, and modern Python.
 
-**Version:** 2.2.0 (April 2026)
+**Version:** 2.0.0 (April 2026)
 **Database:** PostgreSQL with asyncpg (production-ready)
 **Python:** 3.11+ with strict type checking
 
@@ -604,13 +604,6 @@ The container performs comprehensive APNS validation at startup:
 - ✅ **Environment variables are set and properly formatted**
 - ✅ **P8 certificate can be loaded by cryptography library**
 - ❌ **Container exits immediately if any validation fails**
-
-Test the validation:
-```bash
-# Test container validation (should fail without APNS)
-./test-docker-apns.sh
-```
-```
 
 ### Production Considerations
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -303,15 +303,15 @@ See [CLAUDE.md](CLAUDE.md) for complete technical details and improvement areas.
 ## 📊 Analytics & Monitoring
 
 ### Current Implementation
-- Basic console logging for debugging
+- Anonymous usage analytics reported to backend (`/admin/stats`)
+- Per-action tracking (departure searches, train views, trip searches)
+- Version distribution and hourly activity trends
 - No third-party analytics SDKs
-- Privacy-first approach
+- Privacy-first approach (no PII collected)
 
 ### Future Considerations
-- Anonymous usage statistics
 - Crash reporting integration
 - Performance monitoring
-- User feedback system
 
 ## 🔐 Security & Privacy
 

--- a/webpage_v2/CLAUDE.md
+++ b/webpage_v2/CLAUDE.md
@@ -11,6 +11,7 @@
 - **Routing**: React Router DOM 7.14
 - **Date Handling**: date-fns 4.1
 - **HTTP Client**: Native `fetch` (no axios)
+- **Maps**: MapLibre GL 5.22 + react-map-gl 8.1
 - **Deployment**: GCS static hosting (`scripts/deploy-webpage.sh`)
 
 ## Architecture Patterns

--- a/webpage_v2/README.md
+++ b/webpage_v2/README.md
@@ -16,7 +16,7 @@ A mobile-first web application for tracking trains across 11 transit systems (NJ
 - Last route auto-restoration
 - Data freshness indicators and journey date display
 - iOS smart app banner
-- Mobile-first dark mode with glassmorphism UI
+- Mobile-first warm light theme with glassmorphism UI
 - Auto-refresh every 30 seconds
 - PWA support (installable, offline-capable)
 - Web Share API for sharing train links
@@ -74,7 +74,7 @@ The app connects to the TrackRat backend API at `https://apiv2.trackrat.net/api/
 
 ### Key Endpoints
 
-- `GET /trains/departures` - Get train departures between stations
+- `GET /trips/search` - Search trips between stations (primary departure endpoint)
 - `GET /trains/{id}` - Get train details with all stops
 - `GET /predictions/track` - Track/platform predictions
 - `GET /routes/summary` - Route operations summary


### PR DESCRIPTION
## Summary

Weekly audit of all CLAUDE.md and README.md files against the current codebase. Fixes stale documentation across 10 files.

### Key fixes by file

**Root CLAUDE.md** (9 fixes)
- PATCO feed source: SEPTA → National RTAP
- Metra timezone: noted BART also uses non-Eastern time (Pacific)
- WMATA env var: clarified backend vs ground-truth script fallback
- Added `base` to collectors listing
- Expanded iOS Shared files (replaced vague "etc.")
- Added web data/utils/types directories to Key File Locations
- Added Cloud Functions directory to Key File Locations
- Fixed `alembic upgrade head` → `poetry run alembic upgrade head`
- Added BART Pacific Time note to BART section

**backend_v2/CLAUDE.md** (major overhaul)
- NJT discovery stations: 7 → 18 (with correct station list)
- Scheduler timings: corrected all wrong times (schedule collection 4AM→12:30AM, Live Activity 30min→1min, validation timing)
- Added 7 missing scheduled tasks (departure cache, route history cache, lock cleanup, GTFS refresh, morning digest, service alerts, LA token cleanup)
- Fixed column names in 6 schema tables (journey_snapshots, scheduler_task_runs, validation_results, device_tokens, route_alert_subscriptions, journey_stops)
- Added 9 missing tables (discovery_runs, service_alerts, gtfs_*, route_preferences)
- Fixed debug commands (wrong env var name, non-existent function)
- Fixed admin endpoint prefix note

**backend_v2/README.md** — Fixed version mismatch (2.2.0→2.0.0), removed reference to non-existent test-docker-apns.sh

**webpage_v2/CLAUDE.md** — Added MapLibre GL JS to technology stack

**webpage_v2/README.md** — Fixed "dark mode" claim (app uses light cream theme), fixed primary API endpoint

**android/CLAUDE.md + README.md** — Added 6 missing directories to project structure, fixed JDK version (11→17), removed items from "not implemented" that are now implemented

**ios/README.md** — Updated analytics section to reflect new usage analytics

**CONTRIBUTING.md** — Added 4 missing collector directories (bart, mbta, metra, wmata)

**README.md** — Replaced stale nolt.io feedback link

## Test plan

- [ ] Verify all documented file paths still resolve correctly
- [ ] Spot-check corrected scheduler timings against `scheduler.py`
- [ ] Verify corrected schema columns match `database.py` models

https://claude.ai/code/session_01Tq8hMkvSwc9tzbGkdJjmqE