### PR TITLE
Issue #966: Add Beta badge to web app header

### DIFF
--- a/webpage_v2/src/components/Layout.test.tsx
+++ b/webpage_v2/src/components/Layout.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Layout } from './Layout';
+
+function renderLayout() {
+  return render(
+    <MemoryRouter>
+      <Layout />
+    </MemoryRouter>
+  );
+}
+
+describe('Layout', () => {
+  it('renders TrackRat name in header', () => {
+    renderLayout();
+    expect(screen.getByText('TrackRat')).toBeInTheDocument();
+  });
+
+  it('shows Beta badge in header', () => {
+    renderLayout();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('renders feedback button', () => {
+    renderLayout();
+    expect(screen.getByLabelText('Send feedback')).toBeInTheDocument();
+  });
+
+  it('renders GitHub link', () => {
+    renderLayout();
+    expect(screen.getByLabelText('GitHub')).toBeInTheDocument();
+  });
+});

--- a/webpage_v2/src/components/Layout.tsx
+++ b/webpage_v2/src/components/Layout.tsx
@@ -23,6 +23,9 @@ export function Layout() {
               <span className="bg-gradient-to-r from-primary-start to-primary-end bg-clip-text text-transparent">
                 TrackRat
               </span>
+              <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-accent/15 text-accent">
+                Beta
+              </span>
             </Link>
           </h1>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Add a persistent "Beta" badge next to the TrackRat name in the `Layout.tsx` header
- Visible on every page inside the app (not just the landing page)
- Styled with the existing accent color at 15% opacity background, matching the design system

## Files modified
- `webpage_v2/src/components/Layout.tsx` — Added a `<span>` with "Beta" text after the TrackRat name (3 lines)
- `webpage_v2/src/components/Layout.test.tsx` — New test file with 4 test cases verifying header content

## Design decisions
- Used `text-xs` size and `accent` color to keep it visible but non-intrusive — similar to Gmail's historical "Beta" badge
- Did NOT add a dismissible banner (that would be a separate enhancement if desired)
- The existing "BETA" pill on the LandingPage remains unchanged (different context, only visible on marketing page)

## Test coverage
4 test cases covering header rendering: TrackRat name, Beta badge, feedback button, GitHub link. Full suite: 176 tests passing, no regressions.

Closes #966

https://claude.ai/code/session_01PcXPYnrHG9VcTgPpSj7A8a

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcXPYnrHG9VcTgPpSj7A8a)_