### PR TITLE
Issue #959: Eliminate LIRR/MNR N+1 JourneyStop SELECTs on update path

### DIFF
--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -478,16 +478,11 @@ class LIRRCollector:
             journey.actual_departure = first_arrival.arrival_time
             journey.actual_arrival = last_arrival.arrival_time
 
-            # Update stops
+            # Use in-memory lookup from eagerly-loaded stops (avoids N+1 queries).
+            # journey.stops was loaded via selectinload on the existence check above.
+            stops_by_code = {s.station_code: s for s in journey.stops}
             for arr in arrivals:
-                # Find existing stop
-                stop_result = await session.execute(
-                    select(JourneyStop).where(
-                        JourneyStop.journey_id == journey.id,
-                        JourneyStop.station_code == arr.station_code,
-                    )
-                )
-                existing_stop = stop_result.scalar_one_or_none()
+                existing_stop = stops_by_code.get(arr.station_code)
 
                 if existing_stop:
                     existing_stop.actual_arrival = arr.arrival_time
@@ -501,14 +496,10 @@ class LIRRCollector:
                             existing_stop.track_assigned_at = now_et()
                         existing_stop.track = arr.track
 
-            # Update departure status and journey metadata
+            # Update departure status and journey metadata using the in-memory
+            # stops collection — no re-query needed.
             now = now_et()
-            stop_result = await session.execute(
-                select(JourneyStop)
-                .where(JourneyStop.journey_id == journey.id)
-                .order_by(JourneyStop.stop_sequence)
-            )
-            journey_stops = list(stop_result.scalars().all())
+            journey_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
             update_stop_departure_status(journey_stops, now)
             update_journey_metadata(journey, now)
             check_journey_completed(journey, journey_stops)

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -469,16 +469,11 @@ class MNRCollector:
             journey.actual_departure = first_arrival.arrival_time
             journey.actual_arrival = last_arrival.arrival_time
 
-            # Update stops
+            # Use in-memory lookup from eagerly-loaded stops (avoids N+1 queries).
+            # journey.stops was loaded via selectinload on the existence check above.
+            stops_by_code = {s.station_code: s for s in journey.stops}
             for arr in arrivals:
-                # Find existing stop
-                stop_result = await session.execute(
-                    select(JourneyStop).where(
-                        JourneyStop.journey_id == journey.id,
-                        JourneyStop.station_code == arr.station_code,
-                    )
-                )
-                existing_stop = stop_result.scalar_one_or_none()
+                existing_stop = stops_by_code.get(arr.station_code)
 
                 if existing_stop:
                     existing_stop.actual_arrival = arr.arrival_time
@@ -492,14 +487,10 @@ class MNRCollector:
                             existing_stop.track_assigned_at = now_et()
                         existing_stop.track = arr.track
 
-            # Update departure status and journey metadata
+            # Update departure status and journey metadata using the in-memory
+            # stops collection — no re-query needed.
             now = now_et()
-            stop_result = await session.execute(
-                select(JourneyStop)
-                .where(JourneyStop.journey_id == journey.id)
-                .order_by(JourneyStop.stop_sequence)
-            )
-            journey_stops = list(stop_result.scalars().all())
+            journey_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
             update_stop_departure_status(journey_stops, now)
             update_journey_metadata(journey, now)
             check_journey_completed(journey, journey_stops)

--- a/backend_v2/tests/unit/collectors/lirr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/lirr/test_collector.py
@@ -294,67 +294,51 @@ class TestLIRRCollectorProcessTrip:
     async def test_process_trip_updates_existing_journey(
         self, collector, mock_session, sample_arrivals
     ):
-        """Test _process_trip updates existing journey."""
-        # Mock existing journey
+        """Test _process_trip updates an existing journey without issuing
+        per-arrival JourneyStop SELECTs (uses the eagerly-loaded stops)."""
+        # Mock existing journey — station codes must match sample_arrivals
+        # (JAM, NY) since the update path looks stops up by station_code.
+        now = datetime.now(timezone.utc)
+        mock_stop_jam = MagicMock(spec=JourneyStop)
+        mock_stop_jam.station_code = "JAM"
+        mock_stop_jam.track = None
+        mock_stop_jam.actual_departure = now
+        mock_stop_jam.actual_arrival = now
+        mock_stop_jam.scheduled_arrival = now
+        mock_stop_jam.has_departed_station = False
+        mock_stop_jam.departure_source = None
+        mock_stop_jam.stop_sequence = 1
+        mock_stop_ny = MagicMock(spec=JourneyStop)
+        mock_stop_ny.station_code = "NY"
+        mock_stop_ny.track = None
+        mock_stop_ny.actual_departure = None
+        mock_stop_ny.actual_arrival = now + timedelta(minutes=30)
+        mock_stop_ny.scheduled_arrival = now + timedelta(minutes=30)
+        mock_stop_ny.has_departed_station = False
+        mock_stop_ny.departure_source = None
+        mock_stop_ny.stop_sequence = 2
+
         existing_journey = MagicMock(spec=TrainJourney)
         existing_journey.id = 1
         existing_journey.train_id = "L123456"
         existing_journey.data_source = "LIRR"
+        existing_journey.stops = [mock_stop_jam, mock_stop_ny]
 
-        # Mock existing stops (one per sample arrival) with attributes needed
-        # by update_stop_departure_status and the track assignment logic
-        now = datetime.now(timezone.utc)
-        mock_stop_1 = MagicMock(spec=JourneyStop)
-        mock_stop_1.track = None
-        mock_stop_1.actual_departure = now
-        mock_stop_1.actual_arrival = now
-        mock_stop_1.scheduled_arrival = now
-        mock_stop_1.has_departed_station = False
-        mock_stop_1.departure_source = None
-        mock_stop_1.stop_sequence = 1
-        mock_stop_2 = MagicMock(spec=JourneyStop)
-        mock_stop_2.track = None
-        mock_stop_2.actual_departure = None
-        mock_stop_2.actual_arrival = now + timedelta(minutes=30)
-        mock_stop_2.scheduled_arrival = now + timedelta(minutes=30)
-        mock_stop_2.has_departed_station = False
-        mock_stop_2.departure_source = None
-        mock_stop_2.stop_sequence = 2
-
-        # First execute returns journey, next two return stops,
-        # then all-stops query for departure status update
+        # Only two queries expected: existence check + the bulk segment
+        # analyzer's stops query via analyze_new_segments. No per-arrival
+        # JourneyStop SELECTs and no re-query of journey.stops.
         journey_result = MagicMock()
         journey_result.scalar_one_or_none.return_value = existing_journey
 
-        stop_result_1 = MagicMock()
-        stop_result_1.scalar_one_or_none.return_value = mock_stop_1
-
-        stop_result_2 = MagicMock()
-        stop_result_2.scalar_one_or_none.return_value = mock_stop_2
-
-        all_stops_result = MagicMock()
-        all_stops_scalars = MagicMock()
-        all_stops_scalars.all.return_value = [mock_stop_1, mock_stop_2]
-        all_stops_result.scalars.return_value = all_stops_scalars
-
-        # Remaining calls (transit analyzer etc.) return empty results
         empty_result = MagicMock()
         empty_scalars = MagicMock()
         empty_scalars.all.return_value = []
         empty_result.scalars.return_value = empty_scalars
         empty_result.scalar_one_or_none.return_value = None
+        empty_result.scalar.return_value = None
 
         mock_session.execute = AsyncMock(
-            side_effect=[
-                journey_result,
-                stop_result_1,
-                stop_result_2,
-                all_stops_result,
-                empty_result,
-                empty_result,
-                empty_result,
-                empty_result,
-            ]
+            side_effect=[journey_result] + [empty_result] * 10
         )
 
         result = await collector._process_trip(
@@ -362,6 +346,22 @@ class TestLIRRCollectorProcessTrip:
         )
 
         assert result == "updated"
+        # Stops must be updated in memory — actual_arrival assigned from the arrivals
+        assert mock_stop_jam.actual_arrival == sample_arrivals[0].arrival_time
+        assert mock_stop_ny.actual_arrival == sample_arrivals[1].arrival_time
+        # The N+1 SELECT pattern emitted one `select(JourneyStop).where(
+        # journey_id, station_code)` per arrival. That query shape must not
+        # be issued anymore — only the existence check and downstream
+        # analyzer queries remain.
+        per_arrival_select_calls = [
+            call
+            for call in mock_session.execute.call_args_list
+            if "station_code =" in str(call).replace("\n", " ")
+            and "stop_sequence" not in str(call).replace("\n", " ")
+        ]
+        assert (
+            len(per_arrival_select_calls) == 0
+        ), f"N+1 query pattern detected: {per_arrival_select_calls}"
 
     @pytest.mark.asyncio
     async def test_process_trip_returns_none_for_empty_arrivals(

--- a/backend_v2/tests/unit/collectors/mnr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/mnr/test_collector.py
@@ -283,67 +283,47 @@ class TestMNRCollectorProcessTrip:
     async def test_process_trip_updates_existing_journey(
         self, collector, mock_session, sample_arrivals
     ):
-        """Test _process_trip updates existing journey."""
-        # Mock existing journey
+        """Test _process_trip updates an existing journey without issuing
+        per-arrival JourneyStop SELECTs (uses the eagerly-loaded stops)."""
+        now = datetime.now(timezone.utc)
+        # Station codes must match sample_arrivals (GCT, M125).
+        mock_stop_gct = MagicMock(spec=JourneyStop)
+        mock_stop_gct.station_code = "GCT"
+        mock_stop_gct.track = None
+        mock_stop_gct.actual_departure = now
+        mock_stop_gct.actual_arrival = now
+        mock_stop_gct.scheduled_arrival = now
+        mock_stop_gct.has_departed_station = False
+        mock_stop_gct.departure_source = None
+        mock_stop_gct.stop_sequence = 1
+        mock_stop_m125 = MagicMock(spec=JourneyStop)
+        mock_stop_m125.station_code = "M125"
+        mock_stop_m125.track = None
+        mock_stop_m125.actual_departure = None
+        mock_stop_m125.actual_arrival = now + timedelta(minutes=30)
+        mock_stop_m125.scheduled_arrival = now + timedelta(minutes=30)
+        mock_stop_m125.has_departed_station = False
+        mock_stop_m125.departure_source = None
+        mock_stop_m125.stop_sequence = 2
+
         existing_journey = MagicMock(spec=TrainJourney)
         existing_journey.id = 1
         existing_journey.train_id = "M123456"
         existing_journey.data_source = "MNR"
+        existing_journey.stops = [mock_stop_gct, mock_stop_m125]
 
-        # Mock existing stops (one per sample arrival) with attributes needed
-        # by update_stop_departure_status and the track assignment logic
-        now = datetime.now(timezone.utc)
-        mock_stop_1 = MagicMock(spec=JourneyStop)
-        mock_stop_1.track = None
-        mock_stop_1.actual_departure = now
-        mock_stop_1.actual_arrival = now
-        mock_stop_1.scheduled_arrival = now
-        mock_stop_1.has_departed_station = False
-        mock_stop_1.departure_source = None
-        mock_stop_1.stop_sequence = 1
-        mock_stop_2 = MagicMock(spec=JourneyStop)
-        mock_stop_2.track = None
-        mock_stop_2.actual_departure = None
-        mock_stop_2.actual_arrival = now + timedelta(minutes=30)
-        mock_stop_2.scheduled_arrival = now + timedelta(minutes=30)
-        mock_stop_2.has_departed_station = False
-        mock_stop_2.departure_source = None
-        mock_stop_2.stop_sequence = 2
-
-        # First execute returns journey, next two return stops,
-        # then all-stops query for departure status update
         journey_result = MagicMock()
         journey_result.scalar_one_or_none.return_value = existing_journey
 
-        stop_result_1 = MagicMock()
-        stop_result_1.scalar_one_or_none.return_value = mock_stop_1
-
-        stop_result_2 = MagicMock()
-        stop_result_2.scalar_one_or_none.return_value = mock_stop_2
-
-        all_stops_result = MagicMock()
-        all_stops_scalars = MagicMock()
-        all_stops_scalars.all.return_value = [mock_stop_1, mock_stop_2]
-        all_stops_result.scalars.return_value = all_stops_scalars
-
-        # Remaining calls (transit analyzer etc.) return empty results
         empty_result = MagicMock()
         empty_scalars = MagicMock()
         empty_scalars.all.return_value = []
         empty_result.scalars.return_value = empty_scalars
         empty_result.scalar_one_or_none.return_value = None
+        empty_result.scalar.return_value = None
 
         mock_session.execute = AsyncMock(
-            side_effect=[
-                journey_result,
-                stop_result_1,
-                stop_result_2,
-                all_stops_result,
-                empty_result,
-                empty_result,
-                empty_result,
-                empty_result,
-            ]
+            side_effect=[journey_result] + [empty_result] * 10
         )
 
         result = await collector._process_trip(
@@ -351,6 +331,21 @@ class TestMNRCollectorProcessTrip:
         )
 
         assert result == "updated"
+        # Stops must be updated in memory — actual_arrival assigned from the arrivals
+        assert mock_stop_gct.actual_arrival == sample_arrivals[0].arrival_time
+        assert mock_stop_m125.actual_arrival == sample_arrivals[1].arrival_time
+        # The N+1 SELECT pattern emitted one `select(JourneyStop).where(
+        # journey_id, station_code)` per arrival. Its query shape must not
+        # be issued anymore.
+        per_arrival_select_calls = [
+            call
+            for call in mock_session.execute.call_args_list
+            if "station_code =" in str(call).replace("\n", " ")
+            and "stop_sequence" not in str(call).replace("\n", " ")
+        ]
+        assert (
+            len(per_arrival_select_calls) == 0
+        ), f"N+1 query pattern detected: {per_arrival_select_calls}"
 
     @pytest.mark.asyncio
     async def test_process_trip_returns_none_for_empty_arrivals(


### PR DESCRIPTION
## Summary

Ports the subway update-path pattern to LIRR and MNR. The update paths currently issue one `SELECT JourneyStop` per arrival (~15-25 per trip) plus a redundant full-stops `SELECT … ORDER BY stop_sequence` per trip — in a typical cycle this is 750-2500 single-row SELECTs plus 50-100 full-stops SELECTs, all redundant because `journey.stops` is already eagerly loaded via `selectinload` on the existence check.

## Changes

### `backend_v2/src/trackrat/collectors/lirr/collector.py`
`_process_trip` update branch now:
1. Builds `stops_by_code = {s.station_code: s for s in journey.stops}` once
2. Replaces the per-arrival `select(JourneyStop).where(journey_id, station_code)` SELECT with an in-memory `stops_by_code.get(arr.station_code)` lookup
3. Drops the redundant "re-query all stops ordered by sequence" and sorts the in-memory list instead

### `backend_v2/src/trackrat/collectors/mnr/collector.py`
Identical change. Both collectors now mirror the subway reference at `backend_v2/src/trackrat/collectors/subway/collector.py:430`.

## Test coverage

### Updated tests (`backend_v2/tests/unit/collectors/{lirr,mnr}/test_collector.py`)
`test_process_trip_updates_existing_journey` in both test files is updated to:
- Attach stops to the existing journey via `existing_journey.stops = [...]` (matches the production pattern where `selectinload` populates this)
- Assign station codes that match `sample_arrivals` (JAM/NY for LIRR, GCT/M125 for MNR) so the `stops_by_code.get()` lookup resolves
- **Assert that the N+1 query shape (`select(JourneyStop).where(journey_id, station_code)`) is not issued** — walks `mock_session.execute.call_args_list` and fails with a clear message if any call matches. This keeps the test honest: a regression would reintroduce the SELECT and the assertion would fire.
- Verify stops are mutated correctly (`actual_arrival` is set from the incoming arrival times)

## Design decisions

- **Mirror subway, don't invent.** Subway already has this fix (`subway/collector.py:430`) and it works; using the same pattern keeps MTA collectors structurally identical and reduces cognitive load.
- **Keep `selectinload(TrainJourney.stops)` in the existence check.** LIRR/MNR already eagerly load `.stops` via `selectinload` on the existence query, so no extra options block is needed. Verified at `lirr/collector.py:272` and `mnr/collector.py:260`.
- **Don't touch the JIT `collect_journey_details` paths.** Those have the same N+1 shape but are called one journey at a time from user-initiated requests, so the per-cycle volume isn't a concern. Scope the fix to the high-volume collection path the issue calls out.

## Test plan

- [x] `poetry run pytest tests/unit/collectors/{lirr,mnr}/test_collector.py` — all 46 pass
- [ ] On staging: ground-truth validation `poetry run python3 ../scripts/ground-truth-validate.py --provider LIRR --verbose` and same for MNR — expect no regression
- [ ] On staging: observe `lirr_collection` / `mnr_collection` durations drop noticeably (even before #958 lands)

## Related

- Compounds with #958 (per-trip TransitAnalyzer). Both fixes together should collapse the 480s timeout pattern for subway/LIRR/MNR.

Closes #959

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAx82BFMcLLyX7UuC72KXA)_