### PR TITLE
Weekly documentation audit: fix stale docs across 9 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ TrackRat is an open-source transit tracking framework (GPLv3) with:
 - **Android**: Kotlin (Jetpack Compose + Hilt + Retrofit) in `android/`
 - **Web**: React (TypeScript + Vite + Tailwind) in `webpage_v2/` - See `webpage_v2/CLAUDE.md`
 - **Backend docs**: See `backend_v2/CLAUDE.md` for detailed backend architecture
+- **iOS docs**: See `ios/CLAUDE.md` for iOS architecture and development
+- **Android docs**: See `android/CLAUDE.md` for Android architecture and development
 - **Infrastructure**: Terraform (Google Cloud Platform) in `infra_v2/`
 
 ## USE SUB-AGENTS FOR CONTEXT OPTIMIZATION
@@ -474,7 +476,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - Backend collectors: `backend_v2/src/trackrat/collectors/` (base, njt, amtrak, path, lirr, mnr, subway, bart, mbta, metra, wmata, service_alerts, mta_common, mta_extensions)
 - Backend config: `backend_v2/src/trackrat/config/` (stations/ package, route_topology, station_configs, platform_mappings, transfer_points)
 - Backend utilities: `backend_v2/src/trackrat/utils/` (logging, metrics, request_stats, locks, time, train, sanitize, scheduler_utils, system_stats)
-- Backend database: `backend_v2/src/trackrat/db/` (database.py, engine.py, migrations_runner.py)
+- Backend database: `backend_v2/src/trackrat/db/` (database.py, engine.py, migrations_runner.py, migrations/)
 - Backend tests: `backend_v2/tests/`
 - iOS app: `ios/TrackRat/App/` (TrackRatApp.swift, ContentView.swift)
 - iOS views: `ios/TrackRat/Views/Screens/`, `ios/TrackRat/Views/Components/`, `ios/TrackRat/Views/Paywall/`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TrackRat tracks trains across eleven transit systems in real time, predicts plat
 | System | Coverage | Data Source | Real-Time |
 |--------|----------|-------------|-----------|
 | NJ Transit | All rail lines | NJ Transit API | Yes |
-| Amtrak | Northeast Corridor | Amtraker API | Yes |
+| Amtrak | Multi-corridor (NEC, Keystone, Southeast, New England) | Amtraker API | Yes |
 | PATH | All 4 routes, 13 stations | RidePATH API | Yes |
 | LIRR | All branches | MTA GTFS-RT | Yes |
 | Metro-North | All branches | MTA GTFS-RT | Yes |
@@ -22,7 +22,7 @@ TrackRat tracks trains across eleven transit systems in real time, predicts plat
 | BART | All lines | BART GTFS-RT | Yes |
 | MBTA | Commuter Rail | MBTA GTFS-RT | Yes |
 | Metra | All lines (Chicago) | Metra GTFS-RT | Yes |
-| PATCO | Lindenwold–15th St | GTFS Static | Schedule only |
+| PATCO | Lindenwold–15-16th & Locust | GTFS Static | Schedule only |
 
 ## What It Does
 
@@ -102,7 +102,7 @@ npm run build        # Production build
 
 ### iOS App (Swift / SwiftUI)
 
-**Prerequisites:** macOS 14+, Xcode 15+, iOS 18.0+ deployment target
+**Prerequisites:** macOS 14+, Xcode 16+, iOS 18.0+ deployment target
 
 ```bash
 cd ios

--- a/android/CLAUDE.md
+++ b/android/CLAUDE.md
@@ -52,29 +52,29 @@ android/app/src/main/java/com/trackrat/android/
 ├── MainActivity.kt              # Single activity entry point
 ├── TrackRatApp.kt              # Application class with Hilt
 ├── data/
-│   ├── api/                    # Retrofit API interface
+│   ├── api/                    # Retrofit API interface, adapters (HtmlEntityDecoder, ZonedDateTimeAdapter)
 │   ├── mappers/                # TrainMappers
 │   ├── models/                 # Data models (TrainV2, StatusV2, etc.)
-│   ├── preferences/            # DataStore preferences
+│   ├── preferences/            # DataStore preferences, EnvironmentManager
 │   ├── repository/             # Data repository pattern
 │   ├── services/               # TrackPrediction, BackendHealth
 │   └── Stations.kt             # Station data
 ├── di/                         # Hilt DI modules
 ├── navigation/                 # TrackRatDestinations, Navigator
-├── services/                   # TrainTrackingService, RatSense, Notifications
+├── services/                   # TrainTrackingService, RatSense, Notifications, TrackingStateRepository, TrainUpdateReceiver
 ├── ui/
 │   ├── advanced/               # Advanced config screen
 │   ├── components/             # Reusable UI (BottomSheet, Loading, etc.)
 │   ├── destinationselection/   # Destination picker
 │   ├── favorites/              # Favorite stations
-│   ├── map/                    # MapContainerScreen, congestion
+│   ├── map/                    # MapContainerScreen, MapContainerViewModel, PolylineHitDetector
 │   ├── onboarding/             # Onboarding flow
-│   ├── profile/                # Settings screens
+│   ├── profile/                # Settings screens, components/ (ProfileActionRow, ProfileSectionCard)
 │   ├── stationselection/       # Origin picker
 │   ├── theme/                  # Material3 theme, colors, typography
 │   ├── traindetail/            # Journey details
 │   └── trainlist/              # Departure list
-└── utils/                      # Constants, Stations, Helpers
+└── utils/                      # Constants, HapticFeedbackHelper, ShareService, ErrorUtils
 ```
 
 ## API Integration

--- a/android/README.md
+++ b/android/README.md
@@ -204,29 +204,29 @@ android/
 │       │   │   ├── MainActivity.kt         # Entry point
 │       │   │   ├── TrackRatApp.kt         # Application class
 │       │   │   ├── data/
-│       │   │   │   ├── api/              # API service & adapters
+│       │   │   │   ├── api/              # API service, HtmlEntityDecoder, ZonedDateTimeAdapter
 │       │   │   │   ├── mappers/          # TrainMappers
 │       │   │   │   ├── models/           # Data models
-│       │   │   │   ├── preferences/      # User preferences
+│       │   │   │   ├── preferences/      # UserPreferencesRepository, EnvironmentManager
 │       │   │   │   ├── repository/       # Data repositories
 │       │   │   │   ├── services/         # TrackPrediction, BackendHealth
 │       │   │   │   └── Stations.kt       # Station data
 │       │   │   ├── di/                   # Dependency injection
 │       │   │   ├── navigation/           # TrackRatDestinations, Navigator
-│       │   │   ├── services/             # TrainTrackingService, RatSense, Notifications
+│       │   │   ├── services/             # TrainTrackingService, RatSense, Notifications, TrackingStateRepository, TrainUpdateReceiver
 │       │   │   ├── ui/
 │       │   │   │   ├── advanced/         # Advanced config screen
 │       │   │   │   ├── components/       # Reusable UI components
 │       │   │   │   ├── destinationselection/ # Destination picker
 │       │   │   │   ├── favorites/        # Favorite stations
-│       │   │   │   ├── map/              # MapContainerScreen, congestion
+│       │   │   │   ├── map/              # MapContainerScreen, MapContainerViewModel, PolylineHitDetector
 │       │   │   │   ├── onboarding/       # Onboarding flow
-│       │   │   │   ├── profile/          # Settings screens
+│       │   │   │   ├── profile/          # Settings screens, components/ (ProfileActionRow, ProfileSectionCard)
 │       │   │   │   ├── stationselection/ # Station selection screen
 │       │   │   │   ├── theme/            # Material3 theming
 │       │   │   │   ├── traindetail/      # Train detail screen
 │       │   │   │   └── trainlist/        # Train list screen
-│       │   │   └── utils/                # Utilities & helpers
+│       │   │   └── utils/                # Constants, HapticFeedbackHelper, ShareService, ErrorUtils
 │       │   ├── res/                      # Resources (strings, themes)
 │       │   └── AndroidManifest.xml       # App manifest
 │       └── test/                          # Unit tests

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -76,8 +76,8 @@ poetry run uvicorn trackrat.main:app --reload
 
 **No additional steps needed!** The background scheduler starts automatically when you run the application:
 
-- **Daily 4:00 AM ET**: NJT 27-hour schedule collection
-- **Daily 4:30 AM ET**: Amtrak pattern-based schedule generation
+- **Daily 12:30 AM ET**: NJT 27-hour schedule collection
+- **Daily 12:45 AM ET**: Amtrak pattern-based schedule generation
 - **Every 30 minutes**: Train discovery for NJT and Amtrak
 - **Every 15 minutes**: Journey collection for active NJT/Amtrak trains
 - **Every 4 minutes**: PATH train collection (unified discovery + updates)
@@ -349,9 +349,9 @@ The V2 backend includes a comprehensive test suite covering core functionality:
 poetry run pytest -v
 
 # Run specific test categories
-poetry run pytest tests/test_basic.py -v           # Core functionality only
-poetry run pytest tests/test_config.py -v         # Configuration tests
-poetry run pytest tests/test_utils.py -v          # Utility function tests
+poetry run pytest tests/unit/ -v                  # Unit tests (collectors, api, services, config)
+poetry run pytest tests/integration/ -v           # Integration tests
+poetry run pytest tests/e2e/ -v                   # End-to-end tests
 
 # Run with coverage report
 poetry run pytest --cov=trackrat --cov-report=html
@@ -393,19 +393,19 @@ poetry run alembic downgrade -1
 The system uses a sophisticated multi-phase approach:
 
 #### 1. Schedule Generation (Daily)
-- **NJT Schedule Collection** (4:00 AM ET)
+- **NJT Schedule Collection** (12:30 AM ET)
   - Fetches 27-hour schedule data in single API call
   - Creates SCHEDULED journey records for all trains
   - Updates to OBSERVED when trains appear in discovery
 
-- **Amtrak Pattern Analysis** (4:30 AM ET)
+- **Amtrak Pattern Analysis** (12:45 AM ET)
   - Analyzes 22 days of historical patterns
   - Identifies trains that run regularly (≥2 times in 3 weeks)
   - Generates SCHEDULED records for expected trains
 
 #### 2. Train Discovery (Every 30 minutes for NJT/Amtrak)
 - Polls major stations for active trains
-- NJT: NY, NP, PJ, TR, LB, PL, DN stations
+- NJT: 21 stations (NY, NP, TR, LB, PL, DN, MP, HB, HG, GL, ND, BU, HQ, DV, JA, RA, ST, SV, RW, WW, HN)
 - Amtrak: Major corridor stations
 - Updates journey status from SCHEDULED to OBSERVED
 
@@ -429,7 +429,7 @@ The system uses a sophisticated multi-phase approach:
 - Full trip_id used as train ID (not truncated)
 
 #### PATCO Collection (Schedule-based only)
-- Uses GTFS static schedules from SEPTA feed
+- Uses GTFS static schedules from National RTAP feed
 - 14 stations from Lindenwold to 15-16th & Locust
 - No real-time API available; times are scheduled only
 

--- a/infra_v2/README.md
+++ b/infra_v2/README.md
@@ -42,7 +42,7 @@ Simplified GCP infrastructure using Managed Instance Groups with Container-Optim
                    │                                                          │
                    │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   │
                    │  │Secret Manager│  │  Artifact    │  │  GCS Deploy  │   │
-                   │  │  (5 secrets) │  │  Registry    │  │    Bucket    │   │
+                   │  │  (8 secrets) │  │  Registry    │  │    Bucket    │   │
                    │  └──────────────┘  └──────────────┘  └──────────────┘   │
                    └──────────────────────────────────────────────────────────┘
 ```
@@ -58,6 +58,9 @@ gcloud secrets create trackrat-njt-api-token --data-file=-
 gcloud secrets create trackrat-apns-team-id --data-file=-
 gcloud secrets create trackrat-apns-key-id --data-file=-
 gcloud secrets create trackrat-apns-bundle-id --data-file=-
+gcloud secrets create trackrat-apns-auth-key --data-file=-
+gcloud secrets create trackrat-wmata-api-key --data-file=-
+gcloud secrets create trackrat-metra-api-token --data-file=-
 ```
 
 ### Terraform State Bucket

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -5,7 +5,7 @@
 SwiftUI app for tracking trains across 11 transit systems: NJ Transit, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, and WMATA (DC Metro). Features Live Activities, track predictions (Owl), route alerts with recurring train subscriptions, congestion maps, multi-leg trip search, and Pro subscription.
 
 - **iOS 18.0+** deployment target
-- **Xcode 15.0+** required
+- **Xcode 16.0+** required
 
 ## Architecture
 
@@ -28,10 +28,11 @@ TrackRat/
 ├── App/              # TrackRatApp.swift, AppState
 ├── Views/
 │   ├── Screens/      # 16 screen-level views
-│   └── Components/   # 23 reusable UI components
-├── Models/           # Data models, API responses, DeepLink, CompletedTrip
+│   ├── Components/   # 23 reusable UI components
+│   └── Paywall/      # PaywallView, ProFeatureLockView
+├── Models/           # Train, TrainV2, V2APIModels, TrainSystem, TripOption, CompletedTrip, DeepLink
 ├── Services/         # 14 singleton services
-├── Shared/           # Stations, StationData, StationCoordinates, StationDepartures, LiveActivityModels
+├── Shared/           # Stations, StationData, StationCoordinates, StationDepartures, LiveActivityModels, RouteTopology, RouteShapes
 ├── Theme/            # TrackRatTheme.swift
 ├── Utilities/        # Extensions.swift, Logger.swift
 └── Resources/        # Assets, Info.plist
@@ -135,14 +136,12 @@ Physical device recommended for:
 - Live Activity behavior
 - Performance profiling
 
-Use `LiveActivityDebugView` for testing Live Activity states in simulator.
-
 ## Important Notes
 
 - All timestamps use Eastern Time zone
 - Train lookup supports both IDs and train numbers
 - Pro subscription offers 1-week free trial via Apple introductory offer
-- `debugOverrideEnabled = true` gives all users Pro features during soft launch
+- `debugOverrideEnabled` in SubscriptionService controls Pro feature override (defaults to `false`)
 
 ---
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -193,15 +193,16 @@ TrackRatTests/                   # Test suite
 ├── Models/                     # Model tests
 ├── Services/                   # Service tests
 ├── ViewModels/                 # ViewModel tests
+├── Views/                      # View tests (AlertConfiguration, LineSelection)
 ├── TestUtilities/              # Test helpers
-└── TestFixtures/               # JSON fixtures
+└── TestFixtures/               # Swift test data (TrainTestData)
 ```
 
 ## 🚀 Getting Started
 
 ### Prerequisites
 - macOS 14.0+ (Sonoma or later)
-- Xcode 15.0+
+- Xcode 16.0+
 - iOS 18.0+ deployment target
 - Apple Developer account (for device testing)
 
@@ -288,7 +289,7 @@ See [CLAUDE.md](CLAUDE.md) for complete technical details and improvement areas.
 - Use `async/await` for asynchronous code
 
 ### Debugging Tips
-1. **Live Activities**: Use `LiveActivityDebugView` for testing states
+1. **Live Activities**: Test on physical device; use Console.app for APNS logs
 2. **Push Notifications**: Monitor Console.app for APNS logs
 3. **Network Requests**: Enable network debugging in Xcode
 4. **Memory Leaks**: Use Instruments to detect retain cycles
@@ -318,7 +319,7 @@ See [CLAUDE.md](CLAUDE.md) for complete technical details and improvement areas.
 ### Data Protection
 - **No User Accounts**: No personal data stored
 - **Local Storage Only**: Preferences in UserDefaults
-- **No Tracking**: No analytics or advertising SDKs
+- **No Third-Party SDKs**: No analytics or advertising SDKs; anonymous usage stats sent to backend only
 - **Secure Communication**: HTTPS for all API calls
 
 ### Permissions Required

--- a/webpage_v2/CLAUDE.md
+++ b/webpage_v2/CLAUDE.md
@@ -262,7 +262,7 @@ Use `getStatusBadgeClass()` from `utils/formatting.ts`:
 - **In-Memory Cache**: No IndexedDB, clears on refresh
 - **LocalStorage Only**: No backend user preferences
 - **Static Station List**: No dynamic station API calls
-- **No Code Splitting**: Small enough to ship as single bundle
+- **Minimal Code Splitting**: `React.lazy()` used for heavy components (e.g., RouteMap)
 
 ## Data Model
 


### PR DESCRIPTION
## Summary

Weekly documentation accuracy audit. Cross-referenced all CLAUDE.md and README.md files against the current codebase and fixed every stale or inaccurate claim found.

**Files changed:** 9 (CLAUDE.md, README.md, backend_v2/README.md, ios/CLAUDE.md, ios/README.md, android/CLAUDE.md, android/README.md, infra_v2/README.md, webpage_v2/CLAUDE.md)

### Key fixes

- **backend_v2/README.md**: Scheduler times corrected (4:00/4:30 AM → 12:30/12:45 AM ET), NJT discovery stations updated (7 → 21), PATCO data source fixed (SEPTA → National RTAP), test listing updated to reflect actual unit/integration/e2e structure
- **ios/CLAUDE.md + README.md**: Xcode version 15 → 16 (required for iOS 18 target), added RouteTopology + RouteShapes to Shared/ listing, added Paywall/ to project structure, removed nonexistent LiveActivityDebugView, fixed debugOverrideEnabled (defaults to false, not true), fixed privacy section contradiction
- **infra_v2/README.md**: Secret count 5 → 8, added missing apns-auth-key, wmata-api-key, metra-api-token
- **README.md (root)**: Amtrak coverage broadened beyond "Northeast Corridor", PATCO terminal name corrected, Xcode prerequisite updated
- **android/CLAUDE.md + README.md**: Fixed 6 directory descriptions (utils, services, map, profile, api, preferences)
- **webpage_v2/CLAUDE.md**: "No Code Splitting" → "Minimal Code Splitting" (React.lazy used)
- **CLAUDE.md (root)**: Added cross-references to ios/CLAUDE.md and android/CLAUDE.md, added migrations/ to DB directory listing

## Test plan

- [ ] Verify all listed file paths exist in the repo
- [ ] Confirm scheduler times match `backend_v2/src/trackrat/services/scheduler.py`
- [ ] Confirm NJT discovery stations match `backend_v2/src/trackrat/config/stations/njt.py`
- [ ] Confirm infra secrets match `infra_v2/terraform/secrets.tf`

https://claude.ai/code/session_01AC43SA7mSzNtEGpBDYCVFP