### PR TITLE
Issue #960: MTA collectors fail fast on upstream 5xx / hang

### DIFF
--- a/backend_v2/src/trackrat/collectors/lirr/client.py
+++ b/backend_v2/src/trackrat/collectors/lirr/client.py
@@ -21,6 +21,11 @@ from trackrat.config.stations import (
 
 logger = logging.getLogger(__name__)
 
+# Phase-broken HTTP timeout. Bounds a hung TCP connect or stalled TLS handshake
+# independently from read time so an unreachable MTA host can't consume the
+# scheduler's 480s budget waiting on a scalar read timeout.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
+
 
 class LirrArrival(BaseModel):
     """A single arrival/stop time from the LIRR GTFS-RT feed."""
@@ -50,13 +55,19 @@ class LIRRClient:
     Uses a 30-second cache to minimize API calls.
     """
 
-    def __init__(self, timeout: float = 30.0) -> None:
+    def __init__(
+        self, timeout: httpx.Timeout | float | None = None
+    ) -> None:
         """Initialize LIRR client.
 
         Args:
-            timeout: HTTP request timeout in seconds
+            timeout: httpx.Timeout instance or scalar seconds. Defaults to a
+                phase-broken timeout (connect=5s, read=15s, write=5s, pool=5s)
+                so a hung TCP connect can't hold the whole collector.
         """
-        self.timeout = timeout
+        self.timeout: httpx.Timeout | float = (
+            timeout if timeout is not None else _DEFAULT_TIMEOUT
+        )
         self._session: httpx.AsyncClient | None = None
         self._cache: list[LirrArrival] | None = None
         self._cache_time: datetime | None = None

--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -5,6 +5,7 @@ Uses the LIRRClient to fetch GTFS-RT data and creates/updates TrainJourney recor
 Follows the same pattern as the PATH collector for simplicity.
 """
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -33,6 +34,11 @@ from trackrat.services.transit_analyzer import TransitAnalyzer
 from trackrat.utils.time import ET, now_et
 
 logger = logging.getLogger(__name__)
+
+# Outer bound on the feed fetch. Generous relative to the per-phase timeouts in
+# LIRRClient, but still leaves the bulk of the 480s scheduler budget for DB
+# work when the upstream MTA endpoint is degraded.
+_FEED_FETCH_TIMEOUT_SECONDS = 60.0
 
 
 def _generate_train_id(trip_id: str) -> str:
@@ -125,8 +131,22 @@ class LIRRCollector:
         try:
             collection_start = now_et()
 
-            # Fetch all arrivals
-            arrivals = await self.client.get_all_arrivals()
+            # Fetch all arrivals. Wrap in wait_for so an upstream MTA outage
+            # (hung connects, stalled reads beyond the phase timeouts) can't
+            # consume the whole 480s scheduler budget — we bail with empty
+            # stats and pick it up next cycle (~4 min).
+            try:
+                arrivals = await asyncio.wait_for(
+                    self.client.get_all_arrivals(),
+                    timeout=_FEED_FETCH_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "lirr_feed_fetch_timed_out | timeout_s=%.1f",
+                    _FEED_FETCH_TIMEOUT_SECONDS,
+                )
+                return stats
+
             stats["total_arrivals"] = len(arrivals)
 
             if not arrivals:

--- a/backend_v2/src/trackrat/collectors/mnr/client.py
+++ b/backend_v2/src/trackrat/collectors/mnr/client.py
@@ -21,6 +21,11 @@ from trackrat.config.stations import (
 
 logger = logging.getLogger(__name__)
 
+# Phase-broken HTTP timeout. Bounds a hung TCP connect or stalled TLS handshake
+# independently from read time so an unreachable MTA host can't consume the
+# scheduler's 480s budget waiting on a scalar read timeout.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
+
 
 class MnrArrival(BaseModel):
     """A single arrival/stop time from the Metro-North GTFS-RT feed."""
@@ -50,13 +55,19 @@ class MNRClient:
     Uses a 30-second cache to minimize API calls.
     """
 
-    def __init__(self, timeout: float = 30.0) -> None:
+    def __init__(
+        self, timeout: httpx.Timeout | float | None = None
+    ) -> None:
         """Initialize Metro-North client.
 
         Args:
-            timeout: HTTP request timeout in seconds
+            timeout: httpx.Timeout instance or scalar seconds. Defaults to a
+                phase-broken timeout (connect=5s, read=15s, write=5s, pool=5s)
+                so a hung TCP connect can't hold the whole collector.
         """
-        self.timeout = timeout
+        self.timeout: httpx.Timeout | float = (
+            timeout if timeout is not None else _DEFAULT_TIMEOUT
+        )
         self._session: httpx.AsyncClient | None = None
         self._cache: list[MnrArrival] | None = None
         self._cache_time: datetime | None = None

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -5,6 +5,7 @@ Uses the MNRClient to fetch GTFS-RT data and creates/updates TrainJourney record
 Follows the same pattern as the LIRR collector for consistency.
 """
 
+import asyncio
 import logging
 from datetime import timedelta
 from typing import Any
@@ -34,6 +35,11 @@ from trackrat.services.transit_analyzer import TransitAnalyzer
 from trackrat.utils.time import ET, now_et
 
 logger = logging.getLogger(__name__)
+
+# Outer bound on the feed fetch. Generous relative to the per-phase timeouts in
+# MNRClient, but still leaves the bulk of the 480s scheduler budget for DB
+# work when the upstream MTA endpoint is degraded.
+_FEED_FETCH_TIMEOUT_SECONDS = 60.0
 
 
 def _generate_train_id(trip_id: str) -> str:
@@ -116,8 +122,22 @@ class MNRCollector:
         try:
             collection_start = now_et()
 
-            # Fetch all arrivals
-            arrivals = await self.client.get_all_arrivals()
+            # Fetch all arrivals. Wrap in wait_for so an upstream MTA outage
+            # (hung connects, stalled reads beyond the phase timeouts) can't
+            # consume the whole 480s scheduler budget — we bail with empty
+            # stats and pick it up next cycle (~4 min).
+            try:
+                arrivals = await asyncio.wait_for(
+                    self.client.get_all_arrivals(),
+                    timeout=_FEED_FETCH_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "mnr_feed_fetch_timed_out | timeout_s=%.1f",
+                    _FEED_FETCH_TIMEOUT_SECONDS,
+                )
+                return stats
+
             stats["total_arrivals"] = len(arrivals)
 
             if not arrivals:

--- a/backend_v2/src/trackrat/collectors/subway/client.py
+++ b/backend_v2/src/trackrat/collectors/subway/client.py
@@ -25,6 +25,11 @@ from trackrat.config.stations import (
 
 logger = logging.getLogger(__name__)
 
+# Phase-broken HTTP timeout. Bounds a hung TCP connect or stalled TLS handshake
+# independently from read time so an unreachable MTA host can't consume the
+# scheduler's 480s budget waiting on a scalar read timeout.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
+
 # Maps each GTFS route_id to its feed group key in SUBWAY_GTFS_RT_FEED_URLS
 _ROUTE_TO_FEED: dict[str, str] = {
     "1": "1234567S",
@@ -105,8 +110,12 @@ class SubwayClient:
     Uses a 30-second per-feed cache to minimize API calls.
     """
 
-    def __init__(self, timeout: float = 30.0) -> None:
-        self.timeout = timeout
+    def __init__(
+        self, timeout: httpx.Timeout | float | None = None
+    ) -> None:
+        self.timeout: httpx.Timeout | float = (
+            timeout if timeout is not None else _DEFAULT_TIMEOUT
+        )
         self._session: httpx.AsyncClient | None = None
         self._cache: dict[str, list[SubwayArrival]] = {}
         self._cache_times: dict[str, datetime] = {}

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -11,6 +11,7 @@ Key differences from LIRR/MNR:
 - 8 feeds fetched concurrently via SubwayClient
 """
 
+import asyncio
 import hashlib
 import logging
 from datetime import timedelta
@@ -48,6 +49,11 @@ logger = logging.getLogger(__name__)
 # Subway full-replacement window: if a journey was updated within this
 # window but is missing from the current feed, expire it immediately.
 _REPLACEMENT_WINDOW = timedelta(minutes=30)
+
+# Outer bound on the multi-feed fetch. Generous relative to the per-feed phase
+# timeouts, but still leaves the bulk of the 480s scheduler budget for DB work
+# when the upstream MTA endpoints are degraded.
+_FEED_FETCH_TIMEOUT_SECONDS = 60.0
 
 
 def _generate_train_id(trip_id: str, route_id: str) -> str:
@@ -107,8 +113,22 @@ class SubwayCollector:
         try:
             collection_start = now_et()
 
-            # Fetch all arrivals from all 8 feeds
-            arrivals, succeeded_feeds = await self.client.get_all_arrivals()
+            # Fetch all arrivals from all 8 feeds. Wrap in wait_for so that an
+            # upstream MTA outage (hung connects, stalled reads beyond the
+            # phase timeouts) can't consume the whole 480s scheduler budget —
+            # we bail with empty stats and pick it up next cycle (~4 min).
+            try:
+                arrivals, succeeded_feeds = await asyncio.wait_for(
+                    self.client.get_all_arrivals(),
+                    timeout=_FEED_FETCH_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "subway_feed_fetch_timed_out | timeout_s=%.1f",
+                    _FEED_FETCH_TIMEOUT_SECONDS,
+                )
+                return stats
+
             stats["total_arrivals"] = len(arrivals)
 
             if not arrivals:

--- a/backend_v2/tests/unit/collectors/lirr/test_client.py
+++ b/backend_v2/tests/unit/collectors/lirr/test_client.py
@@ -444,3 +444,33 @@ class TestLIRRClient:
 
         assert len(result) == 1
         assert result[0].track is None
+
+
+class TestLIRRClientTimeout:
+    """Tests for LIRRClient phase-broken HTTP timeout (#960)."""
+
+    def test_default_timeout_is_phase_broken(self):
+        """Default timeout breaks connect/read/write/pool into separate budgets.
+
+        Prevents a hung TCP connect from consuming the full read timeout:
+        without this, a stalled connect could tie up a feed-fetch for up to
+        30s per attempt on a scalar timeout.
+        """
+        client = LIRRClient()
+        assert isinstance(client.timeout, httpx.Timeout)
+        # httpx.Timeout exposes per-phase getters via these attributes.
+        assert client.timeout.connect == 5.0
+        assert client.timeout.read == 15.0
+        assert client.timeout.write == 5.0
+        assert client.timeout.pool == 5.0
+
+    def test_explicit_float_timeout_is_preserved(self):
+        """Callers can still pass a scalar for tests / simple scripts."""
+        client = LIRRClient(timeout=10.0)
+        assert client.timeout == 10.0
+
+    def test_explicit_httpx_timeout_is_preserved(self):
+        """Callers can pass an httpx.Timeout for fine-grained control."""
+        custom = httpx.Timeout(connect=1.0, read=2.0, write=1.0, pool=1.0)
+        client = LIRRClient(timeout=custom)
+        assert client.timeout is custom

--- a/backend_v2/tests/unit/collectors/lirr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/lirr/test_collector.py
@@ -760,3 +760,57 @@ class TestLIRRCollectorRun:
             assert "discovered" in result
             assert "updated" in result
             assert "errors" in result
+
+
+class TestLIRRCollectorFailFast:
+    """Tests for LIRR fail-fast on upstream 5xx / hang (#960)."""
+
+    @pytest.fixture
+    def mock_session(self):
+        session = AsyncMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_collect_bails_when_feed_fetch_hangs_past_timeout(
+        self, mock_session
+    ):
+        """If the upstream feed hangs indefinitely, the collector must bail
+        quickly via asyncio.wait_for instead of consuming the scheduler budget.
+        """
+        import asyncio as _asyncio
+
+        hang_event = _asyncio.Event()  # never set, so the fetch hangs forever
+
+        async def hang_forever():
+            await hang_event.wait()
+            return []
+
+        hung_client = AsyncMock(spec=LIRRClient)
+        hung_client.get_all_arrivals = hang_forever
+        hung_client.close = AsyncMock()
+
+        collector = LIRRCollector(client=hung_client)
+
+        # Patch the timeout constant to something small so the test is fast
+        with patch(
+            "trackrat.collectors.lirr.collector._FEED_FETCH_TIMEOUT_SECONDS",
+            0.05,
+        ):
+            import time
+            t0 = time.monotonic()
+            result = await collector.collect(mock_session)
+            elapsed = time.monotonic() - t0
+
+        # Must return well within 1s, not hang forever
+        assert elapsed < 1.0, f"collect() took {elapsed:.2f}s — fail-fast broken"
+        # Stats should be the initial empty dict (no work was done)
+        assert result["total_arrivals"] == 0
+        assert result["discovered"] == 0
+        assert result["updated"] == 0
+        # No DB commit should be attempted when the fetch timed out
+        mock_session.commit.assert_not_called()

--- a/backend_v2/tests/unit/collectors/mnr/test_client.py
+++ b/backend_v2/tests/unit/collectors/mnr/test_client.py
@@ -444,3 +444,30 @@ class TestMNRClient:
 
         assert len(result) == 1
         assert result[0].track is None
+
+
+class TestMNRClientTimeout:
+    """Tests for MNRClient phase-broken HTTP timeout (#960)."""
+
+    def test_default_timeout_is_phase_broken(self):
+        """Default timeout breaks connect/read/write/pool into separate budgets.
+
+        Prevents a hung TCP connect from consuming the full read timeout.
+        """
+        client = MNRClient()
+        assert isinstance(client.timeout, httpx.Timeout)
+        assert client.timeout.connect == 5.0
+        assert client.timeout.read == 15.0
+        assert client.timeout.write == 5.0
+        assert client.timeout.pool == 5.0
+
+    def test_explicit_float_timeout_is_preserved(self):
+        """Callers can still pass a scalar for tests / simple scripts."""
+        client = MNRClient(timeout=10.0)
+        assert client.timeout == 10.0
+
+    def test_explicit_httpx_timeout_is_preserved(self):
+        """Callers can pass an httpx.Timeout for fine-grained control."""
+        custom = httpx.Timeout(connect=1.0, read=2.0, write=1.0, pool=1.0)
+        client = MNRClient(timeout=custom)
+        assert client.timeout is custom

--- a/backend_v2/tests/unit/collectors/mnr/test_collector.py
+++ b/backend_v2/tests/unit/collectors/mnr/test_collector.py
@@ -745,3 +745,53 @@ class TestMNRCollectorRun:
             assert "discovered" in result
             assert "updated" in result
             assert "errors" in result
+
+
+class TestMNRCollectorFailFast:
+    """Tests for MNR fail-fast on upstream 5xx / hang (#960)."""
+
+    @pytest.fixture
+    def mock_session(self):
+        session = AsyncMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_collect_bails_when_feed_fetch_hangs_past_timeout(
+        self, mock_session
+    ):
+        """If the upstream feed hangs indefinitely, the collector must bail
+        quickly via asyncio.wait_for instead of consuming the scheduler budget.
+        """
+        import asyncio as _asyncio
+
+        hang_event = _asyncio.Event()
+
+        async def hang_forever():
+            await hang_event.wait()
+            return []
+
+        hung_client = AsyncMock(spec=MNRClient)
+        hung_client.get_all_arrivals = hang_forever
+        hung_client.close = AsyncMock()
+
+        collector = MNRCollector(client=hung_client)
+
+        with patch(
+            "trackrat.collectors.mnr.collector._FEED_FETCH_TIMEOUT_SECONDS",
+            0.05,
+        ):
+            import time
+            t0 = time.monotonic()
+            result = await collector.collect(mock_session)
+            elapsed = time.monotonic() - t0
+
+        assert elapsed < 1.0, f"collect() took {elapsed:.2f}s — fail-fast broken"
+        assert result["total_arrivals"] == 0
+        assert result["discovered"] == 0
+        assert result["updated"] == 0
+        mock_session.commit.assert_not_called()

--- a/backend_v2/tests/unit/collectors/subway/test_client.py
+++ b/backend_v2/tests/unit/collectors/subway/test_client.py
@@ -676,3 +676,32 @@ class TestSubwayClient:
 
         assert "1234567S" in succeeded_feeds
         assert "ACE" not in succeeded_feeds, "Empty feed should not count as success"
+
+
+class TestSubwayClientTimeout:
+    """Tests for SubwayClient phase-broken HTTP timeout (#960)."""
+
+    def test_default_timeout_is_phase_broken(self):
+        """Default timeout breaks connect/read/write/pool into separate budgets.
+
+        Prevents a hung TCP connect from consuming the full read timeout:
+        without this, a stalled connect could tie up each of the 8 feeds for
+        the scalar read timeout, amplifying the problem.
+        """
+        client = SubwayClient()
+        assert isinstance(client.timeout, httpx.Timeout)
+        assert client.timeout.connect == 5.0
+        assert client.timeout.read == 15.0
+        assert client.timeout.write == 5.0
+        assert client.timeout.pool == 5.0
+
+    def test_explicit_float_timeout_is_preserved(self):
+        """Callers can still pass a scalar for tests / simple scripts."""
+        client = SubwayClient(timeout=10.0)
+        assert client.timeout == 10.0
+
+    def test_explicit_httpx_timeout_is_preserved(self):
+        """Callers can pass an httpx.Timeout for fine-grained control."""
+        custom = httpx.Timeout(connect=1.0, read=2.0, write=1.0, pool=1.0)
+        client = SubwayClient(timeout=custom)
+        assert client.timeout is custom

--- a/backend_v2/tests/unit/collectors/subway/test_collector.py
+++ b/backend_v2/tests/unit/collectors/subway/test_collector.py
@@ -1094,3 +1094,56 @@ class TestGtfsFeedUrl:
         assert (
             "supplemented" in SUBWAY_GTFS_STATIC_URL
         ), f"Expected supplemented feed URL, got: {SUBWAY_GTFS_STATIC_URL}"
+
+
+class TestSubwayCollectorFailFast:
+    """Tests for subway fail-fast on upstream 5xx / hang (#960)."""
+
+    @pytest.fixture
+    def mock_session(self):
+        session = AsyncMock(spec=AsyncSession)
+        session.execute = AsyncMock()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_collect_bails_when_feed_fetch_hangs_past_timeout(
+        self, mock_session
+    ):
+        """If the upstream feeds hang indefinitely, the collector must bail
+        quickly via asyncio.wait_for. Subway is hit hardest by hangs because
+        it fans out to 8 feeds — any one stalled feed can hold the whole
+        gather() until each per-feed timeout expires.
+        """
+        import asyncio as _asyncio
+
+        hang_event = _asyncio.Event()
+
+        async def hang_forever():
+            await hang_event.wait()
+            return ([], set())
+
+        hung_client = AsyncMock(spec=SubwayClient)
+        hung_client.get_all_arrivals = hang_forever
+        hung_client.close = AsyncMock()
+
+        with patch("trackrat.collectors.subway.collector.GTFSService"):
+            collector = SubwayCollector(client=hung_client)
+
+        with patch(
+            "trackrat.collectors.subway.collector._FEED_FETCH_TIMEOUT_SECONDS",
+            0.05,
+        ):
+            import time
+            t0 = time.monotonic()
+            result = await collector.collect(mock_session)
+            elapsed = time.monotonic() - t0
+
+        assert elapsed < 1.0, f"collect() took {elapsed:.2f}s — fail-fast broken"
+        assert result["total_arrivals"] == 0
+        assert result["discovered"] == 0
+        assert result["updated"] == 0
+        mock_session.commit.assert_not_called()


### PR DESCRIPTION
## Summary

Subway / LIRR / MNR clients used a scalar httpx timeout of 30s per feed (applied uniformly to connect / TLS / read), and the collectors had no outer `asyncio.wait_for` around the multi-feed fetch. A hung TCP connect or a stalled read past the 30s scalar could chain per-feed waits and consume most of the 480s scheduler budget waiting on upstream that was already 503'ing (issues #953, #957).

## Changes

### Files modified
- `backend_v2/src/trackrat/collectors/{subway,lirr,mnr}/client.py`
- `backend_v2/src/trackrat/collectors/{subway,lirr,mnr}/collector.py`
- `backend_v2/tests/unit/collectors/{subway,lirr,mnr}/test_client.py`
- `backend_v2/tests/unit/collectors/{subway,lirr,mnr}/test_collector.py`

### 1. Phase-broken `httpx.Timeout` in each client
Replaced the scalar `float = 30.0` default with:
```python
_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=15.0, write=5.0, pool=5.0)
```
Applied uniformly across subway, LIRR, and MNR clients. The `__init__` signature accepts `httpx.Timeout | float | None` so existing callers that pass a float (e.g., `LIRRClient(timeout=10.0)` in tests) still work unchanged.

### 2. Outer `asyncio.wait_for` around the fetch in each collector
Each collector's `collect()` now wraps the `client.get_all_arrivals()` call in `asyncio.wait_for(..., timeout=60.0)`. On `asyncio.TimeoutError`, logs a `{system}_feed_fetch_timed_out` warning and returns the initial empty stats dict — no DB commit, no partial state, no poisoned session. Upstream will be retried on the next scheduler cycle (~4 min).

60s is generous relative to the per-phase client timeouts but still leaves the bulk of the 480s scheduler budget for DB work.

### 3. Error signal unchanged
The issue's recommendation 3 (surface persistent-zero via per-feed failure counter) is already implemented in the subway client — see `succeeded_feeds` set returned by `SubwayClient.get_all_arrivals()` and consumed by the collector's expiration logic. LIRR / MNR are single-feed so this doesn't apply to them.

## Test coverage

### `test_client.py` (subway / LIRR / MNR)
New `TestXClientTimeout` class in each:
- `test_default_timeout_is_phase_broken` — asserts `client.timeout` is an `httpx.Timeout` instance with the expected per-phase values
- `test_explicit_float_timeout_is_preserved` — backwards-compat with existing scalar-based tests
- `test_explicit_httpx_timeout_is_preserved` — callers can supply their own `httpx.Timeout`

### `test_collector.py` (subway / LIRR / MNR)
New `TestXCollectorFailFast` class in each. The test:
1. Builds a mock client whose `get_all_arrivals` awaits an `asyncio.Event` that is never set (hangs forever)
2. Patches `_FEED_FETCH_TIMEOUT_SECONDS` to 0.05s so the test runs fast
3. Asserts `collect()` returns in < 1 second with zeroed stats and **no DB commit**

This is the authoritative regression test for the issue's core failure mode.

## Non-goals (per the issue body)

- **No retries.** Upstream feeds refresh every 4 minutes anyway; failing fast and waiting for the next cycle is correct. Retries would compound hangs.
- **No Metra / BART / MBTA / WMATA changes.** Out of scope; the issue scopes the fix to the MTA collectors documented in the recurring 480s timeout reports.

## Test plan

- [x] `poetry run pytest tests/unit/collectors/{subway,lirr,mnr}/ ` — all 158 pass
- [ ] On staging: point one feed URL at a hung-connection sink (`nc -l 9999`) and confirm the collector returns within ~60s with `succeeded_feeds` reporting that feed missing, instead of taking the full 480s budget.
- [ ] Watch the next MTA upstream blip in production and confirm collector timing does not reach 480s.

## Related

- Complements #958 (per-trip TransitAnalyzer batching — dominant on healthy days) and #959 (LIRR/MNR N+1 fix). This PR specifically targets the degraded-upstream failure mode that compounds with #958 when things go wrong.

Closes #960

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAx82BFMcLLyX7UuC72KXA)_