### PR TITLE
Add recent departures endpoint and UI for recently-departed trains

### DIFF
--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -215,6 +215,65 @@ async def get_departures(
     return response
 
 
+@router.get("/recent-departures", response_model=DeparturesResponse)
+@handle_errors
+async def get_recent_departures(
+    from_station: str = Query(
+        ...,
+        alias="from",
+        min_length=2,
+        max_length=10,
+        description="Departure station code",
+    ),
+    to_station: str | None = Query(
+        None,
+        alias="to",
+        min_length=2,
+        max_length=10,
+        description="Arrival station code",
+    ),
+    window_minutes: int = Query(
+        120,
+        ge=1,
+        le=240,
+        description="Minutes to look back for recently-departed trains",
+    ),
+    data_sources: str | None = Query(
+        None,
+        description="Comma-separated list of data sources to include: NJT,AMTRAK,PATH,PATCO,LIRR,MNR,SUBWAY,BART,MBTA,METRA,WMATA. Default: all",
+    ),
+    limit: int = Query(50, le=1000, description="Maximum results"),
+    db: AsyncSession = Depends(get_db),
+) -> DeparturesResponse:
+    """Get recently-departed trains from a station.
+
+    Mirrors /departures but returns trains whose scheduled departure from the
+    origin station was in the past ``window_minutes``, including cancellations
+    and completed journeys. Results are sorted most-recent-first.
+    """
+    logger.info(
+        "get_recent_departures_request",
+        from_station=from_station,
+        to_station=to_station,
+        window_minutes=window_minutes,
+        data_sources=data_sources,
+    )
+
+    source_list: list[str] | None = None
+    if data_sources:
+        source_list = [s.strip().upper() for s in data_sources.split(",") if s.strip()]
+
+    service = DepartureService()
+    return await service.get_recent_departures(
+        db,
+        from_station,
+        to_station,
+        window_minutes=window_minutes,
+        limit=limit,
+        data_sources=source_list,
+    )
+
+
 @router.get("/{train_id}", response_model=TrainDetailsResponse)
 @handle_errors
 async def get_train_details(

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -576,6 +576,182 @@ class DepartureService:
             },
         )
 
+    async def get_recent_departures(
+        self,
+        db: AsyncSession,
+        from_station: str,
+        to_station: str | None = None,
+        window_minutes: int = 120,
+        limit: int = 50,
+        data_sources: list[str] | None = None,
+    ) -> DeparturesResponse:
+        """Get recently-departed trains from a station.
+
+        Returns trains whose scheduled departure from the origin station was
+        within the last ``window_minutes``, including cancellations and
+        completed journeys. Sorted by scheduled departure, most recent first.
+
+        Unlike ``get_departures``, this intentionally bypasses the
+        ``is_expired`` / ``is_completed`` / ``hide_departed`` filters so that
+        finished trips remain visible. No JIT refresh or GTFS merge — the
+        data is historical.
+        """
+        now = now_et()
+        window_start = now - timedelta(minutes=window_minutes)
+
+        # journey_date range spans yesterday→today to handle overnight journeys
+        # scheduled before midnight for trains observed past midnight.
+        journey_date_filter = and_(
+            TrainJourney.journey_date >= (window_start.date() - timedelta(days=1)),
+            TrainJourney.journey_date <= now.date(),
+        )
+
+        allowed_sources = data_sources if data_sources else ALL_DATA_SOURCES
+        from_codes = expand_station_codes(from_station)
+        to_codes = expand_station_codes(to_station) if to_station else []
+
+        recent_filters = [
+            JourneyStop.scheduled_departure >= window_start,
+            JourneyStop.scheduled_departure < now,
+            journey_date_filter,
+            TrainJourney.data_source.in_(allowed_sources),
+            # A train counts as "recent" if it actually left the origin or
+            # was cancelled. Excludes SCHEDULED trains that never ran and
+            # weren't marked as cancelled (no useful signal for the user).
+            or_(
+                JourneyStop.has_departed_station.is_(True),
+                TrainJourney.is_cancelled.is_(True),
+            ),
+        ]
+
+        stmt = (
+            select(TrainJourney)
+            .join(
+                JourneyStop,
+                and_(
+                    JourneyStop.journey_id == TrainJourney.id,
+                    JourneyStop.station_code.in_(from_codes),
+                ),
+            )
+            .where(and_(*recent_filters))
+            .options(selectinload(TrainJourney.stops))
+            .order_by(JourneyStop.scheduled_departure.desc())
+        )
+
+        result = await db.execute(stmt)
+        journeys = list(result.scalars().unique().all())
+
+        # Deduplicate by train_id (same logic as get_departures): keeps the
+        # first (most-recent) occurrence per train_id.
+        seen_train_ids: set[str] = set()
+        unique_journeys: list[TrainJourney] = []
+        for journey in journeys:
+            train_id = journey.train_id
+            if train_id and train_id not in seen_train_ids:
+                seen_train_ids.add(train_id)
+                unique_journeys.append(journey)
+
+        departures: list[TrainDeparture] = []
+        for journey in unique_journeys:
+            from_stop = None
+            to_stop = None
+            for stop in sorted(journey.stops, key=lambda s: s.stop_sequence or 0):
+                if stop.station_code in from_codes and not from_stop:
+                    from_stop = stop
+                elif to_station and stop.station_code in to_codes and from_stop:
+                    if (stop.stop_sequence or 0) > (from_stop.stop_sequence or 0):
+                        to_stop = stop
+                        break
+
+            if not from_stop or (to_station and not to_stop):
+                continue
+
+            train_position = self._calculate_train_position(journey)
+            departure = TrainDeparture(
+                train_id=journey.train_id,
+                journey_date=journey.journey_date,
+                line=LineInfo(
+                    code=journey.line_code or "UNK",
+                    name=journey.line_name or journey.line_code or "Unknown",
+                    color=(journey.line_color or "#000000").strip(),
+                ),
+                destination=journey.destination,
+                departure=StationInfo(
+                    code=from_station,
+                    name=get_station_name(from_station),
+                    scheduled_time=from_stop.scheduled_departure
+                    or from_stop.scheduled_arrival,
+                    # See get_departures for max() rationale re: NJT semantics.
+                    updated_time=(
+                        max(from_stop.updated_departure, from_stop.updated_arrival)
+                        if from_stop.updated_departure and from_stop.updated_arrival
+                        else from_stop.updated_departure or from_stop.updated_arrival
+                    ),
+                    actual_time=from_stop.actual_departure or from_stop.actual_arrival,
+                    track=from_stop.track,
+                ),
+                arrival=(
+                    StationInfo(
+                        code=to_station,
+                        name=get_station_name(to_station),
+                        scheduled_time=to_stop.scheduled_arrival
+                        or to_stop.scheduled_departure,
+                        updated_time=to_stop.updated_arrival
+                        or to_stop.updated_departure,
+                        actual_time=to_stop.actual_arrival or to_stop.actual_departure,
+                        track=to_stop.track,
+                    )
+                    if to_stop and to_station
+                    else None
+                ),
+                train_position=train_position,
+                data_freshness=DataFreshness(
+                    last_updated=journey.last_updated_at or journey.first_seen_at,
+                    age_seconds=int(
+                        safe_datetime_subtract(
+                            now_et(),
+                            journey.last_updated_at
+                            or journey.first_seen_at
+                            or now_et(),
+                        ).total_seconds()
+                    ),
+                    update_count=journey.update_count,
+                ),
+                data_source=journey.data_source,
+                observation_type=get_effective_observation_type(journey),
+                is_cancelled=journey.is_cancelled,
+                cancellation_reason=journey.cancellation_reason,
+                is_expired=journey.is_expired or False,
+            )
+            departures.append(departure)
+
+        limited_departures = departures[:limit]
+
+        has_direct_route = True
+        if to_station:
+            has_direct_route = _has_direct_route(
+                from_station, to_station, allowed_sources
+            )
+
+        return DeparturesResponse(
+            departures=limited_departures,
+            has_direct_route=has_direct_route,
+            metadata={
+                "from_station": {
+                    "code": from_station,
+                    "name": get_station_name(from_station),
+                },
+                "to_station": (
+                    {"code": to_station, "name": get_station_name(to_station)}
+                    if to_station
+                    else None
+                ),
+                "count": len(limited_departures),
+                "window_minutes": window_minutes,
+                "generated_at": now.isoformat(),
+            },
+        )
+
     def _calculate_train_position(self, journey: TrainJourney) -> TrainPosition:
         """
         Calculate current train position.

--- a/backend_v2/tests/integration/test_recent_departures.py
+++ b/backend_v2/tests/integration/test_recent_departures.py
@@ -1,0 +1,330 @@
+"""
+Integration tests for recently-departed trains (DepartureService.get_recent_departures).
+
+The recent-departures endpoint is a sibling to /departures that intentionally
+relaxes the filters (no hide_departed cutoff, no is_expired/is_completed
+exclusion) so that already-departed, completed, and cancelled trains remain
+visible for a short window after they left the origin station.
+"""
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from trackrat.models.database import JourneyStop, TrainJourney
+from trackrat.services.departure import DepartureService
+from trackrat.utils.time import now_et
+
+
+def _make_njt_journey(
+    *,
+    train_id: str,
+    scheduled_departure,
+    origin: str = "NY",
+    destination_code: str = "TR",
+    is_cancelled: bool = False,
+    is_completed: bool = False,
+    is_expired: bool = False,
+    has_departed_station: bool = True,
+    stop_sequence: int = 0,
+) -> TrainJourney:
+    """Build an NJT journey with a single origin stop for concise setup."""
+    journey = TrainJourney(
+        train_id=train_id,
+        journey_date=scheduled_departure.date(),
+        data_source="NJT",
+        line_code="NE",
+        line_name="Northeast Corridor",
+        line_color="#F7505E",
+        destination="Trenton",
+        origin_station_code=origin,
+        terminal_station_code=destination_code,
+        scheduled_departure=scheduled_departure,
+        first_seen_at=now_et() - timedelta(hours=1),
+        last_updated_at=now_et() - timedelta(minutes=5),
+        has_complete_journey=True,
+        update_count=1,
+        is_cancelled=is_cancelled,
+        is_completed=is_completed,
+        is_expired=is_expired,
+    )
+    origin_stop = JourneyStop(
+        station_code=origin,
+        station_name="New York Penn Station",
+        scheduled_departure=scheduled_departure,
+        updated_departure=scheduled_departure,
+        stop_sequence=stop_sequence,
+        track="7",
+        has_departed_station=has_departed_station,
+        actual_departure=scheduled_departure if has_departed_station else None,
+    )
+    journey.stops = [origin_stop]
+    return journey
+
+
+@pytest.mark.asyncio
+class TestRecentDepartures:
+    """DepartureService.get_recent_departures behavioral coverage."""
+
+    async def test_returns_train_that_departed_within_window(
+        self, db_session: AsyncSession
+    ):
+        """A train scheduled 20 min ago with has_departed=True is returned."""
+        service = DepartureService()
+        twenty_min_ago = now_et() - timedelta(minutes=20)
+
+        journey = _make_njt_journey(
+            train_id="3840",
+            scheduled_departure=twenty_min_ago,
+            has_departed_station=True,
+        )
+        db_session.add(journey)
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        assert len(response.departures) == 1
+        assert response.departures[0].train_id == "3840"
+        assert response.metadata["window_minutes"] == 120
+        assert response.metadata["count"] == 1
+
+    async def test_excludes_trains_outside_window(self, db_session: AsyncSession):
+        """A train scheduled 3 hours ago is excluded from a 120-min window."""
+        service = DepartureService()
+
+        old = _make_njt_journey(
+            train_id="3000",
+            scheduled_departure=now_et() - timedelta(hours=3),
+            has_departed_station=True,
+        )
+        recent = _make_njt_journey(
+            train_id="3100",
+            scheduled_departure=now_et() - timedelta(minutes=15),
+            has_departed_station=True,
+        )
+        db_session.add_all([old, recent])
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        train_ids = {d.train_id for d in response.departures}
+        assert train_ids == {"3100"}
+
+    async def test_excludes_future_trains(self, db_session: AsyncSession):
+        """Upcoming trains (scheduled in the future) are never returned here."""
+        service = DepartureService()
+
+        future = _make_njt_journey(
+            train_id="FUTURE1",
+            scheduled_departure=now_et() + timedelta(minutes=30),
+            has_departed_station=False,
+        )
+        db_session.add(future)
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        assert response.departures == []
+
+    async def test_includes_cancelled_train_even_without_has_departed(
+        self, db_session: AsyncSession
+    ):
+        """A cancelled train within the window is returned even if it never departed."""
+        service = DepartureService()
+
+        cancelled = _make_njt_journey(
+            train_id="CXL1",
+            scheduled_departure=now_et() - timedelta(minutes=10),
+            has_departed_station=False,
+            is_cancelled=True,
+        )
+        db_session.add(cancelled)
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        assert len(response.departures) == 1
+        assert response.departures[0].train_id == "CXL1"
+        assert response.departures[0].is_cancelled is True
+
+    async def test_includes_completed_and_expired_trains(
+        self, db_session: AsyncSession
+    ):
+        """is_completed / is_expired journeys remain visible in the recent window.
+
+        This is the key behavioral difference vs /departures, which filters
+        these out. Without it, any train that reached its terminal disappears
+        from the recent list.
+        """
+        service = DepartureService()
+
+        completed = _make_njt_journey(
+            train_id="DONE1",
+            scheduled_departure=now_et() - timedelta(minutes=30),
+            has_departed_station=True,
+            is_completed=True,
+        )
+        expired = _make_njt_journey(
+            train_id="EXP1",
+            scheduled_departure=now_et() - timedelta(minutes=45),
+            has_departed_station=True,
+            is_expired=True,
+        )
+        db_session.add_all([completed, expired])
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        train_ids = {d.train_id for d in response.departures}
+        assert train_ids == {"DONE1", "EXP1"}
+
+    async def test_excludes_scheduled_train_that_never_departed_and_not_cancelled(
+        self, db_session: AsyncSession
+    ):
+        """A past-scheduled train with has_departed=False and not cancelled
+        carries no useful signal (the user can't tell if it ran). Exclude it."""
+        service = DepartureService()
+
+        ghost = _make_njt_journey(
+            train_id="GHOST1",
+            scheduled_departure=now_et() - timedelta(minutes=30),
+            has_departed_station=False,
+            is_cancelled=False,
+        )
+        db_session.add(ghost)
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        assert response.departures == []
+
+    async def test_results_sorted_most_recent_first(self, db_session: AsyncSession):
+        """Results are ordered by scheduled_departure DESC (newest first)."""
+        service = DepartureService()
+
+        oldest = _make_njt_journey(
+            train_id="T_OLDEST",
+            scheduled_departure=now_et() - timedelta(minutes=90),
+            has_departed_station=True,
+        )
+        middle = _make_njt_journey(
+            train_id="T_MIDDLE",
+            scheduled_departure=now_et() - timedelta(minutes=45),
+            has_departed_station=True,
+        )
+        newest = _make_njt_journey(
+            train_id="T_NEWEST",
+            scheduled_departure=now_et() - timedelta(minutes=10),
+            has_departed_station=True,
+        )
+        db_session.add_all([oldest, middle, newest])
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120
+        )
+
+        returned_ids = [d.train_id for d in response.departures]
+        assert returned_ids == ["T_NEWEST", "T_MIDDLE", "T_OLDEST"]
+
+    async def test_respects_limit(self, db_session: AsyncSession):
+        """``limit`` truncates the result set after sorting."""
+        service = DepartureService()
+
+        for i in range(5):
+            db_session.add(
+                _make_njt_journey(
+                    train_id=f"LIM{i}",
+                    scheduled_departure=now_et() - timedelta(minutes=10 + i * 5),
+                    has_departed_station=True,
+                )
+            )
+        await db_session.commit()
+
+        response = await service.get_recent_departures(
+            db_session, from_station="NY", window_minutes=120, limit=3
+        )
+
+        assert len(response.departures) == 3
+        # Most-recent three: LIM0 (10m), LIM1 (15m), LIM2 (20m)
+        assert [d.train_id for d in response.departures] == ["LIM0", "LIM1", "LIM2"]
+
+    async def test_data_source_filter(self, db_session: AsyncSession):
+        """``data_sources`` restricts results to the requested providers."""
+        service = DepartureService()
+
+        njt = _make_njt_journey(
+            train_id="NJT_A",
+            scheduled_departure=now_et() - timedelta(minutes=15),
+            has_departed_station=True,
+        )
+        # Minimal AMTRAK journey reusing the NJT-style helper but switching source
+        amtrak = _make_njt_journey(
+            train_id="A2150",
+            scheduled_departure=now_et() - timedelta(minutes=20),
+            has_departed_station=True,
+        )
+        amtrak.data_source = "AMTRAK"
+        amtrak.line_code = "AM"
+        db_session.add_all([njt, amtrak])
+        await db_session.commit()
+
+        njt_only = await service.get_recent_departures(
+            db_session, from_station="NY", data_sources=["NJT"]
+        )
+        assert {d.train_id for d in njt_only.departures} == {"NJT_A"}
+
+        amtrak_only = await service.get_recent_departures(
+            db_session, from_station="NY", data_sources=["AMTRAK"]
+        )
+        assert {d.train_id for d in amtrak_only.departures} == {"A2150"}
+
+    async def test_destination_filter_requires_forward_sequence(
+        self, db_session: AsyncSession
+    ):
+        """With ``to_station`` set, the stop must come after the origin in the journey."""
+        service = DepartureService()
+
+        journey = _make_njt_journey(
+            train_id="3840",
+            scheduled_departure=now_et() - timedelta(minutes=15),
+            has_departed_station=True,
+        )
+        # Add a downstream stop (Trenton)
+        tr_stop = JourneyStop(
+            station_code="TR",
+            station_name="Trenton",
+            scheduled_arrival=now_et() - timedelta(minutes=15) + timedelta(minutes=60),
+            stop_sequence=1,
+            has_departed_station=False,
+        )
+        journey.stops = journey.stops + [tr_stop]
+        db_session.add(journey)
+        await db_session.commit()
+
+        # NY → TR: should return the train with arrival info populated
+        forward = await service.get_recent_departures(
+            db_session, from_station="NY", to_station="TR"
+        )
+        assert len(forward.departures) == 1
+        assert forward.departures[0].arrival is not None
+        assert forward.departures[0].arrival.code == "TR"
+
+        # TR → NY: NY has sequence 0, TR has sequence 1, so NY can't follow TR
+        reverse = await service.get_recent_departures(
+            db_session, from_station="TR", to_station="NY"
+        )
+        assert reverse.departures == []

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -158,7 +158,49 @@ final class APIService: ObservableObject {
         )
         return result.trains
     }
-    
+
+    /// Fetch recently-departed trains from origin -> destination, sorted most-recent-first.
+    /// Includes cancellations and completed journeys within the given window.
+    func searchRecentTrains(fromStationCode: String, toStationCode: String? = nil, windowMinutes: Int = 120, dataSources: Set<TrainSystem>? = nil) async throws -> [TrainV2] {
+        guard var components = URLComponents(string: "\(baseURL)/v2/trains/recent-departures") else {
+            throw APIError.invalidURL
+        }
+
+        var queryItems = [
+            URLQueryItem(name: "from", value: fromStationCode),
+            URLQueryItem(name: "window_minutes", value: String(windowMinutes)),
+            URLQueryItem(name: "limit", value: APIService.DEPARTURE_LIMIT),
+        ]
+
+        if let toStationCode = toStationCode {
+            queryItems.append(URLQueryItem(name: "to", value: toStationCode))
+        }
+
+        if let dataSources = dataSources, !dataSources.isEmpty {
+            queryItems.append(URLQueryItem(name: "data_sources", value: dataSources.apiDataSources))
+        }
+
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw APIError.invalidURL
+        }
+
+        return try await executeWithRetry {
+            let (data, _) = try await self.session.data(from: url)
+            do {
+                let response = try self.decoder.decode(V2DeparturesResponse.self, from: data)
+                return response.departures.map { self.adaptV2DepartureToTrainV2($0) }
+            } catch {
+                print("🔴 V2 DECODING ERROR (searchRecentTrains): \(error)")
+                if let jsonString = String(data: data, encoding: .utf8) {
+                    print("🔴 RAW DATA: \(jsonString.prefix(500))")
+                }
+                throw error
+            }
+        }
+    }
+
     // MARK: - Service Alerts
 
     func fetchServiceAlerts(dataSource: String) async throws -> [V2ServiceAlert] {

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -56,6 +56,7 @@ struct RouteStatusView: View {
                     operationsSummarySection
                     historySections
                     upcomingTrainsSection
+                    recentTrainsSection
                     serviceAlertsSection
                     alertSubscriptionSection
                 }
@@ -63,6 +64,7 @@ struct RouteStatusView: View {
                 .animation(.easeInOut(duration: 0.3), value: viewModel.filterLoaded)
                 .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingMap)
                 .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingUpcomingTrains)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingRecentTrains)
                 .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingServiceAlerts)
             }
             .background(Color(.systemGroupedBackground))
@@ -496,7 +498,7 @@ struct RouteStatusView: View {
                     Button {
                         selectedTrain = train
                     } label: {
-                        UpcomingTrainRow(train: train, dataSource: train.dataSource)
+                        TrainRow(train: train, dataSource: train.dataSource)
                     }
                     .buttonStyle(.plain)
                 }
@@ -515,6 +517,33 @@ struct RouteStatusView: View {
                         .foregroundColor(.orange)
                         .padding(.top, 4)
                     }
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        }
+    }
+
+    // MARK: - Recent Trains Section
+
+    /// Recently-departed trains shown by their originally scheduled time, with delay/cancellation
+    /// badges. Uses the same row component as Upcoming; hides if nothing recent is available.
+    @ViewBuilder
+    private var recentTrainsSection: some View {
+        if viewModel.isLoadingRecentTrains {
+            upcomingTrainsSkeletonSection
+        } else if !viewModel.recentTrains.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Recent Trains")
+                    .font(.headline)
+
+                ForEach(viewModel.recentTrains.prefix(3)) { train in
+                    Button {
+                        selectedTrain = train
+                    } label: {
+                        TrainRow(train: train, dataSource: train.dataSource, timeMode: .scheduled)
+                    }
+                    .buttonStyle(.plain)
                 }
             }
             .padding()
@@ -889,11 +918,20 @@ private struct ServiceAlertCard: View {
     }
 }
 
-// MARK: - Upcoming Train Row
+// MARK: - Train Row
 
-private struct UpcomingTrainRow: View {
+/// Which time to display in the trailing column.
+/// `.live` shows the best live estimate (updatedTime ?? scheduledTime) — used for upcoming trains.
+/// `.scheduled` always shows the originally scheduled time — used for recent trains so lateness is
+/// communicated solely via the delay badge.
+enum TrainRowTimeMode {
+    case live, scheduled
+}
+
+private struct TrainRow: View {
     let train: TrainV2
     let dataSource: String
+    var timeMode: TrainRowTimeMode = .live
 
     /// Whether this transit system uses synthetic train IDs (e.g., subway, PATCO)
     private var useSyntheticId: Bool {
@@ -943,7 +981,13 @@ private struct UpcomingTrainRow: View {
     }
 
     private var departureTimeString: String {
-        let time = train.departure.updatedTime ?? train.departure.scheduledTime
+        let time: Date?
+        switch timeMode {
+        case .live:
+            time = train.departure.updatedTime ?? train.departure.scheduledTime
+        case .scheduled:
+            time = train.departure.scheduledTime ?? train.departure.updatedTime
+        }
         guard let time = time else { return "--" }
         let formatter = DateFormatter()
         formatter.dateFormat = "h:mm a"
@@ -987,6 +1031,13 @@ final class RouteStatusViewModel: ObservableObject {
     // Upcoming trains
     @Published var upcomingTrains: [TrainV2] = []
     @Published var isLoadingUpcomingTrains = true
+
+    // Recent trains (already departed within the recent window)
+    @Published var recentTrains: [TrainV2] = []
+    @Published var isLoadingRecentTrains = true
+
+    /// Minutes of history for the Recent Trains section.
+    static let recentTrainsWindowMinutes = 120
 
     // History overall loading state (true until first period loads)
     @Published var isLoadingHistory = true
@@ -1106,6 +1157,8 @@ final class RouteStatusViewModel: ObservableObject {
         isLoadingServiceAlerts = true
         upcomingTrains = []
         isLoadingUpcomingTrains = true
+        recentTrains = []
+        isLoadingRecentTrains = true
         isLoadingHistory = true
         historyBySystem = [:]
         discoveredSystems = []
@@ -1137,6 +1190,7 @@ final class RouteStatusViewModel: ObservableObject {
             }
             group.addTask { await self.loadServiceAlerts() }
             group.addTask { await self.loadUpcomingTrains() }
+            group.addTask { await self.loadRecentTrains() }
         }
     }
 
@@ -1461,6 +1515,45 @@ final class RouteStatusViewModel: ObservableObject {
             upcomingTrains = Array(filtered.prefix(5))
         } catch {
             print("⚠️ Failed to load upcoming trains: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Recent Trains
+
+    private func loadRecentTrains() async {
+        isLoadingRecentTrains = true
+        defer { isLoadingRecentTrains = false }
+
+        guard let from = context.effectiveFromStation,
+              let to = context.effectiveToStation else { return }
+        do {
+            let systemsToFetch: Set<TrainSystem>
+            if enabledSystems.isEmpty {
+                systemsToFetch = TrainSystem(rawValue: context.dataSource).map { Set([$0]) } ?? []
+            } else {
+                systemsToFetch = Set(enabledSystems.compactMap { TrainSystem(rawValue: $0) })
+            }
+
+            let trains = try await APIService.shared.searchRecentTrains(
+                fromStationCode: from,
+                toStationCode: to,
+                windowMinutes: Self.recentTrainsWindowMinutes,
+                dataSources: systemsToFetch
+            )
+
+            // Filter by enabled lines (matches loadUpcomingTrains behavior)
+            let filtered: [TrainV2]
+            if enabledLineIds.isEmpty {
+                filtered = trains
+            } else {
+                filtered = trains.filter { train in
+                    enabledLineIds.contains("\(train.dataSource):\(train.line.code)")
+                }
+            }
+
+            recentTrains = Array(filtered.prefix(5))
+        } catch {
+            print("⚠️ Failed to load recent trains: \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
This PR adds a new "Recent Trains" feature that displays trains that have already departed within a configurable time window (default 120 minutes). Unlike the existing departures endpoint, this intentionally includes cancelled, completed, and expired journeys so users can see the history of recently-departed trains.

## Key Changes

### Backend
- **New endpoint**: `GET /v2/trains/recent-departures` that mirrors `/departures` but returns past trains within a time window
- **New service method**: `DepartureService.get_recent_departures()` with relaxed filtering:
  - Includes `is_cancelled`, `is_completed`, and `is_expired` journeys (unlike `/departures`)
  - Filters out "ghost" trains (scheduled but never departed and not cancelled)
  - Respects `window_minutes` parameter (1-240 min, default 120)
  - Supports `data_sources`, `limit`, and optional `to_station` filtering
  - Results sorted by scheduled departure time, most recent first
- **Comprehensive test coverage**: 10 integration tests covering window filtering, cancellations, completed journeys, sorting, limits, and destination filtering

### iOS
- **New API method**: `APIService.searchRecentTrains()` to fetch recent departures
- **UI section**: "Recent Trains" section in `RouteStatusView` showing up to 3 most recent trains
- **New component**: `TrainRowTimeMode` enum to control whether rows display live-estimated or scheduled times
  - Recent trains use `.scheduled` mode so lateness is communicated via delay badges only
  - Upcoming trains continue using `.live` mode
- **ViewModel updates**: `RouteStatusViewModel` now loads recent trains in parallel with other data, with separate loading state

## Implementation Details
- Recent trains are loaded asynchronously alongside upcoming trains and service alerts
- The feature respects the same line and system filters as upcoming trains
- Time window is configurable per-request but defaults to 120 minutes
- Results are deduplicated by train_id (keeping most recent occurrence)
- Destination filtering validates that arrival stop comes after departure stop in journey sequence

https://claude.ai/code/session_01Be3XEHXGMjD1KHRUuyG3oj