### PR TITLE
Issue #967: Hide track predictions after train departs origin

### DIFF
--- a/webpage_v2/src/pages/TrainDetailsPage.test.ts
+++ b/webpage_v2/src/pages/TrainDetailsPage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests the shouldShowPredictions logic from TrainDetailsPage.
+ * The actual condition in the component is:
+ *   stationSupported && !predictionStop?.track && !predictionStop?.has_departed_station && !train.is_cancelled
+ */
+function shouldShowPredictions(
+  stationSupported: boolean,
+  predictionStop: { track?: string | null; has_departed_station: boolean } | undefined,
+  isCancelled: boolean,
+): boolean {
+  return (
+    stationSupported &&
+    !predictionStop?.track &&
+    !predictionStop?.has_departed_station &&
+    !isCancelled
+  );
+}
+
+describe('shouldShowPredictions', () => {
+  it('shows predictions when station is supported, no track assigned, not departed, not cancelled', () => {
+    expect(shouldShowPredictions(true, { has_departed_station: false }, false)).toBe(true);
+  });
+
+  it('hides predictions when station is not supported', () => {
+    expect(shouldShowPredictions(false, { has_departed_station: false }, false)).toBe(false);
+  });
+
+  it('hides predictions when track is already assigned', () => {
+    expect(shouldShowPredictions(true, { track: '5', has_departed_station: false }, false)).toBe(false);
+  });
+
+  it('hides predictions when train has departed the origin station', () => {
+    expect(shouldShowPredictions(true, { has_departed_station: true }, false)).toBe(false);
+  });
+
+  it('hides predictions when train is cancelled', () => {
+    expect(shouldShowPredictions(true, { has_departed_station: false }, true)).toBe(false);
+  });
+
+  it('does not crash when predictionStop is undefined (station not found in stops)', () => {
+    // When predictionStop is undefined, optional chaining returns undefined,
+    // and !undefined is true — so only stationSupported gates visibility.
+    // In practice, stationSupported would be false if the station isn't in the stops list.
+    expect(shouldShowPredictions(true, undefined, false)).toBe(true);
+    expect(shouldShowPredictions(false, undefined, false)).toBe(false);
+  });
+
+  it('hides predictions when departed AND track assigned (multiple disqualifiers)', () => {
+    expect(shouldShowPredictions(true, { track: '3', has_departed_station: true }, false)).toBe(false);
+  });
+});

--- a/webpage_v2/src/pages/TrainDetailsPage.tsx
+++ b/webpage_v2/src/pages/TrainDetailsPage.tsx
@@ -174,6 +174,7 @@ export function TrainDetailsPage() {
   const shouldShowPredictions =
     stationSupported &&              // Supported station (from API)
     !predictionStop?.track &&        // No track assigned
+    !predictionStop?.has_departed_station && // Train hasn't left user's origin
     !train.is_cancelled;             // Not cancelled
 
   return (


### PR DESCRIPTION
## Summary
- Add `!predictionStop?.has_departed_station` condition to `shouldShowPredictions` in `TrainDetailsPage.tsx`
- This hides the track predictions section once the train has left the user's boarding station
- Follows the exact same pattern already used by `SimilarTrainsPanel` in the same file (line 270)

## Files modified
- `webpage_v2/src/pages/TrainDetailsPage.tsx` — Added one condition to the `shouldShowPredictions` boolean (line 176)
- `webpage_v2/src/pages/TrainDetailsPage.test.ts` — New test file with 7 test cases covering all visibility conditions

## Design decisions
- Used the existing `has_departed_station` field from the API (already available on every stop)
- Used the existing `predictionStop` variable (already resolved to the user's origin station)
- Did NOT add the same guard to `DelayForecastCard` — that's a separate product decision
- Test mirrors the component's boolean logic as a pure function to verify all condition combinations

## Test coverage
All 7 test cases pass. Full suite: 179 tests passing, no regressions.

Closes #967

https://claude.ai/code/session_01PcXPYnrHG9VcTgPpSj7A8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcXPYnrHG9VcTgPpSj7A8a)_