### PR TITLE
Issue #975: Create GitHub issues from in-app feedback

### DIFF
--- a/infra_v2/functions/feedback_notifier/main.py
+++ b/infra_v2/functions/feedback_notifier/main.py
@@ -69,6 +69,12 @@ def format_github_issue(payload):
     return title, body
 
 
+# Bounded timeout keeps GitHub creation non-fatal: a stalled request can't
+# outlast the Cloud Function and trigger a Pub/Sub retry that would duplicate
+# the Slack post (and potentially the GitHub issue).
+GITHUB_API_TIMEOUT_SECONDS = 10
+
+
 def create_github_issue(token, title, body):
     """Create a GitHub issue in the trackrat-dev/TrackRat repository.
 
@@ -89,7 +95,7 @@ def create_github_issue(token, title, body):
     )
 
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=GITHUB_API_TIMEOUT_SECONDS) as response:
             result = json.loads(response.read().decode("utf-8"))
             return result.get("html_url")
     except urllib.error.HTTPError as e:
@@ -107,7 +113,7 @@ def create_github_issue(token, title, body):
                 },
                 method="POST",
             )
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=GITHUB_API_TIMEOUT_SECONDS) as response:
                 result = json.loads(response.read().decode("utf-8"))
                 return result.get("html_url")
         raise

--- a/infra_v2/functions/feedback_notifier/main.py
+++ b/infra_v2/functions/feedback_notifier/main.py
@@ -1,27 +1,124 @@
-"""Cloud Function to send user feedback notifications to Slack."""
+"""Cloud Function to send user feedback notifications to Slack and create GitHub issues."""
 
 import base64
 import json
+import urllib.error
 import urllib.request
-from google.cloud import secretmanager
 
 
-def get_slack_webhook():
-    """Retrieve Slack webhook URL from Secret Manager."""
+def get_secret(secret_id):
+    """Retrieve a secret from Secret Manager."""
+    from google.cloud import secretmanager
+
     client = secretmanager.SecretManagerServiceClient()
-    name = "projects/trackrat-v2/secrets/slack-feedback-webhook/versions/latest"
+    name = f"projects/trackrat-v2/secrets/{secret_id}/versions/latest"
     response = client.access_secret_version(request={"name": name})
     return response.payload.data.decode("UTF-8")
 
 
+def format_github_issue(payload):
+    """Format feedback payload into a GitHub issue title and body.
+
+    Returns (title, body) tuple.
+    """
+    message = payload.get("message", "No message")
+    origin = payload.get("origin_code", "?")
+    dest = payload.get("destination_code", "?")
+    screen = payload.get("screen", "unknown")
+    device = payload.get("device_model", "unknown")
+    train_id = payload.get("train_id") or "N/A"
+    app_version = payload.get("app_version") or "unknown"
+    timestamp = payload.get("timestamp", "unknown")
+
+    is_suggestion = message.startswith("[Improvement Suggestion] ")
+    if is_suggestion:
+        display_message = message[len("[Improvement Suggestion] "):]
+        heading = "Improvement Suggestion"
+    else:
+        display_message = message
+        heading = "Issue Report"
+
+    title_msg = display_message[:80].replace("\n", " ")
+    if len(display_message) > 80:
+        title_msg += "..."
+
+    route = f"{origin} → {dest}" if origin != "?" or dest != "?" else "N/A"
+
+    title = f"[User Feedback] {title_msg}"
+
+    body = "\n".join([
+        f"## {heading}",
+        "",
+        f"> {display_message}",
+        "",
+        "### Context",
+        "",
+        "| Field | Value |",
+        "|-------|-------|",
+        f"| **Route** | {route} |",
+        f"| **Screen** | {screen} |",
+        f"| **Train** | {train_id} |",
+        f"| **Device** | {device} |",
+        f"| **App Version** | {app_version} |",
+        f"| **Submitted** | {timestamp} |",
+        "",
+        "---",
+        "*Automatically created from in-app feedback.*",
+    ])
+
+    return title, body
+
+
+def create_github_issue(token, title, body):
+    """Create a GitHub issue in the trackrat-dev/TrackRat repository.
+
+    Returns the HTML URL of the created issue.
+    """
+    url = "https://api.github.com/repos/trackrat-dev/TrackRat/issues"
+    data = json.dumps({"title": title, "body": body, "labels": ["user-feedback"]})
+    req = urllib.request.Request(
+        url,
+        data=data.encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"token {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "TrackRat-Feedback-Notifier",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            result = json.loads(response.read().decode("utf-8"))
+            return result.get("html_url")
+    except urllib.error.HTTPError as e:
+        if e.code == 422:
+            # Label might not exist — retry without labels
+            data = json.dumps({"title": title, "body": body})
+            req = urllib.request.Request(
+                url,
+                data=data.encode("utf-8"),
+                headers={
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": f"token {token}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "TrackRat-Feedback-Notifier",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req) as response:
+                result = json.loads(response.read().decode("utf-8"))
+                return result.get("html_url")
+        raise
+
+
 def notify_feedback(event, context):
     """Triggered by Pub/Sub when user feedback is submitted."""
-    # Decode the Pub/Sub message
     pubsub_data = base64.b64decode(event["data"]).decode("utf-8")
     log_entry = json.loads(pubsub_data)
     payload = log_entry.get("jsonPayload", {})
 
-    # Extract feedback details
     message = payload.get("message", "No message")
     origin = payload.get("origin_code", "?")
     dest = payload.get("destination_code", "?")
@@ -30,7 +127,7 @@ def notify_feedback(event, context):
     train_id = payload.get("train_id") or "N/A"
     timestamp = payload.get("timestamp", "unknown")
 
-    # Build Slack message
+    # Send Slack notification
     slack_message = {
         "blocks": [
             {
@@ -59,8 +156,7 @@ def notify_feedback(event, context):
         ]
     }
 
-    # Send to Slack
-    webhook_url = get_slack_webhook()
+    webhook_url = get_secret("slack-feedback-webhook")
     req = urllib.request.Request(
         webhook_url,
         data=json.dumps(slack_message).encode("utf-8"),
@@ -73,3 +169,13 @@ def notify_feedback(event, context):
             raise Exception(f"Slack webhook failed: {response.status}")
 
     print(f"Feedback notification sent: {origin}→{dest}: {message[:50]}...")
+
+    # Create GitHub issue
+    try:
+        github_token = get_secret("github-feedback-token")
+        title, body = format_github_issue(payload)
+        issue_url = create_github_issue(github_token, title, body)
+        print(f"GitHub issue created: {issue_url}")
+    except Exception as e:
+        # Non-fatal: Slack notification already succeeded
+        print(f"Failed to create GitHub issue: {e}")

--- a/infra_v2/functions/feedback_notifier/test_main.py
+++ b/infra_v2/functions/feedback_notifier/test_main.py
@@ -1,0 +1,135 @@
+"""Tests for feedback_notifier Cloud Function formatting logic."""
+
+import base64
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from main import format_github_issue
+
+
+def test_issue_report_formatting():
+    """format_github_issue produces correct title and body for issue reports."""
+    payload = {
+        "message": "Train 3961 shows wrong arrival time at Hoboken",
+        "origin_code": "NY",
+        "destination_code": "HB",
+        "screen": "train_details",
+        "train_id": "3961",
+        "device_model": "iPhone 15 Pro",
+        "app_version": "2.3.1",
+        "timestamp": "2026-04-23T01:00:00Z",
+    }
+
+    title, body = format_github_issue(payload)
+
+    assert title == "[User Feedback] Train 3961 shows wrong arrival time at Hoboken"
+    assert "## Issue Report" in body
+    assert "> Train 3961 shows wrong arrival time at Hoboken" in body
+    assert "| **Route** | NY → HB |" in body
+    assert "| **Screen** | train_details |" in body
+    assert "| **Train** | 3961 |" in body
+    assert "| **Device** | iPhone 15 Pro |" in body
+    assert "| **App Version** | 2.3.1 |" in body
+    assert "| **Submitted** | 2026-04-23T01:00:00Z |" in body
+    assert "Automatically created from in-app feedback" in body
+    print("PASS: test_issue_report_formatting")
+
+
+def test_improvement_suggestion_formatting():
+    """format_github_issue detects [Improvement Suggestion] prefix and adjusts heading."""
+    payload = {
+        "message": "[Improvement Suggestion] Add dark mode to the map view",
+        "origin_code": "?",
+        "destination_code": "?",
+        "screen": "congestion_map",
+        "app_version": "2.3.1",
+    }
+
+    title, body = format_github_issue(payload)
+
+    assert title == "[User Feedback] Add dark mode to the map view"
+    assert "[Improvement Suggestion]" not in title
+    assert "## Improvement Suggestion" in body
+    assert "> Add dark mode to the map view" in body
+    assert "| **Route** | N/A |" in body
+    print("PASS: test_improvement_suggestion_formatting")
+
+
+def test_long_message_truncation():
+    """format_github_issue truncates title to 80 chars but keeps full body."""
+    long_msg = "A" * 120
+    payload = {
+        "message": long_msg,
+        "origin_code": "NY",
+        "destination_code": "TR",
+        "screen": "train_list",
+    }
+
+    title, body = format_github_issue(payload)
+
+    assert len(title) < 100
+    assert title.endswith("...")
+    assert f"> {long_msg}" in body
+    print("PASS: test_long_message_truncation")
+
+
+def test_missing_optional_fields():
+    """format_github_issue handles missing optional fields gracefully."""
+    payload = {
+        "message": "Something is broken",
+        "screen": "train_list",
+    }
+
+    title, body = format_github_issue(payload)
+
+    assert title == "[User Feedback] Something is broken"
+    assert "| **Train** | N/A |" in body
+    assert "| **App Version** | unknown |" in body
+    assert "| **Device** | unknown |" in body
+    assert "| **Submitted** | unknown |" in body
+    print("PASS: test_missing_optional_fields")
+
+
+def test_newlines_in_message_stripped_from_title():
+    """format_github_issue replaces newlines in title but preserves them in body."""
+    payload = {
+        "message": "Line one\nLine two\nLine three",
+        "origin_code": "NY",
+        "destination_code": "HB",
+        "screen": "train_details",
+    }
+
+    title, body = format_github_issue(payload)
+
+    assert "\n" not in title
+    assert "Line one Line two Line three" in title
+    assert "Line one\nLine two\nLine three" in body
+    print("PASS: test_newlines_in_message_stripped_from_title")
+
+
+def test_partial_route_info():
+    """format_github_issue shows route even if only origin or destination is set."""
+    payload = {
+        "message": "Departures not loading",
+        "origin_code": "NY",
+        "destination_code": "?",
+        "screen": "train_list",
+    }
+
+    title, body = format_github_issue(payload)
+
+    assert "| **Route** | NY → ? |" in body
+    print("PASS: test_partial_route_info")
+
+
+if __name__ == "__main__":
+    test_issue_report_formatting()
+    test_improvement_suggestion_formatting()
+    test_long_message_truncation()
+    test_missing_optional_fields()
+    test_newlines_in_message_stripped_from_title()
+    test_partial_route_info()
+    print("\nAll tests passed!")


### PR DESCRIPTION
## Summary

Closes #975

When users submit feedback through the iOS app's "Report an Issue" or "Help Us Improve" flow, the `feedback_notifier` Cloud Function now **also creates a GitHub issue** in `trackrat-dev/TrackRat`, in addition to the existing Slack notification.

## Changes

- **`infra_v2/functions/feedback_notifier/main.py`** — Extended the Cloud Function:
  - Refactored `get_slack_webhook()` → generic `get_secret(secret_id)` for retrieving any secret
  - Added `format_github_issue(payload)` — formats feedback into a GitHub issue with title, body (markdown table with route, screen, train, device, app version, timestamp)
  - Added `create_github_issue(token, title, body)` — calls GitHub REST API to create the issue; retries without labels on 422 (in case `user-feedback` label doesn't exist yet)
  - Modified `notify_feedback()` — creates a GitHub issue after the Slack notification; failure is non-fatal (logged, doesn't break the Slack flow)
  - Distinguishes "Report Issue" vs "Improvement Suggestion" feedback modes via the `[Improvement Suggestion]` message prefix

- **`infra_v2/functions/feedback_notifier/test_main.py`** — 6 tests covering formatting logic:
  - Issue report formatting (title, body, all fields)
  - Improvement suggestion detection and heading
  - Long message truncation in title (80 char limit)
  - Missing optional fields (graceful defaults)
  - Newline stripping in title
  - Partial route info

## Infrastructure Setup Required

A GitHub Personal Access Token (PAT) with `repo` scope must be stored in GCP Secret Manager:

```bash
echo -n "ghp_your_token_here" | gcloud secrets create github-feedback-token \
  --data-file=- --project=trackrat-v2
```

Optionally, create a `user-feedback` label in the repository for automatic labeling. The function handles missing labels gracefully.

## Design Decisions

- **Cloud Function, not backend or iOS**: The feedback_notifier already receives all feedback fields via Pub/Sub log sink. Adding GitHub issue creation here requires zero changes to iOS or the backend API.
- **Non-fatal GitHub creation**: If the token isn't configured or GitHub API is down, the Slack notification still succeeds. This ensures no regression in existing behavior.
- **No new dependencies**: Uses `urllib.request` (stdlib) for the GitHub API call, matching the existing pattern for Slack.
- **Lazy GCP import**: `google.cloud.secretmanager` is imported inside `get_secret()` so the pure formatting functions are testable without GCP dependencies.

## Test Plan

- [x] All 6 formatting tests pass (`python3 infra_v2/functions/feedback_notifier/test_main.py`)
- [ ] After deploying: store `github-feedback-token` secret in GCP Secret Manager
- [ ] After deploying: submit test feedback via iOS app and verify both Slack notification and GitHub issue are created
- [ ] Verify GitHub issue creation fails gracefully when token is missing (check Cloud Function logs)

https://claude.ai/code/session_01CwgGebLZJQmDyGgA6xtSSG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwgGebLZJQmDyGgA6xtSSG)_