### PR TITLE
Fix Penn Station waiting guide visibility for non-Amtrak/NJT services

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -1368,8 +1368,11 @@ struct SegmentedTrackPredictionView: View {
                 }
 
                 // Penn Station waiting guide link for NY departures
-                if isDepartingFromNYPenn && showWaitingLink {
-                    PennStationWaitingLink(isAmtrak: train.trainId.hasPrefix("A"))
+                // Only Amtrak and NJ Transit have authored guide content; other systems
+                // (e.g., LIRR) also depart from NY Penn but would be shown the wrong guide.
+                if isDepartingFromNYPenn && showWaitingLink &&
+                    (train.dataSource == "AMTRAK" || train.dataSource == "NJT") {
+                    PennStationWaitingLink(isAmtrak: train.dataSource == "AMTRAK")
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }


### PR DESCRIPTION
## Summary
Fixed an issue where the Penn Station waiting guide link was being displayed for train services that don't have authored guide content, such as LIRR trains departing from NY Penn Station.

## Key Changes
- Added a data source check to only display the Penn Station waiting guide for Amtrak and NJ Transit services
- Updated the `PennStationWaitingLink` initialization to use `train.dataSource` instead of checking the train ID prefix
- Added clarifying comments explaining why the data source restriction is necessary

## Implementation Details
The previous implementation used `train.trainId.hasPrefix("A")` to determine if a train was Amtrak, which was insufficient for filtering. The fix now explicitly checks if the train's data source is either "AMTRAK" or "NJT" before displaying the waiting guide link, preventing incorrect guide content from being shown to users of other transit systems that also depart from NY Penn Station.

https://claude.ai/code/session_01AAtUdmesc245QeSoR5bvMm