### PR TITLE
Improve Live Activity cache handling on app foreground

### DIFF
--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -55,6 +55,15 @@ struct TrackRatApp: App {
                     SubscriptionService.shared.refreshOnForeground()
                     // Re-sync route alert subscriptions if stale (e.g. after server DB restore)
                     AlertSubscriptionService.shared.syncIfNeeded()
+                    // Refresh Live Activity's cached train data on foreground.
+                    // The 30s polling Timer is suspended while backgrounded and resumes on
+                    // its next scheduled fire, so the cache can be stale (or expired past
+                    // the 5min ceiling) when the user taps the Live Activity. Refreshing
+                    // here writes fresh data to TrainCacheService so the deep-link
+                    // navigation into TrainDetailsView can render progress instantly.
+                    if LiveActivityService.shared.isActivityActive {
+                        Task { await LiveActivityService.shared.refreshCurrentActivity() }
+                    }
                 case .inactive:
                     print("📱 Scene Phase Inactive")
                 case .background:

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -979,23 +979,18 @@ class TrainDetailsViewModel: ObservableObject {
         let trainIdentifier = trainNumber ?? databaseId.map(String.init) ?? ""
         let effectiveDate = journeyDate ?? Date()
 
-        // PRIORITY 1: Check cache first (will have full train data with stops from previous visits)
-        // Skip stale cache (>60s) to avoid showing outdated data when resuming from background
-        // (e.g., tapping Live Activity after app was suspended — polling timer doesn't fire in background)
+        // PRIORITY 1: Render any non-expired cache instantly, reconcile in background.
+        // The 5-minute isExpired ceiling in TrainCacheService bounds staleness; the
+        // background refresh corrects any drift. Critical for Live Activity taps: the
+        // Activity's ContentState has progress info but no stops array, so the cache
+        // (written by LiveActivityService.fetchAndUpdateTrain) is the only instant
+        // source of departed-stops state.
         if !trainIdentifier.isEmpty,
-           let cached = cacheService.getCachedTrain(trainNumber: trainIdentifier, date: effectiveDate),
-           cached.ageSeconds <= 60 {
-            // Load from cache immediately - NO loading indicator
+           let cached = cacheService.getCachedTrain(trainNumber: trainIdentifier, date: effectiveDate) {
             print("📦 Loading from cache (\(cached.ageSeconds)s old) - instant display")
             train = cached.train
             updateComputedProperties()
-
-            // Only fetch fresh data in background if cache is older than 30 seconds
-            if cached.ageSeconds > 30 {
-                await refreshTrainDetailsInBackground(fromStationCode: fromStationCode, toStationCode: toStationCode, selectedDestinationName: selectedDestinationName)
-            } else {
-                print("📦 Cache is fresh (\(cached.ageSeconds)s old) - skipping background refresh")
-            }
+            await refreshTrainDetailsInBackground(fromStationCode: fromStationCode, toStationCode: toStationCode, selectedDestinationName: selectedDestinationName)
             return
         }
 


### PR DESCRIPTION
## Summary
This PR improves the reliability of displaying train data when users tap a Live Activity notification after the app has been backgrounded. It removes overly aggressive cache expiration logic and ensures fresh data is available when navigating from Live Activities.

## Key Changes

- **TrainDetailsView**: Simplified cache validation logic
  - Removed the 60-second staleness threshold that was skipping valid cached data
  - Now uses the 5-minute expiration ceiling from `TrainCacheService` as the source of truth
  - Always performs a background refresh to reconcile any drift, rather than conditionally refreshing based on a 30-second threshold
  - Updated comments to clarify that Live Activities provide progress info but lack the stops array, making the cache the only instant source for departed-stops state

- **TrackRatApp**: Added foreground refresh for Live Activities
  - When the app returns to foreground, explicitly refresh the current Live Activity's cached train data if one is active
  - This addresses the gap where the 30-second polling timer is suspended while backgrounded and may not fire immediately upon resuming
  - Ensures `TrainCacheService` has fresh data before the user navigates into `TrainDetailsView` via the Live Activity deep link

## Implementation Details

The changes work together to solve a timing issue: when a user taps a Live Activity after the app has been suspended, the polling timer hasn't fired yet, so the cache may be stale or expired. By refreshing on foreground and removing the aggressive 60-second cache rejection, the UI can now render train progress instantly from the cache while a background refresh corrects any data drift.

https://claude.ai/code/session_01RSigL8EfZCpprMYAea2v5V