### PR TITLE
Close NJT discovery coverage gaps: add RW, WW, HN

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -74,7 +74,7 @@ The V2 backend eliminates the complexity of V1 by:
    - Provides future train visibility beyond 30-60 minute window
 
 2. **Discovery Phase** (Every 30 minutes, configurable)
-   - **NJT**: Polls 18 stations (NY, NP, TR, LB, PL, DN, MP, HB, HG, GL, ND, BU, HQ, DV, JA, RA, ST, SV) via `getTrainSchedule`
+   - **NJT**: Polls 21 stations (NY, NP, TR, LB, PL, DN, MP, HB, HG, GL, ND, BU, HQ, DV, JA, RA, ST, SV, RW, WW, HN) via `getTrainSchedule`
    - **Amtrak**: Polls major stations for active trains
    - Updates journey records from SCHEDULED to OBSERVED when trains appear
 
@@ -831,7 +831,7 @@ The backend is organized into service classes for better maintainability:
 
 ### Performance Characteristics
 - API response time: <100ms (p95) with caching
-- Discovery completion: ~30 seconds for 18 stations
+- Discovery completion: ~30 seconds for 21 stations
 - Schedule generation: <60 seconds for all NJT trains
 - Cache hit rate: ~80% for popular routes
 - Database queries: <10ms for indexed queries

--- a/backend_v2/src/trackrat/config/stations/njt.py
+++ b/backend_v2/src/trackrat/config/stations/njt.py
@@ -364,14 +364,22 @@ NJT_GTFS_STOP_TO_INTERNAL_MAP: dict[str, str] = {
 # PATCO GTFS stop_id to internal station code mapping
 # GTFS uses numeric stop_id (1-14), matching stop_code
 
-# Discovery stations for train polling - centralized configuration
+# Discovery stations for train polling - centralized configuration.
+#
+# Every NJT line must have at least one *intermediate* station here (not just
+# a terminal), otherwise trains originating from non-discovery stations on
+# that line remain SCHEDULED forever and are hidden by the
+# SCHEDULED_VISIBILITY_THRESHOLD_MINUTES filter in departure.py before users
+# ever see them. Terminal stations catch only trains that *depart* from them
+# (outbound), because arriving trains have no SCHED_DEP_DATE and are skipped
+# by discovery.py.
 DISCOVERY_STATIONS = [
     "NY",  # New York Penn Station
     "NP",  # Newark Penn Station
     "TR",  # Trenton
     "LB",  # Long Branch
-    "PL",  # Plauderville
-    "DN",  # Denville
+    "PL",  # Plauderville - Bergen County Line midline
+    "DN",  # Dunellen - Raritan Valley Line midline
     "MP",  # Metropark
     "HB",  # Hoboken
     "HG",  # High Bridge
@@ -379,9 +387,12 @@ DISCOVERY_STATIONS = [
     "ND",  # Newark Broad Street
     "BU",  # Brick Church - Morris & Essex junction near Newark
     "HQ",  # Hackettstown
-    "DV",  # Dover
+    "DV",  # Denville - Morris & Essex / Montclair-Boonton western coverage
     "JA",  # Jersey Avenue
     "RA",  # Raritan
     "ST",  # Summit - major Morris & Essex terminal for inbound trains
     "SV",  # Spring Valley - Pascack Valley Line terminus
+    "RW",  # Ridgewood - Main / Bergen County / Port Jervis shared trunk
+    "WW",  # Westwood - Pascack Valley Line midline
+    "HN",  # Hammonton - Atlantic City Line midline
 ]

--- a/backend_v2/tests/unit/collectors/njt/test_discovery.py
+++ b/backend_v2/tests/unit/collectors/njt/test_discovery.py
@@ -201,8 +201,9 @@ class TestTrainDiscoveryCollector:
     @pytest.mark.asyncio
     async def test_collect_aggregates_all_train_ids(self, discovery_collector):
         """Test that collect method aggregates train IDs from all stations."""
-        # Mock discover_station_trains to return different results for each station
-        # Need to include all discovery stations: NY, NP, TR, LB, PL, DN, MP, HB, HG, GL, ND, BU, HQ, DV, JA, RA, ST, SV
+        # Mock discover_station_trains to return different results for each station.
+        # Must include all DISCOVERY_STATIONS:
+        # NY, NP, TR, LB, PL, DN, MP, HB, HG, GL, ND, BU, HQ, DV, JA, RA, ST, SV, RW, WW, HN
         station_results = {
             "NY": {
                 "trains_discovered": 3,
@@ -312,6 +313,24 @@ class TestTrainDiscoveryCollector:
                 "new_train_ids": [],
                 "all_train_ids": [],
             },
+            "RW": {
+                "trains_discovered": 0,
+                "new_trains": 0,
+                "new_train_ids": [],
+                "all_train_ids": [],
+            },
+            "WW": {
+                "trains_discovered": 0,
+                "new_trains": 0,
+                "new_train_ids": [],
+                "all_train_ids": [],
+            },
+            "HN": {
+                "trains_discovered": 0,
+                "new_trains": 0,
+                "new_train_ids": [],
+                "all_train_ids": [],
+            },
         }
 
         mock_session = AsyncMock()
@@ -334,16 +353,16 @@ class TestTrainDiscoveryCollector:
             result = await discovery_collector.collect()
 
         # Verify aggregation
-        assert result["stations_processed"] == 18  # Updated discovery stations count
+        assert result["stations_processed"] == 21  # Updated discovery stations count
         assert result["total_discovered"] == 5  # 3 + 2 (from NY and NP stations)
         assert result["total_new"] == 1  # 1 (from NY station)
 
         # Verify station_results contains all station data
         assert "station_results" in result
-        assert len(result["station_results"]) == 18
+        assert len(result["station_results"]) == 21
 
         # Verify discover_station_trains was called for each discovery station
-        assert mock_discover.call_count == 18
+        assert mock_discover.call_count == 21
 
     @pytest.mark.asyncio
     async def test_process_discovered_trains_creates_journey_records(


### PR DESCRIPTION
Static cross-reference of route_topology.py against DISCOVERY_STATIONS revealed five NJT lines where no *intermediate* discovery station exists, meaning trains originating from non-discovery stations on those lines remain SCHEDULED and get hidden by departure.py's 15-minute SCHEDULED_VISIBILITY_THRESHOLD filter before users see them. This is the same class of bug as the SO->NY Maplewood issue fixed in 1eb2b04.

Adds three stations, closing four of the five gaps:

  RW (Ridgewood)  - Main / Bergen County / Port Jervis shared trunk.
                    Fixes Main Line and Port Jervis (previously
                    terminal-only at HB), adds redundancy to Bergen.
  WW (Westwood)   - Pascack Valley Line midline. Previously only HB
                    and SV (both terminals) were covered.
  HN (Hammonton)  - Atlantic City Line midline. Previously no
                    discovery station at all on the line.

The Princeton Branch (2-station PJ<->PR dinky shuttle) is deferred; no "intermediate" station exists on a 2-stop route, and the line is very low traffic.

Also fixes two misleading comments on DN/DV: the codes are correct for their actual stations (DN=Dunellen, DV=Denville per NJT_STATION_NAMES) but the comments said "Denville" and "Dover" respectively.

After these additions every NJT route except Princeton Branch has at least one intermediate discovery station. Going from 18 -> 21 stations adds 144 NJT API calls/day, negligible vs rate limits.

https://claude.ai/code/session_01V4cchG6hRfNP8qwVNDLJgf