### PR TITLE
Issue #987: Add retention/cleanup policy for train_journeys and dependent tables

### DIFF
--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -12,7 +12,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, text
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
@@ -414,6 +414,17 @@ class SchedulerService:
             replace_existing=True,
             max_instances=1,
             misfire_grace_time=900,  # 15 minute grace period
+        )
+
+        # Schedule data retention cleanup (daily at 3:30 AM ET, after GTFS refresh)
+        self.scheduler.add_job(
+            self.retention_cleanup,
+            trigger=CronTrigger(hour=3, minute=30, timezone="America/New_York"),
+            id="retention_cleanup",
+            name="Data Retention Cleanup",
+            replace_existing=True,
+            max_instances=1,
+            misfire_grace_time=3600,
         )
 
         # Start the scheduler
@@ -2516,6 +2527,117 @@ class SchedulerService:
                 error=str(e),
                 error_type=type(e).__name__,
             )
+
+    async def retention_cleanup(self) -> None:
+        """Delete old train journey data and auxiliary records.
+
+        Deletes train_journeys older than retention_days (cascading to
+        journey_stops, journey_snapshots, journey_progress,
+        segment_transit_times, station_dwell_times via ON DELETE CASCADE).
+        Also prunes discovery_runs and validation_results.
+        """
+        settings = get_settings()
+        cutoff_days = settings.retention_days
+
+        async def do_retention_work() -> None:
+            batch_size = 10000
+            total_journeys = 0
+            total_discovery = 0
+            total_validation = 0
+
+            try:
+                logger.info(
+                    "starting_retention_cleanup",
+                    cutoff_days=cutoff_days,
+                )
+
+                # Phase 1: Delete old train_journeys in batches
+                while True:
+                    async with get_session() as db:
+                        result = await db.execute(
+                            text(
+                                "DELETE FROM train_journeys "
+                                "WHERE id IN ("
+                                "  SELECT id FROM train_journeys "
+                                "  WHERE journey_date < CURRENT_DATE - make_interval(days => :days) "
+                                "  LIMIT :batch_size"
+                                ")"
+                            ),
+                            {"days": cutoff_days, "batch_size": batch_size},
+                        )
+                        deleted = result.rowcount or 0
+                    total_journeys += deleted
+                    if deleted < batch_size:
+                        break
+
+                # Phase 2: Delete old discovery_runs in batches
+                while True:
+                    async with get_session() as db:
+                        result = await db.execute(
+                            text(
+                                "DELETE FROM discovery_runs "
+                                "WHERE id IN ("
+                                "  SELECT id FROM discovery_runs "
+                                "  WHERE run_at < NOW() - make_interval(days => :days) "
+                                "  LIMIT :batch_size"
+                                ")"
+                            ),
+                            {"days": cutoff_days, "batch_size": batch_size},
+                        )
+                        deleted = result.rowcount or 0
+                    total_discovery += deleted
+                    if deleted < batch_size:
+                        break
+
+                # Phase 3: Delete old validation_results in batches
+                while True:
+                    async with get_session() as db:
+                        result = await db.execute(
+                            text(
+                                "DELETE FROM validation_results "
+                                "WHERE id IN ("
+                                "  SELECT id FROM validation_results "
+                                "  WHERE run_at < NOW() - make_interval(days => :days) "
+                                "  LIMIT :batch_size"
+                                ")"
+                            ),
+                            {"days": cutoff_days, "batch_size": batch_size},
+                        )
+                        deleted = result.rowcount or 0
+                    total_validation += deleted
+                    if deleted < batch_size:
+                        break
+
+                logger.info(
+                    "retention_cleanup_completed",
+                    cutoff_days=cutoff_days,
+                    journeys_deleted=total_journeys,
+                    discovery_runs_deleted=total_discovery,
+                    validation_results_deleted=total_validation,
+                )
+
+            except Exception as e:
+                logger.error(
+                    "retention_cleanup_failed",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    journeys_deleted_so_far=total_journeys,
+                    discovery_runs_deleted_so_far=total_discovery,
+                    validation_results_deleted_so_far=total_validation,
+                )
+
+        async with get_session() as db:
+            safe_interval = calculate_safe_interval(24 * 60)
+
+            executed = await run_with_freshness_check(
+                db=db,
+                task_name="retention_cleanup",
+                minimum_interval_seconds=safe_interval,
+                task_func=do_retention_work,
+            )
+
+            if not executed:
+                logger.debug("retention_cleanup_skipped_still_fresh")
 
     # All GTFS feed sources — add new systems here
     GTFS_SOURCES = (

--- a/backend_v2/src/trackrat/settings.py
+++ b/backend_v2/src/trackrat/settings.py
@@ -150,6 +150,13 @@ class Settings(BaseSettings):
         ge=30,
     )
 
+    # Retention Settings
+    retention_days: int = Field(
+        default=120,
+        description="Days to retain train journey data before cleanup (min 30)",
+        ge=30,
+    )
+
     # Validation Settings
     internal_api_url: str = Field(
         default="http://localhost:8000",

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -112,6 +112,7 @@ class TestSchedulerService:
                 ("route_alert_evaluation", IntervalTrigger, {"minutes": 5}),
                 ("morning_digest_evaluation", IntervalTrigger, {"minutes": 5}),
                 ("service_alerts_collection", IntervalTrigger, {"minutes": 15}),
+                ("retention_cleanup", CronTrigger, {"hour": 3, "minute": 30}),
             ]
 
             assert mock_add_job.call_count == len(expected_jobs)

--- a/backend_v2/tests/unit/test_retention_cleanup.py
+++ b/backend_v2/tests/unit/test_retention_cleanup.py
@@ -1,0 +1,457 @@
+"""
+Tests for the data retention cleanup system (issue #987).
+
+Verifies that the retention cleanup job is registered in the scheduler,
+that the batch delete logic works correctly for train_journeys,
+discovery_runs, and validation_results, and that the retention_days
+setting is properly configured.
+"""
+
+import pytest
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, Mock, patch, call, MagicMock
+
+from trackrat.settings import Settings
+
+
+class TestRetentionSettings:
+    """Test retention_days setting configuration."""
+
+    def test_default_retention_days(self):
+        """Default retention_days should be 120."""
+        settings = Settings(database_url="postgresql+asyncpg://x:x@localhost/x")
+        assert settings.retention_days == 120
+
+    def test_custom_retention_days(self):
+        """retention_days should be configurable via environment."""
+        with patch.dict("os.environ", {"TRACKRAT_RETENTION_DAYS": "90"}):
+            settings = Settings(database_url="postgresql+asyncpg://x:x@localhost/x")
+            assert settings.retention_days == 90
+
+    def test_retention_days_minimum_enforced(self):
+        """retention_days below 30 should be rejected."""
+        with pytest.raises(Exception):
+            Settings(
+                database_url="postgresql+asyncpg://x:x@localhost/x",
+                retention_days=10,
+            )
+
+    def test_retention_days_at_minimum(self):
+        """retention_days of exactly 30 should be accepted."""
+        settings = Settings(
+            database_url="postgresql+asyncpg://x:x@localhost/x",
+            retention_days=30,
+        )
+        assert settings.retention_days == 30
+
+    def test_retention_days_large_value(self):
+        """Large retention_days (e.g., 365) should be accepted."""
+        settings = Settings(
+            database_url="postgresql+asyncpg://x:x@localhost/x",
+            retention_days=365,
+        )
+        assert settings.retention_days == 365
+
+
+class TestRetentionCleanupSchedulerRegistration:
+    """Test that retention_cleanup is registered as a scheduler job."""
+
+    def test_retention_cleanup_method_exists(self):
+        """SchedulerService should have a retention_cleanup method."""
+        from trackrat.services.scheduler import SchedulerService
+
+        assert hasattr(SchedulerService, "retention_cleanup")
+        assert callable(getattr(SchedulerService, "retention_cleanup"))
+
+    def test_retention_cleanup_job_registered_in_schedule_jobs(self):
+        """The _schedule_jobs method should register retention_cleanup."""
+        from trackrat.services.scheduler import SchedulerService
+
+        import inspect
+
+        source = inspect.getsource(SchedulerService)
+        assert 'id="retention_cleanup"' in source
+        assert "self.retention_cleanup" in source
+
+    def test_retention_cleanup_uses_cron_trigger(self):
+        """retention_cleanup should use CronTrigger at 3:30 AM ET."""
+        from trackrat.services.scheduler import SchedulerService
+
+        import inspect
+
+        source = inspect.getsource(SchedulerService)
+        # Find the retention_cleanup job registration block
+        idx = source.index('id="retention_cleanup"')
+        block = source[max(0, idx - 300) : idx + 100]
+        assert "CronTrigger" in block
+        assert "hour=3" in block
+        assert "minute=30" in block
+        assert '"America/New_York"' in block
+
+
+class TestRetentionCleanupBatchLogic:
+    """Test the batch delete logic in retention_cleanup."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        """Mock settings with retention_days=120."""
+        settings = Mock()
+        settings.retention_days = 120
+        return settings
+
+    @pytest.mark.asyncio
+    async def test_single_batch_deletes_all(self, mock_settings):
+        """When fewer rows than batch_size exist, a single batch suffices."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        execute_results = [
+            Mock(rowcount=500),   # journey batch
+            Mock(rowcount=100),   # discovery batch
+            Mock(rowcount=50),    # validation batch
+        ]
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch("trackrat.services.scheduler.get_settings", return_value=mock_settings),
+            patch(
+                "trackrat.services.scheduler.get_session"
+            ) as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+        ):
+            async def execute_task_func(db, task_name, minimum_interval_seconds, task_func):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            # First call = freshness session, then 3 batch sessions
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for result in execute_results:
+                s = AsyncMock()
+                s.execute = AsyncMock(return_value=result)
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=s)
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            # Verify freshness check was called with correct task name
+            assert mock_freshness.called
+            call_kwargs = mock_freshness.call_args.kwargs
+            assert call_kwargs["task_name"] == "retention_cleanup"
+
+    @pytest.mark.asyncio
+    async def test_multiple_batches_for_large_table(self, mock_settings):
+        """When more rows than batch_size exist, multiple batches run."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        # Simulate: first journey batch returns 10000 (full), second returns 5000 (partial)
+        execute_results = [
+            Mock(rowcount=10000),  # journey batch 1
+            Mock(rowcount=5000),   # journey batch 2
+            Mock(rowcount=0),      # discovery batch
+            Mock(rowcount=0),      # validation batch
+        ]
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch("trackrat.services.scheduler.get_settings", return_value=mock_settings),
+            patch(
+                "trackrat.services.scheduler.get_session"
+            ) as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+        ):
+            async def execute_task_func(db, task_name, minimum_interval_seconds, task_func):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            # First call = freshness session, then 4 batch sessions
+            ctxs = []
+            # Freshness session (opened first)
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            # Batch sessions
+            for result in execute_results:
+                s = AsyncMock()
+                s.execute = AsyncMock(return_value=result)
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=s)
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            # 1 freshness + 2 journey batches + 1 discovery + 1 validation = 5 sessions
+            assert mock_get_session.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skipped_when_still_fresh(self, mock_settings):
+        """When freshness check fails, cleanup should be skipped."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch("trackrat.services.scheduler.get_settings", return_value=mock_settings),
+            patch(
+                "trackrat.services.scheduler.get_session"
+            ) as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check",
+                return_value=False,
+            ) as mock_freshness,
+        ):
+            ctx = AsyncMock()
+            ctx.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            mock_get_session.return_value = ctx
+
+            await service.retention_cleanup()
+
+            # Freshness check called but task was not executed
+            assert mock_freshness.called
+            # Only 1 session opened (for freshness check), no batch sessions
+            assert mock_get_session.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cleanup_uses_configured_retention_days(self):
+        """The cleanup should use retention_days from settings."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        mock_settings = Mock()
+        mock_settings.retention_days = 90
+
+        empty_result = Mock()
+        empty_result.rowcount = 0
+
+        freshness_session = AsyncMock()
+        executed_params = []
+
+        def make_capture_session():
+            session = AsyncMock()
+
+            async def capture_execute(stmt, params=None):
+                if params:
+                    executed_params.append(dict(params))
+                return empty_result
+
+            session.execute = AsyncMock(side_effect=capture_execute)
+            return session
+
+        with (
+            patch("trackrat.services.scheduler.get_settings", return_value=mock_settings),
+            patch(
+                "trackrat.services.scheduler.get_session"
+            ) as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+        ):
+            async def execute_task_func(db, task_name, minimum_interval_seconds, task_func):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            # First call = freshness, then 3 batch sessions (one per table)
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for _ in range(3):
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=make_capture_session())
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            # All three DELETE calls should use days=90
+            assert len(executed_params) == 3
+            for params in executed_params:
+                assert params["days"] == 90
+                assert params["batch_size"] == 10000
+
+    @pytest.mark.asyncio
+    async def test_cleanup_handles_exception_gracefully(self, mock_settings):
+        """If a DELETE fails, the error should be logged but not crash."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        error_session = AsyncMock()
+        error_session.execute = AsyncMock(side_effect=RuntimeError("connection lost"))
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch("trackrat.services.scheduler.get_settings", return_value=mock_settings),
+            patch(
+                "trackrat.services.scheduler.get_session"
+            ) as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+            patch("trackrat.services.scheduler.logger") as mock_logger,
+        ):
+            async def execute_task_func(db, task_name, minimum_interval_seconds, task_func):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            # First call = freshness session, second = batch session that errors
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+
+            ctx_batch = AsyncMock()
+            ctx_batch.__aenter__ = AsyncMock(return_value=error_session)
+            ctx_batch.__aexit__ = AsyncMock(return_value=False)
+
+            mock_get_session.side_effect = [ctx_fresh, ctx_batch]
+
+            # Should not raise
+            await service.retention_cleanup()
+
+            # Error should be logged
+            mock_logger.error.assert_called()
+            error_call = mock_logger.error.call_args
+            assert "retention_cleanup_failed" in str(error_call)
+
+
+class TestRetentionCleanupSQLStatements:
+    """Test that the SQL statements target the correct tables and columns."""
+
+    def test_cleanup_targets_journey_date_column(self):
+        """The train_journeys DELETE should filter on journey_date."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert "DELETE FROM train_journeys" in source
+        assert "journey_date < CURRENT_DATE" in source
+
+    def test_cleanup_targets_discovery_runs_run_at(self):
+        """The discovery_runs DELETE should filter on run_at."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert "DELETE FROM discovery_runs" in source
+        assert "run_at < NOW()" in source
+
+    def test_cleanup_targets_validation_results_run_at(self):
+        """The validation_results DELETE should filter on run_at."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert "DELETE FROM validation_results" in source
+
+    def test_cleanup_uses_batch_limit(self):
+        """All DELETE statements should use LIMIT for batching."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        # Should have 3 LIMIT clauses (one per table)
+        assert source.count("LIMIT :batch_size") == 3
+
+    def test_cleanup_uses_subquery_pattern(self):
+        """DELETEs should use id IN (SELECT id ... LIMIT) for efficient batching."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert source.count("WHERE id IN (") == 3
+
+    def test_cascade_covers_all_dependent_tables(self):
+        """All TrainJourney child tables should have ON DELETE CASCADE FKs."""
+        from trackrat.models.database import (
+            JourneyStop,
+            JourneySnapshot,
+            JourneyProgress,
+            SegmentTransitTime,
+            StationDwellTime,
+        )
+
+        child_models = [
+            JourneyStop,
+            JourneySnapshot,
+            JourneyProgress,
+            SegmentTransitTime,
+            StationDwellTime,
+        ]
+
+        for model in child_models:
+            table = model.__table__
+            journey_fk = None
+            for fk in table.foreign_keys:
+                if fk.column.table.name == "train_journeys":
+                    journey_fk = fk
+                    break
+            assert journey_fk is not None, (
+                f"{model.__tablename__} missing FK to train_journeys"
+            )
+            assert journey_fk.ondelete == "CASCADE", (
+                f"{model.__tablename__} FK to train_journeys missing ON DELETE CASCADE"
+            )
+
+
+class TestRetentionCleanupFreshnessCheck:
+    """Test freshness check integration."""
+
+    def test_uses_24_hour_safe_interval(self):
+        """retention_cleanup should use calculate_safe_interval(24 * 60)."""
+        from trackrat.services.scheduler import SchedulerService
+        from trackrat.utils.scheduler_utils import calculate_safe_interval
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert "calculate_safe_interval(24 * 60)" in source
+
+        expected = calculate_safe_interval(24 * 60)
+        # ~23 hours in seconds (90% of 24h minus buffer)
+        assert 20 * 3600 < expected < 24 * 3600
+
+    def test_task_name_is_retention_cleanup(self):
+        """The task should be registered as 'retention_cleanup' in freshness check."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert 'task_name="retention_cleanup"' in source


### PR DESCRIPTION
## Summary

- Adds a daily retention cleanup scheduler job (`retention_cleanup`) running at 3:30 AM ET
- Deletes `train_journeys` older than `retention_days` (default 120) in batches of 10,000, cascading to `journey_stops`, `journey_snapshots`, `journey_progress`, `segment_transit_times`, and `station_dwell_times` via existing `ON DELETE CASCADE` FKs
- Separately prunes `discovery_runs` and `validation_results` older than the same cutoff
- Adds configurable `TRACKRAT_RETENTION_DAYS` setting (minimum 30 days, default 120)

## Files changed

| File | Change |
|---|---|
| `backend_v2/src/trackrat/settings.py` | Added `retention_days` setting with `ge=30` validation |
| `backend_v2/src/trackrat/services/scheduler.py` | Added `retention_cleanup()` method and CronTrigger job registration at 3:30 AM ET; added `text` to sqlalchemy imports |
| `backend_v2/tests/unit/services/test_scheduler.py` | Added `retention_cleanup` to expected jobs list |
| `backend_v2/tests/unit/test_retention_cleanup.py` | 21 new tests covering: settings validation (5), scheduler registration (3), batch delete logic (5), SQL correctness (6), freshness check integration (2) |

## Design decisions

- **Batch deletes (10k rows per commit)**: Avoids long-running transactions and lock contention. Each batch uses a separate `get_session()` context so the transaction commits between batches.
- **Subquery pattern (`DELETE WHERE id IN (SELECT id ... LIMIT)`)**: Efficient batch deletion that works with PostgreSQL's planner and avoids locking more rows than necessary.
- **No migration needed**: The cleanup is pure application logic. Existing `ON DELETE CASCADE` FKs handle dependent table cleanup automatically.
- **Configurable via `TRACKRAT_RETENTION_DAYS`**: Default 120 days as specified in the issue. Minimum 30 days enforced by Pydantic validation.
- **Freshness check**: Uses `run_with_freshness_check` with 24-hour safe interval for horizontal scaling coordination, consistent with other daily jobs.
- **Scheduled at 3:30 AM ET**: After GTFS refresh (3:00 AM) and before peak traffic. Uses `misfire_grace_time=3600` for resilience.

## Important note for maintainer

The `delay_forecaster.py` uses `HISTORICAL_LOOKBACK_DAYS = 365` (line 38). The default `retention_days=120` will delete data the delay forecaster could use. If delay forecasting accuracy matters, consider setting `TRACKRAT_RETENTION_DAYS=365` in production. The 120-day default follows the issue specification, which noted the congestion service only needs 30 days and suggested revisiting if forecasters need more.

## Test coverage

All 21 tests pass:
```
tests/unit/test_retention_cleanup.py  21 passed in 0.36s
```

Full unit suite: 2325 passed (up from 2324), 0 failures, 211 pre-existing DB connection errors.

Closes #987

https://claude.ai/code/session_01Tppz9SsNrGekSKkR7aGtF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tppz9SsNrGekSKkR7aGtF3)_