### PR TITLE
Issue #964: Fix bash octal parse error on hour 08/09 in e2e-api-test.sh

### DIFF
--- a/scripts/e2e-api-test.sh
+++ b/scripts/e2e-api-test.sh
@@ -643,7 +643,7 @@ done
 
 echo -e "${BOLD}Trip Search API (bidirectional)...${NC}"
 
-TRIP_ET_HOUR=$(TZ=America/New_York date +%H)
+TRIP_ET_HOUR=$(TZ=America/New_York date +%-H)
 
 # Test a single trip search direction.
 # Returns 0 on success, 1 on failure.


### PR DESCRIPTION
## Summary

- Fixes bash octal parse error when `TRIP_ET_HOUR` is `08` or `09` (8–10 AM ET)
- Changes `date +%H` to `date +%-H` to strip the leading zero that bash interprets as an octal prefix
- Single-character fix on line 646 of `scripts/e2e-api-test.sh`

## Files modified

- `scripts/e2e-api-test.sh` — Changed `%H` to `%-H` in the `TRIP_ET_HOUR` assignment (line 646). The zero-padded values `"08"` and `"09"` were invalid octal literals in bash `[[ -ge / -lt ]]` arithmetic comparisons (lines 670, 672), causing the script to abort under `set -euo pipefail` and silently skip trip-search test failures.

## Test coverage

This is a shell utility script without a unit test suite. Verification:
- Confirmed `%-H` produces non-padded output (e.g. `9` instead of `09`)
- Confirmed arithmetic comparisons work correctly with the non-padded value
- Full verification per the issue: run the script at 8–9 AM ET and confirm no `value too great for base` errors

## Design decisions

- Used `%-H` (GNU date format) rather than `10#$TRIP_ET_HOUR` at comparison sites, because fixing at the source eliminates risk of missing a comparison site — matches the issue's recommendation.

Closes #964

https://claude.ai/code/session_01NszjNL7mDgtaBmWXu6s1hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NszjNL7mDgtaBmWXu6s1hd)_