### PR TITLE
Fix on-time percentage calculation to exclude scheduled_fallback arrivals

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -69,7 +69,15 @@ CARRIER_DISPLAY_NAMES: dict[str, str] = {
 
 @dataclass
 class LineStats:
-    """Statistics for a single line."""
+    """Statistics for a single line.
+
+    `arrival_data_count` is the number of non-cancelled trains with usable
+    arrival data (real actual_arrival + scheduled_arrival, with
+    arrival_source != "scheduled_fallback"). It is the correct denominator
+    for on-time percentage and average delay; `train_count` is informational
+    only and includes scheduled_fallback / in-progress trains that don't
+    contribute to delay calculations.
+    """
 
     line_name: str
     line_code: str
@@ -78,20 +86,19 @@ class LineStats:
     cancellation_count: int
     total_delay_minutes: float
     data_source: str
+    arrival_data_count: int = 0
 
     @property
     def on_time_percentage(self) -> float:
-        non_cancelled = self.train_count - self.cancellation_count
-        if non_cancelled <= 0:
+        if self.arrival_data_count <= 0:
             return 0.0
-        return (self.on_time_count / non_cancelled) * 100
+        return (self.on_time_count / self.arrival_data_count) * 100
 
     @property
     def average_delay_minutes(self) -> float:
-        non_cancelled = self.train_count - self.cancellation_count
-        if non_cancelled <= 0:
+        if self.arrival_data_count <= 0:
             return 0.0
-        return self.total_delay_minutes / non_cancelled
+        return self.total_delay_minutes / self.arrival_data_count
 
 
 @dataclass
@@ -565,7 +572,15 @@ class SummaryService:
     def _calculate_line_stats(
         self, journeys: list[TrainJourney]
     ) -> dict[str, LineStats]:
-        """Calculate statistics grouped by line."""
+        """Calculate statistics grouped by line.
+
+        On-time percentage and average delay use `arrival_data_count` (trains
+        with real arrival data) as the denominator — NOT `train_count`. Trains
+        with scheduled_fallback arrivals or no arrival data (still in progress)
+        are intentionally excluded from both numerator and denominator so they
+        neither inflate nor deflate the metric. This matches the SQL logic in
+        api/routes.py for /routes/history.
+        """
         stats: dict[str, dict[str, Any]] = defaultdict(
             lambda: {
                 "line_name": "",
@@ -574,6 +589,7 @@ class SummaryService:
                 "on_time_count": 0,
                 "cancellation_count": 0,
                 "total_delay_minutes": 0.0,
+                "arrival_data_count": 0,
                 "data_source": "",
             }
         )
@@ -589,29 +605,32 @@ class SummaryService:
 
             if journey.is_cancelled:
                 line_data["cancellation_count"] += 1
-            else:
-                # Calculate delay from last stop
-                if journey.stops:
-                    last_stop = max(journey.stops, key=lambda s: s.stop_sequence or 0)
-                    if last_stop.actual_arrival and last_stop.scheduled_arrival:
-                        # Exclude scheduled_fallback arrivals — they always show
-                        # 0 delay (actual == scheduled) and inflate on-time stats.
-                        # NOTE: Historical stops (before ~March 2026) may have
-                        # NULL arrival_source (partial backfill). Those stops
-                        # still contribute to OTP here since we only exclude
-                        # "scheduled_fallback", not NULL.
-                        if last_stop.arrival_source == "scheduled_fallback":
-                            pass
-                        else:
-                            delay = (
-                                last_stop.actual_arrival - last_stop.scheduled_arrival
-                            ).total_seconds() / 60
-                            line_data["total_delay_minutes"] += max(0, delay)
-                            if delay <= ON_TIME_THRESHOLD_MINUTES:
-                                line_data["on_time_count"] += 1
-                    else:
-                        # No arrival data (in-progress), assume on time
-                        line_data["on_time_count"] += 1
+                continue
+
+            if not journey.stops:
+                continue
+
+            last_stop = max(journey.stops, key=lambda s: s.stop_sequence or 0)
+            if not (last_stop.actual_arrival and last_stop.scheduled_arrival):
+                # In-progress: no usable arrival data yet. Excluded from OTP.
+                continue
+            if last_stop.arrival_source == "scheduled_fallback":
+                # Collector wrote actual_arrival = scheduled_arrival because the
+                # feed didn't supply a real arrival timestamp. Including this
+                # would always count as on-time (0 delay) and is misleading.
+                # NOTE: Historical stops (before ~March 2026) may have NULL
+                # arrival_source (partial backfill); those still count toward
+                # OTP since we only exclude the explicit "scheduled_fallback"
+                # tag, consistent with api/routes.py and api/trains.py.
+                continue
+
+            delay = (
+                last_stop.actual_arrival - last_stop.scheduled_arrival
+            ).total_seconds() / 60
+            line_data["arrival_data_count"] += 1
+            line_data["total_delay_minutes"] += max(0, delay)
+            if delay <= ON_TIME_THRESHOLD_MINUTES:
+                line_data["on_time_count"] += 1
 
         return {
             key: LineStats(
@@ -622,6 +641,7 @@ class SummaryService:
                 cancellation_count=data["cancellation_count"],
                 total_delay_minutes=data["total_delay_minutes"],
                 data_source=data["data_source"],
+                arrival_data_count=data["arrival_data_count"],
             )
             for key, data in stats.items()
         }
@@ -646,26 +666,63 @@ class SummaryService:
                 metrics=None,
             )
 
-        # Aggregate totals (note: line_stats uses arrival-based on-time)
+        # Aggregate totals. OTP and avg_delay use `arrival_data_count` as the
+        # denominator (trains with usable arrival data), NOT `train_count`.
+        # Including scheduled_fallback or in-progress trains in the denominator
+        # would deflate OTP for frequency-first systems (PATH, Subway) where
+        # GTFS-RT often emits scheduled_fallback arrivals.
         total_trains = sum(ls.train_count for ls in line_stats.values())
         total_on_time = sum(ls.on_time_count for ls in line_stats.values())
         total_cancellations = sum(ls.cancellation_count for ls in line_stats.values())
         total_delay = sum(ls.total_delay_minutes for ls in line_stats.values())
+        total_with_arrival = sum(ls.arrival_data_count for ls in line_stats.values())
 
-        non_cancelled = total_trains - total_cancellations
-        on_time_pct = (total_on_time / non_cancelled * 100) if non_cancelled > 0 else 0
-        avg_delay = total_delay / non_cancelled if non_cancelled > 0 else 0
+        if total_with_arrival == 0 and total_cancellations == 0:
+            # No usable arrival data and no cancellations to report — hide
+            # the section entirely (empty headline/body is the iOS signal).
+            logger.info(
+                "network_summary_empty",
+                reason="no_arrival_data",
+                total_trains=total_trains,
+                line_count=len(line_stats),
+                message="Returning empty body - no usable arrival data",
+            )
+            return OperationsSummary(
+                headline="",
+                body="",
+                scope="network",
+                time_window_minutes=SUMMARY_TIME_WINDOW_MINUTES,
+                data_freshness_seconds=0,
+                generated_at=now_et(),
+                metrics=None,
+            )
 
-        # Generate headline and body
-        headline, body = self._format_network_headline_body(
-            on_time_pct, avg_delay, total_cancellations
-        )
+        on_time_pct: float | None
+        avg_delay: float | None
+        if total_with_arrival > 0:
+            on_time_pct = total_on_time / total_with_arrival * 100
+            avg_delay = total_delay / total_with_arrival
+            headline, body = self._format_network_headline_body(
+                on_time_pct, avg_delay, total_cancellations
+            )
+        else:
+            # Cancellations only — report them without claiming an OTP we
+            # can't compute.
+            on_time_pct = None
+            avg_delay = None
+            cancel_word = (
+                "cancellation" if total_cancellations == 1 else "cancellations"
+            )
+            train_word = "train" if total_cancellations == 1 else "trains"
+            headline = f"{total_cancellations} {cancel_word}"
+            body = f"{total_cancellations} {train_word} cancelled."
 
         logger.info(
             "network_summary_generated",
             total_trains=total_trains,
-            on_time_pct=round(on_time_pct, 1),
-            avg_delay=round(avg_delay, 1),
+            total_with_arrival=total_with_arrival,
+            on_time_pct=round(on_time_pct, 1) if on_time_pct is not None else None,
+            avg_delay=round(avg_delay, 1) if avg_delay is not None else None,
             cancellations=total_cancellations,
             line_count=len(line_stats),
             headline=headline,
@@ -953,7 +1010,10 @@ class SummaryService:
         Calculate on-time arrival statistics for a list of journeys.
 
         Uses arrival delay at the destination station. Only includes journeys
-        that have actual arrival data (completed journeys).
+        with real arrival data: actual_arrival is set, scheduled_arrival is
+        set, and arrival_source is not "scheduled_fallback". Fallback arrivals
+        always show 0 delay (collector wrote actual = scheduled because the
+        feed didn't supply a real arrival timestamp) and would inflate OTP.
 
         Args:
             journeys: List of journeys to analyze
@@ -977,7 +1037,12 @@ class SummaryService:
                 (s for s in journey.stops if s.station_code in to_codes_set), None
             )
 
-            if to_stop and to_stop.scheduled_arrival and to_stop.actual_arrival:
+            if (
+                to_stop
+                and to_stop.scheduled_arrival
+                and to_stop.actual_arrival
+                and to_stop.arrival_source != "scheduled_fallback"
+            ):
                 counted_trains += 1
                 delay = (
                     to_stop.actual_arrival - to_stop.scheduled_arrival

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -37,7 +37,12 @@ class TestLineStats:
     """Test cases for LineStats data class."""
 
     def test_line_stats_on_time_percentage_calculation(self):
-        """Test on-time percentage calculation."""
+        """On-time percentage uses arrival_data_count as the denominator.
+
+        Trains without real arrival data (scheduled_fallback or in-progress)
+        contribute to train_count but not to arrival_data_count, so they
+        must not affect OTP.
+        """
         stats = LineStats(
             line_name="Northeast Corridor",
             line_code="NEC",
@@ -46,13 +51,14 @@ class TestLineStats:
             cancellation_count=1,
             total_delay_minutes=45.0,
             data_source="NJT",
+            arrival_data_count=9,
         )
 
-        # 8 on-time out of 9 non-cancelled = 88.89%
+        # 8 on-time out of 9 trains with arrival data = 88.89%
         assert abs(stats.on_time_percentage - 88.89) < 0.1
 
     def test_line_stats_average_delay_calculation(self):
-        """Test average delay calculation."""
+        """Average delay uses arrival_data_count as the denominator."""
         stats = LineStats(
             line_name="Northeast Corridor",
             line_code="NEC",
@@ -61,9 +67,10 @@ class TestLineStats:
             cancellation_count=1,
             total_delay_minutes=45.0,
             data_source="NJT",
+            arrival_data_count=9,
         )
 
-        # 45 minutes / 9 non-cancelled = 5.0 minutes
+        # 45 minutes / 9 trains with arrival data = 5.0 minutes
         assert stats.average_delay_minutes == 5.0
 
     def test_line_stats_all_cancelled(self):
@@ -76,6 +83,7 @@ class TestLineStats:
             cancellation_count=5,
             total_delay_minutes=0.0,
             data_source="NJT",
+            arrival_data_count=0,
         )
 
         assert stats.on_time_percentage == 0.0
@@ -91,6 +99,25 @@ class TestLineStats:
             cancellation_count=0,
             total_delay_minutes=0.0,
             data_source="NJT",
+            arrival_data_count=0,
+        )
+
+        assert stats.on_time_percentage == 0.0
+        assert stats.average_delay_minutes == 0.0
+
+    def test_line_stats_only_scheduled_fallback_trains(self):
+        """Regression: trains with only scheduled_fallback arrivals must
+        not deflate OTP. arrival_data_count=0 means we have no usable data,
+        so OTP returns 0.0 (callers treat that as "no signal")."""
+        stats = LineStats(
+            line_name="PATH",
+            line_code="PATH",
+            train_count=20,
+            on_time_count=0,
+            cancellation_count=0,
+            total_delay_minutes=0.0,
+            data_source="PATH",
+            arrival_data_count=0,
         )
 
         assert stats.on_time_percentage == 0.0
@@ -211,7 +238,12 @@ class TestSummaryService:
         return journeys
 
     def test_calculate_line_stats(self, summary_service, sample_journeys):
-        """Test line statistics calculation from journeys."""
+        """Test line statistics calculation from journeys.
+
+        sample_journeys has: 1 on-time arrival, 1 ten-minute-late arrival,
+        1 cancelled (no stops). Both arrival stops have real data
+        (arrival_source is unset on the Mock, so it's not "scheduled_fallback").
+        """
         line_stats = summary_service._calculate_line_stats(sample_journeys)
 
         assert "Northeast Corridor" in line_stats
@@ -221,6 +253,80 @@ class TestSummaryService:
         assert nec_stats.cancellation_count == 1
         assert nec_stats.line_code == "NEC"
         assert nec_stats.data_source == "NJT"
+        # Both non-cancelled trains had usable arrival data.
+        assert nec_stats.arrival_data_count == 2
+        # One was on time (0 min), the other was 10 min late.
+        assert nec_stats.on_time_count == 1
+        assert nec_stats.total_delay_minutes == 10.0
+        # 1 / 2 = 50% on time
+        assert nec_stats.on_time_percentage == 50.0
+
+    def test_calculate_line_stats_excludes_scheduled_fallback(self, summary_service):
+        """Regression: a non-cancelled train whose last stop arrival is
+        flagged scheduled_fallback must not contribute to on_time_count or
+        arrival_data_count, so OTP reflects only trains with real data."""
+        current_time = datetime.now(UTC)
+
+        # Real on-time arrival
+        real_journey = Mock(spec=TrainJourney)
+        real_journey.id = 1
+        real_journey.train_id = "REAL-1"
+        real_journey.data_source = "PATH"
+        real_journey.line_name = "PATH"
+        real_journey.line_code = "PATH"
+        real_journey.is_cancelled = False
+        real_stop = Mock()
+        real_stop.station_code = "WTC"
+        real_stop.stop_sequence = 5
+        real_stop.scheduled_arrival = current_time - timedelta(minutes=10)
+        real_stop.actual_arrival = current_time - timedelta(minutes=10)
+        real_stop.arrival_source = "api_observed"
+        real_journey.stops = [real_stop]
+
+        # Scheduled-fallback arrival (collector wrote actual = scheduled
+        # because the GTFS-RT feed didn't supply a real arrival time)
+        fallback_journey = Mock(spec=TrainJourney)
+        fallback_journey.id = 2
+        fallback_journey.train_id = "FALLBACK-1"
+        fallback_journey.data_source = "PATH"
+        fallback_journey.line_name = "PATH"
+        fallback_journey.line_code = "PATH"
+        fallback_journey.is_cancelled = False
+        fallback_stop = Mock()
+        fallback_stop.station_code = "WTC"
+        fallback_stop.stop_sequence = 5
+        fallback_stop.scheduled_arrival = current_time - timedelta(minutes=10)
+        fallback_stop.actual_arrival = current_time - timedelta(minutes=10)
+        fallback_stop.arrival_source = "scheduled_fallback"
+        fallback_journey.stops = [fallback_stop]
+
+        # In-progress: no actual_arrival yet
+        inprogress_journey = Mock(spec=TrainJourney)
+        inprogress_journey.id = 3
+        inprogress_journey.train_id = "INPROGRESS-1"
+        inprogress_journey.data_source = "PATH"
+        inprogress_journey.line_name = "PATH"
+        inprogress_journey.line_code = "PATH"
+        inprogress_journey.is_cancelled = False
+        inprogress_stop = Mock()
+        inprogress_stop.station_code = "WTC"
+        inprogress_stop.stop_sequence = 5
+        inprogress_stop.scheduled_arrival = current_time + timedelta(minutes=5)
+        inprogress_stop.actual_arrival = None
+        inprogress_stop.arrival_source = None
+        inprogress_journey.stops = [inprogress_stop]
+
+        stats = summary_service._calculate_line_stats(
+            [real_journey, fallback_journey, inprogress_journey]
+        )
+
+        path = stats["PATH"]
+        # All three observed trains stay in train_count.
+        assert path.train_count == 3
+        # Only the train with real arrival data contributes to OTP.
+        assert path.arrival_data_count == 1
+        assert path.on_time_count == 1
+        assert path.on_time_percentage == 100.0
 
     def test_generate_network_summary_excellent(self, summary_service):
         """Test network summary generation for excellent performance."""
@@ -233,6 +339,7 @@ class TestSummaryService:
                 cancellation_count=0,
                 total_delay_minutes=15.0,
                 data_source="NJT",
+                arrival_data_count=20,
             )
         }
 
@@ -244,6 +351,7 @@ class TestSummaryService:
             or "on time" in summary.headline.lower()
         )
         assert summary.metrics is not None
+        assert summary.metrics.on_time_percentage is not None
         assert summary.metrics.on_time_percentage >= 90
 
     def test_generate_network_summary_degraded(self, summary_service):
@@ -257,6 +365,7 @@ class TestSummaryService:
                 cancellation_count=3,
                 total_delay_minutes=150.0,
                 data_source="NJT",
+                arrival_data_count=17,
             )
         }
 
@@ -265,6 +374,89 @@ class TestSummaryService:
         assert summary.scope == "network"
         # When cancellations are present, they lead the headline
         assert "cancellation" in summary.headline.lower()
+
+    def test_generate_network_summary_excludes_scheduled_fallback(
+        self, summary_service
+    ):
+        """Regression: scheduled_fallback trains stay in train_count but not
+        in arrival_data_count, so OTP reflects only trains with real data.
+
+        This is the original PATH bug — 100 observed trains where most have
+        arrival_source="scheduled_fallback" used to deflate OTP because the
+        denominator counted them. Now the denominator is arrival_data_count.
+        """
+        line_stats = {
+            "PATH": LineStats(
+                line_name="PATH",
+                line_code="PATH",
+                train_count=100,  # observed trains in window
+                on_time_count=18,  # 18 of 20 with real data were on time
+                cancellation_count=0,
+                total_delay_minutes=24.0,  # only from real-data trains
+                data_source="PATH",
+                arrival_data_count=20,  # 80 had scheduled_fallback or were in-progress
+            )
+        }
+
+        summary = summary_service._generate_network_summary(line_stats)
+
+        assert summary.metrics is not None
+        # 18 / 20 = 90% — NOT 18 / 100 = 18% (the old buggy denominator)
+        assert summary.metrics.on_time_percentage is not None
+        assert abs(summary.metrics.on_time_percentage - 90.0) < 0.01
+        # train_count still reflects all observed trains
+        assert summary.metrics.train_count == 100
+
+    def test_generate_network_summary_no_arrival_data_only_cancellations(
+        self, summary_service
+    ):
+        """When we have cancellations but no usable arrival data, report
+        cancellations without claiming an OTP we can't compute."""
+        line_stats = {
+            "PATH": LineStats(
+                line_name="PATH",
+                line_code="PATH",
+                train_count=10,
+                on_time_count=0,
+                cancellation_count=3,
+                total_delay_minutes=0.0,
+                data_source="PATH",
+                arrival_data_count=0,
+            )
+        }
+
+        summary = summary_service._generate_network_summary(line_stats)
+
+        assert "cancellation" in summary.headline.lower()
+        assert "3" in summary.headline
+        assert summary.metrics is not None
+        assert summary.metrics.on_time_percentage is None
+        assert summary.metrics.average_delay_minutes is None
+        assert summary.metrics.cancellation_count == 3
+
+    def test_generate_network_summary_no_arrival_data_no_cancellations(
+        self, summary_service
+    ):
+        """When we have observed trains but no usable arrival data and no
+        cancellations, hide the section (empty headline/body, metrics=None)."""
+        line_stats = {
+            "PATH": LineStats(
+                line_name="PATH",
+                line_code="PATH",
+                train_count=10,
+                on_time_count=0,
+                cancellation_count=0,
+                total_delay_minutes=0.0,
+                data_source="PATH",
+                arrival_data_count=0,
+            )
+        }
+
+        summary = summary_service._generate_network_summary(line_stats)
+
+        assert summary.headline == ""
+        assert summary.body == ""
+        assert summary.metrics is None
 
     def test_generate_network_summary_empty(self, summary_service):
         """Test network summary with no data returns empty headline."""
@@ -456,6 +648,62 @@ class TestSummaryService:
         assert stats.total_count == 1
         assert stats.on_time_percentage == 100.0
 
+    def test_calculate_arrival_stats_excludes_scheduled_fallback(self, summary_service):
+        """Regression: route arrival stats must not count scheduled_fallback
+        arrivals. Those always show 0 delay (collector wrote actual = scheduled
+        because the feed didn't supply a real arrival timestamp) and would
+        falsely inflate OTP."""
+        current_time = datetime.now(UTC)
+
+        def make_journey(*, late_minutes: float, arrival_source: str | None) -> Mock:
+            journey = Mock(spec=TrainJourney)
+            journey.is_cancelled = False
+            stop = Mock()
+            stop.station_code = "WTC"
+            stop.stop_sequence = 5
+            stop.scheduled_arrival = current_time - timedelta(minutes=10)
+            stop.actual_arrival = current_time - timedelta(minutes=10 - late_minutes)
+            stop.arrival_source = arrival_source
+            journey.stops = [stop]
+            return journey
+
+        # 1 real on-time train + 5 scheduled_fallback trains (all show 0 delay)
+        real_on_time = make_journey(late_minutes=0, arrival_source="api_observed")
+        fallbacks = [
+            make_journey(late_minutes=0, arrival_source="scheduled_fallback")
+            for _ in range(5)
+        ]
+
+        stats = summary_service._calculate_arrival_stats(
+            [real_on_time, *fallbacks], "WTC"
+        )
+
+        assert stats is not None
+        # Only the 1 real train counts.
+        assert stats.total_count == 1
+        assert stats.on_time_percentage == 100.0
+        assert stats.average_delay_minutes == 0.0
+
+    def test_calculate_arrival_stats_returns_none_when_only_fallbacks(
+        self, summary_service
+    ):
+        """When every train has scheduled_fallback arrivals, return None
+        (no arrival data) — caller falls back to departure stats."""
+        current_time = datetime.now(UTC)
+
+        journey = Mock(spec=TrainJourney)
+        journey.is_cancelled = False
+        stop = Mock()
+        stop.station_code = "WTC"
+        stop.stop_sequence = 5
+        stop.scheduled_arrival = current_time - timedelta(minutes=10)
+        stop.actual_arrival = current_time - timedelta(minutes=10)
+        stop.arrival_source = "scheduled_fallback"
+        journey.stops = [stop]
+
+        stats = summary_service._calculate_arrival_stats([journey], "WTC")
+        assert stats is None
+
     def test_generate_train_summary_good_performance(self, summary_service):
         """Test train summary for train with good historical performance."""
         current_time = datetime.now(UTC)
@@ -634,6 +882,7 @@ class TestSummaryService:
                 cancellation_count=0,
                 total_delay_minutes=20.0,
                 data_source="NJT",
+                arrival_data_count=20,
             )
         }
 


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where on-time percentage (OTP) calculations were being deflated by trains with `scheduled_fallback` arrivals. These are trains where the GTFS-RT feed didn't provide a real arrival timestamp, so the collector wrote `actual_arrival = scheduled_arrival`, always showing 0 delay. The fix changes the denominator for OTP and average delay calculations from `train_count - cancellations` to a new `arrival_data_count` field that only includes trains with real arrival data.

## Key Changes

- **Added `arrival_data_count` field to `LineStats`**: A new field that tracks only non-cancelled trains with usable arrival data (real `actual_arrival` + `scheduled_arrival` with `arrival_source != "scheduled_fallback"`). This is now the correct denominator for OTP and average delay calculations.

- **Updated `LineStats` properties**: Modified `on_time_percentage` and `average_delay_minutes` to use `arrival_data_count` instead of `train_count - cancellation_count` as the denominator.

- **Refactored `_calculate_line_stats()`**: Changed logic to explicitly exclude trains with:
  - `scheduled_fallback` arrivals (always show 0 delay, misleading)
  - In-progress trains with no actual arrival data yet
  - Cancelled trains (already excluded)
  
  Only trains with real arrival data increment `arrival_data_count` and contribute to OTP/delay metrics.

- **Updated `_generate_network_summary()`**: 
  - Now uses `arrival_data_count` for aggregated OTP/delay calculations
  - Returns empty section (headline="", body="", metrics=None) when there's no usable arrival data and no cancellations to report
  - When there are cancellations but no arrival data, reports cancellations without claiming an OTP that can't be computed (OTP and avg_delay are None)

- **Updated `_calculate_arrival_stats()`**: Added check to exclude `scheduled_fallback` arrivals from route-level arrival statistics, consistent with line-level logic.

- **Comprehensive test coverage**: Added regression tests covering:
  - Trains with only `scheduled_fallback` arrivals
  - Mixed real/fallback/in-progress trains
  - Network summaries with no arrival data
  - Route arrival stats excluding fallback arrivals

## Implementation Details

The fix maintains backward compatibility by:
- Keeping `train_count` unchanged (still includes all observed trains for informational purposes)
- Only changing the denominator used in percentage/average calculations
- Defaulting `arrival_data_count` to 0 for backward compatibility with existing code
- Handling edge cases where there's no usable data (returns 0.0 for OTP/delay, which callers treat as "no signal")

This matches the SQL logic in the existing `/routes/history` endpoint and resolves the PATH bug where 100 observed trains with mostly `scheduled_fallback` arrivals were deflating OTP calculations.

https://claude.ai/code/session_0162GKk9iZJzZtiNhe6FjpAF