### PR TITLE
Issue #961: Fix congestion query timeout via cutoff_time pushdown

### DIFF
--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -90,6 +90,37 @@ __all__ = [
 ]
 
 
+def _stop_pairs_cte(ds_filter: str) -> str:
+    """Generate the stop_pairs CTE with cutoff_time pushdown.
+
+    Filters on tj_pre.last_updated_at >= :cutoff_time so PostgreSQL prunes
+    journeys before the expensive LEAD() window function runs.
+    Requires :cutoff_time in the query's params dict.
+    """
+    return f"""stop_pairs AS (
+        SELECT
+            js.journey_id,
+            js.station_code as from_station,
+            js.actual_departure as from_actual_departure,
+            js.actual_arrival as from_actual_arrival,
+            js.updated_departure as from_updated_departure,
+            js.updated_arrival as from_updated_arrival,
+            js.scheduled_departure as from_scheduled_departure,
+            LEAD(js.station_code) OVER w as to_station,
+            LEAD(js.actual_arrival) OVER w as to_actual_arrival,
+            LEAD(js.updated_arrival) OVER w as to_updated_arrival,
+            LEAD(js.scheduled_arrival) OVER w as to_scheduled_arrival,
+            LEAD(js.scheduled_departure) OVER w as to_scheduled_departure
+        FROM journey_stops js
+        JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
+        WHERE js.station_code IS NOT NULL
+          AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
+          AND tj_pre.last_updated_at >= :cutoff_time
+          {ds_filter}
+        WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
+    )"""
+
+
 class CongestionAnalyzer:
     """Analyzes route congestion in real-time from journey data."""
 
@@ -406,32 +437,7 @@ class CongestionAnalyzer:
         # SQL query that calculates segment times and aggregates in database
         # This replaces loading thousands of objects into Python memory
         query = text(f"""
-        WITH stop_pairs AS (
-            -- Pair each stop with its next stop using LEAD window function.
-            -- Pre-filter by journey_date to avoid scanning the entire history.
-            -- Handles non-consecutive stop_sequence values (common in GTFS
-            -- static data from MTA feeds like MNR/LIRR) by ordering by
-            -- stop_sequence and taking the actual next mapped stop.
-            SELECT
-                js.journey_id,
-                js.station_code as from_station,
-                js.actual_departure as from_actual_departure,
-                js.actual_arrival as from_actual_arrival,
-                js.updated_departure as from_updated_departure,
-                js.updated_arrival as from_updated_arrival,
-                js.scheduled_departure as from_scheduled_departure,
-                LEAD(js.station_code) OVER w as to_station,
-                LEAD(js.actual_arrival) OVER w as to_actual_arrival,
-                LEAD(js.updated_arrival) OVER w as to_updated_arrival,
-                LEAD(js.scheduled_arrival) OVER w as to_scheduled_arrival,
-                LEAD(js.scheduled_departure) OVER w as to_scheduled_departure
-            FROM journey_stops js
-            JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
-            WHERE js.station_code IS NOT NULL
-              AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
-              {ds_filter}
-            WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
-        ),
+        WITH {_stop_pairs_cte(ds_filter)},
         segment_data AS (
             -- Calculate segment transit times from paired stops.
             -- Only use real-time data (actual/updated) for transit time calculation.
@@ -725,28 +731,7 @@ class CongestionAnalyzer:
         if max_per_segment > 0:
             # With per-route limiting using ROW_NUMBER()
             query = text(f"""
-            WITH stop_pairs AS (
-                -- Pre-filter by journey_date to avoid scanning entire history
-                SELECT
-                    js.journey_id,
-                    js.station_code as from_station,
-                    js.actual_departure as from_actual_departure,
-                    js.actual_arrival as from_actual_arrival,
-                    js.updated_departure as from_updated_departure,
-                    js.updated_arrival as from_updated_arrival,
-                    js.scheduled_departure as from_scheduled_departure,
-                    LEAD(js.station_code) OVER w as to_station,
-                    LEAD(js.actual_arrival) OVER w as to_actual_arrival,
-                    LEAD(js.updated_arrival) OVER w as to_updated_arrival,
-                    LEAD(js.scheduled_arrival) OVER w as to_scheduled_arrival,
-                    LEAD(js.scheduled_departure) OVER w as to_scheduled_departure
-                FROM journey_stops js
-                JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
-                WHERE js.station_code IS NOT NULL
-                  AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
-                  {ds_filter}
-                WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
-            ),
+            WITH {_stop_pairs_cte(ds_filter)},
             segment_data AS (
                 -- Calculate individual train segments between adjacent stops.
                 -- Only real-time data (actual/updated) used; scheduled times excluded
@@ -827,28 +812,7 @@ class CongestionAnalyzer:
         else:
             # No per-route limiting - return ALL individual segments
             query = text(f"""
-            WITH stop_pairs AS (
-                -- Pre-filter by journey_date to avoid scanning entire history
-                SELECT
-                    js.journey_id,
-                    js.station_code as from_station,
-                    js.actual_departure as from_actual_departure,
-                    js.actual_arrival as from_actual_arrival,
-                    js.updated_departure as from_updated_departure,
-                    js.updated_arrival as from_updated_arrival,
-                    js.scheduled_departure as from_scheduled_departure,
-                    LEAD(js.station_code) OVER w as to_station,
-                    LEAD(js.actual_arrival) OVER w as to_actual_arrival,
-                    LEAD(js.updated_arrival) OVER w as to_updated_arrival,
-                    LEAD(js.scheduled_arrival) OVER w as to_scheduled_arrival,
-                    LEAD(js.scheduled_departure) OVER w as to_scheduled_departure
-                FROM journey_stops js
-                JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
-                WHERE js.station_code IS NOT NULL
-                  AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
-                  {ds_filter}
-                WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
-            ),
+            WITH {_stop_pairs_cte(ds_filter)},
             segment_data AS (
                 -- Calculate individual train segments between adjacent stops.
                 -- Only real-time data (actual/updated) used; scheduled times excluded
@@ -930,6 +894,7 @@ class CongestionAnalyzer:
         if max_per_segment > 0:
             seg_params["max_per_segment"] = max_per_segment
 
+        await db.execute(text("SET LOCAL statement_timeout = '30000'"))
         query_start = now_et()
         result = await db.execute(query, seg_params)
         rows = result.fetchall()

--- a/backend_v2/tests/unit/services/test_congestion.py
+++ b/backend_v2/tests/unit/services/test_congestion.py
@@ -13,7 +13,11 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from trackrat.models.database import TrainJourney
-from trackrat.services.congestion import CongestionAnalyzer, SegmentCongestion
+from trackrat.services.congestion import (
+    CongestionAnalyzer,
+    SegmentCongestion,
+    _stop_pairs_cte,
+)
 
 
 class TestSegmentCongestion:
@@ -678,3 +682,112 @@ class TestCongestionAnalyzer:
         segment = results[0]
         # Should only use valid positive transit times
         assert segment.sample_count == 2  # Only the valid 15 and 20 minute segments
+
+    def test_stop_pairs_cte_includes_cutoff_time_filter(self):
+        """The stop_pairs CTE must filter by last_updated_at >= :cutoff_time
+        so PostgreSQL prunes journeys before the expensive LEAD() window
+        function runs. Without this, high-volume providers like SUBWAY
+        materialize millions of rows and hit the 30s statement timeout.
+        """
+        sql = _stop_pairs_cte("")
+        assert "last_updated_at >= :cutoff_time" in sql
+        assert "journey_date >= CURRENT_DATE" in sql
+        assert "LEAD(js.station_code) OVER w" in sql
+
+    def test_stop_pairs_cte_includes_data_source_filter(self):
+        """When a data_source filter is provided, it must appear in the CTE."""
+        sql_with_ds = _stop_pairs_cte("AND tj_pre.data_source = :data_source")
+        assert "tj_pre.data_source = :data_source" in sql_with_ds
+
+        sql_without_ds = _stop_pairs_cte("")
+        assert "data_source" not in sql_without_ds
+
+    @pytest.mark.asyncio
+    async def test_aggregated_congestion_sql_has_cutoff_in_stop_pairs(
+        self, congestion_analyzer, mock_db
+    ):
+        """The aggregated congestion query must push cutoff_time into the
+        stop_pairs CTE — not just segment_data. This is the fix for the
+        statement timeout on high-volume providers (SUBWAY).
+        """
+        mock_result = Mock()
+        mock_result.fetchall.return_value = []
+        mock_db.execute.return_value = mock_result
+        congestion_analyzer._cache.clear()
+
+        await congestion_analyzer.get_network_congestion_optimized(
+            mock_db, time_window_hours=3, data_source="SUBWAY"
+        )
+
+        main_sql = next(
+            (
+                str(call.args[0])
+                for call in mock_db.execute.call_args_list
+                if "stop_pairs" in str(call.args[0])
+            ),
+            None,
+        )
+        assert main_sql is not None, "stop_pairs query was not executed"
+        # The cutoff_time filter must be inside the stop_pairs CTE definition
+        # (before the closing parenthesis of the CTE), not just in segment_data
+        stop_pairs_section = main_sql.split("stop_pairs AS")[1].split("segment_data AS")[0]
+        assert "last_updated_at >= :cutoff_time" in stop_pairs_section, (
+            "cutoff_time filter missing from stop_pairs CTE — "
+            "this causes statement timeouts for high-volume providers"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_per_segment", [10, 0])
+    async def test_individual_segments_sql_has_cutoff_in_stop_pairs(
+        self, congestion_analyzer, mock_db, max_per_segment
+    ):
+        """Both branches of get_individual_segments_optimized (with and
+        without per-route limiting) must push cutoff_time into stop_pairs.
+        """
+        mock_result = Mock()
+        mock_result.fetchall.return_value = []
+        mock_db.execute.return_value = mock_result
+
+        await congestion_analyzer.get_individual_segments_optimized(
+            mock_db, max_per_segment=max_per_segment, data_source="SUBWAY"
+        )
+
+        main_sql = next(
+            (
+                str(call.args[0])
+                for call in mock_db.execute.call_args_list
+                if "stop_pairs" in str(call.args[0])
+            ),
+            None,
+        )
+        assert main_sql is not None, "stop_pairs query was not executed"
+        stop_pairs_section = main_sql.split("stop_pairs AS")[1].split("segment_data AS")[0]
+        assert "last_updated_at >= :cutoff_time" in stop_pairs_section, (
+            f"cutoff_time filter missing from stop_pairs CTE "
+            f"(max_per_segment={max_per_segment})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_individual_segments_sets_statement_timeout(
+        self, congestion_analyzer, mock_db
+    ):
+        """get_individual_segments_optimized must set a statement timeout
+        to guard against runaway queries, just like the aggregated method.
+        """
+        mock_result = Mock()
+        mock_result.fetchall.return_value = []
+        mock_db.execute.return_value = mock_result
+
+        await congestion_analyzer.get_individual_segments_optimized(
+            mock_db, data_source="SUBWAY"
+        )
+
+        timeout_calls = [
+            call
+            for call in mock_db.execute.call_args_list
+            if "statement_timeout" in str(call.args[0])
+        ]
+        assert len(timeout_calls) >= 1, (
+            "get_individual_segments_optimized must SET LOCAL statement_timeout "
+            "before executing the query"
+        )


### PR DESCRIPTION
## Summary

- Fixes the `stop_pairs` CTE in `congestion.py` which was missing a `cutoff_time` filter, causing it to materialize the full LEAD() window over all journeys from the last 24-48h before the `segment_data` CTE applied any time-window filtering. For SUBWAY (472 stations, thousands of trips), this exceeded the 30s statement timeout → `QueryCanceledError` → empty congestion cache → HTTP 503 on `/routes/congestion`.
- Extracts the duplicated `stop_pairs` CTE (3 identical copies) into a shared `_stop_pairs_cte()` helper function to prevent future drift.
- Adds `tj_pre.last_updated_at >= :cutoff_time` to the CTE, leveraging the existing `idx_last_updated` index for efficient pruning before the window function runs.
- Adds the missing `SET LOCAL statement_timeout = '30000'` guard to `get_individual_segments_optimized` (was only present in `get_network_congestion_optimized`).

## Files Modified

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/services/congestion.py` | Added `_stop_pairs_cte()` helper with `cutoff_time` filter; replaced 3 inline CTEs; added statement timeout to `get_individual_segments_optimized` |
| `backend_v2/tests/unit/services/test_congestion.py` | 6 new tests: CTE helper output validation, SQL cutoff pushdown assertions for both aggregated and individual-segments paths (parametrized over both branches), statement timeout presence |

## Design Decisions

- **`last_updated_at` over stop-level time filtering**: Filtering at the journey level (`tj_pre.last_updated_at >= :cutoff_time`) is cheaper than filtering on individual stop columns (which would require OR-ing across 4 nullable timestamp columns). The `idx_last_updated` index already exists. A journey with stops in the cutoff window will necessarily have `last_updated_at` within that window.
- **Kept the `journey_date >= CURRENT_DATE - INTERVAL '1 day'` guard**: This broad filter handles cross-midnight edge cases and is still useful as a coarse first filter alongside the tighter `last_updated_at` pushdown.
- **Shared helper function**: The three copies of the CTE were character-for-character identical. Factoring into `_stop_pairs_cte(ds_filter)` eliminates the drift risk that caused this bug to exist in three places.

## Test Coverage

- `test_stop_pairs_cte_includes_cutoff_time_filter` — verifies the helper generates `last_updated_at >= :cutoff_time`
- `test_stop_pairs_cte_includes_data_source_filter` — verifies `ds_filter` injection
- `test_aggregated_congestion_sql_has_cutoff_in_stop_pairs` — verifies the filter lands inside the `stop_pairs` section (not just `segment_data`) for `get_network_congestion_optimized`
- `test_individual_segments_sql_has_cutoff_in_stop_pairs[10]` / `[0]` — same check for both branches of `get_individual_segments_optimized`
- `test_individual_segments_sets_statement_timeout` — verifies the new timeout guard

Closes #961

https://claude.ai/code/session_01978RaXus2DGisVqiYYvUkz

---
_Generated by [Claude Code](https://claude.ai/code/session_01978RaXus2DGisVqiYYvUkz)_