### PR TITLE
Issue #984: Fix scheduler connection leak via BaseException handling

### DIFF
--- a/backend_v2/src/trackrat/db/engine.py
+++ b/backend_v2/src/trackrat/db/engine.py
@@ -7,6 +7,7 @@ Uses PostgreSQL with asyncpg for scalable, concurrent database access.
 import asyncio
 import functools
 from collections.abc import AsyncGenerator, Awaitable, Callable
+import contextlib
 from contextlib import asynccontextmanager
 from typing import Any, TypeVar
 
@@ -198,6 +199,10 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
             await session.commit()
         except Exception:
             await session.rollback()
+            raise
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await session.rollback()
             raise
         finally:
             await session.close()

--- a/backend_v2/src/trackrat/utils/scheduler_utils.py
+++ b/backend_v2/src/trackrat/utils/scheduler_utils.py
@@ -5,6 +5,7 @@ Ensures scheduled tasks only run once across multiple Cloud Run replicas.
 """
 
 import asyncio
+import contextlib
 import os
 import time
 from collections.abc import Awaitable, Callable
@@ -264,6 +265,13 @@ async def run_with_freshness_check(
         )
         # If we can't check freshness, don't run the task (fail safe)
         return False
+
+    except BaseException:
+        # CancelledError, KeyboardInterrupt, SystemExit bypass except Exception.
+        # Rollback to release the FOR UPDATE lock and avoid idle-in-transaction.
+        with contextlib.suppress(Exception):
+            await db.rollback()
+        raise
 
 
 def calculate_task_timeout(scheduled_minutes: int) -> int:

--- a/backend_v2/tests/unit/test_engine_session.py
+++ b/backend_v2/tests/unit/test_engine_session.py
@@ -1,0 +1,92 @@
+"""
+Tests for get_session() BaseException handling in db/engine.py.
+
+Verifies that CancelledError and other BaseException subclasses
+trigger an explicit rollback before propagating, preventing
+idle-in-transaction connection leaks.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from trackrat.db.engine import get_session
+
+
+class TestGetSessionBaseExceptionHandling:
+    """Verify get_session() rolls back on BaseException subclasses."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock AsyncSession."""
+        session = AsyncMock()
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        session.close = AsyncMock()
+        return session
+
+    @pytest.fixture
+    def mock_sessionmaker(self, mock_session):
+        """Create a mock sessionmaker that yields our mock session."""
+        sm = MagicMock()
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        sm.return_value = ctx
+        return sm
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_triggers_rollback(
+        self, mock_session, mock_sessionmaker
+    ):
+        """CancelledError inside get_session must trigger explicit rollback."""
+        with patch("trackrat.db.engine.get_sessionmaker", return_value=mock_sessionmaker):
+            with pytest.raises(asyncio.CancelledError):
+                async with get_session() as session:
+                    raise asyncio.CancelledError()
+
+        mock_session.rollback.assert_called()
+        mock_session.commit.assert_not_called()
+        mock_session.close.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_regular_exception_triggers_rollback(
+        self, mock_session, mock_sessionmaker
+    ):
+        """Regular Exception inside get_session triggers rollback (existing behavior)."""
+        with patch("trackrat.db.engine.get_sessionmaker", return_value=mock_sessionmaker):
+            with pytest.raises(ValueError):
+                async with get_session() as session:
+                    raise ValueError("test error")
+
+        mock_session.rollback.assert_called()
+        mock_session.commit.assert_not_called()
+        mock_session.close.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_session_commits(self, mock_session, mock_sessionmaker):
+        """Successful session usage commits and closes."""
+        with patch("trackrat.db.engine.get_sessionmaker", return_value=mock_sessionmaker):
+            async with get_session() as session:
+                pass  # No error
+
+        mock_session.commit.assert_called_once()
+        mock_session.rollback.assert_not_called()
+        mock_session.close.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_rollback_failure_during_cancellation_still_propagates(
+        self, mock_session, mock_sessionmaker
+    ):
+        """If rollback fails during CancelledError, the error still propagates."""
+        mock_session.rollback.side_effect = RuntimeError("connection lost")
+
+        with patch("trackrat.db.engine.get_sessionmaker", return_value=mock_sessionmaker):
+            with pytest.raises(asyncio.CancelledError):
+                async with get_session() as session:
+                    raise asyncio.CancelledError()
+
+        # Rollback was attempted even though it failed
+        mock_session.rollback.assert_called()
+        mock_session.close.assert_called()

--- a/backend_v2/tests/unit/test_scheduler_utils.py
+++ b/backend_v2/tests/unit/test_scheduler_utils.py
@@ -5,6 +5,8 @@ Tests the distributed task execution system that prevents duplicate
 task runs across multiple Cloud Run replicas.
 """
 
+import asyncio
+
 import pytest
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
@@ -555,3 +557,197 @@ class TestRunWithFreshnessCheckTimeout:
                 assert len(timeout_calls) == 1
                 assert timeout_calls[0].kwargs["task"] == "slow_collector"
                 assert timeout_calls[0].kwargs["timeout_seconds"] == 1
+
+
+class TestRunWithFreshnessCheckCancelledError:
+    """Test that CancelledError (BaseException) is handled correctly.
+
+    CancelledError inherits from BaseException, not Exception, so it
+    bypasses except Exception handlers. Before the fix, this would leave
+    the AsyncSession with an open transaction holding a FOR UPDATE lock.
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        """Mock AsyncSession database."""
+        mock = AsyncMock(spec=AsyncSession)
+        mock.execute = AsyncMock()
+        mock.flush = AsyncMock()
+        mock.commit = AsyncMock()
+        mock.rollback = AsyncMock()
+        mock.add = Mock()
+        return mock
+
+    def _setup_stale_task(self, mock_db):
+        """Set up a mock task that needs to run (last ran long ago)."""
+        from datetime import timezone
+
+        old_time = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        mock_task_run = Mock(spec=SchedulerTaskRun)
+        mock_task_run.task_name = "test_task"
+        mock_task_run.last_successful_run = old_time
+        mock_task_run.run_count = 1
+        mock_task_run.average_duration_ms = 5000
+
+        upsert_result = Mock()
+        select_result = Mock()
+        select_result.scalar_one_or_none.return_value = mock_task_run
+        mock_db.execute.side_effect = [upsert_result, select_result]
+        return mock_task_run
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_task_rolls_back(self, mock_db):
+        """CancelledError during task execution must rollback the transaction.
+
+        This is the core bug from issue #984: CancelledError bypasses
+        except Exception, leaving the FOR UPDATE lock held indefinitely.
+        """
+        self._setup_stale_task(mock_db)
+
+        async def cancelled_task():
+            raise asyncio.CancelledError()
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            with pytest.raises(asyncio.CancelledError):
+                await run_with_freshness_check(
+                    db=mock_db,
+                    task_name="test_task",
+                    minimum_interval_seconds=60,
+                    task_func=cancelled_task,
+                )
+
+        # The critical assertion: rollback MUST have been called
+        mock_db.rollback.assert_called()
+        mock_db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates(self, mock_db):
+        """CancelledError must propagate after rollback, not be swallowed."""
+        self._setup_stale_task(mock_db)
+
+        async def cancelled_task():
+            raise asyncio.CancelledError()
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            with pytest.raises(asyncio.CancelledError):
+                await run_with_freshness_check(
+                    db=mock_db,
+                    task_name="test_task",
+                    minimum_interval_seconds=60,
+                    task_func=cancelled_task,
+                )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_db_setup_rolls_back(self, mock_db):
+        """CancelledError during the upsert/lock phase must also rollback."""
+        mock_db.execute.side_effect = asyncio.CancelledError()
+        task_func = AsyncMock()
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_with_freshness_check(
+                db=mock_db,
+                task_name="test_task",
+                minimum_interval_seconds=60,
+                task_func=task_func,
+            )
+
+        mock_db.rollback.assert_called()
+        task_func.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_keyboard_interrupt_rolls_back(self, mock_db):
+        """KeyboardInterrupt (also BaseException) must rollback."""
+        self._setup_stale_task(mock_db)
+
+        async def interrupted_task():
+            raise KeyboardInterrupt()
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            with pytest.raises(KeyboardInterrupt):
+                await run_with_freshness_check(
+                    db=mock_db,
+                    task_name="test_task",
+                    minimum_interval_seconds=60,
+                    task_func=interrupted_task,
+                )
+
+        mock_db.rollback.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_rollback_failure_during_cancellation_still_propagates(self, mock_db):
+        """If rollback itself fails during CancelledError, the error still propagates."""
+        self._setup_stale_task(mock_db)
+        mock_db.rollback.side_effect = RuntimeError("connection lost")
+
+        async def cancelled_task():
+            raise asyncio.CancelledError()
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            # CancelledError should propagate even if rollback fails
+            with pytest.raises(asyncio.CancelledError):
+                await run_with_freshness_check(
+                    db=mock_db,
+                    task_name="test_task",
+                    minimum_interval_seconds=60,
+                    task_func=cancelled_task,
+                )
+
+    @pytest.mark.asyncio
+    async def test_normal_exception_still_returns_false(self, mock_db):
+        """Verify existing behavior is preserved: Exception returns False."""
+        self._setup_stale_task(mock_db)
+
+        async def failing_task():
+            raise ValueError("something broke")
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            result = await run_with_freshness_check(
+                db=mock_db,
+                task_name="test_task",
+                minimum_interval_seconds=60,
+                task_func=failing_task,
+            )
+
+        # Exception subclasses are caught and return False (existing behavior)
+        assert result is False
+        mock_db.rollback.assert_called()


### PR DESCRIPTION
## Summary

- Fix `run_with_freshness_check()` in `scheduler_utils.py` to catch `BaseException` (including `asyncio.CancelledError`, `KeyboardInterrupt`, `SystemExit`) and rollback the database transaction before re-raising
- Fix `get_session()` in `engine.py` with the same `BaseException` handling pattern
- Use `contextlib.suppress(Exception)` around rollback calls in `BaseException` handlers to prevent rollback failures from masking the original error

## Root Cause

`asyncio.CancelledError` inherits from `BaseException` (not `Exception`) in Python 3.8+. The existing `except Exception` handlers in both `run_with_freshness_check()` and `get_session()` did not catch it, leaving `AsyncSession` objects with open transactions holding `FOR UPDATE` row locks. These leaked transactions pinned old snapshots, blocking autovacuum across the entire database and causing unbounded bloat.

## Files Modified

| File | Change |
|---|---|
| `backend_v2/src/trackrat/utils/scheduler_utils.py` | Added `except BaseException` handler after existing `except Exception` in `run_with_freshness_check()` |
| `backend_v2/src/trackrat/db/engine.py` | Added `except BaseException` handler after existing `except Exception` in `get_session()` |
| `backend_v2/tests/unit/test_scheduler_utils.py` | Added 6 tests for `CancelledError` behavior: rollback on cancel during task, rollback on cancel during DB setup, propagation, `KeyboardInterrupt`, rollback failure resilience, and existing `Exception` behavior preservation |
| `backend_v2/tests/unit/test_engine_session.py` | New file with 4 tests for `get_session()` `BaseException` handling |

## Test Coverage

10 new tests covering:
- `CancelledError` during task execution triggers rollback
- `CancelledError` during DB setup phase triggers rollback
- `CancelledError` propagates (not swallowed) after rollback
- `KeyboardInterrupt` triggers rollback
- Rollback failure during cancellation still propagates the original error
- Existing `Exception` behavior preserved (returns `False`)
- `get_session()` rollback on `CancelledError`, regular `Exception`, success path, and rollback failure resilience

## Production Notes

After deploying, the maintainer should also consider:
1. Killing existing stuck sessions: `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE state = 'idle in transaction' AND now() - query_start > interval '30 seconds';`
2. Setting a cluster-level safety net: `ALTER SYSTEM SET idle_in_transaction_session_timeout = '60000'; SELECT pg_reload_conf();`

Closes #984

https://claude.ai/code/session_01FmGizRQ5A41ZnCHTLkgdPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmGizRQ5A41ZnCHTLkgdPF)_