### PR TITLE
Issue #963: Fix Metra collector error swallowing and add consecutive-zero detection

### DIFF
--- a/backend_v2/src/trackrat/collectors/metra/client.py
+++ b/backend_v2/src/trackrat/collectors/metra/client.py
@@ -1,8 +1,9 @@
 """
 Metra GTFS-RT client for fetching real-time train data.
 
-Uses Metra's official GTFS-RT feed with API token authentication.
-Follows the same pattern as the LIRR client.
+Uses Metra's official GTFS-RT feed with query-parameter token authentication
+(gtfspublic.metrarr.com). Supports optional HTTP Basic Auth for forward
+compatibility if Metra changes endpoints.
 """
 
 import logging
@@ -42,37 +43,72 @@ class MetraArrival(BaseModel):
         arbitrary_types_allowed = True
 
 
+class MetraFetchError(Exception):
+    """Raised when the Metra GTFS-RT feed fetch fails."""
+
+
 class MetraClient:
     """
     Client for fetching Metra real-time data from GTFS-RT feed.
 
     Parses GTFS-RT protobuf format and converts to our internal models.
     Uses a 30-second cache to minimize API calls.
-    Requires TRACKRAT_METRA_API_TOKEN environment variable.
+
+    Auth: query-parameter token by default (current gtfspublic.metrarr.com API).
+    If username/password are set, uses HTTP Basic Auth instead.
     """
 
-    def __init__(self, api_token: str | None = None, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        api_token: str | None = None,
+        api_username: str | None = None,
+        api_password: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
         """Initialize Metra client.
 
         Args:
-            api_token: Metra API token. If None, reads from settings.
+            api_token: Metra API token (query-param auth). If None, reads from settings.
+            api_username: Metra API username for Basic Auth. If None, reads from settings.
+            api_password: Metra API password for Basic Auth. If None, reads from settings.
             timeout: HTTP request timeout in seconds
         """
         self.timeout = timeout
-        if api_token is None:
+
+        if api_token is None and api_username is None:
             from trackrat.settings import get_settings
 
-            api_token = get_settings().metra_api_token
-        self._api_token = api_token
+            settings = get_settings()
+            api_token = settings.metra_api_token
+            api_username = settings.metra_api_username
+            api_password = settings.metra_api_password
+
+        # Prefer Basic Auth when username/password are explicitly set
+        if api_username and api_password:
+            self._auth: httpx.BasicAuth | None = httpx.BasicAuth(
+                api_username, api_password
+            )
+            self._api_token = ""
+            self._auth_method = "basic"
+        else:
+            self._auth = None
+            self._api_token = api_token or ""
+            self._auth_method = "query_param"
+
         self._session: httpx.AsyncClient | None = None
         self._cache: list[MetraArrival] | None = None
         self._cache_time: datetime | None = None
         self._cache_ttl = 30  # seconds
 
-        if not self._api_token:
+        if not self.has_credentials:
             logger.warning(
-                "TRACKRAT_METRA_API_TOKEN not set — Metra collection will be skipped"
+                "Metra API credentials not set — Metra collection will be skipped"
             )
+
+    @property
+    def has_credentials(self) -> bool:
+        """Whether valid credentials are configured."""
+        return bool(self._api_token) or self._auth is not None
 
     @property
     def session(self) -> httpx.AsyncClient:
@@ -80,6 +116,7 @@ class MetraClient:
         if self._session is None:
             self._session = httpx.AsyncClient(
                 timeout=self.timeout,
+                auth=self._auth,
                 headers={
                     "User-Agent": "TrackRat/2.0 (Metra Real-time Tracker)",
                     "Accept": "application/x-protobuf",
@@ -116,6 +153,12 @@ class MetraClient:
         """Get route info (line_code, name, color) for a route ID."""
         return METRA_ROUTES.get(route_id)
 
+    def _build_url(self) -> str:
+        """Build the feed URL, appending the token as a query param if needed."""
+        if self._auth_method == "query_param" and self._api_token:
+            return f"{METRA_GTFS_RT_FEED_URL}?api_token={self._api_token}"
+        return METRA_GTFS_RT_FEED_URL
+
     async def get_all_arrivals(self) -> list[MetraArrival]:
         """
         Fetch and parse all Metra arrivals from GTFS-RT feed.
@@ -124,18 +167,21 @@ class MetraClient:
 
         Returns:
             List of MetraArrival objects for all upcoming stops.
-            Empty list if API token is not configured.
+
+        Raises:
+            ValueError: If API credentials are not configured.
+            MetraFetchError: If the HTTP request fails (propagated to caller).
         """
-        if not self._api_token:
+        if not self.has_credentials:
             raise ValueError(
-                "TRACKRAT_METRA_API_TOKEN not configured — cannot fetch Metra data"
+                "Metra API credentials not configured — cannot fetch Metra data"
             )
 
         if self._is_cache_valid():
             return self._cache or []
 
         try:
-            url = f"{METRA_GTFS_RT_FEED_URL}?api_token={self._api_token}"
+            url = self._build_url()
             response = await self.session.get(url)
             response.raise_for_status()
 
@@ -214,16 +260,37 @@ class MetraClient:
             return arrivals
 
         except httpx.HTTPStatusError as e:
+            status = e.response.status_code
             logger.error(
-                f"HTTP error fetching Metra GTFS-RT feed: {e.response.status_code}"
+                "metra_feed_http_error",
+                extra={
+                    "status_code": status,
+                    "auth_method": self._auth_method,
+                },
             )
-            return self._cache or []
+            if status in (401, 403):
+                raise MetraFetchError(
+                    f"Metra API authentication failed (HTTP {status}). "
+                    f"Check credentials (auth_method={self._auth_method})."
+                ) from e
+            raise MetraFetchError(
+                f"Metra GTFS-RT feed returned HTTP {status}"
+            ) from e
         except httpx.HTTPError as e:
-            logger.error(f"HTTP error fetching Metra GTFS-RT feed: {type(e).__name__}")
-            return self._cache or []
+            logger.error(
+                "metra_feed_network_error",
+                extra={"error_type": type(e).__name__},
+            )
+            raise MetraFetchError(
+                f"Network error fetching Metra GTFS-RT feed: {type(e).__name__}"
+            ) from e
+        except MetraFetchError:
+            raise
         except Exception as e:
             logger.error(f"Error parsing Metra GTFS-RT feed: {e}")
-            return self._cache or []
+            raise MetraFetchError(
+                f"Error parsing Metra GTFS-RT feed: {e}"
+            ) from e
 
     async def get_station_arrivals(self, station_code: str) -> list[MetraArrival]:
         """

--- a/backend_v2/src/trackrat/collectors/metra/collector.py
+++ b/backend_v2/src/trackrat/collectors/metra/collector.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from trackrat.collectors.metra.client import MetraArrival, MetraClient
+from trackrat.collectors.metra.client import MetraArrival, MetraClient, MetraFetchError
 from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
@@ -37,6 +37,11 @@ from trackrat.utils.time import now_for_provider
 logger = logging.getLogger(__name__)
 
 DATA_SOURCE = "METRA"
+
+# Module-level counter that persists across collector instantiations (same process).
+# Reset on any successful non-empty fetch.
+_consecutive_empty_cycles = 0
+_CONSECUTIVE_EMPTY_THRESHOLD = 3
 
 
 def _generate_train_id(trip_id: str) -> str:
@@ -111,6 +116,8 @@ class MetraCollector:
         Returns:
             Statistics dict
         """
+        global _consecutive_empty_cycles
+
         stats = {
             "discovered": 0,
             "updated": 0,
@@ -119,21 +126,41 @@ class MetraCollector:
             "total_arrivals": 0,
         }
 
-        if not self.client._api_token:
+        if not self.client.has_credentials:
             raise RuntimeError(
-                "Metra collection failed: TRACKRAT_METRA_API_TOKEN not configured"
+                "Metra collection failed: API credentials not configured"
             )
 
         try:
             collection_start = now_for_provider(DATA_SOURCE)
 
-            # Fetch all arrivals
-            arrivals = await self.client.get_all_arrivals()
+            # Fetch all arrivals — let MetraFetchError propagate
+            try:
+                arrivals = await self.client.get_all_arrivals()
+            except MetraFetchError as e:
+                raise RuntimeError(f"Metra feed fetch failed: {e}") from e
+
             stats["total_arrivals"] = len(arrivals)
 
             if not arrivals:
-                logger.warning("No Metra arrivals found in GTFS-RT feed")
+                _consecutive_empty_cycles += 1
+                if _consecutive_empty_cycles >= _CONSECUTIVE_EMPTY_THRESHOLD:
+                    raise RuntimeError(
+                        f"Metra collection: {_consecutive_empty_cycles} consecutive "
+                        f"cycles returned 0 arrivals — possible auth or API failure "
+                        f"(auth_method={self.client._auth_method})"
+                    )
+                logger.warning(
+                    "metra_empty_feed",
+                    extra={
+                        "consecutive_empty_cycles": _consecutive_empty_cycles,
+                        "threshold": _CONSECUTIVE_EMPTY_THRESHOLD,
+                    },
+                )
                 return stats
+
+            # Successful non-empty fetch — reset the counter
+            _consecutive_empty_cycles = 0
 
             # Group arrivals by trip_id
             trips: dict[str, list[MetraArrival]] = {}
@@ -204,6 +231,8 @@ class MetraCollector:
                 f"{stats['errors']} errors"
             )
 
+        except RuntimeError:
+            raise
         except Exception as e:
             logger.error(f"Metra collection failed: {e}")
             await session.rollback()
@@ -523,7 +552,13 @@ class MetraCollector:
         if journey.data_source != DATA_SOURCE:
             return
 
-        arrivals = await self.client.get_all_arrivals()
+        try:
+            arrivals = await self.client.get_all_arrivals()
+        except MetraFetchError:
+            logger.warning(
+                "metra_jit_fetch_failed", extra={"train_id": journey.train_id}
+            )
+            return
 
         journey_station_codes = {s.station_code for s in journey.stops}
 

--- a/backend_v2/src/trackrat/collectors/metra/collector.py
+++ b/backend_v2/src/trackrat/collectors/metra/collector.py
@@ -138,6 +138,7 @@ class MetraCollector:
             try:
                 arrivals = await self.client.get_all_arrivals()
             except MetraFetchError as e:
+                _consecutive_empty_cycles = 0
                 raise RuntimeError(f"Metra feed fetch failed: {e}") from e
 
             stats["total_arrivals"] = len(arrivals)

--- a/backend_v2/src/trackrat/settings.py
+++ b/backend_v2/src/trackrat/settings.py
@@ -78,8 +78,16 @@ class Settings(BaseSettings):
                 break
         return v
 
-    # Metra API
-    metra_api_token: str = Field(default="", description="Metra GTFS-RT API token")
+    # Metra API — prefer username/password (Basic Auth); fall back to legacy token
+    metra_api_token: str = Field(
+        default="", description="Metra GTFS-RT API token (legacy query-param auth)"
+    )
+    metra_api_username: str = Field(
+        default="", description="Metra GTFS-RT API username (HTTP Basic Auth)"
+    )
+    metra_api_password: str = Field(
+        default="", description="Metra GTFS-RT API password (HTTP Basic Auth)"
+    )
 
     @field_validator("metra_api_token", mode="before")
     @classmethod
@@ -88,6 +96,22 @@ class Settings(BaseSettings):
         if v:
             return v
         return os.environ.get("METRA_API_TOKEN", "")
+
+    @field_validator("metra_api_username", mode="before")
+    @classmethod
+    def load_metra_api_username(cls, v: str) -> str:
+        """Load Metra API username from env vars."""
+        if v:
+            return v
+        return os.environ.get("METRA_API_USERNAME", "")
+
+    @field_validator("metra_api_password", mode="before")
+    @classmethod
+    def load_metra_api_password(cls, v: str) -> str:
+        """Load Metra API password from env vars."""
+        if v:
+            return v
+        return os.environ.get("METRA_API_PASSWORD", "")
 
     # MBTA API
     mbta_api_key: str = Field(default="", description="MBTA API key")

--- a/backend_v2/tests/unit/collectors/metra/test_client.py
+++ b/backend_v2/tests/unit/collectors/metra/test_client.py
@@ -1,8 +1,8 @@
 """
 Unit tests for MetraClient.
 
-Tests GTFS-RT API communication, protobuf parsing, caching, and
-authentication token handling.
+Tests GTFS-RT API communication, protobuf parsing, caching,
+authentication (query-param and Basic Auth), and error propagation.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -15,6 +15,7 @@ from google.transit import gtfs_realtime_pb2
 from trackrat.collectors.metra.client import (
     MetraArrival,
     MetraClient,
+    MetraFetchError,
 )
 
 
@@ -92,26 +93,57 @@ class TestMetraClient:
 
     @pytest.fixture
     def client_no_token(self):
-        """Create a MetraClient instance without an API token."""
+        """Create a MetraClient instance without any credentials."""
         return MetraClient(api_token="", timeout=10.0)
 
+    @pytest.fixture
+    def client_basic_auth(self):
+        """Create a MetraClient instance with Basic Auth credentials."""
+        return MetraClient(
+            api_username="test_user", api_password="test_pass", timeout=10.0
+        )
+
     def test_initialization_with_token(self, client):
-        """Test client initializes with correct defaults when token is set."""
+        """Test client initializes with query-param auth when token is set."""
         assert client.timeout == 10.0
         assert client._session is None
         assert client._api_token == "test_token"
+        assert client._auth is None
+        assert client._auth_method == "query_param"
+        assert client.has_credentials is True
         assert client._cache is None
         assert client._cache_time is None
         assert client._cache_ttl == 30
 
     def test_initialization_without_token(self, client_no_token):
-        """Test client initializes gracefully without API token."""
+        """Test client initializes gracefully without any credentials."""
         assert client_no_token._api_token == ""
+        assert client_no_token._auth is None
+        assert client_no_token.has_credentials is False
+
+    def test_initialization_with_basic_auth(self, client_basic_auth):
+        """Test client initializes with Basic Auth when username/password are set."""
+        assert client_basic_auth._auth is not None
+        assert isinstance(client_basic_auth._auth, httpx.BasicAuth)
+        assert client_basic_auth._auth_method == "basic"
+        assert client_basic_auth._api_token == ""
+        assert client_basic_auth.has_credentials is True
+
+    def test_basic_auth_takes_precedence_over_token(self):
+        """When both token and username/password are set, Basic Auth wins."""
+        client = MetraClient(
+            api_token="my_token",
+            api_username="user",
+            api_password="pass",
+        )
+        assert client._auth_method == "basic"
+        assert client._api_token == ""
+        assert client._auth is not None
 
     @pytest.mark.asyncio
-    async def test_get_all_arrivals_raises_without_token(self, client_no_token):
-        """Client should raise ValueError when no API token is configured."""
-        with pytest.raises(ValueError, match="TRACKRAT_METRA_API_TOKEN not configured"):
+    async def test_get_all_arrivals_raises_without_credentials(self, client_no_token):
+        """Client should raise ValueError when no credentials are configured."""
+        with pytest.raises(ValueError, match="credentials not configured"):
             await client_no_token.get_all_arrivals()
 
     def test_cache_validity_when_empty(self, client):
@@ -154,6 +186,16 @@ class TestMetraClient:
         """Unknown routes should return None."""
         assert client._get_route_info("UNKNOWN") is None
 
+    def test_build_url_query_param(self, client):
+        """Query-param client should append token to URL."""
+        url = client._build_url()
+        assert "?api_token=test_token" in url
+
+    def test_build_url_basic_auth(self, client_basic_auth):
+        """Basic Auth client should use plain URL without query params."""
+        url = client_basic_auth._build_url()
+        assert "?api_token" not in url
+
     @pytest.mark.asyncio
     async def test_session_property_creates_client(self, client):
         """Accessing session property should create an httpx client."""
@@ -161,6 +203,14 @@ class TestMetraClient:
         assert session is not None
         assert isinstance(session, httpx.AsyncClient)
         await client.close()
+
+    @pytest.mark.asyncio
+    async def test_session_basic_auth_sets_auth(self, client_basic_auth):
+        """Basic Auth client should pass auth to httpx.AsyncClient."""
+        session = client_basic_auth.session
+        assert session is not None
+        assert session._auth is not None
+        await client_basic_auth.close()
 
     @pytest.mark.asyncio
     async def test_close_clears_session(self, client):
@@ -301,32 +351,62 @@ class TestMetraClient:
         assert result[0].arrival_time == result[0].departure_time
 
     @pytest.mark.asyncio
-    async def test_get_all_arrivals_http_error_returns_cache(self, client):
-        """HTTP errors should return cached data if available."""
-        cached_arrival = MetraArrival(
-            station_code="CUS",
-            gtfs_stop_id="CUS",
-            trip_id="ME_ME2012_V1_B",
-            route_id="ME",
-            direction_id=1,
-            headsign=None,
-            arrival_time=datetime(2026, 3, 25, 10, 30, tzinfo=UTC),
-            departure_time=None,
-            delay_seconds=0,
-            track=None,
-        )
-        client._cache = [cached_arrival]
-        client._cache_time = datetime.now(UTC) - timedelta(seconds=60)  # Expired
-
+    async def test_get_all_arrivals_http_status_error_raises(self, client):
+        """HTTP status errors should raise MetraFetchError instead of silently returning."""
         client._session = AsyncMock()
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_request.url = "https://example.com"
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 500
         client._session.get = AsyncMock(
             side_effect=httpx.HTTPStatusError(
-                "500", request=MagicMock(), response=MagicMock()
+                "500", request=mock_request, response=mock_response
             )
         )
 
-        result = await client.get_all_arrivals()
-        assert len(result) == 1  # Returns stale cache
+        with pytest.raises(MetraFetchError, match="HTTP 500"):
+            await client.get_all_arrivals()
+
+    @pytest.mark.asyncio
+    async def test_get_all_arrivals_auth_error_raises_with_detail(self, client):
+        """401/403 errors should raise MetraFetchError with auth-specific message."""
+        client._session = AsyncMock()
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_request.url = "https://example.com"
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 401
+        client._session.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "401", request=mock_request, response=mock_response
+            )
+        )
+
+        with pytest.raises(MetraFetchError, match="authentication failed"):
+            await client.get_all_arrivals()
+
+    @pytest.mark.asyncio
+    async def test_get_all_arrivals_network_error_raises(self, client):
+        """Network errors should raise MetraFetchError."""
+        client._session = AsyncMock()
+        client._session.get = AsyncMock(
+            side_effect=httpx.ConnectTimeout("timeout")
+        )
+
+        with pytest.raises(MetraFetchError, match="Network error"):
+            await client.get_all_arrivals()
+
+    @pytest.mark.asyncio
+    async def test_get_all_arrivals_parse_error_raises(self, client):
+        """Protobuf parse errors should raise MetraFetchError."""
+        mock_response = MagicMock()
+        mock_response.content = b"not a valid protobuf"
+        mock_response.raise_for_status = MagicMock()
+
+        client._session = AsyncMock()
+        client._session.get = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(MetraFetchError, match="Error parsing"):
+            await client.get_all_arrivals()
 
     @pytest.mark.asyncio
     async def test_get_station_arrivals_filters_by_station(self, client):
@@ -432,21 +512,15 @@ class TestMetraClient:
                 assert client is not None
 
 
-class TestMetraClientMissingToken:
-    """Tests that MetraClient fails loudly when API token is missing.
-
-    Bug: get_all_arrivals() silently returned [] when token was empty,
-    causing the collector to report zero departures as a successful run.
-
-    See: https://github.com/trackrat-dev/trackrat/issues/901
-    """
+class TestMetraClientMissingCredentials:
+    """Tests that MetraClient fails loudly when credentials are missing."""
 
     @pytest.mark.asyncio
-    async def test_get_all_arrivals_raises_without_token(self):
-        """get_all_arrivals raises ValueError when no API token configured."""
+    async def test_get_all_arrivals_raises_without_credentials(self):
+        """get_all_arrivals raises ValueError when no credentials configured."""
         client = MetraClient(api_token="")
 
-        with pytest.raises(ValueError, match="TRACKRAT_METRA_API_TOKEN not configured"):
+        with pytest.raises(ValueError, match="credentials not configured"):
             await client.get_all_arrivals()
 
     @pytest.mark.asyncio
@@ -471,9 +545,134 @@ class TestMetraClientMissingToken:
 
         assert isinstance(result, list)  # No ValueError raised
 
-    def test_init_warns_on_empty_token(self):
-        """MetraClient logs a warning at init when token is empty."""
-        # This just verifies the client can be created with empty token
-        # without crashing — the warning is for ops visibility
+    @pytest.mark.asyncio
+    async def test_get_all_arrivals_works_with_basic_auth(self):
+        """get_all_arrivals does not raise when Basic Auth credentials are provided."""
+        client = MetraClient(api_username="user", api_password="pass")
+
+        feed = gtfs_realtime_pb2.FeedMessage()
+        feed.header.gtfs_realtime_version = "2.0"
+        feed.header.timestamp = int(datetime.now(UTC).timestamp())
+
+        mock_response = MagicMock()
+        mock_response.content = feed.SerializeToString()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.get = AsyncMock(return_value=mock_response)
+        client._session = mock_http
+
+        result = await client.get_all_arrivals()
+
+        assert isinstance(result, list)
+
+    def test_init_warns_on_empty_credentials(self):
+        """MetraClient logs a warning at init when credentials are empty."""
         client = MetraClient(api_token="")
-        assert client._api_token == ""
+        assert client.has_credentials is False
+
+    def test_has_credentials_token(self):
+        """has_credentials is True with a token."""
+        client = MetraClient(api_token="test")
+        assert client.has_credentials is True
+
+    def test_has_credentials_basic_auth(self):
+        """has_credentials is True with Basic Auth."""
+        client = MetraClient(api_username="u", api_password="p")
+        assert client.has_credentials is True
+
+    def test_has_credentials_empty(self):
+        """has_credentials is False with no credentials."""
+        client = MetraClient(api_token="")
+        assert client.has_credentials is False
+
+
+class TestMetraFetchError:
+    """Tests for MetraFetchError propagation from get_all_arrivals."""
+
+    @pytest.mark.asyncio
+    async def test_http_403_raises_auth_specific_error(self):
+        """HTTP 403 should raise MetraFetchError mentioning authentication."""
+        client = MetraClient(api_token="bad_token")
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_request.url = "https://example.com"
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 403
+        client._session = AsyncMock()
+        client._session.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "403", request=mock_request, response=mock_response
+            )
+        )
+
+        with pytest.raises(MetraFetchError) as exc_info:
+            await client.get_all_arrivals()
+
+        assert "authentication failed" in str(exc_info.value)
+        assert "query_param" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_http_403_with_basic_auth_mentions_basic(self):
+        """HTTP 403 with Basic Auth should mention auth_method=basic."""
+        client = MetraClient(api_username="bad", api_password="creds")
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_request.url = "https://example.com"
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 403
+        client._session = AsyncMock()
+        client._session.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "403", request=mock_request, response=mock_response
+            )
+        )
+
+        with pytest.raises(MetraFetchError) as exc_info:
+            await client.get_all_arrivals()
+
+        assert "basic" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_raises_fetch_error(self):
+        """Connection timeouts should raise MetraFetchError, not be swallowed."""
+        client = MetraClient(api_token="test")
+        client._session = AsyncMock()
+        client._session.get = AsyncMock(
+            side_effect=httpx.ConnectTimeout("timed out")
+        )
+
+        with pytest.raises(MetraFetchError, match="Network error"):
+            await client.get_all_arrivals()
+
+    @pytest.mark.asyncio
+    async def test_stale_cache_not_returned_on_error(self):
+        """Errors should NOT silently return stale cache — they should raise."""
+        client = MetraClient(api_token="test")
+        client._cache = [
+            MetraArrival(
+                station_code="CUS",
+                gtfs_stop_id="CUS",
+                trip_id="ME_ME2012_V1_B",
+                route_id="ME",
+                direction_id=1,
+                headsign=None,
+                arrival_time=datetime(2026, 3, 25, 10, 30, tzinfo=UTC),
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+            ),
+        ]
+        client._cache_time = datetime.now(UTC) - timedelta(seconds=60)  # Expired
+
+        client._session = AsyncMock()
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_request.url = "https://example.com"
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 500
+        client._session.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=mock_request, response=mock_response
+            )
+        )
+
+        with pytest.raises(MetraFetchError):
+            await client.get_all_arrivals()

--- a/backend_v2/tests/unit/collectors/metra/test_collector.py
+++ b/backend_v2/tests/unit/collectors/metra/test_collector.py
@@ -495,6 +495,31 @@ class TestCollectorErrorPropagation:
         with pytest.raises(RuntimeError, match="feed fetch failed"):
             await collector.collect(session)
 
+    @pytest.mark.asyncio
+    async def test_fetch_error_resets_consecutive_empty_counter(self):
+        """MetraFetchError should reset the consecutive empty counter.
+
+        A fetch error breaks the "consecutive empty" chain because it's a
+        different failure mode (already surfaced as RuntimeError). Without
+        the reset, empty→empty→error→empty would falsely count as 3
+        consecutive empty cycles.
+        """
+        collector_module._consecutive_empty_cycles = 2
+
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(
+            side_effect=MetraFetchError("HTTP 500")
+        )
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="Metra feed fetch failed"):
+            await collector.collect(session)
+
+        assert collector_module._consecutive_empty_cycles == 0
+
 
 # =============================================================================
 # CONSECUTIVE EMPTY CYCLE DETECTION TESTS

--- a/backend_v2/tests/unit/collectors/metra/test_collector.py
+++ b/backend_v2/tests/unit/collectors/metra/test_collector.py
@@ -2,7 +2,8 @@
 Unit tests for MetraCollector.
 
 Tests unified Metra train discovery and journey update logic,
-including train ID generation, timezone handling, and origin inference.
+including train ID generation, timezone handling, origin inference,
+error propagation, and consecutive-zero cycle detection.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -10,12 +11,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from trackrat.collectors.metra.client import MetraArrival, MetraClient
+from trackrat.collectors.metra.client import MetraArrival, MetraClient, MetraFetchError
 from trackrat.collectors.metra.collector import (
     DATA_SOURCE,
     MetraCollector,
     _generate_train_id,
 )
+import trackrat.collectors.metra.collector as collector_module
 
 # =============================================================================
 # HELPER FUNCTION TESTS
@@ -386,46 +388,217 @@ class TestMetraCommonIntegration:
 
 
 # =============================================================================
-# MISSING TOKEN HANDLING TESTS
+# MISSING CREDENTIALS HANDLING TESTS
 # =============================================================================
 
 
-class TestCollectorMissingToken:
-    """Tests that MetraCollector returns error stats when API token is missing.
-
-    Bug: collector received empty list from client, logged "No Metra arrivals
-    found", and returned stats with zeros — indistinguishable from success.
-    Scheduler marked this as a completed run, preventing retries.
-
-    See: https://github.com/trackrat-dev/trackrat/issues/901
-    """
+class TestCollectorMissingCredentials:
+    """Tests that MetraCollector raises when credentials are missing."""
 
     @pytest.mark.asyncio
-    async def test_collect_raises_when_no_token(self):
-        """collect() raises RuntimeError when API token is empty so the scheduler records a failure."""
+    async def test_collect_raises_when_no_credentials(self):
+        """collect() raises RuntimeError when no credentials are configured."""
         client = MetraClient(api_token="")
         collector = MetraCollector(client=client)
         session = AsyncMock()
 
-        with pytest.raises(
-            RuntimeError, match="TRACKRAT_METRA_API_TOKEN not configured"
-        ):
+        with pytest.raises(RuntimeError, match="credentials not configured"):
             await collector.collect(session)
 
-        # Session should not have been touched
         session.commit.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_collect_proceeds_with_valid_token(self):
         """collect() does NOT return early when token is configured."""
         client = MagicMock(spec=MetraClient)
-        client._api_token = "valid-token"
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(return_value=[])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        # Reset module-level counter
+        collector_module._consecutive_empty_cycles = 0
+
+        result = await collector.collect(session)
+
+        client.get_all_arrivals.assert_called_once()
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_collect_proceeds_with_basic_auth(self):
+        """collect() works with Basic Auth credentials."""
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "basic"
+        client.get_all_arrivals = AsyncMock(return_value=[])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        collector_module._consecutive_empty_cycles = 0
+
+        result = await collector.collect(session)
+
+        client.get_all_arrivals.assert_called_once()
+        assert "error" not in result
+
+
+# =============================================================================
+# ERROR PROPAGATION TESTS
+# =============================================================================
+
+
+class TestCollectorErrorPropagation:
+    """Tests that MetraCollector propagates MetraFetchError from the client.
+
+    Bug: get_all_arrivals() silently returned [] on HTTP errors,
+    causing the collector to report 0 departures as a successful run.
+    Now MetraFetchError propagates and the collector wraps it in RuntimeError.
+
+    See: https://github.com/trackrat-dev/trackrat/issues/963
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_counter(self):
+        """Reset the module-level consecutive empty counter before each test."""
+        collector_module._consecutive_empty_cycles = 0
+        yield
+        collector_module._consecutive_empty_cycles = 0
+
+    @pytest.mark.asyncio
+    async def test_fetch_error_propagates_as_runtime_error(self):
+        """MetraFetchError from client should propagate as RuntimeError."""
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(
+            side_effect=MetraFetchError("HTTP 500")
+        )
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="Metra feed fetch failed"):
+            await collector.collect(session)
+
+    @pytest.mark.asyncio
+    async def test_auth_error_propagates(self):
+        """Authentication errors should propagate, not be swallowed."""
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(
+            side_effect=MetraFetchError("authentication failed (HTTP 401)")
+        )
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="feed fetch failed"):
+            await collector.collect(session)
+
+
+# =============================================================================
+# CONSECUTIVE EMPTY CYCLE DETECTION TESTS
+# =============================================================================
+
+
+class TestConsecutiveEmptyCycles:
+    """Tests for consecutive-zero arrival detection.
+
+    When the feed returns 0 arrivals for N consecutive cycles, the collector
+    should raise so the scheduler marks the run as failed, making the problem
+    visible in error logs and health checks.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_counter(self):
+        """Reset the module-level consecutive empty counter before each test."""
+        collector_module._consecutive_empty_cycles = 0
+        yield
+        collector_module._consecutive_empty_cycles = 0
+
+    @pytest.mark.asyncio
+    async def test_first_empty_cycle_warns_but_succeeds(self):
+        """First empty cycle should warn but not raise."""
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
         client.get_all_arrivals = AsyncMock(return_value=[])
         collector = MetraCollector(client=client)
         session = AsyncMock()
 
         result = await collector.collect(session)
 
-        # Should have called get_all_arrivals (not returned early)
-        client.get_all_arrivals.assert_called_once()
-        assert "error" not in result
+        assert result["total_arrivals"] == 0
+        assert collector_module._consecutive_empty_cycles == 1
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_empty_cycles_still_warns(self):
+        """Two consecutive empty cycles should warn but not raise."""
+        collector_module._consecutive_empty_cycles = 1
+
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(return_value=[])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        result = await collector.collect(session)
+
+        assert result["total_arrivals"] == 0
+        assert collector_module._consecutive_empty_cycles == 2
+
+    @pytest.mark.asyncio
+    async def test_three_consecutive_empty_cycles_raises(self):
+        """Three consecutive empty cycles should raise RuntimeError."""
+        collector_module._consecutive_empty_cycles = 2
+
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(return_value=[])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="consecutive.*cycles returned 0"):
+            await collector.collect(session)
+
+    @pytest.mark.asyncio
+    async def test_nonempty_cycle_resets_counter(self):
+        """A successful non-empty fetch should reset the consecutive counter."""
+        collector_module._consecutive_empty_cycles = 2
+
+        # Build a minimal arrival that will cause the collector to proceed
+        arrival = MetraArrival(
+            station_code="CUS",
+            gtfs_stop_id="CUS",
+            trip_id="ME_ME2012_V1_B",
+            route_id="ME",
+            direction_id=1,
+            headsign=None,
+            arrival_time=datetime(2026, 3, 25, 10, 30, tzinfo=UTC),
+            departure_time=None,
+            delay_seconds=0,
+            track=None,
+        )
+
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(return_value=[arrival])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        # The collector will try to process the trip and likely fail (no DB),
+        # but the counter should still be reset before that
+        try:
+            await collector.collect(session)
+        except Exception:
+            pass
+
+        assert collector_module._consecutive_empty_cycles == 0
+
+    @pytest.mark.asyncio
+    async def test_threshold_is_configurable(self):
+        """The threshold constant should be accessible and reasonable."""
+        assert collector_module._CONSECUTIVE_EMPTY_THRESHOLD == 3


### PR DESCRIPTION
## Summary

- **Stop swallowing HTTP errors** in `MetraClient.get_all_arrivals()` — raise `MetraFetchError` instead of silently returning stale cache or empty list. Auth failures (401/403) get a specific error message identifying the auth method in use.
- **Add consecutive-zero cycle detection** in the collector: after 3 consecutive cycles with 0 arrivals, raise `RuntimeError` so the scheduler marks the run as failed and the problem surfaces in `gcp-logs.py --errors` and health checks.
- **Re-raise `RuntimeError`** from the outer exception handler in `collect()` so critical failures (missing credentials, feed fetch errors, persistent empty feeds) propagate to the scheduler instead of being swallowed.
- **Add optional HTTP Basic Auth support** via `TRACKRAT_METRA_API_USERNAME` and `TRACKRAT_METRA_API_PASSWORD` env vars, while keeping query-parameter token auth as the default.

### Auth scheme note

Research found that the current Metra API (`gtfspublic.metrarr.com`) uses **query-parameter token auth** (`?api_token=`), not HTTP Basic Auth. The old API (`gtfsapi.metrarail.com`) that used Basic Auth was retired in November 2025. The Transitland Atlas confirms query-param auth for the current feed. So the existing auth mechanism is correct — the intermittent 0-departure failures were caused by **error swallowing**, not a wrong auth scheme. Basic Auth is added as an opt-in for forward compatibility.

## Files modified

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/collectors/metra/client.py` | Raise `MetraFetchError` on HTTP/network/parse errors instead of returning stale cache. Add `MetraFetchError` exception class. Support Basic Auth via `api_username`/`api_password` params. Add `has_credentials` property and `_build_url()` helper. |
| `backend_v2/src/trackrat/collectors/metra/collector.py` | Module-level `_consecutive_empty_cycles` counter with threshold of 3. Wrap `MetraFetchError` in `RuntimeError`. Re-raise `RuntimeError` from outer handler. Update credential check to use `has_credentials`. Handle `MetraFetchError` gracefully in JIT path. |
| `backend_v2/src/trackrat/settings.py` | Add `metra_api_username` and `metra_api_password` fields with env var fallback (`METRA_API_USERNAME`, `METRA_API_PASSWORD`). |
| `backend_v2/tests/unit/collectors/metra/test_client.py` | Tests for error propagation (HTTP status, auth, network, parse errors no longer swallowed), Basic Auth initialization, URL building, `has_credentials`, `MetraFetchError` details. |
| `backend_v2/tests/unit/collectors/metra/test_collector.py` | Tests for consecutive-zero detection (warns at 1-2, raises at 3, resets on non-empty), `MetraFetchError` propagation as `RuntimeError`, credential check with both auth methods. |

## Test coverage

93 tests pass (`poetry run pytest tests/unit/collectors/metra/ -v`):
- 44 client tests (auth, caching, protobuf parsing, error propagation)
- 49 collector tests (train ID generation, timezone, station config, integration, credentials, error propagation, consecutive-zero detection)

## Design decisions

1. **Module-level counter** for consecutive empty cycles — the collector is instantiated fresh each scheduler run, so instance-level state doesn't persist. Module-level globals survive across runs in the same process.
2. **`MetraFetchError`** as a distinct exception — separates feed-level failures from other errors so the collector can handle them differently (raise in scheduled collection, log-and-skip in JIT).
3. **Threshold of 3** consecutive empty cycles — generous enough to tolerate a single bad cycle (e.g., feed temporarily empty during maintenance) but catches persistent failures within ~12 minutes (3 × 4min cycles).

Closes #963

https://claude.ai/code/session_016hFQLgva1LdXhazmUbPqLF

---
_Generated by [Claude Code](https://claude.ai/code/session_016hFQLgva1LdXhazmUbPqLF)_