### PR TITLE
Fix cancellation rate underreporting for intermediate-stop routes

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -341,10 +341,12 @@ async def _calculate_route_stats_sql(
         line_filter = "AND tj.line_code = ANY(:line_codes)"
 
     # Build the route_journeys CTE SQL (reused by stats and track queries)
-    # Non-cancelled trains require stops at both origin AND destination.
-    # Cancelled trains only require an origin stop — they never completed the
-    # journey so requiring a destination stop would silently exclude them,
-    # causing cancellation_rate to underreport (shows 0% during disruptions).
+    # Non-cancelled trains are time-windowed by destination arrival.
+    # Cancelled trains are time-windowed by origin departure — they never
+    # arrived, so dest arrival is NULL (and for NJT intermediate stops even
+    # scheduled_arrival is NULL, since the schedule time lives in
+    # scheduled_departure). Using dest arrival for cancelled trains silently
+    # excludes them, making cancellation_rate read 0% during disruptions.
     route_journeys_cte = f"""
         SELECT tj.id AS journey_id, tj.is_cancelled
         FROM train_journeys tj
@@ -354,7 +356,8 @@ async def _calculate_route_stats_sql(
           {train_filter}
           {line_filter}
           AND (
-              -- Non-cancelled: require stops at both origin and destination
+              -- Non-cancelled: require stops at both origin and destination,
+              -- time-windowed by destination arrival.
               (NOT tj.is_cancelled AND EXISTS (
                   SELECT 1 FROM journey_stops fs
                   WHERE fs.journey_id = tj.id
@@ -368,31 +371,24 @@ async def _calculate_route_stats_sql(
                     )
               ))
               OR
-              -- Cancelled: require origin stop OR full journey covering both stations
-              (tj.is_cancelled AND (
-                  EXISTS (
-                      SELECT 1 FROM journey_stops fs
-                      WHERE fs.journey_id = tj.id
-                        AND fs.station_code = ANY(:from_codes)
-                        AND EXISTS (
+              -- Cancelled: time-window by origin departure. Require a
+              -- destination stop after origin when the stop list is complete;
+              -- allow origin-only for reconciled SCHEDULED trains where stop
+              -- backfill failed.
+              (tj.is_cancelled AND EXISTS (
+                  SELECT 1 FROM journey_stops fs
+                  WHERE fs.journey_id = tj.id
+                    AND fs.station_code = ANY(:from_codes)
+                    {origin_time_filter}
+                    AND (
+                        NOT tj.has_complete_journey
+                        OR EXISTS (
                             SELECT 1 FROM journey_stops ts
                             WHERE ts.journey_id = tj.id
                               AND ts.station_code = ANY(:to_codes)
                               AND ts.stop_sequence > fs.stop_sequence
-                              {dest_time_filter}
                         )
-                  )
-                  OR
-                  -- Cancelled trains without full stop list but with origin stop
-                  -- (e.g. reconciled SCHEDULED trains where stop backfill failed).
-                  -- Uses origin departure time for sub-day filtering since there's
-                  -- no destination stop to filter on.
-                  (NOT tj.has_complete_journey AND EXISTS (
-                      SELECT 1 FROM journey_stops fs
-                      WHERE fs.journey_id = tj.id
-                        AND fs.station_code = ANY(:from_codes)
-                        {origin_time_filter}
-                  ))
+                    )
               ))
           )
         ORDER BY tj.journey_date DESC

--- a/backend_v2/tests/unit/api/test_route_history.py
+++ b/backend_v2/tests/unit/api/test_route_history.py
@@ -1809,3 +1809,189 @@ class TestCancelledTrainsWithoutDestinationStops:
             f"Cancelled train from NB should not match NY→TR route, "
             f"got {result['total_journeys']} journeys"
         )
+
+
+@pytest.mark.asyncio
+class TestCancelledTrainsWithSubDayWindow:
+    """Verify cancelled trains are counted in sub-day (hours=N) windows.
+
+    Regression: for NJT trains whose destination is an intermediate stop
+    (e.g. NY→Hamilton on a NY→Trenton train), cancelled journeys have NULL
+    actual_arrival AND NULL scheduled_arrival at the destination stop — NJT
+    only populates scheduled_departure at intermediate stops. Filtering the
+    window by destination arrival therefore excludes every cancelled train
+    on an intermediate-destination route, making cancellation_rate read 0%
+    during disruptions even when the per-train display shows "Cancelled".
+    """
+
+    async def test_cancelled_train_with_intermediate_dest_counts_in_hour_window(
+        self, db_session: AsyncSession
+    ):
+        """NJT-shaped cancelled train: dest stop has NULL arrival fields.
+
+        Origin departure is inside the 1-hour window; destination arrival
+        fields are NULL (NJT intermediate-stop shape). The train must still
+        be counted in the windowed aggregate.
+        """
+        # Cancelled train: origin NY @ BASE_TIME+30min, dest HL has sched_dep
+        # only (no scheduled_arrival, no actual_arrival) — matches NJT's
+        # intermediate-stop data shape.
+        await _create_journey(
+            db_session,
+            train_id="3887",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME + timedelta(minutes=30),
+                },
+                {
+                    "station_code": "HL",
+                    "stop_sequence": 11,
+                    "scheduled_departure": BASE_TIME + timedelta(minutes=90),
+                    # scheduled_arrival and actual_arrival both NULL.
+                },
+            ],
+            is_cancelled=True,
+        )
+        # One non-cancelled train that completes normally in the window.
+        await _create_journey(
+            db_session,
+            train_id="3885",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME,
+                    "actual_departure": BASE_TIME,
+                },
+                {
+                    "station_code": "HL",
+                    "stop_sequence": 11,
+                    "scheduled_arrival": BASE_TIME + timedelta(minutes=55),
+                    "actual_arrival": BASE_TIME + timedelta(minutes=55),
+                },
+            ],
+        )
+        await db_session.commit()
+
+        # 1-hour window centered so both trains' origin departures fall inside.
+        now = BASE_TIME + timedelta(hours=1)
+        cutoff = now - timedelta(hours=1)
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="NJT",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["HL"],
+            cutoff_time=cutoff,
+            now=now,
+        )
+
+        assert result["total_journeys"] == 2, (
+            f"Expected 2 journeys in 1-hour window (1 running + 1 cancelled "
+            f"with intermediate destination), got {result['total_journeys']}. "
+            "Cancelled trains must be windowed by origin departure, not by "
+            "destination arrival (which is NULL for NJT intermediate stops)."
+        )
+        assert result["cancellation_rate"] == pytest.approx(50.0, abs=1), (
+            f"Expected 50% cancellation (1 of 2), got "
+            f"{result['cancellation_rate']}%. Matches the NYP→Hamilton "
+            "production bug where train 3887 showed Cancelled on the train "
+            "card but the aggregate read 0%."
+        )
+
+    async def test_cancelled_train_excluded_when_origin_departure_outside_window(
+        self, db_session: AsyncSession
+    ):
+        """Cancelled trains outside the window must not leak in.
+
+        Guards against a naive fix that drops the time filter entirely.
+        """
+        # Cancelled train whose origin departure is 3 hours before `now`.
+        await _create_journey(
+            db_session,
+            train_id="old_cancelled",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": BASE_TIME - timedelta(hours=3),
+                },
+                {
+                    "station_code": "HL",
+                    "stop_sequence": 11,
+                    "scheduled_departure": BASE_TIME - timedelta(hours=2),
+                },
+            ],
+            is_cancelled=True,
+        )
+        await db_session.commit()
+
+        now = BASE_TIME
+        cutoff = now - timedelta(hours=1)
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="NJT",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["HL"],
+            cutoff_time=cutoff,
+            now=now,
+        )
+
+        assert result["total_journeys"] == 0, (
+            f"Cancelled train with origin departure 3h outside the 1h window "
+            f"must not be counted, got {result['total_journeys']}"
+        )
+
+    async def test_cancelled_origin_only_included_in_hour_window(
+        self, db_session: AsyncSession
+    ):
+        """Reconciled SCHEDULED train (no dest stop) still counted in window."""
+        cancelled_journey = TrainJourney(
+            train_id="no_dest_cancelled",
+            journey_date=BASE_DATE,
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            observation_type="SCHEDULED",
+            scheduled_departure=BASE_TIME + timedelta(minutes=10),
+            is_cancelled=True,
+            cancellation_reason="Not observed in real-time feed",
+            has_complete_journey=False,
+            stops_count=1,
+        )
+        db_session.add(cancelled_journey)
+        await db_session.flush()
+        db_session.add(
+            JourneyStop(
+                journey_id=cancelled_journey.id,
+                station_code="NY",
+                station_name="New York Penn Station",
+                stop_sequence=None,
+                scheduled_departure=BASE_TIME + timedelta(minutes=10),
+            )
+        )
+        await db_session.commit()
+
+        now = BASE_TIME + timedelta(hours=1)
+        cutoff = now - timedelta(hours=1)
+        result = await _calculate_route_stats_sql(
+            db=db_session,
+            data_source="NJT",
+            start_date=BASE_DATE - timedelta(days=1),
+            end_date=BASE_DATE + timedelta(days=1),
+            from_codes=["NY"],
+            to_codes=["HL"],
+            cutoff_time=cutoff,
+            now=now,
+        )
+
+        assert result["total_journeys"] == 1
+        assert result["cancellation_rate"] == 100.0


### PR DESCRIPTION
## Summary
Fixes a regression where cancelled trains on intermediate-destination routes (e.g., NY→Hamilton on a NY→Trenton train) were excluded from cancellation rate calculations, causing the metric to incorrectly read 0% during disruptions even when individual trains showed "Cancelled".

## Root Cause
NJT trains destined for intermediate stops have NULL `actual_arrival` and `scheduled_arrival` fields at the destination stop—only `scheduled_departure` is populated. The previous query logic filtered cancelled trains by destination arrival time, which silently excluded all cancelled trains on intermediate-stop routes since their destination arrival was NULL.

## Key Changes
- **Refactored cancelled train time-windowing logic**: Changed from filtering by destination arrival (which is NULL for intermediate stops) to filtering by origin departure time
- **Simplified conditional logic**: Consolidated the cancelled train matching into a single EXISTS clause that:
  - Always filters by origin departure time (via `origin_time_filter`)
  - Requires a destination stop when `has_complete_journey=true` (normal case)
  - Allows origin-only matches when `has_complete_journey=false` (reconciled SCHEDULED trains where stop backfill failed)
- **Updated comments**: Clarified the distinction between non-cancelled trains (windowed by destination arrival) and cancelled trains (windowed by origin departure)

## Testing
Added comprehensive regression tests in `TestCancelledTrainsWithSubDayWindow`:
- Verifies cancelled trains with intermediate destinations are counted in hourly windows
- Ensures cancelled trains outside the window are properly excluded
- Confirms origin-only cancelled trains (reconciled SCHEDULED) are still counted

https://claude.ai/code/session_01Rs7miUhZ6RdpzHW6F7JHq2