### PR TITLE
Issue #958: Batch TransitAnalyzer out of MTA per-trip loop

### DIFF
--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -146,16 +146,19 @@ class LIRRCollector:
             # to preserve partial progress on timeout or late-stage failure.
             batch_size = 50
             trips_in_batch = 0
+            analyzed_journeys: list[TrainJourney] = []
             for trip_id, trip_arrivals in trips.items():
                 try:
                     async with session.begin_nested():
-                        result = await self._process_trip(
+                        result, journey = await self._process_trip(
                             session, trip_id, trip_arrivals
                         )
                         if result == "discovered":
                             stats["discovered"] += 1
                         elif result == "updated":
                             stats["updated"] += 1
+                        if journey is not None and journey.id is not None:
+                            analyzed_journeys.append(journey)
                 except Exception as e:
                     logger.error(f"Error processing LIRR trip {trip_id}: {e}")
                     stats["errors"] += 1
@@ -171,6 +174,14 @@ class LIRRCollector:
                     f"LIRR collection: all {stats['errors']} trips failed, "
                     f"no successful discoveries or updates"
                 )
+
+            # Batched segment analysis for all processed journeys. Moving this
+            # out of the per-trip loop eliminates the O(trips * stops)
+            # per-segment SELECTs that dominate per-cycle cost.
+            transit_analyzer = TransitAnalyzer()
+            await transit_analyzer.analyze_new_segments_bulk(
+                session, analyzed_journeys
+            )
 
             # Expire active OBSERVED journeys not seen in this collection cycle.
             # Processed journeys have last_updated_at >= collection_start;
@@ -213,7 +224,7 @@ class LIRRCollector:
 
     async def _process_trip(
         self, session: AsyncSession, trip_id: str, arrivals: list[LirrArrival]
-    ) -> str | None:
+    ) -> tuple[str | None, TrainJourney | None]:
         """
         Process a single trip from the GTFS-RT feed.
 
@@ -226,10 +237,13 @@ class LIRRCollector:
             arrivals: List of arrivals for this trip
 
         Returns:
-            "discovered", "updated", or None
+            Tuple of (result_type, journey) where result_type is
+            "discovered", "updated", or None. The journey reference is
+            returned so the caller can batch post-processing (e.g.,
+            TransitAnalyzer) after the per-trip loop completes.
         """
         if not arrivals:
-            return None
+            return None, None
 
         # Sort arrivals by time to get stop sequence
         arrivals.sort(key=lambda a: a.arrival_time)
@@ -331,7 +345,7 @@ class LIRRCollector:
                     trip_id,
                     effective_stop_count,
                 )
-                return None
+                return None, None
 
             # Compute scheduled times
             if merged_stops:
@@ -466,12 +480,8 @@ class LIRRCollector:
             update_journey_metadata(journey, now)
             check_journey_completed(journey, created_stops)
 
-            # Analyze segments for congestion data
-            transit_analyzer = TransitAnalyzer()
-            await transit_analyzer.analyze_new_segments(session, journey)
-
             logger.debug(f"Discovered LIRR train {train_id}")
-            return "discovered"
+            return "discovered", journey
 
         else:
             # Update existing journey — arrival_time is already the predicted time
@@ -513,12 +523,8 @@ class LIRRCollector:
             update_journey_metadata(journey, now)
             check_journey_completed(journey, journey_stops)
 
-            # Analyze segments for congestion data
-            transit_analyzer = TransitAnalyzer()
-            await transit_analyzer.analyze_new_segments(session, journey)
-
             logger.debug(f"Updated LIRR train {train_id}")
-            return "updated"
+            return "updated", journey
 
     async def collect_journey_details(
         self, session: AsyncSession, journey: TrainJourney

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -137,16 +137,19 @@ class MNRCollector:
             # to preserve partial progress on timeout or late-stage failure.
             batch_size = 50
             trips_in_batch = 0
+            analyzed_journeys: list[TrainJourney] = []
             for trip_id, trip_arrivals in trips.items():
                 try:
                     async with session.begin_nested():
-                        result = await self._process_trip(
+                        result, journey = await self._process_trip(
                             session, trip_id, trip_arrivals
                         )
                         if result == "discovered":
                             stats["discovered"] += 1
                         elif result == "updated":
                             stats["updated"] += 1
+                        if journey is not None and journey.id is not None:
+                            analyzed_journeys.append(journey)
                 except Exception as e:
                     logger.error(f"Error processing MNR trip {trip_id}: {e}")
                     stats["errors"] += 1
@@ -162,6 +165,14 @@ class MNRCollector:
                     f"MNR collection: all {stats['errors']} trips failed, "
                     f"no successful discoveries or updates"
                 )
+
+            # Batched segment analysis for all processed journeys. Moving this
+            # out of the per-trip loop eliminates the O(trips * stops)
+            # per-segment SELECTs that dominate per-cycle cost.
+            transit_analyzer = TransitAnalyzer()
+            await transit_analyzer.analyze_new_segments_bulk(
+                session, analyzed_journeys
+            )
 
             # Expire active OBSERVED journeys not seen in this collection cycle.
             today = collection_start.date()
@@ -202,7 +213,7 @@ class MNRCollector:
 
     async def _process_trip(
         self, session: AsyncSession, trip_id: str, arrivals: list[MnrArrival]
-    ) -> str | None:
+    ) -> tuple[str | None, TrainJourney | None]:
         """
         Process a single trip from the GTFS-RT feed.
 
@@ -215,10 +226,13 @@ class MNRCollector:
             arrivals: List of arrivals for this trip
 
         Returns:
-            "discovered", "updated", or None
+            Tuple of (result_type, journey) where result_type is
+            "discovered", "updated", or None. The journey reference is
+            returned so the caller can batch post-processing (e.g.,
+            TransitAnalyzer) after the per-trip loop completes.
         """
         if not arrivals:
-            return None
+            return None, None
 
         # Sort arrivals by time to get stop sequence
         arrivals.sort(key=lambda a: a.arrival_time)
@@ -322,7 +336,7 @@ class MNRCollector:
                     trip_id,
                     effective_stop_count,
                 )
-                return None
+                return None, None
 
             # Compute scheduled times
             if merged_stops:
@@ -457,12 +471,8 @@ class MNRCollector:
             update_journey_metadata(journey, now)
             check_journey_completed(journey, created_stops)
 
-            # Analyze segments for congestion data
-            transit_analyzer = TransitAnalyzer()
-            await transit_analyzer.analyze_new_segments(session, journey)
-
             logger.debug(f"Discovered MNR train {train_id}")
-            return "discovered"
+            return "discovered", journey
 
         else:
             # Update existing journey — arrival_time is already the predicted time
@@ -504,12 +514,8 @@ class MNRCollector:
             update_journey_metadata(journey, now)
             check_journey_completed(journey, journey_stops)
 
-            # Analyze segments for congestion data
-            transit_analyzer = TransitAnalyzer()
-            await transit_analyzer.analyze_new_segments(session, journey)
-
             logger.debug(f"Updated MNR train {train_id}")
-            return "updated"
+            return "updated", journey
 
     async def collect_journey_details(
         self, session: AsyncSession, journey: TrainJourney

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -128,19 +128,21 @@ class SubwayCollector:
             # to preserve partial progress on timeout or late-stage failure.
             batch_size = 50
             seen_journey_ids: set[int] = set()
+            analyzed_journeys: list[TrainJourney] = []
             trips_in_batch = 0
             for trip_id, trip_arrivals in trips.items():
                 try:
                     async with session.begin_nested():
-                        result, journey_id = await self._process_trip(
+                        result, journey = await self._process_trip(
                             session, trip_id, trip_arrivals
                         )
                         if result == "discovered":
                             stats["discovered"] += 1
                         elif result == "updated":
                             stats["updated"] += 1
-                        if journey_id:
-                            seen_journey_ids.add(journey_id)
+                        if journey is not None and journey.id is not None:
+                            seen_journey_ids.add(journey.id)
+                            analyzed_journeys.append(journey)
                 except Exception as e:
                     logger.error(f"Error processing subway trip {trip_id}: {e}")
                     stats["errors"] += 1
@@ -154,6 +156,15 @@ class SubwayCollector:
                 raise RuntimeError(
                     f"Subway collection: all {stats['errors']} trips failed"
                 )
+
+            # Batched segment analysis for all processed journeys. Moving this
+            # out of the per-trip loop reduces O(trips * stops) per-segment
+            # SELECTs to two total queries regardless of fleet size — critical
+            # for subway's ~500 trips per cycle.
+            transit_analyzer = TransitAnalyzer()
+            await transit_analyzer.analyze_new_segments_bulk(
+                session, analyzed_journeys
+            )
 
             # Full-replacement expiration: subway feeds are complete snapshots,
             # so any active journey NOT in the current feed should be expired
@@ -207,13 +218,15 @@ class SubwayCollector:
 
     async def _process_trip(
         self, session: AsyncSession, trip_id: str, arrivals: list[SubwayArrival]
-    ) -> tuple[str | None, int | None]:
+    ) -> tuple[str | None, TrainJourney | None]:
         """
         Process a single trip from the GTFS-RT feed.
 
         Returns:
-            Tuple of (result_type, journey_id) where result_type is
-            "discovered", "updated", or None
+            Tuple of (result_type, journey) where result_type is
+            "discovered", "updated", or None. The journey reference is
+            returned so the caller can batch post-processing (e.g.,
+            TransitAnalyzer) after the per-trip loop completes.
         """
         if not arrivals:
             return None, None
@@ -415,11 +428,8 @@ class SubwayCollector:
             update_journey_metadata(journey, now)
             check_journey_completed(journey, created_stops)
 
-            transit_analyzer = TransitAnalyzer()
-            await transit_analyzer.analyze_new_segments(session, journey)
-
             logger.debug(f"Discovered subway train {train_id}")
-            return "discovered", journey.id
+            return "discovered", journey
 
         else:
             # Update existing journey
@@ -446,11 +456,8 @@ class SubwayCollector:
             update_journey_metadata(journey, now)
             check_journey_completed(journey, journey_stops)
 
-            transit_analyzer = TransitAnalyzer()
-            await transit_analyzer.analyze_new_segments(session, journey)
-
             logger.debug(f"Updated subway train {train_id}")
-            return "updated", journey.id
+            return "updated", journey
 
     async def collect_journey_details(
         self, session: AsyncSession, journey: TrainJourney

--- a/backend_v2/src/trackrat/services/transit_analyzer.py
+++ b/backend_v2/src/trackrat/services/transit_analyzer.py
@@ -97,12 +97,82 @@ class TransitAnalyzer:
 
         return await self._analyze_segments(db, journey, stops, check_duplicates=True)
 
+    async def analyze_new_segments_bulk(
+        self, db: AsyncSession, journeys: list[TrainJourney]
+    ) -> int:
+        """
+        Analyze new segments for multiple journeys in a single bulk operation.
+
+        Uses two queries total (existing-segment tuples + stops) regardless of
+        journey count, instead of O(journeys * segments) per-segment SELECTs
+        emitted by per-journey ``analyze_new_segments`` calls. Callers should
+        batch up journeys processed during a collection cycle and invoke this
+        once at the end of the cycle.
+
+        Returns:
+            Total number of new segments created across all journeys.
+        """
+        if not journeys:
+            return 0
+
+        journey_ids = [j.id for j in journeys if j.id is not None]
+        if not journey_ids:
+            return 0
+
+        # Fetch the set of (journey_id, from_station, to_station) tuples that
+        # already have segment records, in one query.
+        existing_stmt = select(
+            SegmentTransitTime.journey_id,
+            SegmentTransitTime.from_station_code,
+            SegmentTransitTime.to_station_code,
+        ).where(SegmentTransitTime.journey_id.in_(journey_ids))
+        existing_result = await db.execute(existing_stmt)
+        existing_set: set[tuple[int, str, str]] = {
+            (row[0], row[1], row[2]) for row in existing_result.all()
+        }
+
+        # Fetch all stops for these journeys in one query.
+        stops_stmt = (
+            select(JourneyStop)
+            .where(JourneyStop.journey_id.in_(journey_ids))
+            .order_by(JourneyStop.journey_id, JourneyStop.stop_sequence)
+        )
+        stops_result = await db.execute(stops_stmt)
+        stops_by_journey: dict[int, list[JourneyStop]] = {}
+        for stop in stops_result.scalars():
+            stops_by_journey.setdefault(stop.journey_id, []).append(stop)
+
+        total_created = 0
+        for journey in journeys:
+            if journey.id is None:
+                continue
+            stops = stops_by_journey.get(journey.id, [])
+            if len(stops) < 2:
+                continue
+            total_created += await self._analyze_segments(
+                db,
+                journey,
+                stops,
+                check_duplicates=True,
+                known_existing=existing_set,
+            )
+
+        if total_created > 0:
+            logger.debug(
+                "bulk_segments_analyzed",
+                journey_count=len(journey_ids),
+                segments_created=total_created,
+            )
+
+        return total_created
+
     async def _analyze_segments(
         self,
         db: AsyncSession,
         journey: TrainJourney,
         stops: list[JourneyStop],
         check_duplicates: bool = False,
+        known_existing: set[tuple[int, str, str]] | None = None,
     ) -> int:
         """Calculate and store transit times between consecutive stations.
 
@@ -111,6 +181,9 @@ class TransitAnalyzer:
             journey: Journey to analyze
             stops: List of journey stops
             check_duplicates: If True, check if segment already exists before creating
+            known_existing: Precomputed set of (journey_id, from, to) tuples that
+                already have segment records. When provided, avoids the per-segment
+                DB SELECT and uses an in-memory lookup instead.
 
         Returns:
             Number of segments created
@@ -134,17 +207,26 @@ class TransitAnalyzer:
 
             # Check if segment already exists (to avoid duplicates)
             if check_duplicates:
-                exists_stmt = select(SegmentTransitTime).where(
-                    and_(
-                        SegmentTransitTime.journey_id == journey.id,
-                        SegmentTransitTime.from_station_code
-                        == current_stop.station_code,
-                        SegmentTransitTime.to_station_code == next_stop.station_code,
+                if known_existing is not None:
+                    if (
+                        journey.id,
+                        current_stop.station_code,
+                        next_stop.station_code,
+                    ) in known_existing:
+                        continue
+                else:
+                    exists_stmt = select(SegmentTransitTime).where(
+                        and_(
+                            SegmentTransitTime.journey_id == journey.id,
+                            SegmentTransitTime.from_station_code
+                            == current_stop.station_code,
+                            SegmentTransitTime.to_station_code
+                            == next_stop.station_code,
+                        )
                     )
-                )
-                result = await db.execute(exists_stmt)
-                if result.scalar():
-                    continue  # Skip if already analyzed
+                    result = await db.execute(exists_stmt)
+                    if result.scalar():
+                        continue  # Skip if already analyzed
 
             # Calculate scheduled transit time
             scheduled_minutes = None

--- a/backend_v2/src/trackrat/services/transit_analyzer.py
+++ b/backend_v2/src/trackrat/services/transit_analyzer.py
@@ -285,6 +285,10 @@ class TransitAnalyzer:
             )
 
             db.add(segment)
+            if known_existing is not None:
+                known_existing.add(
+                    (journey.id, current_stop.station_code, next_stop.station_code)
+                )
             segments_created += 1
 
         if segments_created > 0:

--- a/backend_v2/tests/unit/collectors/lirr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/lirr/test_collector.py
@@ -281,11 +281,12 @@ class TestLIRRCollectorProcessTrip:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        result = await collector._process_trip(
+        result, journey = await collector._process_trip(
             mock_session, "trip_123456", sample_arrivals
         )
 
         assert result == "discovered"
+        assert journey is not None
         # Should add journey and stops
         assert mock_session.add.call_count >= 1
         mock_session.flush.assert_called()
@@ -357,20 +358,22 @@ class TestLIRRCollectorProcessTrip:
             ]
         )
 
-        result = await collector._process_trip(
+        result, journey = await collector._process_trip(
             mock_session, "trip_123456", sample_arrivals
         )
 
         assert result == "updated"
+        assert journey is existing_journey
 
     @pytest.mark.asyncio
     async def test_process_trip_returns_none_for_empty_arrivals(
         self, collector, mock_session
     ):
-        """Test _process_trip returns None for empty arrivals list."""
-        result = await collector._process_trip(mock_session, "trip_123", [])
+        """Test _process_trip returns (None, None) for empty arrivals list."""
+        result, journey = await collector._process_trip(mock_session, "trip_123", [])
 
         assert result is None
+        assert journey is None
 
     @pytest.mark.asyncio
     async def test_process_trip_sorts_arrivals_by_time(self, collector, mock_session):
@@ -408,9 +411,12 @@ class TestLIRRCollectorProcessTrip:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        result = await collector._process_trip(mock_session, "trip_123", arrivals)
+        result, journey = await collector._process_trip(
+            mock_session, "trip_123", arrivals
+        )
 
         assert result == "discovered"
+        assert journey is not None
         # Origin should be JAM (earlier time)
         # This is implicitly tested by the journey being created correctly
 

--- a/backend_v2/tests/unit/collectors/mnr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/mnr/test_collector.py
@@ -270,11 +270,12 @@ class TestMNRCollectorProcessTrip:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        result = await collector._process_trip(
+        result, journey = await collector._process_trip(
             mock_session, "trip_123456", sample_arrivals
         )
 
         assert result == "discovered"
+        assert journey is not None
         # Should add journey and stops
         assert mock_session.add.call_count >= 1
         mock_session.flush.assert_called()
@@ -346,20 +347,22 @@ class TestMNRCollectorProcessTrip:
             ]
         )
 
-        result = await collector._process_trip(
+        result, journey = await collector._process_trip(
             mock_session, "trip_123456", sample_arrivals
         )
 
         assert result == "updated"
+        assert journey is existing_journey
 
     @pytest.mark.asyncio
     async def test_process_trip_returns_none_for_empty_arrivals(
         self, collector, mock_session
     ):
-        """Test _process_trip returns None for empty arrivals list."""
-        result = await collector._process_trip(mock_session, "trip_123", [])
+        """Test _process_trip returns (None, None) for empty arrivals list."""
+        result, journey = await collector._process_trip(mock_session, "trip_123", [])
 
         assert result is None
+        assert journey is None
 
     @pytest.mark.asyncio
     async def test_process_trip_sorts_arrivals_by_time(self, collector, mock_session):
@@ -397,9 +400,12 @@ class TestMNRCollectorProcessTrip:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        result = await collector._process_trip(mock_session, "trip_123", arrivals)
+        result, journey = await collector._process_trip(
+            mock_session, "trip_123", arrivals
+        )
 
         assert result == "discovered"
+        assert journey is not None
         # Origin should be GCT (earlier time)
         # This is implicitly tested by the journey being created correctly
 

--- a/backend_v2/tests/unit/collectors/subway/test_collector.py
+++ b/backend_v2/tests/unit/collectors/subway/test_collector.py
@@ -337,13 +337,12 @@ class TestSubwayCollectorProcessTrip:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        with patch("trackrat.collectors.subway.collector.TransitAnalyzer") as mock_ta:
-            mock_ta.return_value.analyze_new_segments = AsyncMock()
-            result, journey_id = await collector._process_trip(
-                mock_session, "131800_1..S03R", sample_arrivals
-            )
+        result, journey = await collector._process_trip(
+            mock_session, "131800_1..S03R", sample_arrivals
+        )
 
         assert result == "discovered"
+        assert journey is not None
         assert mock_session.add.call_count >= 1
         mock_session.flush.assert_called()
 
@@ -373,24 +372,22 @@ class TestSubwayCollectorProcessTrip:
             mock_result_stops_list,  # Get all stops for update
         ]
 
-        with patch("trackrat.collectors.subway.collector.TransitAnalyzer") as mock_ta:
-            mock_ta.return_value.analyze_new_segments = AsyncMock()
-            result, journey_id = await collector._process_trip(
-                mock_session, "131800_1..S03R", sample_arrivals
-            )
+        result, journey = await collector._process_trip(
+            mock_session, "131800_1..S03R", sample_arrivals
+        )
 
         assert result == "updated"
-        assert journey_id == 42
+        assert journey is existing_journey
 
     @pytest.mark.asyncio
     async def test_process_trip_returns_none_for_empty_arrivals(
         self, collector, mock_session
     ):
         """Test _process_trip returns (None, None) for empty arrivals list."""
-        result, journey_id = await collector._process_trip(mock_session, "trip_123", [])
+        result, journey = await collector._process_trip(mock_session, "trip_123", [])
 
         assert result is None
-        assert journey_id is None
+        assert journey is None
 
     @pytest.mark.asyncio
     async def test_process_trip_sorts_arrivals_by_time(self, collector, mock_session):
@@ -432,11 +429,10 @@ class TestSubwayCollectorProcessTrip:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        with patch("trackrat.collectors.subway.collector.TransitAnalyzer") as mock_ta:
-            mock_ta.return_value.analyze_new_segments = AsyncMock()
-            result, _ = await collector._process_trip(mock_session, "trip_1", arrivals)
+        result, journey = await collector._process_trip(mock_session, "trip_1", arrivals)
 
         assert result == "discovered"
+        assert journey is not None
 
 
 # =============================================================================

--- a/backend_v2/tests/unit/test_transit_analyzer.py
+++ b/backend_v2/tests/unit/test_transit_analyzer.py
@@ -253,3 +253,207 @@ async def test_empty_journey(mock_session):
 
     # Should not add any objects
     assert len(mock_session.added_objects) == 0
+
+
+# =============================================================================
+# Bulk segment analysis tests (issue #958)
+# =============================================================================
+
+
+def _make_journey(journey_id: int, data_source: str, line_code: str) -> TrainJourney:
+    """Build a TrainJourney with three consecutive stops at 15-minute spacing.
+
+    All stops have actual arrival/departure times set, so two consecutive
+    segments are analyzable. Stops are attached to the journey via `stops`
+    so that callers which want to pre-populate stops can still do so;
+    ``analyze_new_segments_bulk`` itself fetches stops from the DB.
+    """
+    base_time = datetime(2026, 4, 23, 8, 0, 0)
+    journey = TrainJourney(
+        id=journey_id,
+        train_id=f"T{journey_id}",
+        journey_date=base_time.date(),
+        data_source=data_source,
+        line_code=line_code,
+    )
+    journey.stops = [
+        JourneyStop(
+            journey_id=journey_id,
+            station_code="A",
+            stop_sequence=0,
+            scheduled_departure=base_time,
+            actual_departure=base_time,
+        ),
+        JourneyStop(
+            journey_id=journey_id,
+            station_code="B",
+            stop_sequence=1,
+            scheduled_arrival=base_time + timedelta(minutes=15),
+            scheduled_departure=base_time + timedelta(minutes=15),
+            actual_arrival=base_time + timedelta(minutes=15),
+            actual_departure=base_time + timedelta(minutes=15),
+        ),
+        JourneyStop(
+            journey_id=journey_id,
+            station_code="C",
+            stop_sequence=2,
+            scheduled_arrival=base_time + timedelta(minutes=30),
+            actual_arrival=base_time + timedelta(minutes=30),
+        ),
+    ]
+    return journey
+
+
+def _setup_bulk_mocks(
+    mock_session,
+    stops_by_journey: dict[int, list[JourneyStop]],
+    existing_tuples: list[tuple[int, str, str]],
+) -> None:
+    """Wire up two sequential execute() results: existing segments, then stops.
+
+    The bulk method issues exactly two queries; this fixture mirrors that
+    contract so a test failure tied to an extra query surfaces immediately.
+    """
+    existing_result = MagicMock()
+    existing_result.all = MagicMock(return_value=existing_tuples)
+
+    stops_flat = [s for stops in stops_by_journey.values() for s in stops]
+    stops_scalars = MagicMock()
+    stops_scalars.__iter__ = lambda self: iter(stops_flat)
+    stops_result = MagicMock()
+    stops_result.scalars = MagicMock(return_value=stops_scalars)
+
+    mock_session.execute = AsyncMock(side_effect=[existing_result, stops_result])
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_empty_list_returns_zero(mock_session):
+    """Empty input must not issue any DB queries."""
+    analyzer = TransitAnalyzer()
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [])
+    assert created == 0
+    mock_session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_no_ids_returns_zero(mock_session):
+    """Journeys without IDs (not yet flushed) must be skipped entirely."""
+    analyzer = TransitAnalyzer()
+    j = TrainJourney(train_id="T0", data_source="SUBWAY", line_code="1")
+    # Intentionally no id assigned; simulates a journey that wasn't flushed.
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [j])
+    assert created == 0
+    mock_session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_creates_segments_for_multiple_journeys(mock_session):
+    """Processes multiple journeys in two queries total."""
+    j1 = _make_journey(1, "SUBWAY", "1")
+    j2 = _make_journey(2, "LIRR", "BBR")
+    _setup_bulk_mocks(
+        mock_session,
+        stops_by_journey={1: j1.stops, 2: j2.stops},
+        existing_tuples=[],
+    )
+
+    analyzer = TransitAnalyzer()
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [j1, j2])
+
+    # Two consecutive segments per journey, no existing records -> 4 total.
+    assert created == 4
+    segments = [
+        obj for obj in mock_session.added_objects if isinstance(obj, SegmentTransitTime)
+    ]
+    assert len(segments) == 4
+    # Bulk method must issue exactly two queries regardless of journey count.
+    assert mock_session.execute.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_skips_existing_segments(mock_session):
+    """Segments already recorded in the DB must not be re-created."""
+    j1 = _make_journey(1, "MNR", "HDN")
+    # Both A->B and B->C are already recorded, so nothing new should be created.
+    _setup_bulk_mocks(
+        mock_session,
+        stops_by_journey={1: j1.stops},
+        existing_tuples=[(1, "A", "B"), (1, "B", "C")],
+    )
+
+    analyzer = TransitAnalyzer()
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [j1])
+
+    assert created == 0
+    segments = [
+        obj for obj in mock_session.added_objects if isinstance(obj, SegmentTransitTime)
+    ]
+    assert len(segments) == 0
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_skips_journeys_with_too_few_stops(mock_session):
+    """Journeys with fewer than 2 stops must be skipped silently."""
+    j1 = _make_journey(1, "SUBWAY", "6")
+    short = TrainJourney(
+        id=2,
+        train_id="T2",
+        journey_date=datetime(2026, 4, 23).date(),
+        data_source="SUBWAY",
+        line_code="6",
+    )
+    # A fresh stop bound to journey 2 — reusing a stop from j1 would wrongly
+    # inflate j1's stop list since journey_id is what groups stops.
+    short.stops = [
+        JourneyStop(
+            journey_id=2,
+            station_code="A",
+            stop_sequence=0,
+            scheduled_departure=datetime(2026, 4, 23, 8, 0, 0),
+            actual_departure=datetime(2026, 4, 23, 8, 0, 0),
+        )
+    ]
+
+    _setup_bulk_mocks(
+        mock_session,
+        stops_by_journey={1: j1.stops, 2: short.stops},
+        existing_tuples=[],
+    )
+
+    analyzer = TransitAnalyzer()
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [j1, short])
+
+    # Only the 3-stop journey should yield segments.
+    assert created == 2
+    segments = [
+        obj for obj in mock_session.added_objects if isinstance(obj, SegmentTransitTime)
+    ]
+    assert len(segments) == 2
+    assert {s.journey_id for s in segments} == {1}
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_respects_existing_per_journey(mock_session):
+    """Existing set is scoped by journey_id; identical segments on different
+    journeys must still each be created."""
+    j1 = _make_journey(1, "LIRR", "BBR")
+    j2 = _make_journey(2, "LIRR", "BBR")
+    # j1's A->B is already recorded, j2's isn't.
+    _setup_bulk_mocks(
+        mock_session,
+        stops_by_journey={1: j1.stops, 2: j2.stops},
+        existing_tuples=[(1, "A", "B")],
+    )
+
+    analyzer = TransitAnalyzer()
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [j1, j2])
+
+    # j1 -> B->C only, j2 -> A->B + B->C -> 3 total.
+    assert created == 3
+    segments = [
+        obj for obj in mock_session.added_objects if isinstance(obj, SegmentTransitTime)
+    ]
+    created_keys = {
+        (s.journey_id, s.from_station_code, s.to_station_code) for s in segments
+    }
+    assert created_keys == {(1, "B", "C"), (2, "A", "B"), (2, "B", "C")}

--- a/backend_v2/tests/unit/test_transit_analyzer.py
+++ b/backend_v2/tests/unit/test_transit_analyzer.py
@@ -457,3 +457,33 @@ async def test_bulk_analyzer_respects_existing_per_journey(mock_session):
         (s.journey_id, s.from_station_code, s.to_station_code) for s in segments
     }
     assert created_keys == {(1, "B", "C"), (2, "A", "B"), (2, "B", "C")}
+
+
+@pytest.mark.asyncio
+async def test_bulk_analyzer_deduplicates_same_journey_appearing_twice(mock_session):
+    """If the same journey appears more than once in the input list (e.g.,
+    because a train ID showed up in multiple GTFS-RT feeds), its segments
+    must only be created once — the in-memory known_existing set must be
+    updated after each insert to prevent duplicates."""
+    j1 = _make_journey(1, "SUBWAY", "1")
+
+    _setup_bulk_mocks(
+        mock_session,
+        stops_by_journey={1: j1.stops},
+        existing_tuples=[],
+    )
+
+    analyzer = TransitAnalyzer()
+    # Pass the same journey twice to simulate a duplicate in the collector list.
+    created = await analyzer.analyze_new_segments_bulk(mock_session, [j1, j1])
+
+    # Should create exactly 2 segments (A->B, B->C), not 4.
+    assert created == 2
+    segments = [
+        obj for obj in mock_session.added_objects if isinstance(obj, SegmentTransitTime)
+    ]
+    assert len(segments) == 2
+    created_keys = [
+        (s.journey_id, s.from_station_code, s.to_station_code) for s in segments
+    ]
+    assert sorted(created_keys) == [(1, "A", "B"), (1, "B", "C")]


### PR DESCRIPTION
## Summary

MTA GTFS-RT collectors (subway, LIRR, MNR) were constructing a fresh `TransitAnalyzer()` and awaiting `analyze_new_segments(session, journey)` **inside the per-trip loop**, both on the discovery and update paths. Each call issued one `SELECT` per segment (~15-30 per trip) to check if a `SegmentTransitTime` record already existed. For subway's ~500 trips per cycle, that produced **10k+ per-segment SELECTs every 4 minutes**, a primary driver of the `task_execution_timed_out | task=subway_collection | duration_ms=480000` pattern observed for 11 consecutive days.

This PR implements option 1 from the issue: defer analysis to end-of-cycle using a batched bulk method.

## Changes

### `backend_v2/src/trackrat/services/transit_analyzer.py`
- New `TransitAnalyzer.analyze_new_segments_bulk(session, journeys)` method. Issues exactly **two queries total** regardless of journey count:
  1. Pre-loads all existing `(journey_id, from, to)` tuples for the input journeys via a single `SELECT … WHERE journey_id IN (…)`.
  2. Pre-loads all `JourneyStop` rows for the input journeys in one query, grouped in-memory by `journey_id`.
- `_analyze_segments` gains an optional `known_existing` parameter; when provided, it does an in-memory set lookup instead of per-segment `SELECT`. Old per-call path is preserved for non-MTA callers.

### `backend_v2/src/trackrat/collectors/{subway,lirr,mnr}/collector.py`
- `_process_trip` now returns `(result_type, journey)` instead of `(result_type, journey_id)` / `result_type`. Callers accumulate the journey references into `analyzed_journeys: list[TrainJourney]`.
- The per-trip `TransitAnalyzer()` + `analyze_new_segments()` calls are removed from both discovery and update paths.
- After the trip loop finishes, each collector makes a **single** `analyze_new_segments_bulk(session, analyzed_journeys)` call.

## Test coverage

### New tests (`backend_v2/tests/unit/test_transit_analyzer.py`)
- `test_bulk_analyzer_empty_list_returns_zero` — no DB queries for empty input
- `test_bulk_analyzer_no_ids_returns_zero` — journeys without IDs are skipped before querying
- `test_bulk_analyzer_creates_segments_for_multiple_journeys` — processes 2 journeys in 2 queries, asserts exactly 2 `execute()` calls
- `test_bulk_analyzer_skips_existing_segments` — in-memory existing-set lookup correctly suppresses duplicates
- `test_bulk_analyzer_skips_journeys_with_too_few_stops` — journeys with <2 stops are silently skipped
- `test_bulk_analyzer_respects_existing_per_journey` — existing segments on one journey don't mask identical segments on a different journey

### Updated tests
- `subway/test_collector.py`, `lirr/test_collector.py`, `mnr/test_collector.py` — `_process_trip` return shape updated (`(result, journey)` everywhere). The redundant `patch("…TransitAnalyzer")` contexts in subway tests are removed since `_process_trip` no longer calls it.

## Design decisions

- **Two queries, not one per journey.** A single `JOIN` query combining segments and stops would be denser but harder to reason about; two cleanly-scoped queries keep the code readable and still eliminate the O(trips × stops) problem.
- **Journey references, not IDs.** Since the session uses `expire_on_commit=False`, ORM objects stay live across batch commits, so passing journey references lets the bulk method access `journey.data_source` / `journey.line_code` for segment attributes without a third query.
- **Preserve existing behavior for non-MTA callers.** NJT, Amtrak, PATH, BART, MBTA, Metra, WMATA all still use the per-journey path; their per-cycle volumes are low enough that batching isn't required. `analyze_new_segments()` keeps its original signature and the per-segment DB fallback.

## Test plan

- [x] `poetry run pytest tests/unit/test_transit_analyzer.py` — all 12 pass (6 new + 6 existing)
- [x] `poetry run pytest tests/unit/collectors/{subway,lirr,mnr}/test_collector.py` — all 75 pass
- [x] Full backend unit suite — pre-existing unrelated DB-fixture errors in `test_service_alert_evaluator.py` / `test_scheduler_timezone.py` (require a live PostgreSQL); everything else passes.
- [ ] On staging: confirm `subway_collection` / `mnr_collection` / `lirr_collection` duration drops from 480000ms (timeout) to well under 60s.
- [ ] On staging: ground-truth validation `poetry run python3 ../scripts/ground-truth-validate.py --provider SUBWAY --verbose` — expect ~0 "not found in TrackRat" failures.
- [ ] On staging: `/api/v2/routes/congestion?data_source=SUBWAY` returns 200.

Closes #958

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAx82BFMcLLyX7UuC72KXA)_