### PR TITLE
Fix Canal St station name to include N train service

### DIFF
--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -16,9 +16,9 @@ from structlog import get_logger
 from trackrat.api.utils import handle_errors
 from trackrat.collectors.njt.client import NJTransitClient
 from trackrat.config.stations import (
+    STATION_NAMES,
     canonical_station_code,
     expand_station_codes,
-    get_station_name,
 )
 from trackrat.db.engine import get_db, get_session
 from trackrat.models.api import (
@@ -388,7 +388,7 @@ async def get_train_details(
         stop_detail = StopDetails(
             station=SimpleStationInfo(
                 code=stop.station_code,
-                name=get_station_name(stop.station_code) or stop.station_name,
+                name=STATION_NAMES.get(stop.station_code) or stop.station_name or stop.station_code,
             ),
             stop_sequence=stop.stop_sequence or 0,
             scheduled_arrival=stop.scheduled_arrival,

--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -15,7 +15,11 @@ from structlog import get_logger
 
 from trackrat.api.utils import handle_errors
 from trackrat.collectors.njt.client import NJTransitClient
-from trackrat.config.stations import canonical_station_code, expand_station_codes
+from trackrat.config.stations import (
+    canonical_station_code,
+    expand_station_codes,
+    get_station_name,
+)
 from trackrat.db.engine import get_db, get_session
 from trackrat.models.api import (
     DataFreshness,
@@ -384,7 +388,7 @@ async def get_train_details(
         stop_detail = StopDetails(
             station=SimpleStationInfo(
                 code=stop.station_code,
-                name=stop.station_name,
+                name=get_station_name(stop.station_code) or stop.station_name,
             ),
             stop_sequence=stop.stop_sequence or 0,
             scheduled_arrival=stop.scheduled_arrival,

--- a/backend_v2/src/trackrat/config/stations/subway.py
+++ b/backend_v2/src/trackrat/config/stations/subway.py
@@ -457,7 +457,7 @@ SUBWAY_STATION_NAMES: dict[str, str] = {
     "SN08": "Kings Hwy (N/W)",
     "SN09": "Avenue U (N/W)",
     "SN10": "86 St (N/W)",
-    "SQ01": "Canal St (Q)",
+    "SQ01": "Canal St (N/Q)",
     "SQ03": "72 St (Q)",
     "SQ04": "86 St (Q)",
     "SQ05": "96 St (Q)",

--- a/backend_v2/tests/unit/config/test_stations.py
+++ b/backend_v2/tests/unit/config/test_stations.py
@@ -99,6 +99,16 @@ class TestStationMapping:
         # Function should either return the code itself or a default
         assert result is not None
 
+    def test_canal_st_bridge_platform_lists_n_and_q(self):
+        """SQ01 is the BMT Broadway bridge platform at Canal St, shared by
+        the Q (always) and the N (via Manhattan Bridge during weekday daytime).
+        MTA's GTFS static feed only lists Q, but users boarding an N train
+        here expect to see N in the displayed name."""
+        assert SUBWAY_STATION_NAMES["SQ01"] == "Canal St (N/Q)"
+        assert get_station_name("SQ01") == "Canal St (N/Q)"
+        # Sibling tunnel platform stays untouched
+        assert SUBWAY_STATION_NAMES["SR23"] == "Canal St (N/R/W)"
+
     def test_mapping_completeness(self):
         """Test that all expected stations are mapped."""
         expected_internal_codes = [

--- a/backend_v2/tests/unit/config/test_stations.py
+++ b/backend_v2/tests/unit/config/test_stations.py
@@ -976,6 +976,108 @@ class TestSubwayGTFSStopMapping:
             SUBWAY_STATION_NAMES["SA64"] == "111 St (A)"
         ), f"SA64 should be '111 St (A)' but got '{SUBWAY_STATION_NAMES['SA64']}'"
 
+    def test_subway_route_topology_consistent_with_station_name_suffixes(self):
+        """For every (route, station) pair declared in route_topology, if the
+        station's display name carries a route suffix in parentheses, that
+        suffix must include every line_code the route uses.
+
+        Catches the class of bug where a station is wired into a route but its
+        displayed name doesn't advertise the route letter — for instance, a
+        future regression that drops 'N' from 'Canal St (N/Q)' while SUBWAY_N
+        still lists SQ01, or any analogous mis-edit on other routes.
+
+        Stations with no parenthetical suffix are skipped: those are
+        unambiguous single-line-group stations and don't need disambiguation.
+
+        Normalizations applied (mirroring generate_subway_data.py logic):
+        - Express variants (line_code ending in 'X' e.g. '6X') are stripped by
+          the generator's `_format_route_suffix` and therefore never appear in
+          display names. Skip these line_codes.
+        - Shuttles use 'S' in display names but 'FS'/'GS' line_codes in
+          topology.
+        - Staten Island Railway uses 'SIR' in display names but 'SI'
+          line_code.
+        """
+        import re
+
+        from trackrat.config.route_topology import ALL_ROUTES
+
+        line_code_display = {"FS": "S", "GS": "S", "SI": "SIR"}
+
+        # Known (route_id, station_code) pairs where the display-name suffix
+        # does not include a route's line_code. Each entry is an open bug of
+        # the same class as SQ01/N (MTA GTFS static underreports service
+        # patterns that genuinely share the platform), OR a bug in the
+        # route_topology that lists a station the route doesn't actually
+        # serve. Both need human triage: the fix path differs.
+        #
+        # Entries should be REMOVED from this allowlist as each case is
+        # resolved — either by updating SUBWAY_STATION_NAMES (and the
+        # generator's MANUAL_STATION_ROUTE_ADDITIONS) or by pruning the
+        # station from the route in route_topology.py.
+        #
+        # New entries should NOT be added without investigation. The point of
+        # this test is to catch the class of bug the user reported about
+        # Canal St showing "(Q)" on an N train.
+        known_open_issues: set[tuple[str, str]] = {
+            # 5 train rush-hour Brooklyn extension (runs on 2-line tracks to
+            # Flatbush Av during AM/PM peaks). Real service — station names
+            # should add "5".
+            ("subway-5", "S244"),
+            ("subway-5", "S236"),
+            ("subway-5", "S235"),
+            ("subway-5", "S423"),
+            # 5 train off-peak/weekend local claim on Lexington Av. Less
+            # well-documented than the Brooklyn extension — the 5 normally
+            # runs express on Lex. May indicate route_topology is wrong and
+            # these entries should be pruned from SUBWAY_5.stations instead
+            # of added to station names. Needs verification against MTA
+            # service schedules.
+            ("subway-5", "S639"),
+            ("subway-5", "S638"),
+            ("subway-5", "S633"),
+            ("subway-5", "S627"),
+        }
+
+        suffix_re = re.compile(r"\s*\(([A-Z0-9/]+)\)\s*$")
+        mismatches: list[str] = []
+
+        for route in ALL_ROUTES:
+            if route.data_source != "SUBWAY":
+                continue
+            # Mirror generator: drop X-express variants, remap shuttles/SIR.
+            required = {
+                line_code_display.get(lc, lc)
+                for lc in route.line_codes
+                if not lc.endswith("X")
+            }
+            if not required:
+                continue
+            for code in route.stations:
+                if (route.id, code) in known_open_issues:
+                    continue
+                name = SUBWAY_STATION_NAMES.get(code)
+                if not name:
+                    continue
+                match = suffix_re.search(name)
+                if not match:
+                    continue
+                listed = set(match.group(1).split("/"))
+                missing = required - listed
+                if missing:
+                    mismatches.append(
+                        f"  {route.id}: station {code} = {name!r}, "
+                        f"suffix omits {sorted(missing)}"
+                    )
+
+        assert not mismatches, (
+            "route_topology lists stations whose display-name suffix does "
+            "not include the route's line_code(s). Either fix "
+            "SUBWAY_STATION_NAMES (the station actually serves that route) "
+            "or remove the station from the route topology:\n"
+            + "\n".join(mismatches)
+        )
+
 
 class TestMNRGTFSStopMapping:
     """Tests for Metro-North GTFS stop_id to internal station code mapping.

--- a/scripts/generate_subway_data.py
+++ b/scripts/generate_subway_data.py
@@ -325,6 +325,17 @@ def build_consolidated_stations(
     return consolidated
 
 
+# Manual additions to the GTFS-derived station_routes mapping.
+# Used where MTA's GTFS static feed misses service patterns that are genuinely
+# present in the real world (e.g., platforms shared by multiple routes where
+# only one shows up in the static schedule sample).
+MANUAL_STATION_ROUTE_ADDITIONS: dict[str, set[str]] = {
+    # Canal St BMT Broadway express/bridge platform: both N (via Manhattan
+    # Bridge during weekday daytime) and Q use it; GTFS static only lists Q.
+    "SQ01": {"N"},
+}
+
+
 def build_station_routes(
     trips: list[dict], stop_times: list[dict], stations: list[dict]
 ) -> dict[str, set[str]]:
@@ -346,6 +357,9 @@ def build_station_routes(
         code = gtfs_to_internal.get(parent_id)
         if code:
             station_routes[code].add(route_id)
+
+    for code, extra_routes in MANUAL_STATION_ROUTE_ADDITIONS.items():
+        station_routes[code].update(extra_routes)
 
     return dict(station_routes)
 


### PR DESCRIPTION
## Summary
Updates the Canal St (BMT Broadway bridge platform) station display name to correctly show both N and Q train service, and adds infrastructure to prevent similar mismatches between route topology and station display names in the future.

## Key Changes

- **Station name correction**: Changed `SQ01` display name from "Canal St (Q)" to "Canal St (N/Q)" to reflect that the N train serves this platform via the Manhattan Bridge during weekday daytime hours, even though MTA's GTFS static feed only lists the Q train.

- **Manual route additions**: Added `MANUAL_STATION_ROUTE_ADDITIONS` dictionary in `generate_subway_data.py` to handle cases where MTA's GTFS static feed underreports actual service patterns. This allows the data generator to augment the GTFS-derived station-route mapping with real-world service that isn't captured in the static schedule.

- **Validation test**: Implemented `test_subway_route_topology_consistent_with_station_name_suffixes()` to catch regressions where a station is wired into a route topology but its display name doesn't advertise that route. The test includes:
  - Automatic checking of all subway routes against their station display names
  - Normalization logic for express variants (X suffix), shuttles (FS/GS → S), and Staten Island Railway (SI → SIR)
  - A `known_open_issues` allowlist for documented cases awaiting resolution (5 train Brooklyn extension and Lexington Ave service patterns)

- **API improvement**: Updated `get_train_details()` to use `get_station_name()` for consistent station name display, falling back to the database value if no mapping exists.

- **Test coverage**: Added `test_canal_st_bridge_platform_lists_n_and_q()` to verify the specific fix and prevent regression.

## Implementation Details

The validation test is designed to catch the exact class of bug reported: when a route is listed in route_topology but the station's display name doesn't include that route's line code(s). The allowlist approach allows known issues to be tracked and resolved systematically without blocking the test suite.

https://claude.ai/code/session_011z9MrT6zFkA21vJiPX2Qp7