### PR TITLE
Add time_from filtering for future-date train schedules

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -183,6 +183,7 @@ class DepartureService:
         # For future dates, use GTFS static schedule data
         if target_date > today:
             from trackrat.services.gtfs import GTFSService
+            from trackrat.utils.time import ensure_timezone_aware
 
             gtfs_service = GTFSService()
             logger.info(
@@ -191,6 +192,11 @@ class DepartureService:
                 from_station=from_station,
                 to_station=to_station,
             )
+            # Normalize time_from to ET-aware so comparisons with parsed
+            # GTFS times (always ET-aware) don't raise TypeError.
+            aware_time_from = (
+                ensure_timezone_aware(time_from) if time_from is not None else None
+            )
             response = await gtfs_service.get_scheduled_departures(
                 db=db,
                 from_station=from_station,
@@ -198,6 +204,7 @@ class DepartureService:
                 target_date=target_date,
                 limit=limit,
                 data_sources=data_sources,
+                time_from=aware_time_from,
             )
             if data_sources:
                 response.departures = [

--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -1258,6 +1258,7 @@ class GTFSService:
         target_date: date,
         limit: int = 50,
         data_sources: list[str] | None = None,
+        time_from: datetime | None = None,
     ) -> DeparturesResponse:
         """Get scheduled departures from GTFS data for a future date.
 
@@ -1268,6 +1269,10 @@ class GTFSService:
             target_date: The date to get schedules for
             limit: Maximum number of results
             data_sources: If provided, only query these data sources
+            time_from: If provided, only return departures at or after this time.
+                Applied after sort, before limit — critical for high-frequency
+                providers (e.g. SUBWAY) whose first `limit` trains would
+                otherwise all fall inside the overnight window.
 
         Returns:
             DeparturesResponse with scheduled trains
@@ -1312,6 +1317,16 @@ class GTFSService:
         # Sort by departure time
         # Use timezone-aware constant for safe comparison with ET-localized times
         departures.sort(key=lambda d: d.departure.scheduled_time or DATETIME_MAX_ET)
+
+        # Drop departures before time_from so `limit` counts trains from the
+        # requested window rather than always from the start of the day.
+        if time_from is not None:
+            departures = [
+                d
+                for d in departures
+                if d.departure.scheduled_time is not None
+                and d.departure.scheduled_time >= time_from
+            ]
 
         # Apply limit
         departures = departures[:limit]

--- a/backend_v2/tests/unit/services/test_gtfs.py
+++ b/backend_v2/tests/unit/services/test_gtfs.py
@@ -1299,3 +1299,114 @@ class TestGetStaticStopTimesLirrFallback:
         assert len(find_calls) == 2
         assert find_calls[0] == ("9999_2026-02-24", "trip_id")
         assert find_calls[1] == ("9999", "train_id")
+
+
+class TestGetScheduledDeparturesTimeFrom:
+    """Tests for `time_from` filtering in get_scheduled_departures().
+
+    High-frequency providers like SUBWAY would otherwise return only the
+    overnight sliver of the day because the first `limit` trains sorted by
+    departure time are all pre-dawn. `time_from` moves the limit window to
+    the caller's time of interest.
+    """
+
+    def setup_method(self):
+        self.service = GTFSService()
+
+    def _make_departure(self, train_id: str, dt: datetime):
+        from trackrat.models.api import (
+            DataFreshness,
+            LineInfo,
+            StationInfo,
+            TrainDeparture,
+            TrainPosition,
+        )
+
+        return TrainDeparture(
+            train_id=train_id,
+            journey_date=dt.date(),
+            line=LineInfo(code="1", name="1", color="#EE352E"),
+            destination="South Ferry",
+            departure=StationInfo(code="S127", name="Times Sq", scheduled_time=dt),
+            arrival=None,
+            train_position=TrainPosition(),
+            data_freshness=DataFreshness(last_updated=dt, age_seconds=0),
+            data_source="SUBWAY",
+            observation_type="SCHEDULED",
+        )
+
+    @pytest.mark.asyncio
+    async def test_time_from_shifts_limit_window(self):
+        """Setting time_from should skip earlier departures before applying limit."""
+        target_date = date(2026, 4, 23)
+        # 10 hourly SUBWAY departures from 00:30 to 09:30 ET
+        mock_deps = [
+            self._make_departure(
+                f"S{i:03d}",
+                ET.localize(datetime.combine(target_date, time(i, 30))),
+            )
+            for i in range(10)
+        ]
+
+        mock_db = AsyncMock()
+        cutoff = ET.localize(datetime.combine(target_date, time(8, 0)))
+
+        with (
+            patch.object(
+                self.service, "get_active_service_ids", return_value={"WD_SUBWAY"}
+            ),
+            patch.object(
+                self.service,
+                "_query_departures_for_source",
+                AsyncMock(return_value=mock_deps),
+            ),
+        ):
+            response = await self.service.get_scheduled_departures(
+                db=mock_db,
+                from_station="S127",
+                to_station=None,
+                target_date=target_date,
+                limit=5,
+                data_sources=["SUBWAY"],
+                time_from=cutoff,
+            )
+
+        # Only 08:30 and 09:30 departures survive the cutoff
+        returned_ids = [d.train_id for d in response.departures]
+        assert returned_ids == ["S008", "S009"]
+
+    @pytest.mark.asyncio
+    async def test_no_time_from_returns_first_limit_of_day(self):
+        """Without time_from, behavior matches pre-fix: earliest N departures."""
+        target_date = date(2026, 4, 23)
+        mock_deps = [
+            self._make_departure(
+                f"S{i:03d}",
+                ET.localize(datetime.combine(target_date, time(i, 30))),
+            )
+            for i in range(10)
+        ]
+
+        mock_db = AsyncMock()
+
+        with (
+            patch.object(
+                self.service, "get_active_service_ids", return_value={"WD_SUBWAY"}
+            ),
+            patch.object(
+                self.service,
+                "_query_departures_for_source",
+                AsyncMock(return_value=mock_deps),
+            ),
+        ):
+            response = await self.service.get_scheduled_departures(
+                db=mock_db,
+                from_station="S127",
+                to_station=None,
+                target_date=target_date,
+                limit=5,
+                data_sources=["SUBWAY"],
+            )
+
+        returned_ids = [d.train_id for d in response.departures]
+        assert returned_ids == ["S000", "S001", "S002", "S003", "S004"]

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -92,7 +92,23 @@ final class APIService: ObservableObject {
         }
         return decoder
     }()
-    
+
+    /// For a future `selectedDate`, project today's wall-clock time-of-day (ET)
+    /// onto it so the backend's limit-50 window lands around the user's current
+    /// commute time rather than always at midnight. Returns nil for today or
+    /// past dates so the existing today-path behavior is unchanged.
+    static func timeFromForFutureDate(_ selectedDate: Date, now: Date = Date()) -> Date? {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York") ?? .current
+        guard let selectedStart = calendar.dateInterval(of: .day, for: selectedDate)?.start,
+              let todayStart = calendar.dateInterval(of: .day, for: now)?.start,
+              selectedStart > todayStart else {
+            return nil
+        }
+        let timeOfDay = now.timeIntervalSince(todayStart)
+        return selectedStart.addingTimeInterval(timeOfDay)
+    }
+
     // MARK: - Train Search
 
     struct DepartureSearchResult {
@@ -240,10 +256,20 @@ final class APIService: ObservableObject {
         ]
 
         if let date = date {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            formatter.timeZone = TimeZone(identifier: "America/New_York")
-            queryItems.append(URLQueryItem(name: "date", value: formatter.string(from: date)))
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            dateFormatter.timeZone = TimeZone(identifier: "America/New_York")
+            queryItems.append(URLQueryItem(name: "date", value: dateFormatter.string(from: date)))
+
+            // For future dates, anchor the backend's `limit` window to the
+            // user's current time-of-day on the selected day. Without this,
+            // high-frequency providers (e.g. SUBWAY) return only the pre-dawn
+            // sliver of the day because all 50 returned trains fall before sunrise.
+            if let futureTimeFrom = Self.timeFromForFutureDate(date) {
+                let isoFormatter = ISO8601DateFormatter()
+                isoFormatter.formatOptions = [.withInternetDateTime]
+                queryItems.append(URLQueryItem(name: "time_from", value: isoFormatter.string(from: futureTimeFrom)))
+            }
         }
 
         if let dataSources = dataSources, !dataSources.isEmpty {

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -552,6 +552,22 @@ class TrainListViewModel: ObservableObject {
             return time1 < time2
         }
     }
+
+    /// Drop trains outside the "next 6 hours" live-board window. Skipped for
+    /// future dates — on those days every train is >6 h from wall-clock now,
+    /// so the filter would wipe the entire response.
+    func filterUpcomingTrains(_ trains: [TrainV2], fromStationCode: String, date: Date) -> [TrainV2] {
+        guard Calendar.current.isDateInToday(date) else { return trains }
+
+        let sixHoursFromNow = Date().addingTimeInterval(6 * 60 * 60)
+        return trains.filter { train in
+            if let minutesAgo = train.minutesSinceDeparture(fromStationCode: fromStationCode) {
+                return minutesAgo <= 10
+            }
+            let departureTime = train.getDepartureTime(fromStationCode: fromStationCode) ?? Date.distantFuture
+            return departureTime <= sixHoursFromNow
+        }
+    }
     
     // Initializer for dependency injection
     @MainActor
@@ -601,16 +617,7 @@ class TrainListViewModel: ObservableObject {
             } else {
                 // Direct results: convert to TrainV2 for existing UI
                 let fetchedTrains = fetchedTrips.compactMap { $0.asTrainV2() }
-                let sixHoursFromNow = Date().addingTimeInterval(6 * 60 * 60)
-
-                let filteredTrains = fetchedTrains.filter { train in
-                    let departureTime = train.getDepartureTime(fromStationCode: fromStationCode) ?? Date.distantFuture
-                    let isWithinTimeWindow = departureTime <= sixHoursFromNow
-                    if let minutesAgo = train.minutesSinceDeparture(fromStationCode: fromStationCode) {
-                        return minutesAgo <= 10
-                    }
-                    return isWithinTimeWindow
-                }
+                let filteredTrains = filterUpcomingTrains(fetchedTrains, fromStationCode: fromStationCode, date: date)
 
                 let uniqueTrains = Array(Dictionary(grouping: filteredTrains, by: \.id).compactMapValues(\.first).values)
                 trains = sortTrainsByDepartureTime(uniqueTrains, fromStationCode: fromStationCode)
@@ -657,17 +664,7 @@ class TrainListViewModel: ObservableObject {
                 isTransferSearch = true
             } else {
                 let fetchedTrains = fetchedTrips.compactMap { $0.asTrainV2() }
-                let sixHoursFromNow = Date().addingTimeInterval(6 * 60 * 60)
-
-                let filteredTrains = fetchedTrains.filter { train in
-                    let departureTime = train.getDepartureTime(fromStationCode: fromStationCode) ?? Date.distantFuture
-                    let isWithinTimeWindow = departureTime <= sixHoursFromNow
-                    if let minutesAgo = train.minutesSinceDeparture(fromStationCode: fromStationCode) {
-                        return minutesAgo <= 10
-                    }
-                    return isWithinTimeWindow
-                }
-
+                let filteredTrains = filterUpcomingTrains(fetchedTrains, fromStationCode: fromStationCode, date: date)
                 let uniqueTrains = Array(Dictionary(grouping: filteredTrains, by: \.id).compactMapValues(\.first).values)
                 let newTrains = sortTrainsByDepartureTime(uniqueTrains, fromStationCode: fromStationCode)
 

--- a/ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift
+++ b/ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift
@@ -140,6 +140,64 @@ class TrainListViewModelTests: XCTestCase {
         XCTAssertEqual(cancelledCount, 1)
     }
 
+    // MARK: - Future-schedule filter tests
+
+    func testFilterUpcomingTrainsRemovesFarFutureTrainsForToday() {
+        let now = Date()
+        let near = MockDataFactory.createMockTrainV2(trainId: "NEAR", departureTime: now.addingTimeInterval(3600))
+        let far = MockDataFactory.createMockTrainV2(trainId: "FAR", departureTime: now.addingTimeInterval(10 * 3600))
+
+        let filtered = viewModel.filterUpcomingTrains([near, far], fromStationCode: "NY", date: now)
+
+        XCTAssertEqual(filtered.map { $0.trainId }, ["NEAR"],
+                       "Today view should keep the 6-hour window and drop trains beyond it")
+    }
+
+    func testFilterUpcomingTrainsKeepsAllTrainsForFutureDate() {
+        let now = Date()
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: now)!
+        let startOfTomorrow = Calendar.current.startOfDay(for: tomorrow)
+
+        // All "tomorrow" trains are > 6h from now; without the fix, 100% get filtered.
+        let earlyMorning = MockDataFactory.createMockTrainV2(trainId: "EARLY",
+                                                             departureTime: startOfTomorrow.addingTimeInterval(3600))
+        let evening = MockDataFactory.createMockTrainV2(trainId: "EVENING",
+                                                        departureTime: startOfTomorrow.addingTimeInterval(18 * 3600))
+
+        let filtered = viewModel.filterUpcomingTrains([earlyMorning, evening],
+                                                      fromStationCode: "NY",
+                                                      date: startOfTomorrow)
+
+        XCTAssertEqual(Set(filtered.map { $0.trainId }), Set(["EARLY", "EVENING"]),
+                       "Future-date view should not apply the 6-hour live-board filter")
+    }
+
+    func testTimeFromForFutureDateProjectsTodaysTimeOfDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        // Today at 15:30 ET; tomorrow at midnight ET (as DateSelectorSheet produces)
+        let today = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 5, day: 4, hour: 15, minute: 30))!
+        let tomorrowStart = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 5, day: 5))!
+
+        let timeFrom = APIService.timeFromForFutureDate(tomorrowStart, now: today)
+
+        XCTAssertNotNil(timeFrom)
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: timeFrom!)
+        XCTAssertEqual(components.year, 2026)
+        XCTAssertEqual(components.month, 5)
+        XCTAssertEqual(components.day, 5)
+        XCTAssertEqual(components.hour, 15)
+        XCTAssertEqual(components.minute, 30)
+    }
+
+    func testTimeFromForFutureDateReturnsNilForToday() {
+        let now = Date()
+        let todayStart = Calendar.current.startOfDay(for: now)
+        XCTAssertNil(APIService.timeFromForFutureDate(todayStart, now: now),
+                     "Today should preserve existing behavior (no time_from sent)")
+    }
+
     // MARK: - Performance Tests
 
     func testLargeDataSetPerformance() {


### PR DESCRIPTION
## Summary
This PR adds support for filtering train departures by a `time_from` parameter to improve schedule results for future dates. High-frequency providers like SUBWAY would otherwise return only pre-dawn trains because the first N results (sorted by departure time) all fall before sunrise. The `time_from` parameter shifts the limit window to the user's current time-of-day on the selected date.

## Key Changes

**Backend (Python)**
- Added `time_from` parameter to `GTFSService.get_scheduled_departures()` that filters departures after sorting but before applying the limit
- Updated `DepartureService.get_departures()` to normalize and pass `time_from` to the GTFS service for future dates
- Added timezone-aware conversion utility to ensure `time_from` comparisons work correctly with ET-localized GTFS times

**iOS (Swift)**
- Added `APIService.timeFromForFutureDate()` helper that projects the user's current wall-clock time-of-day (ET) onto a selected future date
- Modified train search requests to include `time_from` query parameter for future dates (returns nil for today to preserve existing behavior)
- Extracted train filtering logic into `TrainListViewModel.filterUpcomingTrains()` method that:
  - Applies the 6-hour live-board window only for today's view
  - Skips filtering for future dates (where all trains would be >6 hours from wall-clock now)
- Added comprehensive unit tests covering both backend and iOS implementations

## Implementation Details
- The `time_from` filtering is applied **after** sorting by departure time but **before** applying the limit, ensuring the limit window captures trains around the user's commute time rather than always from midnight
- For today's date, the iOS client preserves the existing behavior (no `time_from` sent)
- For future dates, the client calculates `time_from` by taking today's time-of-day and applying it to the selected date in ET timezone
- Timezone handling is critical: GTFS times are always ET-aware, so `time_from` must be normalized to ET before comparison

https://claude.ai/code/session_01WrjcrF8fg45Xaxf4tH1n1H