### PR TITLE
Issue #986: Drop 11 unused indexes to speed up writes

### DIFF
--- a/backend_v2/src/trackrat/db/migrations/versions/20260423_1749-d170389c0848_drop_unused_indexes.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260423_1749-d170389c0848_drop_unused_indexes.py
@@ -1,0 +1,80 @@
+"""Drop unused indexes to reclaim ~100MB and speed up writes.
+
+All indexes have idx_scan = 0 in pg_stat_user_indexes on production.
+idx_track_occupancy_lookup is excluded despite zero scans because
+track_occupancy.py actively queries its column combination; the zero
+scans are likely due to stale planner stats from the P0 scheduler leak.
+
+Dropped: idx_captured_at, idx_station_dwell, idx_recent_dwell,
+idx_discovery_time, idx_validation_coverage, idx_validation_time,
+idx_service_alert_type, idx_alert_sub_line, idx_alert_sub_stations,
+idx_task_freshness, idx_gtfs_feed_source.
+
+Revision ID: d170389c0848
+Revises: 6feb0d5b5600
+Create Date: 2026-04-23T17:49:00Z
+
+"""
+
+from alembic import op
+
+revision = "d170389c0848"
+down_revision = "6feb0d5b5600"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("idx_captured_at", table_name="journey_snapshots")
+    op.drop_index("idx_station_dwell", table_name="station_dwell_times")
+    op.drop_index("idx_recent_dwell", table_name="station_dwell_times")
+    op.drop_index("idx_discovery_time", table_name="discovery_runs")
+    op.drop_index("idx_validation_coverage", table_name="validation_results")
+    op.drop_index("idx_validation_time", table_name="validation_results")
+    op.drop_index("idx_service_alert_type", table_name="service_alerts")
+    op.drop_index("idx_alert_sub_line", table_name="route_alert_subscriptions")
+    op.drop_index("idx_alert_sub_stations", table_name="route_alert_subscriptions")
+    op.drop_index("idx_task_freshness", table_name="scheduler_task_runs")
+    op.drop_index("idx_gtfs_feed_source", table_name="gtfs_feed_info")
+
+
+def downgrade() -> None:
+    op.create_index("idx_captured_at", "journey_snapshots", ["captured_at"])
+    op.create_index(
+        "idx_station_dwell",
+        "station_dwell_times",
+        ["station_code", "data_source", "departure_time"],
+    )
+    op.create_index(
+        "idx_recent_dwell", "station_dwell_times", ["station_code", "created_at"]
+    )
+    op.create_index(
+        "idx_discovery_time", "discovery_runs", ["station_code", "run_at"]
+    )
+    op.create_index(
+        "idx_validation_coverage",
+        "validation_results",
+        ["route", "source", "coverage_percent"],
+    )
+    op.create_index(
+        "idx_validation_time", "validation_results", ["run_at", "route", "source"]
+    )
+    op.create_index(
+        "idx_service_alert_type", "service_alerts", ["alert_type", "data_source"]
+    )
+    op.create_index(
+        "idx_alert_sub_line",
+        "route_alert_subscriptions",
+        ["data_source", "line_id"],
+    )
+    op.create_index(
+        "idx_alert_sub_stations",
+        "route_alert_subscriptions",
+        ["data_source", "from_station_code", "to_station_code"],
+    )
+    op.create_index(
+        "idx_task_freshness",
+        "scheduler_task_runs",
+        ["task_name", "last_successful_run"],
+    )
+    op.create_index("idx_gtfs_feed_source", "gtfs_feed_info", ["data_source"])

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -219,22 +219,14 @@ class JourneyStop(Base):
         UniqueConstraint("journey_id", "station_code", name="unique_journey_stop"),
         Index("idx_station_times", "station_code", "scheduled_departure"),
         Index("idx_journey_sequence", "journey_id", "stop_sequence"),
-        # Performance optimization: composite index for track occupancy queries
-        # Used by track_occupancy.py to find occupied tracks at a station
         Index(
             "idx_track_occupancy_lookup",
             "station_code",
             "has_departed_station",
             "scheduled_departure",
         ),
-        # Performance optimization: composite index for track distribution queries
-        # Used by historical_track_predictor.py for GROUP BY aggregations
         Index("idx_stop_track_distribution", "station_code", "track"),
-        # Performance optimization: composite index for stop-level delay forecaster joins
-        # Used by delay_forecaster.py to join journey_stops to train_journeys
         Index("idx_stop_delay_forecaster", "station_code", "journey_id"),
-        # Performance optimization: composite index for route history EXISTS subquery
-        # Used by routes.py to check station pair ordering on journeys
         Index(
             "idx_stop_journey_station_seq",
             "journey_id",
@@ -274,10 +266,7 @@ class JourneySnapshot(Base):
         "TrainJourney", back_populates="snapshots", lazy="raise_on_sql"
     )
 
-    __table_args__ = (
-        Index("idx_journey_time", "journey_id", "captured_at"),
-        Index("idx_captured_at", "captured_at"),
-    )
+    __table_args__ = (Index("idx_journey_time", "journey_id", "captured_at"),)
 
 
 class DiscoveryRun(Base):
@@ -293,8 +282,6 @@ class DiscoveryRun(Base):
     duration_ms = Column(Integer)
     success = Column(Boolean, default=True, nullable=False)
     error_details = Column(Text)
-
-    __table_args__ = (Index("idx_discovery_time", "station_code", "run_at"),)
 
 
 class LiveActivityToken(Base):
@@ -405,13 +392,6 @@ class RouteAlertSubscription(Base):
             name="ck_alert_sub_type",
         ),
         Index("idx_alert_sub_device", "device_id"),
-        Index("idx_alert_sub_line", "data_source", "line_id"),
-        Index(
-            "idx_alert_sub_stations",
-            "data_source",
-            "from_station_code",
-            "to_station_code",
-        ),
         Index("idx_alert_sub_train", "data_source", "train_id"),
     )
 
@@ -447,7 +427,6 @@ class ServiceAlert(Base):
     __table_args__ = (
         UniqueConstraint("alert_id", "data_source", name="uq_service_alert_id"),
         Index("idx_service_alert_active", "is_active", "data_source"),
-        Index("idx_service_alert_type", "alert_type", "data_source"),
     )
 
 
@@ -542,11 +521,6 @@ class StationDwellTime(Base):
         "TrainJourney", back_populates="dwell_times", lazy="raise_on_sql"
     )
 
-    __table_args__ = (
-        Index("idx_station_dwell", "station_code", "data_source", "departure_time"),
-        Index("idx_recent_dwell", "station_code", "created_at"),
-    )
-
 
 class JourneyProgress(Base):
     """Journey progress snapshots for real-time tracking."""
@@ -638,8 +612,6 @@ class SchedulerTaskRun(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
-    __table_args__ = (Index("idx_task_freshness", "task_name", "last_successful_run"),)
-
 
 class ValidationResult(Base):
     """Store results from train validation service for monitoring and analysis."""
@@ -665,12 +637,6 @@ class ValidationResult(Base):
     # Additional details for debugging
     details = Column(JSON)  # Store sample accessibility checks, error details, etc.
 
-    # Indexing for efficient queries
-    __table_args__ = (
-        Index("idx_validation_time", "run_at", "route", "source"),
-        Index("idx_validation_coverage", "route", "source", "coverage_percent"),
-    )
-
 
 # =============================================================================
 # GTFS Static Schedule Tables
@@ -693,8 +659,6 @@ class GTFSFeedInfo(Base):
     trip_count = Column(Integer)
     stop_time_count = Column(Integer)
     error_message = Column(Text)  # Last error if download/parse failed
-
-    __table_args__ = (Index("idx_gtfs_feed_source", "data_source"),)
 
 
 class GTFSRoute(Base):

--- a/backend_v2/tests/unit/test_drop_unused_indexes.py
+++ b/backend_v2/tests/unit/test_drop_unused_indexes.py
@@ -1,0 +1,321 @@
+"""Tests for unused index removal (Issue #986).
+
+Verifies that dropped indexes are no longer in model definitions,
+retained indexes are still present, and the migration drops/recreates
+exactly the right set.
+"""
+
+import importlib
+import types
+
+from sqlalchemy import Index, UniqueConstraint
+
+from trackrat.models.database import (
+    DiscoveryRun,
+    GTFSFeedInfo,
+    JourneySnapshot,
+    JourneyStop,
+    RouteAlertSubscription,
+    SchedulerTaskRun,
+    ServiceAlert,
+    StationDwellTime,
+    ValidationResult,
+)
+
+DROPPED_INDEXES = {
+    "idx_captured_at",
+    "idx_station_dwell",
+    "idx_recent_dwell",
+    "idx_discovery_time",
+    "idx_validation_coverage",
+    "idx_validation_time",
+    "idx_service_alert_type",
+    "idx_alert_sub_line",
+    "idx_alert_sub_stations",
+    "idx_task_freshness",
+    "idx_gtfs_feed_source",
+}
+
+RETAINED_INDEXES = {
+    "idx_station_times",
+    "idx_journey_sequence",
+    "idx_track_occupancy_lookup",
+    "idx_stop_track_distribution",
+    "idx_stop_delay_forecaster",
+    "idx_stop_journey_station_seq",
+    "idx_journey_time",
+    "idx_service_alert_active",
+    "idx_alert_sub_device",
+    "idx_alert_sub_train",
+}
+
+
+def _get_index_names(model_class):
+    """Extract index names from a model's __table_args__."""
+    table_args = getattr(model_class, "__table_args__", ())
+    if isinstance(table_args, dict):
+        return set()
+    names = set()
+    for arg in table_args:
+        if isinstance(arg, Index):
+            names.add(arg.name)
+    return names
+
+
+def test_dropped_indexes_not_in_journey_snapshots_model():
+    indexes = _get_index_names(JourneySnapshot)
+    assert "idx_captured_at" not in indexes, (
+        f"idx_captured_at should be removed from JourneySnapshot, "
+        f"found indexes: {indexes}"
+    )
+
+
+def test_dropped_indexes_not_in_station_dwell_times_model():
+    indexes = _get_index_names(StationDwellTime)
+    assert "idx_station_dwell" not in indexes, (
+        f"idx_station_dwell should be removed from StationDwellTime"
+    )
+    assert "idx_recent_dwell" not in indexes, (
+        f"idx_recent_dwell should be removed from StationDwellTime"
+    )
+
+
+def test_dropped_indexes_not_in_discovery_runs_model():
+    indexes = _get_index_names(DiscoveryRun)
+    assert "idx_discovery_time" not in indexes, (
+        f"idx_discovery_time should be removed from DiscoveryRun"
+    )
+
+
+def test_dropped_indexes_not_in_validation_results_model():
+    indexes = _get_index_names(ValidationResult)
+    assert "idx_validation_time" not in indexes
+    assert "idx_validation_coverage" not in indexes
+
+
+def test_dropped_indexes_not_in_service_alerts_model():
+    indexes = _get_index_names(ServiceAlert)
+    assert "idx_service_alert_type" not in indexes, (
+        f"idx_service_alert_type should be removed from ServiceAlert"
+    )
+
+
+def test_dropped_indexes_not_in_route_alert_subscriptions_model():
+    indexes = _get_index_names(RouteAlertSubscription)
+    assert "idx_alert_sub_line" not in indexes
+    assert "idx_alert_sub_stations" not in indexes
+
+
+def test_dropped_indexes_not_in_scheduler_task_runs_model():
+    indexes = _get_index_names(SchedulerTaskRun)
+    assert "idx_task_freshness" not in indexes, (
+        f"idx_task_freshness should be removed from SchedulerTaskRun "
+        f"(task_name is already PK)"
+    )
+
+
+def test_dropped_indexes_not_in_gtfs_feed_info_model():
+    indexes = _get_index_names(GTFSFeedInfo)
+    assert "idx_gtfs_feed_source" not in indexes, (
+        f"idx_gtfs_feed_source should be removed from GTFSFeedInfo "
+        f"(data_source already has unique=True)"
+    )
+
+
+def test_retained_indexes_still_present_on_journey_stops():
+    indexes = _get_index_names(JourneyStop)
+    expected = {
+        "idx_station_times",
+        "idx_journey_sequence",
+        "idx_track_occupancy_lookup",
+        "idx_stop_track_distribution",
+        "idx_stop_delay_forecaster",
+        "idx_stop_journey_station_seq",
+    }
+    missing = expected - indexes
+    assert not missing, (
+        f"JourneyStop is missing retained indexes: {missing}. "
+        f"Current indexes: {indexes}"
+    )
+
+
+def test_track_occupancy_lookup_explicitly_retained():
+    """idx_track_occupancy_lookup must be kept — track_occupancy.py uses it."""
+    indexes = _get_index_names(JourneyStop)
+    assert "idx_track_occupancy_lookup" in indexes, (
+        "idx_track_occupancy_lookup must NOT be dropped; "
+        "track_occupancy.py queries on (station_code, has_departed_station, "
+        "scheduled_departure)"
+    )
+
+
+def test_retained_indexes_still_present_on_journey_snapshots():
+    indexes = _get_index_names(JourneySnapshot)
+    assert "idx_journey_time" in indexes, (
+        f"idx_journey_time should be retained on JourneySnapshot"
+    )
+
+
+def test_retained_indexes_still_present_on_service_alerts():
+    indexes = _get_index_names(ServiceAlert)
+    assert "idx_service_alert_active" in indexes, (
+        f"idx_service_alert_active should be retained on ServiceAlert"
+    )
+
+
+def test_retained_indexes_still_present_on_route_alert_subscriptions():
+    indexes = _get_index_names(RouteAlertSubscription)
+    expected = {"idx_alert_sub_device", "idx_alert_sub_train"}
+    missing = expected - indexes
+    assert not missing, (
+        f"RouteAlertSubscription is missing retained indexes: {missing}"
+    )
+
+
+def test_unique_constraint_preserved_on_journey_stops():
+    """unique_journey_stop constraint must survive the index cleanup."""
+    table_args = getattr(JourneyStop, "__table_args__", ())
+    constraints = [
+        arg for arg in table_args if isinstance(arg, UniqueConstraint)
+    ]
+    names = {c.name for c in constraints}
+    assert "unique_journey_stop" in names, (
+        f"unique_journey_stop constraint missing from JourneyStop"
+    )
+
+
+def test_unique_constraint_preserved_on_service_alerts():
+    """uq_service_alert_id constraint must survive the index cleanup."""
+    table_args = getattr(ServiceAlert, "__table_args__", ())
+    constraints = [
+        arg for arg in table_args if isinstance(arg, UniqueConstraint)
+    ]
+    names = {c.name for c in constraints}
+    assert "uq_service_alert_id" in names
+
+
+def test_no_dropped_index_appears_in_any_model():
+    """Cross-check: none of the 11 dropped indexes appear in any model."""
+    all_models = [
+        JourneyStop,
+        JourneySnapshot,
+        StationDwellTime,
+        DiscoveryRun,
+        ValidationResult,
+        ServiceAlert,
+        RouteAlertSubscription,
+        SchedulerTaskRun,
+        GTFSFeedInfo,
+    ]
+    for model in all_models:
+        indexes = _get_index_names(model)
+        overlap = DROPPED_INDEXES & indexes
+        assert not overlap, (
+            f"{model.__name__} still has dropped indexes: {overlap}"
+        )
+
+
+def test_migration_drops_exactly_eleven_indexes():
+    """Verify the migration upgrade function drops exactly 11 indexes."""
+    migration = importlib.import_module(
+        "trackrat.db.migrations.versions."
+        "20260423_1749-d170389c0848_drop_unused_indexes"
+    )
+    assert migration.revision == "d170389c0848"
+    assert migration.down_revision == "6feb0d5b5600"
+
+    calls = []
+    mock_op = types.SimpleNamespace(
+        drop_index=lambda name, **kwargs: calls.append(
+            ("drop", name, kwargs.get("table_name"))
+        )
+    )
+
+    import trackrat.db.migrations.versions as versions_pkg
+    mod = getattr(
+        versions_pkg,
+        "20260423_1749-d170389c0848_drop_unused_indexes",
+        migration,
+    )
+
+    original_op = None
+    try:
+        original_op = getattr(mod, "op", None)
+        mod.op = mock_op
+        mod.upgrade()
+    finally:
+        if original_op is not None:
+            mod.op = original_op
+        else:
+            delattr(mod, "op")
+
+    dropped_names = {name for _, name, _ in calls}
+    assert dropped_names == DROPPED_INDEXES, (
+        f"Migration should drop exactly {DROPPED_INDEXES}, "
+        f"but dropped {dropped_names}. "
+        f"Missing: {DROPPED_INDEXES - dropped_names}, "
+        f"Extra: {dropped_names - DROPPED_INDEXES}"
+    )
+    assert len(calls) == 11, f"Expected 11 drop_index calls, got {len(calls)}"
+
+
+def test_migration_does_not_drop_track_occupancy_lookup():
+    """idx_track_occupancy_lookup must NOT be in the migration drop list."""
+    migration = importlib.import_module(
+        "trackrat.db.migrations.versions."
+        "20260423_1749-d170389c0848_drop_unused_indexes"
+    )
+
+    calls = []
+    mock_op = types.SimpleNamespace(
+        drop_index=lambda name, **kwargs: calls.append(name)
+    )
+
+    try:
+        original_op = getattr(migration, "op", None)
+        migration.op = mock_op
+        migration.upgrade()
+    finally:
+        if original_op is not None:
+            migration.op = original_op
+        else:
+            delattr(migration, "op")
+
+    assert "idx_track_occupancy_lookup" not in calls, (
+        "Migration must NOT drop idx_track_occupancy_lookup; "
+        "it is actively used by track_occupancy.py"
+    )
+
+
+def test_migration_downgrade_recreates_all_eleven_indexes():
+    """Verify the migration downgrade recreates all 11 indexes."""
+    migration = importlib.import_module(
+        "trackrat.db.migrations.versions."
+        "20260423_1749-d170389c0848_drop_unused_indexes"
+    )
+
+    calls = []
+    mock_op = types.SimpleNamespace(
+        create_index=lambda name, table, columns, **kwargs: calls.append(
+            ("create", name, table, columns)
+        )
+    )
+
+    try:
+        original_op = getattr(migration, "op", None)
+        migration.op = mock_op
+        migration.downgrade()
+    finally:
+        if original_op is not None:
+            migration.op = original_op
+        else:
+            delattr(migration, "op")
+
+    created_names = {name for _, name, _, _ in calls}
+    assert created_names == DROPPED_INDEXES, (
+        f"Downgrade should recreate exactly {DROPPED_INDEXES}, "
+        f"but created {created_names}"
+    )
+    assert len(calls) == 11, (
+        f"Expected 11 create_index calls, got {len(calls)}"
+    )


### PR DESCRIPTION
## Summary

- Drops 11 indexes with `idx_scan = 0` in production across 9 tables
- Removes corresponding `Index()` entries from `database.py` model definitions
- **Excludes `idx_track_occupancy_lookup`** (1.6GB) despite zero scans — codebase analysis found `track_occupancy.py` actively queries its column combination `(station_code, has_departed_station, scheduled_departure)`. The zero scans are likely due to stale planner stats from the P0 scheduler leak (#984).

### Indexes dropped

| Index | Table | Size |
|---|---|---|
| `idx_captured_at` | journey_snapshots | 100 MB |
| `idx_station_dwell` | station_dwell_times | 53 MB |
| `idx_recent_dwell` | station_dwell_times | 43 MB |
| `idx_discovery_time` | discovery_runs | 8 MB |
| `idx_validation_coverage` | validation_results | 1.5 MB |
| `idx_validation_time` | validation_results | 1.2 MB |
| `idx_service_alert_type` | service_alerts | 120 kB |
| `idx_alert_sub_line` | route_alert_subscriptions | 16 kB |
| `idx_alert_sub_stations` | route_alert_subscriptions | 16 kB |
| `idx_task_freshness` | scheduler_task_runs | 16 kB |
| `idx_gtfs_feed_source` | gtfs_feed_info | 16 kB |

### Codebase verification

Each index was verified unused via grep/AST analysis:
- `idx_captured_at`: All snapshot access is via `journey_id`; `idx_journey_time` covers it
- `idx_station_dwell` / `idx_recent_dwell`: `station_dwell_times` is write-only (never queried)
- `idx_discovery_time`: Only query filters on `run_at` alone, not `station_code`
- `idx_validation_*`: Low-volume table (~few hundred rows/day); PK scan is sufficient
- `idx_service_alert_type`: `alert_type` is never a leading filter; `idx_service_alert_active` covers all queries
- `idx_alert_sub_line` / `idx_alert_sub_stations`: All access is via `device_id` or full relationship load
- `idx_task_freshness`: `task_name` is already PK; composite adds zero selectivity
- `idx_gtfs_feed_source`: `data_source` already has `unique=True` (duplicate index)

## Files changed

| File | Change |
|---|---|
| `backend_v2/src/trackrat/models/database.py` | Removed 11 `Index()` entries from `__table_args__` across 9 models |
| `backend_v2/src/trackrat/db/migrations/versions/20260423_1749-d170389c0848_drop_unused_indexes.py` | Alembic migration dropping 11 indexes with full downgrade support |
| `backend_v2/tests/unit/test_drop_unused_indexes.py` | 19 tests covering: dropped indexes absent from models, retained indexes present, constraints preserved, migration drops/recreates correct set, `idx_track_occupancy_lookup` explicitly retained |

## Test coverage

All 19 tests pass:
```
tests/unit/test_drop_unused_indexes.py  19 passed in 0.18s
```

Full unit suite: 2323 passed (211 errors are pre-existing DB connection failures, unrelated).

## Design decisions

- **Kept `idx_track_occupancy_lookup`**: Despite `idx_scan = 0`, the code in `track_occupancy.py:113-127` queries exactly `(station_code, has_departed_station, scheduled_departure)`. Zero scans are likely from stale planner stats due to the P0 scheduler leak. Once #984 lands and `ANALYZE` runs, this index should start being used.
- **No `CONCURRENTLY`**: Consistent with existing migration patterns. Migrations run during startup (brief downtime window).
- **All tiers in one migration**: The issue suggested staging Tier 1 vs Tier 2, but with `idx_track_occupancy_lookup` excluded, the remaining indexes are all small. Single migration is simpler.

Closes #986

https://claude.ai/code/session_01DreDgbgtehigHJoT2exz1h

---
_Generated by [Claude Code](https://claude.ai/code/session_01DreDgbgtehigHJoT2exz1h)_