### PR TITLE
Bulk-load existing journeys to fix subway collector timeout

### DIFF
--- a/backend_v2/src/trackrat/collectors/bart/collector.py
+++ b/backend_v2/src/trackrat/collectors/bart/collector.py
@@ -11,10 +11,10 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from trackrat.collectors.bart.client import BartArrival, BARTClient
 from trackrat.collectors.mta_common import (
+    JOURNEY_UPDATE_LOAD_OPTIONS,
     build_complete_stops,
     check_journey_completed,
     update_journey_metadata,
@@ -244,16 +244,7 @@ class BARTCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "BART",
             )
-            .options(
-                selectinload(TrainJourney.stops),
-                # Load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush orphan checks
-                selectinload(TrainJourney.snapshots),
-                selectinload(TrainJourney.segment_times),
-                selectinload(TrainJourney.dwell_times),
-                selectinload(TrainJourney.progress),
-                selectinload(TrainJourney.progress_snapshots),
-            )
+            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -12,10 +12,10 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from trackrat.collectors.lirr.client import LirrArrival, LIRRClient
 from trackrat.collectors.mta_common import (
+    JOURNEY_UPDATE_LOAD_OPTIONS,
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
@@ -301,16 +301,7 @@ class LIRRCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "LIRR",
             )
-            .options(
-                selectinload(TrainJourney.stops),
-                # Load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush orphan checks
-                selectinload(TrainJourney.snapshots),
-                selectinload(TrainJourney.segment_times),
-                selectinload(TrainJourney.dwell_times),
-                selectinload(TrainJourney.progress),
-                selectinload(TrainJourney.progress_snapshots),
-            )
+            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/mbta/collector.py
+++ b/backend_v2/src/trackrat/collectors/mbta/collector.py
@@ -11,10 +11,10 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from trackrat.collectors.mbta.client import MbtaArrival, MBTAClient
 from trackrat.collectors.mta_common import (
+    JOURNEY_UPDATE_LOAD_OPTIONS,
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
@@ -263,16 +263,7 @@ class MBTACollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "MBTA",
             )
-            .options(
-                selectinload(TrainJourney.stops),
-                # Load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush orphan checks
-                selectinload(TrainJourney.snapshots),
-                selectinload(TrainJourney.segment_times),
-                selectinload(TrainJourney.dwell_times),
-                selectinload(TrainJourney.progress),
-                selectinload(TrainJourney.progress_snapshots),
-            )
+            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/metra/collector.py
+++ b/backend_v2/src/trackrat/collectors/metra/collector.py
@@ -11,10 +11,10 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from trackrat.collectors.metra.client import MetraArrival, MetraClient, MetraFetchError
 from trackrat.collectors.mta_common import (
+    JOURNEY_UPDATE_LOAD_OPTIONS,
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
@@ -299,16 +299,7 @@ class MetraCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == DATA_SOURCE,
             )
-            .options(
-                selectinload(TrainJourney.stops),
-                # Load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush orphan checks
-                selectinload(TrainJourney.snapshots),
-                selectinload(TrainJourney.segment_times),
-                selectinload(TrainJourney.dwell_times),
-                selectinload(TrainJourney.progress),
-                selectinload(TrainJourney.progress_snapshots),
-            )
+            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -12,10 +12,10 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from trackrat.collectors.mnr.client import MnrArrival, MNRClient
 from trackrat.collectors.mta_common import (
+    JOURNEY_UPDATE_LOAD_OPTIONS,
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
@@ -289,16 +289,7 @@ class MNRCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "MNR",
             )
-            .options(
-                selectinload(TrainJourney.stops),
-                # Load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush orphan checks
-                selectinload(TrainJourney.snapshots),
-                selectinload(TrainJourney.segment_times),
-                selectinload(TrainJourney.dwell_times),
-                selectinload(TrainJourney.progress),
-                selectinload(TrainJourney.progress_snapshots),
-            )
+            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/mta_common.py
+++ b/backend_v2/src/trackrat/collectors/mta_common.py
@@ -12,10 +12,28 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any
 
+from sqlalchemy.orm import noload, selectinload
+
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.utils.time import normalize_to_et
 
 logger = logging.getLogger(__name__)
+
+# Loader options for GTFS-RT collector update queries (subway, LIRR, MNR,
+# BART, MBTA, Metra). TrainJourney has 5 delete-orphan child collections
+# (snapshots, segment_times, dwell_times, progress, progress_snapshots)
+# that SQLAlchemy would lazy-load during flush orphan checks, triggering
+# greenlet_spawn errors in async context. These collectors never modify
+# any of them — they only read/merge journey.stops — so noload() skips
+# the check without the per-journey round-trips that selectinload costs.
+JOURNEY_UPDATE_LOAD_OPTIONS = (
+    selectinload(TrainJourney.stops),
+    noload(TrainJourney.snapshots),
+    noload(TrainJourney.segment_times),
+    noload(TrainJourney.dwell_times),
+    noload(TrainJourney.progress),
+    noload(TrainJourney.progress_snapshots),
+)
 
 # Terminal stations where outbound trains originate (direction_id=0).
 # Used as a fallback when GTFS static backfill is unavailable.

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -19,9 +19,9 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from trackrat.collectors.mta_common import (
+    JOURNEY_UPDATE_LOAD_OPTIONS,
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
@@ -283,16 +283,7 @@ class SubwayCollector:
                 TrainJourney.journey_date == journey_date,
                 TrainJourney.data_source == "SUBWAY",
             )
-            .options(
-                selectinload(TrainJourney.stops),
-                # Load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush orphan checks
-                selectinload(TrainJourney.snapshots),
-                selectinload(TrainJourney.segment_times),
-                selectinload(TrainJourney.dwell_times),
-                selectinload(TrainJourney.progress),
-                selectinload(TrainJourney.progress_snapshots),
-            )
+            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
         )
         journey = existing.scalar_one_or_none()
 

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -14,7 +14,7 @@ Key differences from LIRR/MNR:
 import asyncio
 import hashlib
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 from typing import Any
 
 from sqlalchemy import select
@@ -145,17 +145,54 @@ class SubwayCollector:
 
             logger.info(f"Found {len(trips)} subway trips in GTFS-RT feeds")
 
+            # Pre-compute the (train_id, journey_date) key for every trip so
+            # we can bulk-load matching journeys in one query. Without this,
+            # each _process_trip did its own SELECT + 6-way selectinload —
+            # ~500 trips × 7 round-trips per cycle. See issue #962 context.
+            trip_meta: list[tuple[str, str, date, list[SubwayArrival]]] = (
+                []
+            )  # (trip_id, train_id, journey_date, arrivals)
+            for trip_id, trip_arrivals in trips.items():
+                if not trip_arrivals:
+                    continue
+                first_arrival = min(trip_arrivals, key=lambda a: a.arrival_time)
+                tid = _generate_train_id(trip_id, first_arrival.route_id)
+                jd = first_arrival.arrival_time.astimezone(ET).date()
+                trip_meta.append((trip_id, tid, jd, trip_arrivals))
+
+            existing_by_key: dict[tuple[str, date], TrainJourney] = {}
+            if trip_meta:
+                train_ids = {m[1] for m in trip_meta}
+                journey_dates = {m[2] for m in trip_meta}
+                existing_q = await session.execute(
+                    select(TrainJourney)
+                    .where(
+                        TrainJourney.data_source == "SUBWAY",
+                        TrainJourney.train_id.in_(train_ids),
+                        TrainJourney.journey_date.in_(journey_dates),
+                    )
+                    .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
+                )
+                existing_by_key = {
+                    (j.train_id, j.journey_date): j
+                    for j in existing_q.scalars()
+                    if j.train_id is not None and j.journey_date is not None
+                }
+
             # Process each trip inside a savepoint, committing in batches
             # to preserve partial progress on timeout or late-stage failure.
             batch_size = 50
             seen_journey_ids: set[int] = set()
             analyzed_journeys: list[TrainJourney] = []
             trips_in_batch = 0
-            for trip_id, trip_arrivals in trips.items():
+            for trip_id, tid, jd, trip_arrivals in trip_meta:
                 try:
                     async with session.begin_nested():
                         result, journey = await self._process_trip(
-                            session, trip_id, trip_arrivals
+                            session,
+                            trip_id,
+                            trip_arrivals,
+                            existing_by_key.get((tid, jd)),
                         )
                         if result == "discovered":
                             stats["discovered"] += 1
@@ -236,10 +273,21 @@ class SubwayCollector:
         return stats
 
     async def _process_trip(
-        self, session: AsyncSession, trip_id: str, arrivals: list[SubwayArrival]
+        self,
+        session: AsyncSession,
+        trip_id: str,
+        arrivals: list[SubwayArrival],
+        existing_journey: TrainJourney | None,
     ) -> tuple[str | None, TrainJourney | None]:
         """
         Process a single trip from the GTFS-RT feed.
+
+        Args:
+            existing_journey: Pre-fetched TrainJourney for this (train_id,
+                journey_date, data_source) key, or None if no existing
+                record. The caller bulk-loads these before the per-trip
+                loop so we avoid ~500 per-trip SELECTs per cycle; see
+                collect().
 
         Returns:
             Tuple of (result_type, journey) where result_type is
@@ -275,17 +323,7 @@ class SubwayCollector:
         arrival_et = first_arrival.arrival_time.astimezone(ET)
         journey_date = arrival_et.date()
 
-        # Check if journey already exists
-        existing = await session.execute(
-            select(TrainJourney)
-            .where(
-                TrainJourney.train_id == train_id,
-                TrainJourney.journey_date == journey_date,
-                TrainJourney.data_source == "SUBWAY",
-            )
-            .options(*JOURNEY_UPDATE_LOAD_OPTIONS)
-        )
-        journey = existing.scalar_one_or_none()
+        journey = existing_journey
 
         if journey is None:
             # Try GTFS static backfill

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -353,7 +353,6 @@ class DepartureService:
                 jit_ran_inline = await self._run_inline_jit_refresh(
                     from_station,
                     target_date,
-                    skip_individual_refresh,
                     hide_departed,
                 )
             if not jit_ran_inline:
@@ -948,7 +947,6 @@ class DepartureService:
         self,
         from_station: str,
         target_date: date,
-        skip_individual_refresh: bool,
         hide_departed: bool,
     ) -> bool:
         """Run JIT station refresh inline, waiting up to 10 seconds.
@@ -957,6 +955,12 @@ class DepartureService:
         query sees promoted trains.  If the refresh doesn't finish in time the
         task keeps running in the background and the request proceeds with
         whatever data is in the DB.
+
+        The second pass (per-train getTrainStopList refresh of trains past
+        their scheduled time) is always skipped on the inline path: it adds
+        up to 50 sequential NJT API calls, which blows the 10s inline budget,
+        and the user-visible upcoming trains have already been refreshed
+        by the bulk getTrainSchedule call in the first pass.
 
         Returns True if the refresh completed (caller can skip the background
         trigger), False otherwise.
@@ -967,8 +971,8 @@ class DepartureService:
                 self,
                 from_station,
                 target_date,
-                skip_individual_refresh,
-                hide_departed,
+                skip_individual_refresh=True,
+                hide_departed=hide_departed,
             ),
             name=f"inline_jit_{from_station}",
         )

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -10,7 +10,7 @@ from typing import Any
 from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import noload, selectinload
 from structlog import get_logger
 
 from trackrat.collectors.njt.client import NJTransitClient, TrainNotFoundError
@@ -43,6 +43,21 @@ from trackrat.utils.train import (
 )
 
 logger = get_logger(__name__)
+
+# Loader options for the NJT JIT refresh path. Must load `stops` (merged by
+# NJT journey collector) and `snapshots` (cleared and rewritten by
+# JourneyCollector.create_journey_snapshot). The other 3 delete-orphan child
+# collections aren't touched in this path, so noload() skips the orphan-check
+# lazy-loads that would otherwise trigger greenlet_spawn errors in async
+# context — at much lower per-journey cost than a defensive selectinload.
+_NJT_REFRESH_LOAD_OPTIONS = (
+    selectinload(TrainJourney.stops),
+    selectinload(TrainJourney.snapshots),
+    noload(TrainJourney.segment_times),
+    noload(TrainJourney.dwell_times),
+    noload(TrainJourney.progress),
+    noload(TrainJourney.progress_snapshots),
+)
 
 # Tracks station codes currently being refreshed in background tasks.
 # Prevents duplicate concurrent JIT refreshes for the same station.
@@ -1115,16 +1130,7 @@ class DepartureService:
                                 TrainJourney.data_source == "NJT",
                             )
                         )
-                        .options(
-                            selectinload(TrainJourney.stops),
-                            # Load all delete-orphan collections to prevent
-                            # greenlet_spawn errors during flush orphan checks
-                            selectinload(TrainJourney.snapshots),
-                            selectinload(TrainJourney.segment_times),
-                            selectinload(TrainJourney.dwell_times),
-                            selectinload(TrainJourney.progress),
-                            selectinload(TrainJourney.progress_snapshots),
-                        )
+                        .options(*_NJT_REFRESH_LOAD_OPTIONS)
                         .order_by(TrainJourney.id)
                     )
                     result = await db.execute(stmt)
@@ -1291,17 +1297,7 @@ class DepartureService:
                         TrainJourney.is_cancelled.is_not(True),
                     )
                 )
-                # Eagerly load all delete-orphan collections to prevent
-                # greenlet_spawn errors during flush/commit orphan checks.
-                # Must match the selectinloads in refresh_journey below.
-                .options(
-                    selectinload(TrainJourney.stops),
-                    selectinload(TrainJourney.snapshots),
-                    selectinload(TrainJourney.segment_times),
-                    selectinload(TrainJourney.dwell_times),
-                    selectinload(TrainJourney.progress),
-                    selectinload(TrainJourney.progress_snapshots),
-                )
+                .options(*_NJT_REFRESH_LOAD_OPTIONS)
                 .limit(50)
             )
             remaining_stale = list(remaining_stale_result.scalars().unique().all())
@@ -1332,16 +1328,7 @@ class DepartureService:
                         result = await db.execute(
                             select(TrainJourney)
                             .where(TrainJourney.id == jid)
-                            .options(
-                                selectinload(TrainJourney.stops),
-                                # Load all delete-orphan collections to prevent
-                                # greenlet_spawn errors during flush orphan checks
-                                selectinload(TrainJourney.snapshots),
-                                selectinload(TrainJourney.segment_times),
-                                selectinload(TrainJourney.dwell_times),
-                                selectinload(TrainJourney.progress),
-                                selectinload(TrainJourney.progress_snapshots),
-                            )
+                            .options(*_NJT_REFRESH_LOAD_OPTIONS)
                             .execution_options(populate_existing=True)
                         )
                         fresh = result.scalar_one_or_none()

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2792,7 +2792,7 @@ class SchedulerService:
                     self._running_tasks[task_id] = task
 
                 from sqlalchemy import and_, select
-                from sqlalchemy.orm import selectinload, sessionmaker
+                from sqlalchemy.orm import noload, selectinload, sessionmaker
 
                 # Use synchronous database access to avoid greenlet issues in scheduler context
                 SyncSession = sessionmaker(self._get_sync_engine())
@@ -2850,14 +2850,18 @@ class SchedulerService:
                                 )
                             )
                             .options(
+                                # Live Activity status calc reads journey.stops
+                                # and journey.snapshots[-1].train_status; the
+                                # other 4 delete-orphan collections aren't
+                                # touched, so noload() skips orphan-check
+                                # lazy-loads without the per-journey round-
+                                # trips a defensive selectinload would cost.
                                 selectinload(TrainJourney.stops),
-                                # Load all delete-orphan collections to prevent
-                                # greenlet_spawn errors during flush orphan checks
                                 selectinload(TrainJourney.snapshots),
-                                selectinload(TrainJourney.segment_times),
-                                selectinload(TrainJourney.dwell_times),
-                                selectinload(TrainJourney.progress),
-                                selectinload(TrainJourney.progress_snapshots),
+                                noload(TrainJourney.segment_times),
+                                noload(TrainJourney.dwell_times),
+                                noload(TrainJourney.progress),
+                                noload(TrainJourney.progress_snapshots),
                             )
                         )
 

--- a/backend_v2/tests/unit/collectors/subway/test_collector.py
+++ b/backend_v2/tests/unit/collectors/subway/test_collector.py
@@ -5,22 +5,23 @@ Tests unified NYC Subway train discovery, journey updates,
 full-replacement expiration logic, and JIT updates.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from trackrat.collectors.subway.client import (
+    _ROUTE_TO_FEED,
+    SubwayArrival,
+    SubwayClient,
+)
 from trackrat.collectors.subway.collector import (
     SubwayCollector,
     _generate_train_id,
 )
-from trackrat.collectors.subway.client import (
-    SubwayArrival,
-    SubwayClient,
-    _ROUTE_TO_FEED,
-)
 from trackrat.models.database import JourneyStop, TrainJourney
+from trackrat.utils.time import ET
 
 # =============================================================================
 # HELPER FUNCTION TESTS
@@ -182,7 +183,7 @@ class TestSubwayCollectorCollect:
         self, collector, mock_client, mock_session
     ):
         """Test arrivals are grouped by trip_id for processing."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         arrivals = [
             SubwayArrival(
                 station_code="S127",
@@ -233,13 +234,14 @@ class TestSubwayCollectorCollect:
         # Mock _process_trip to track calls without hitting DB
         process_calls = []
 
-        async def mock_process_trip(session, trip_id, trip_arrivals):
+        async def mock_process_trip(session, trip_id, trip_arrivals, existing):
             process_calls.append((trip_id, len(trip_arrivals)))
             return "discovered", len(process_calls)
 
         collector._process_trip = mock_process_trip
 
-        # Mock stale journey query (for expiration logic)
+        # Mock both the bulk-load query and the stale-expiration query
+        # (both call session.execute and iterate .scalars()).
         mock_stale_result = MagicMock()
         mock_stale_result.scalars.return_value = iter([])
         mock_session.execute.return_value = mock_stale_result
@@ -255,6 +257,74 @@ class TestSubwayCollectorCollect:
         assert "trip_1" in trip_ids
         assert "trip_2" in trip_ids
         mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_collect_bulk_loads_existing_journeys_once(
+        self, collector, mock_client, mock_session
+    ):
+        """collect() must bulk-load existing journeys in a single query
+        BEFORE the per-trip loop, and pass the resolved journey (or None)
+        into _process_trip. Regression guard for the per-trip SELECT
+        pattern that was a primary driver of subway_collection timeouts.
+        """
+        now = datetime.now(UTC)
+        arrivals = [
+            SubwayArrival(
+                station_code="S127",
+                gtfs_stop_id="127S",
+                trip_id="t1",
+                route_id="1",
+                direction_id=1,
+                headsign=None,
+                arrival_time=now,
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+                nyct_train_id="01 0100+ SFR",
+                is_assigned=True,
+            ),
+            SubwayArrival(
+                station_code="SA41",
+                gtfs_stop_id="A41S",
+                trip_id="t2",
+                route_id="A",
+                direction_id=1,
+                headsign=None,
+                arrival_time=now,
+                departure_time=None,
+                delay_seconds=0,
+                track=None,
+                nyct_train_id="05 0500+ FAR",
+                is_assigned=True,
+            ),
+        ]
+        mock_client.get_all_arrivals.return_value = (arrivals, {"1234567S", "ACE"})
+
+        # Pre-existing journey for t1 (train_id matches _generate_train_id("t1", "1"))
+        existing = MagicMock(spec=TrainJourney)
+        existing.train_id = _generate_train_id("t1", "1")
+        existing.journey_date = now.astimezone(ET).date()
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = [existing]
+        mock_session.execute.return_value = mock_result
+
+        process_calls: list[tuple[str, TrainJourney | None]] = []
+
+        async def mock_process_trip(session, trip_id, trip_arrivals, existing_journey):
+            process_calls.append((trip_id, existing_journey))
+            return "discovered", None
+
+        collector._process_trip = mock_process_trip
+
+        await collector.collect(mock_session)
+
+        by_trip = dict(process_calls)
+        assert by_trip["t1"] is existing, "pre-existing journey should be passed in"
+        assert by_trip["t2"] is None, "unseen trip should get None"
+        # Exactly one SELECT for the bulk journey lookup (the second call
+        # is the stale-expiration query); both hit mock_session.execute.
+        assert mock_session.execute.call_count == 2
 
 
 # =============================================================================
@@ -296,7 +366,7 @@ class TestSubwayCollectorProcessTrip:
     @pytest.fixture
     def sample_arrivals(self):
         """Create sample arrivals for a subway trip."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return [
             SubwayArrival(
                 station_code="S127",
@@ -333,12 +403,8 @@ class TestSubwayCollectorProcessTrip:
         self, collector, mock_session, sample_arrivals
     ):
         """Test _process_trip creates new journey and returns ('discovered', id)."""
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        mock_session.execute.return_value = mock_result
-
         result, journey = await collector._process_trip(
-            mock_session, "131800_1..S03R", sample_arrivals
+            mock_session, "131800_1..S03R", sample_arrivals, None
         )
 
         assert result == "discovered"
@@ -358,22 +424,8 @@ class TestSubwayCollectorProcessTrip:
         existing_journey.data_source = "SUBWAY"
         existing_journey.stops = []
 
-        # First execute returns existing journey, subsequent ones return stops
-        mock_result_journey = MagicMock()
-        mock_result_journey.scalar_one_or_none.return_value = existing_journey
-        mock_result_stop = MagicMock()
-        mock_result_stop.scalar_one_or_none.return_value = None
-        mock_result_stops_list = MagicMock()
-        mock_result_stops_list.scalars.return_value.all.return_value = []
-        mock_session.execute.side_effect = [
-            mock_result_journey,  # Journey lookup
-            mock_result_stop,  # Stop 1 lookup
-            mock_result_stop,  # Stop 2 lookup
-            mock_result_stops_list,  # Get all stops for update
-        ]
-
         result, journey = await collector._process_trip(
-            mock_session, "131800_1..S03R", sample_arrivals
+            mock_session, "131800_1..S03R", sample_arrivals, existing_journey
         )
 
         assert result == "updated"
@@ -384,7 +436,9 @@ class TestSubwayCollectorProcessTrip:
         self, collector, mock_session
     ):
         """Test _process_trip returns (None, None) for empty arrivals list."""
-        result, journey = await collector._process_trip(mock_session, "trip_123", [])
+        result, journey = await collector._process_trip(
+            mock_session, "trip_123", [], None
+        )
 
         assert result is None
         assert journey is None
@@ -392,7 +446,7 @@ class TestSubwayCollectorProcessTrip:
     @pytest.mark.asyncio
     async def test_process_trip_sorts_arrivals_by_time(self, collector, mock_session):
         """Test arrivals are sorted by arrival time to determine origin."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         # Intentionally out of order
         arrivals = [
             SubwayArrival(
@@ -425,12 +479,8 @@ class TestSubwayCollectorProcessTrip:
             ),
         ]
 
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        mock_session.execute.return_value = mock_result
-
         result, journey = await collector._process_trip(
-            mock_session, "trip_1", arrivals
+            mock_session, "trip_1", arrivals, None
         )
 
         assert result == "discovered"
@@ -507,7 +557,7 @@ class TestSubwayCollectorJourneyDetails:
         self, collector, mock_client, mock_session
     ):
         """Test JIT update selects the trip with highest station overlap."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         journey = MagicMock(spec=TrainJourney)
         journey.id = 1
@@ -621,7 +671,7 @@ class TestSubwayCollectorJourneyDetails:
         a newer train closer to origin), but trip_correct is the actual train.
         The JIT must pick trip_correct via exact hash match.
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         trip_correct = "074850_L..S"
         trip_wrong = "075200_L..S"
 
@@ -749,7 +799,7 @@ class TestSubwayCollectorJourneyDetails:
         """When the original trip_id is no longer in the feed (rare: MTA
         reassignment), the JIT falls back to fuzzy matching by station overlap
         and time proximity."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         # Journey has a hash from a trip_id that's no longer in the feed
         journey = MagicMock(spec=TrainJourney)
@@ -903,7 +953,7 @@ class TestSubwayFeedResilience:
         the current arrivals. It should be preserved (not expired) because
         we can't distinguish 'train gone' from 'feed unavailable'.
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         # Return arrivals only from 1234567S feed (NQRW failed)
         arrivals = [
@@ -926,7 +976,7 @@ class TestSubwayFeedResilience:
         mock_client.get_all_arrivals.return_value = (arrivals, {"1234567S"})
 
         # Mock _process_trip to return a discovered journey
-        async def mock_process_trip(session, trip_id, trip_arrivals):
+        async def mock_process_trip(session, trip_id, trip_arrivals, existing):
             return "discovered", 100
 
         collector._process_trip = mock_process_trip
@@ -941,8 +991,10 @@ class TestSubwayFeedResilience:
         stale_journey.api_error_count = 0
         stale_journey.last_updated_at = now - timedelta(minutes=2)
 
+        # Use a list so both session.execute queries (bulk-load + stale
+        # expiration) can iterate .scalars() independently.
         mock_stale_result = MagicMock()
-        mock_stale_result.scalars.return_value = iter([stale_journey])
+        mock_stale_result.scalars.return_value = [stale_journey]
         mock_session.execute.return_value = mock_stale_result
 
         result = await collector.collect(mock_session)
@@ -963,7 +1015,7 @@ class TestSubwayFeedResilience:
         current arrivals and was recently active. It should be expired
         (full-replacement semantics).
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         arrivals = [
             SubwayArrival(
@@ -987,7 +1039,7 @@ class TestSubwayFeedResilience:
             {"1234567S", "ACE"},
         )
 
-        async def mock_process_trip(session, trip_id, trip_arrivals):
+        async def mock_process_trip(session, trip_id, trip_arrivals, existing):
             return "discovered", 300
 
         collector._process_trip = mock_process_trip
@@ -1004,8 +1056,12 @@ class TestSubwayFeedResilience:
         # Recently active: 2 minutes ago (within 30-min replacement window)
         stale_journey.last_updated_at = now - timedelta(minutes=2)
 
+        # collect() now runs two session.execute queries that iterate
+        # .scalars(): a bulk-load for existing journeys (new in A.1 perf
+        # fix) and the stale-expiration query. Use a list so each call
+        # gets a fresh iterator.
         mock_stale_result = MagicMock()
-        mock_stale_result.scalars.return_value = iter([stale_journey])
+        mock_stale_result.scalars.return_value = [stale_journey]
         mock_session.execute.return_value = mock_stale_result
 
         result = await collector.collect(mock_session)

--- a/backend_v2/tests/unit/services/test_jit_promotion.py
+++ b/backend_v2/tests/unit/services/test_jit_promotion.py
@@ -10,16 +10,14 @@ These tests verify the fix for the bug where NJT trains like #6318
 """
 
 import asyncio
-from datetime import date, timedelta
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from trackrat.models.database import TrainJourney, JourneyStop
+from trackrat.models.database import TrainJourney
 from trackrat.services.departure import (
     DepartureService,
-    SCHEDULED_VISIBILITY_THRESHOLD_MINUTES,
-    _background_refresh_station,
     _refreshing_stations,
 )
 from trackrat.utils.time import now_et
@@ -268,12 +266,14 @@ class TestRunInlineJitRefresh:
         with patch(
             "trackrat.services.departure._background_refresh_station",
             new_callable=AsyncMock,
-        ):
-            result = await service._run_inline_jit_refresh(
-                "SO", now_et().date(), True, True
-            )
+        ) as mock_refresh:
+            result = await service._run_inline_jit_refresh("SO", now_et().date(), True)
 
         assert result is True
+        # Inline path always skips the second pass to stay within its
+        # 10s budget; see _run_inline_jit_refresh docstring.
+        _, kwargs = mock_refresh.call_args
+        assert kwargs["skip_individual_refresh"] is True
         # Station should be cleaned up after task completes
         # (done callback fires)
 
@@ -290,9 +290,7 @@ class TestRunInlineJitRefresh:
             "trackrat.services.departure._background_refresh_station",
             side_effect=slow_refresh,
         ):
-            result = await service._run_inline_jit_refresh(
-                "SO", now_et().date(), True, True
-            )
+            result = await service._run_inline_jit_refresh("SO", now_et().date(), True)
 
         assert result is False
 
@@ -302,8 +300,6 @@ class TestRunInlineJitRefresh:
         get_departures code skips inline refresh."""
         # This tests the guard in get_departures, not _run_inline_jit_refresh
         _refreshing_stations.add("SO")
-
-        service = DepartureService.__new__(DepartureService)
         # _run_inline_jit_refresh should not be called due to guard,
         # but verify the guard condition works
         assert "SO" in _refreshing_stations


### PR DESCRIPTION
## Summary

This PR fixes a critical performance issue in the subway collector that was causing timeouts during collection cycles. The root cause was that each trip processed by `_process_trip()` was executing its own database SELECT query plus 6-way selectinload, resulting in ~500 trips × 7 round-trips per cycle (~3,500 queries). The fix bulk-loads all existing journeys in a single query before the per-trip loop, reducing database round-trips by ~99%.

## Key Changes

- **Subway Collector (`collector.py`)**:
  - Pre-compute `(train_id, journey_date)` keys for all trips before processing
  - Execute a single bulk-load query to fetch all existing journeys matching those keys
  - Pass the pre-fetched journey (or None) to `_process_trip()` instead of having each trip query the database
  - Remove the per-trip SELECT + selectinload from `_process_trip()`
  - Updated `_process_trip()` signature to accept `existing_journey` parameter

- **Shared MTA Common Module (`mta_common.py`)**:
  - Extracted `JOURNEY_UPDATE_LOAD_OPTIONS` constant defining loader strategy for all GTFS-RT collectors
  - Uses `selectinload()` for `stops` (actively modified by collectors) and `noload()` for the 4 delete-orphan collections that aren't touched (avoiding greenlet_spawn errors without per-journey round-trips)

- **Other GTFS-RT Collectors** (BART, LIRR, MNR, MBTA, Metra):
  - Updated to use the shared `JOURNEY_UPDATE_LOAD_OPTIONS` constant instead of duplicating the loader configuration

- **NJT Departure Service (`departure.py`)**:
  - Extracted `_NJT_REFRESH_LOAD_OPTIONS` with the same noload strategy for NJT-specific refresh paths
  - Simplified `_run_inline_jit_refresh()` to always skip the second pass (per-train getTrainStopList refresh) to stay within the 10-second inline budget
  - Removed unused `skip_individual_refresh` parameter from inline refresh call

- **Scheduler (`scheduler.py`)**:
  - Updated live activity work loader options to use `noload()` for unused delete-orphan collections

- **Tests**:
  - Added regression test `test_collect_bulk_loads_existing_journeys_once()` to verify bulk-load behavior
  - Updated all test mocks to pass the new `existing_journey` parameter to `_process_trip()`
  - Fixed mock setup to use lists instead of iterators for `.scalars()` to support multiple calls

## Implementation Details

The bulk-load strategy uses a two-phase approach:
1. **Phase 1**: Iterate trips to extract `(train_id, journey_date)` keys and collect all unique values
2. **Phase 2**: Execute a single SELECT with `IN` clauses on both `train_id` and `journey_date`, indexed for performance
3. **Phase 3**: Build a lookup dict keyed by `(train_id, journey_date)` for O(1) access during per-trip processing

The loader options strategy (`selectinload` for modified collections, `noload` for untouched ones) prevents greenlet_spawn errors during async flush orphan checks while avoiding the per-journey cost of defensive selectinloads on collections that are never modified.

https://claude.ai/code/session_01QfAM899zTULktp2ZdMXkjB