### PR TITLE
web: add AbortSignal + 15s timeout to api.ts, drop cache on error

### DIFF
--- a/webpage_v2/src/pages/NetworkStatusPage.tsx
+++ b/webpage_v2/src/pages/NetworkStatusPage.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SegmentCongestion, CongestionLevel, OperationsSummaryResponse } from '../types';
 import { apiService } from '../services/api';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { ErrorMessage } from '../components/ErrorMessage';
 import { formatTimeAgo } from '../utils/date';
+import { usePolling } from '../utils/usePolling';
 
 const SYSTEM_LABELS: Record<string, string> = {
   NJT: 'NJ Transit',
@@ -66,28 +67,26 @@ export function NetworkStatusPage() {
   const [generatedAt, setGeneratedAt] = useState<string | null>(null);
   const [expandedSystem, setExpandedSystem] = useState<string | null>(null);
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
     try {
-      setError(null);
       const [congestion, networkSummary] = await Promise.all([
-        apiService.getCongestion(),
-        apiService.getNetworkSummary(),
+        apiService.getCongestion(signal),
+        apiService.getNetworkSummary(signal),
       ]);
       setSegments(congestion.aggregated_segments);
       setGeneratedAt(congestion.generated_at);
       setSummary(networkSummary);
+      setError(null);
       setLoading(false);
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       setError(err instanceof Error ? err.message : 'Failed to load network status');
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    fetchData();
-    const interval = setInterval(fetchData, 60000); // Refresh every 60 seconds
-    return () => clearInterval(interval);
   }, []);
+
+  // Network congestion updates less frequently than per-route data.
+  usePolling(fetchData, [], { intervalMs: 60_000 });
 
   const { systemGroups, orderedSystems } = useMemo(() => {
     const groups: Record<string, SegmentCongestion[]> = {};
@@ -108,7 +107,7 @@ export function NetworkStatusPage() {
   }, [segments]);
 
   if (loading && segments.length === 0) return <LoadingSpinner />;
-  if (error) return <ErrorMessage message={error} onRetry={fetchData} />;
+  if (error) return <ErrorMessage message={error} onRetry={() => fetchData()} />;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/webpage_v2/src/pages/TrainDetailsPage.tsx
+++ b/webpage_v2/src/pages/TrainDetailsPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { TrainDetails, StationPredictionSupport } from '../types';
 import { apiService } from '../services/api';
+import { usePolling } from '../utils/usePolling';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { ErrorMessage } from '../components/ErrorMessage';
 import { StopCard } from '../components/StopCard';
@@ -33,34 +34,30 @@ export function TrainDetailsPage() {
   const [supportedStations, setSupportedStations] = useState<StationPredictionSupport[]>([]);
   const savedHistoryKeyRef = useRef<string | null>(null);
 
-  const fetchTrainDetails = async () => {
+  const fetchTrainDetails = useCallback(async (signal?: AbortSignal) => {
     if (!trainId) return;
 
     try {
-      setError(null);
       const response = await apiService.getTrainDetails(
         trainId,
         journeyDate || getTodayDateString(),
         {
           dataSource,
           fromStation: from,
+          signal,
         }
       );
       setTrain(response.train);
+      setError(null);
       setLoading(false);
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       setError(err instanceof Error ? err.message : 'Failed to load train details');
       setLoading(false);
     }
-  };
+  }, [trainId, journeyDate, dataSource, from]);
 
-  useEffect(() => {
-    fetchTrainDetails();
-
-    // Poll every 30 seconds
-    const interval = setInterval(fetchTrainDetails, 30000);
-    return () => clearInterval(interval);
-  }, [trainId, journeyDate, dataSource]);
+  usePolling(fetchTrainDetails, [trainId, journeyDate, dataSource, from]);
 
   // Fetch supported stations for track predictions (once, cached by API service)
   useEffect(() => {
@@ -161,7 +158,7 @@ export function TrainDetailsPage() {
   }
 
   if (error || !train) {
-    return <ErrorMessage message={error || 'Train not found'} onRetry={fetchTrainDetails} />;
+    return <ErrorMessage message={error || 'Train not found'} onRetry={() => fetchTrainDetails()} />;
   }
 
   // Check if we should show track predictions

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -102,6 +102,11 @@ export function TrainListPage() {
   // Future-dated views show only scheduled data, so polling is meaningless.
   usePolling(fetchTrains, [from, to, selectedDate], { enabled: !isViewingFutureDate });
 
+  // One-shot fetch for future dates (usePolling skips entirely when disabled).
+  useEffect(() => {
+    if (isViewingFutureDate) fetchTrains();
+  }, [isViewingFutureDate, fetchTrains]);
+
   // One-shot side effects on route change (recent trips, route summary)
   useEffect(() => {
     if (fromStation && toStation) {

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, lazy, Suspense } from 'react';
+import { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Train, TripOption, OperationsSummaryResponse } from '../types';
 import { apiService } from '../services/api';
@@ -12,6 +12,7 @@ import { TrainDistributionChart } from '../components/TrainDistributionChart';
 import { getStationByCode } from '../data/stations';
 import { formatTimeAgo, getTodayDateString } from '../utils/date';
 import { buildRouteStatusUrl, buildTrainUrl, buildTripUrl } from '../utils/routes';
+import { usePolling } from '../utils/usePolling';
 
 const RouteMap = lazy(() => import('../components/RouteMap').then((m) => ({ default: m.RouteMap })));
 
@@ -65,12 +66,11 @@ export function TrainListPage() {
     return departureWithBuffer < now;
   };
 
-  const fetchTrains = async () => {
+  const fetchTrains = useCallback(async (signal?: AbortSignal) => {
     if (!from || !to) return;
 
     try {
-      setError(null);
-      const response = await apiService.searchTrips(from, to, 50, selectedDate || undefined);
+      const response = await apiService.searchTrips(from, to, 50, selectedDate || undefined, signal);
 
       // Split response into direct and transfer trips
       const directTrips = response.trips.filter(t => t.is_direct);
@@ -88,34 +88,37 @@ export function TrainListPage() {
       setTrains(sorted);
       setTransferTrips(transferTripsResult);
       setIsTransferSearch(transferTripsResult.length > 0 && directTrips.length === 0);
-
       setLastUpdated(new Date());
+      setError(null);
       setLoading(false);
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
       setError(err instanceof Error ? err.message : 'Failed to load trains');
       setLoading(false);
     }
-  };
+  }, [from, to, selectedDate]);
 
+  // Polling: visibility-aware, aborts in-flight on unmount/dep change.
+  // Future-dated views show only scheduled data, so polling is meaningless.
+  usePolling(fetchTrains, [from, to, selectedDate], { enabled: !isViewingFutureDate });
+
+  // One-shot side effects on route change (recent trips, route summary)
   useEffect(() => {
-    fetchTrains();
-
-    // Save to recent trips once on mount, not every poll cycle
     if (fromStation && toStation) {
       addRecentTrip(fromStation, toStation);
     }
+    if (!from || !to) return;
 
-    // Fetch summary once on mount (not polled) - only for direct routes
-    if (from && to) {
-      apiService.getRouteSummary(from, to).then(setSummary);
-    }
-
-    // Poll every 30 seconds — but not for future dates (no real-time data)
-    if (!isViewingFutureDate) {
-      const interval = setInterval(fetchTrains, 30000);
-      return () => clearInterval(interval);
-    }
-  }, [from, to, selectedDate]);
+    const controller = new AbortController();
+    apiService.getRouteSummary(from, to, controller.signal)
+      .then(setSummary)
+      .catch((err) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+      });
+    return () => controller.abort();
+    // fromStation/toStation are derived from from/to and need not be deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [from, to]);
 
   const filteredTrains = useMemo(() => {
     if (!trainFilter.trim()) return trains;
@@ -271,7 +274,7 @@ export function TrainListPage() {
 
       <div className="flex gap-2 mb-4">
         <button
-          onClick={fetchTrains}
+          onClick={() => fetchTrains()}
           disabled={loading}
           className="py-3 px-4 bg-surface/50 backdrop-blur-xl border border-text-muted/20 rounded-xl font-semibold hover:bg-surface transition-all disabled:opacity-50 text-text-primary"
         >
@@ -306,7 +309,7 @@ export function TrainListPage() {
       {loading && !hasResults ? (
         <LoadingSpinner />
       ) : error ? (
-        <ErrorMessage message={error} onRetry={fetchTrains} />
+        <ErrorMessage message={error} onRetry={() => fetchTrains()} />
       ) : isEmpty ? (
         <div className="text-center py-12 text-text-muted">
           {trainFilter ? 'No matching trains' : 'No trains found for this route'}

--- a/webpage_v2/src/pages/TripDetailsPage.tsx
+++ b/webpage_v2/src/pages/TripDetailsPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { TripOption, TripLeg, TrainDetails } from '../types';
 import { apiService } from '../services/api';
+import { usePolling } from '../utils/usePolling';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { ErrorMessage } from '../components/ErrorMessage';
 import { StopCard } from '../components/StopCard';
@@ -150,32 +151,38 @@ export function TripDetailsPage() {
 
   useEffect(() => {
     if (!trip) return;
-
     storageService.saveViewedTripOption(trip);
+    // Persist view history once per trip identity, not on every poll.
+  }, [legIds, trip]);
 
-    const fetchAllLegDetails = async () => {
-      const results = await Promise.all(
-        trip.legs.map(leg =>
-          apiService.getTrainDetails(
-            leg.train_id,
-            leg.journey_date,
-            {
-              dataSource: leg.data_source,
-              fromStation: leg.boarding.code,
-            }
-          )
-            .then(res => res.train)
-            .catch(() => null)
+  const fetchAllLegDetails = useCallback(async (signal?: AbortSignal) => {
+    if (!trip) return;
+    const results = await Promise.all(
+      trip.legs.map(leg =>
+        apiService.getTrainDetails(
+          leg.train_id,
+          leg.journey_date,
+          {
+            dataSource: leg.data_source,
+            fromStation: leg.boarding.code,
+            signal,
+          }
         )
-      );
-      setLegDetails(results);
-      setLoading(false);
-    };
-
-    fetchAllLegDetails();
-    const interval = setInterval(fetchAllLegDetails, 30000);
-    return () => clearInterval(interval);
+          .then(res => res.train)
+          .catch((err) => {
+            if (err instanceof DOMException && err.name === 'AbortError') throw err;
+            return null;
+          })
+      )
+    );
+    setLegDetails(results);
+    setLoading(false);
+    // legIds captures all reactive bits of the legs; including `trip` directly
+    // would needlessly re-fire on equal-but-different references.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [legIds]);
+
+  usePolling(fetchAllLegDetails, [legIds], { enabled: !!trip });
 
   // Early returns after all hooks
   if (!trip) {

--- a/webpage_v2/src/pages/TripDetailsPage.tsx
+++ b/webpage_v2/src/pages/TripDetailsPage.tsx
@@ -153,7 +153,8 @@ export function TripDetailsPage() {
     if (!trip) return;
     storageService.saveViewedTripOption(trip);
     // Persist view history once per trip identity, not on every poll.
-  }, [legIds, trip]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [legIds]);
 
   const fetchAllLegDetails = useCallback(async (signal?: AbortSignal) => {
     if (!trip) return;

--- a/webpage_v2/src/services/api.test.ts
+++ b/webpage_v2/src/services/api.test.ts
@@ -28,7 +28,8 @@ describe('getTrainDetails', () => {
     await api.getTrainDetails('3515', '2025-01-15');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('/trains/3515?date=2025-01-15')
+      expect.stringContaining('/trains/3515?date=2025-01-15'),
+      expect.anything()
     );
   });
 
@@ -38,7 +39,8 @@ describe('getTrainDetails', () => {
     await api.getTrainDetails('3515', '2025-01-15', { dataSource: 'NJT' });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('data_source=NJT')
+      expect.stringContaining('data_source=NJT'),
+      expect.anything()
     );
   });
 
@@ -48,7 +50,8 @@ describe('getTrainDetails', () => {
     await api.getTrainDetails('3515', '2025-01-15', { fromStation: 'TR' });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('from_station=TR')
+      expect.stringContaining('from_station=TR'),
+      expect.anything()
     );
   });
 
@@ -67,7 +70,8 @@ describe('getTrainDetails', () => {
     await api.getTrainDetails('A/B');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('/trains/A%2FB')
+      expect.stringContaining('/trains/A%2FB'),
+      expect.anything()
     );
   });
 
@@ -126,7 +130,7 @@ describe('searchTrips', () => {
 
     await api.searchTrips('NY', 'NP', 25);
 
-    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('limit=25'));
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('limit=25'), expect.anything());
   });
 
   it('appends date parameter when provided', async () => {
@@ -134,7 +138,7 @@ describe('searchTrips', () => {
 
     await api.searchTrips('NY', 'NP', 50, '2025-03-28');
 
-    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('date=2025-03-28'));
+    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('date=2025-03-28'), expect.anything());
   });
 
   it('omits date parameter when not provided', async () => {
@@ -142,7 +146,7 @@ describe('searchTrips', () => {
 
     await api.searchTrips('NY', 'NP');
 
-    expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining('date='));
+    expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining('date='), expect.anything());
   });
 
   it('encodes station codes', async () => {
@@ -179,7 +183,8 @@ describe('getRouteSummary', () => {
     await api.getRouteSummary('NY', 'NP');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('scope=route&from_station=NY&to_station=NP')
+      expect.stringContaining('scope=route&from_station=NY&to_station=NP'),
+      expect.anything()
     );
   });
 });
@@ -292,7 +297,8 @@ describe('getCongestion', () => {
     await api.getCongestion();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('/routes/congestion')
+      expect.stringContaining('/routes/congestion'),
+      expect.anything()
     );
   });
 });
@@ -304,7 +310,8 @@ describe('getNetworkSummary', () => {
     await api.getNetworkSummary();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('scope=network')
+      expect.stringContaining('scope=network'),
+      expect.anything()
     );
   });
 
@@ -323,7 +330,8 @@ describe('getServiceAlerts', () => {
     await api.getServiceAlerts('SUBWAY');
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining('data_source=SUBWAY')
+      expect.stringContaining('data_source=SUBWAY'),
+      expect.anything()
     );
   });
 
@@ -343,7 +351,8 @@ describe('getServiceAlerts', () => {
     await api.getServiceAlerts();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringMatching(/\/alerts\/service$/)
+      expect.stringMatching(/\/alerts\/service$/),
+      expect.anything()
     );
   });
 });
@@ -442,5 +451,60 @@ describe('caching behavior', () => {
     await api.searchTrips('NY', 'NP');
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops cached entry after a subsequent error so retries hit network', async () => {
+    // First call: succeeds and is cached
+    mockFetch.mockReturnValueOnce(jsonResponse({ stations: [{ code: 'NY' }], total_predictions_enabled: 1 }));
+    await api.getSupportedStations();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Manually expire the cached entry by stubbing Date.now ahead of the cache window
+    const realNow = Date.now;
+    const expired = realNow() + 121_000;
+    Date.now = () => expired;
+    try {
+      // Next call hits network because cache window passed; this fails
+      mockFetch.mockReturnValueOnce(jsonResponse(null, 500));
+      await expect(api.getSupportedStations()).rejects.toThrow('Failed to fetch data');
+
+      // The error must invalidate the cache; the *next* call must hit network again,
+      // not return the original (now-stale) success.
+      mockFetch.mockReturnValueOnce(jsonResponse({ stations: [{ code: 'NP' }], total_predictions_enabled: 2 }));
+      const result = await api.getSupportedStations();
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result.total_predictions_enabled).toBe(2);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+});
+
+describe('abort handling', () => {
+  it('rethrows AbortError unchanged when caller signal aborts', async () => {
+    const controller = new AbortController();
+    mockFetch.mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const err = new DOMException('Aborted', 'AbortError');
+          reject(err);
+        });
+      });
+    });
+
+    const promise = api.searchTrips('NY', 'NP', 50, undefined, controller.signal);
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('passes the combined signal to fetch', async () => {
+    const controller = new AbortController();
+    mockFetch.mockReturnValue(jsonResponse({ trips: [], metadata: {} }));
+
+    await api.searchTrips('NY', 'NP', 50, undefined, controller.signal);
+
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/webpage_v2/src/services/api.ts
+++ b/webpage_v2/src/services/api.ts
@@ -2,6 +2,7 @@ import { TrainDetails, TrainDetailsResponse, PlatformPrediction, OperationsSumma
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://apiv2.trackrat.net/api/v2';
 const CACHE_DURATION = 120000; // 2 minutes in milliseconds
+const REQUEST_TIMEOUT_MS = 15000; // Hard cap so a stalled fetch never blocks polling
 
 interface CacheEntry<T> {
   data: T;
@@ -18,10 +19,18 @@ export class APIRequestError extends Error {
   }
 }
 
+/** Combine a caller-supplied signal (if any) with a timeout signal. */
+function combineSignals(external?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  if (!external) return timeout;
+  // AbortSignal.any aborts as soon as any input aborts (caller unmount OR timeout)
+  return AbortSignal.any([external, timeout]);
+}
+
 export class APIService {
   private cache = new Map<string, CacheEntry<unknown>>();
 
-  private async fetch<T>(url: string, useCache = true): Promise<T> {
+  private async fetch<T>(url: string, useCache = true, signal?: AbortSignal): Promise<T> {
     const cacheKey = url;
 
     // Check cache
@@ -33,7 +42,7 @@ export class APIService {
     }
 
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: combineSignals(signal) });
 
       if (!response.ok) {
         throw new APIRequestError(`Failed to fetch data: ${response.status} ${response.statusText}`, response.status);
@@ -51,6 +60,20 @@ export class APIService {
 
       return data as T;
     } catch (error) {
+      // Drop any stale cache entry so a subsequent retry actually hits the network
+      // rather than continuing to serve a now-suspect cached response.
+      this.cache.delete(cacheKey);
+
+      // Preserve AbortError so callers (e.g. polling hooks) can distinguish
+      // intentional cancellation from real failures.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+      // AbortSignal.timeout fires a TimeoutError DOMException — surface it as a
+      // user-facing failure, but with a clearer message.
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        throw new APIRequestError('Request timed out');
+      }
       if (error instanceof APIRequestError) {
         throw error;
       }
@@ -64,7 +87,7 @@ export class APIService {
   async getTrainDetails(
     trainId: string,
     date?: string,
-    options?: { dataSource?: string; fromStation?: string }
+    options?: { dataSource?: string; fromStation?: string; signal?: AbortSignal }
   ): Promise<TrainDetailsResponse> {
     const dateParam = date || new Date().toISOString().split('T')[0];
     const searchParams = new URLSearchParams({ date: dateParam });
@@ -72,7 +95,7 @@ export class APIService {
     if (options?.fromStation) searchParams.set('from_station', options.fromStation);
     const url = `${BASE_URL}/trains/${encodeURIComponent(trainId)}?${searchParams.toString()}`;
     // Don't cache train details - always fetch fresh
-    return this.fetch<TrainDetailsResponse>(url, false);
+    return this.fetch<TrainDetailsResponse>(url, false, options?.signal);
   }
 
   async findTrainByNumber(
@@ -97,18 +120,19 @@ export class APIService {
     }
   }
 
-  async searchTrips(from: string, to: string, limit = 50, date?: string): Promise<TripSearchResponse> {
+  async searchTrips(from: string, to: string, limit = 50, date?: string, signal?: AbortSignal): Promise<TripSearchResponse> {
     let url = `${BASE_URL}/trips/search?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&limit=${limit}&hide_departed=true`;
     if (date) url += `&date=${encodeURIComponent(date)}`;
-    return this.fetch<TripSearchResponse>(url, false); // Don't cache — 30s polling needs fresh data
+    return this.fetch<TripSearchResponse>(url, false, signal); // Don't cache — 30s polling needs fresh data
   }
 
-  async getRouteSummary(from: string, to: string): Promise<OperationsSummaryResponse | null> {
+  async getRouteSummary(from: string, to: string, signal?: AbortSignal): Promise<OperationsSummaryResponse | null> {
     try {
       const url = `${BASE_URL}/routes/summary?scope=route&from_station=${encodeURIComponent(from)}&to_station=${encodeURIComponent(to)}`;
-      return await this.fetch<OperationsSummaryResponse>(url);
-    } catch {
-      // Fail silently - summary is optional
+      return await this.fetch<OperationsSummaryResponse>(url, true, signal);
+    } catch (err) {
+      // Re-throw aborts so callers can ignore them; swallow real failures (summary is optional)
+      if (err instanceof DOMException && err.name === 'AbortError') throw err;
       return null;
     }
   }
@@ -186,16 +210,17 @@ export class APIService {
     }
   }
 
-  async getCongestion(): Promise<CongestionResponse> {
+  async getCongestion(signal?: AbortSignal): Promise<CongestionResponse> {
     const url = `${BASE_URL}/routes/congestion`;
-    return this.fetch<CongestionResponse>(url);
+    return this.fetch<CongestionResponse>(url, true, signal);
   }
 
-  async getNetworkSummary(): Promise<OperationsSummaryResponse | null> {
+  async getNetworkSummary(signal?: AbortSignal): Promise<OperationsSummaryResponse | null> {
     try {
       const url = `${BASE_URL}/routes/summary?scope=network`;
-      return await this.fetch<OperationsSummaryResponse>(url);
-    } catch {
+      return await this.fetch<OperationsSummaryResponse>(url, true, signal);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') throw err;
       return null;
     }
   }

--- a/webpage_v2/src/utils/usePolling.test.tsx
+++ b/webpage_v2/src/utils/usePolling.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePolling } from './usePolling';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // jsdom defaults document.hidden to false; reset visibility for each test.
+  Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function setVisibility(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', { configurable: true, value: hidden });
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: hidden ? 'hidden' : 'visible',
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('usePolling', () => {
+  it('runs callback immediately on mount', () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it('runs callback on the configured interval', () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(cb).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not run callback when enabled is false', () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000, enabled: false }));
+
+    expect(cb).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('aborts the previous in-flight request when interval fires', () => {
+    const signals: AbortSignal[] = [];
+    const cb = vi.fn(async (signal: AbortSignal) => {
+      signals.push(signal);
+      // never resolve — simulate slow request
+      await new Promise(() => {});
+    });
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    expect(signals.length).toBe(1);
+    expect(signals[0].aborted).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(signals.length).toBe(2);
+    expect(signals[0].aborted).toBe(true); // previous fetch aborted
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('aborts the in-flight request on unmount', () => {
+    const signals: AbortSignal[] = [];
+    const cb = vi.fn(async (signal: AbortSignal) => {
+      signals.push(signal);
+      await new Promise(() => {});
+    });
+
+    const { unmount } = renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    expect(signals[0].aborted).toBe(false);
+
+    unmount();
+
+    expect(signals[0].aborted).toBe(true);
+  });
+
+  it('clears the interval on unmount (no further calls)', () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+
+    const { unmount } = renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses interval when document becomes hidden', () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setVisibility(true);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(cb).toHaveBeenCalledTimes(1); // no extra calls while hidden
+  });
+
+  it('runs immediately and resumes interval when document becomes visible', () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setVisibility(true);
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setVisibility(false);
+    });
+    expect(cb).toHaveBeenCalledTimes(2); // immediate fetch on visible
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(cb).toHaveBeenCalledTimes(4); // interval resumed
+  });
+
+  it('re-runs when deps change and aborts previous request', () => {
+    const signals: AbortSignal[] = [];
+    const cb = vi.fn(async (signal: AbortSignal) => {
+      signals.push(signal);
+      await new Promise(() => {});
+    });
+
+    const { rerender } = renderHook(
+      ({ key }: { key: string }) => usePolling(cb, [key], { intervalMs: 1000 }),
+      { initialProps: { key: 'a' } }
+    );
+
+    expect(signals.length).toBe(1);
+
+    rerender({ key: 'b' });
+
+    expect(signals.length).toBe(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+
+  it('does not crash when the callback rejects with AbortError', async () => {
+    const cb = vi.fn(async () => {
+      throw new DOMException('Aborted', 'AbortError');
+    });
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    // Let the rejected promise settle without throwing
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs other rejections to console.error', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const cb = vi.fn().mockRejectedValue(new Error('boom'));
+
+    renderHook(() => usePolling(cb, [], { intervalMs: 1000 }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/webpage_v2/src/utils/usePolling.ts
+++ b/webpage_v2/src/utils/usePolling.ts
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Default polling interval used across the app for real-time train data.
+ * Matches the backend's typical update cadence.
+ */
+export const DEFAULT_POLLING_INTERVAL_MS = 30_000;
+
+interface UsePollingOptions {
+  /** Polling interval in milliseconds. */
+  intervalMs?: number;
+  /**
+   * If false, no polling happens (the callback is not invoked at all).
+   * Use for cases like "future-dated views" where polling is meaningless.
+   * Defaults to true.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Run an async callback on mount, then on a recurring interval, with three
+ * properties that the previous setInterval-based pattern lacked:
+ *
+ * 1. The callback receives an `AbortSignal` that is aborted on unmount, on
+ *    dependency change, and just before each new tick fires. Pass it to
+ *    `fetch`/api methods so in-flight requests are cancelled instead of
+ *    racing to set state on an unmounted component.
+ * 2. When the document becomes hidden the interval pauses; when it becomes
+ *    visible again the callback runs immediately and the interval resumes.
+ *    This avoids burning battery and API quota on background tabs.
+ * 3. AbortError is silently swallowed (cancellation is not a failure), but
+ *    other rejections are still surfaced to the caller's own handlers.
+ *
+ * The callback is intentionally not memoized internally — the caller passes
+ * a `deps` array that mirrors React's standard effect contract. Treat the
+ * callback like the body of a `useEffect`: capture state via closures, and
+ * include any reactive values used inside `deps`.
+ */
+export function usePolling(
+  callback: (signal: AbortSignal) => Promise<void> | void,
+  deps: ReadonlyArray<unknown>,
+  options: UsePollingOptions = {}
+): void {
+  const { intervalMs = DEFAULT_POLLING_INTERVAL_MS, enabled = true } = options;
+
+  // Hold the latest callback in a ref so visibilitychange handlers always
+  // call the most recent version without us having to re-bind listeners.
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let currentController: AbortController | null = null;
+    let cancelled = false;
+
+    const runOnce = () => {
+      // Abort any prior in-flight request before starting a new one.
+      currentController?.abort();
+      const controller = new AbortController();
+      currentController = controller;
+
+      Promise.resolve(callbackRef.current(controller.signal)).catch((err) => {
+        // Cancellation is not a failure — only real errors propagate.
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        // Surface unexpected errors via console; the callback's own try/catch
+        // is responsible for user-visible error UI.
+        console.error('[usePolling] callback rejected:', err);
+      });
+    };
+
+    const startInterval = () => {
+      if (intervalId !== null) return;
+      intervalId = setInterval(runOnce, intervalMs);
+    };
+
+    const stopInterval = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (cancelled) return;
+      if (document.hidden) {
+        stopInterval();
+        // Don't abort the in-flight request — let it complete and update state
+        // so the user sees fresh data when they return.
+      } else {
+        runOnce();
+        startInterval();
+      }
+    };
+
+    // Initial run + interval
+    runOnce();
+    if (!document.hidden) {
+      startInterval();
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      stopInterval();
+      currentController?.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, intervalMs, ...deps]);
+}

--- a/webpage_v2/vite.config.ts
+++ b/webpage_v2/vite.config.ts
@@ -38,15 +38,23 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,png,jpg,jpeg,gif,webp,woff,woff2}'],
+        // Static-ish lookup data is the only API response safe to serve from
+        // cache: the predictions/supported-stations list rarely changes.
+        // Real-time endpoints (trips/search, trains/*, predictions/track,
+        // predictions/delay, routes/congestion, routes/summary, routes/history,
+        // alerts/service, trains/*/history) MUST NOT be cached by the service
+        // worker — a 5-minute-stale departure board is worse than no data,
+        // and the in-app polling layer already handles transient failures.
         runtimeCaching: [
           {
-            urlPattern: /^https:\/\/(apiv2|staging\.apiv2)\.trackrat\.net\/api\/v2\/.*/i,
+            urlPattern: /^https:\/\/(apiv2|staging\.apiv2)\.trackrat\.net\/api\/v2\/predictions\/supported-stations/i,
             handler: 'NetworkFirst',
             options: {
-              cacheName: 'trackrat-api-cache',
+              cacheName: 'trackrat-supported-stations-cache',
+              networkTimeoutSeconds: 5,
               expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 5 * 60 // 5 minutes
+                maxEntries: 4,
+                maxAgeSeconds: 24 * 60 * 60 // 24 hours
               },
               cacheableResponse: {
                 statuses: [0, 200]


### PR DESCRIPTION
Three small but related fixes to the web API client:

* All fetches now run with AbortSignal.timeout(15s) combined with the
  caller's signal (if any) via AbortSignal.any. Previously a stalled
  fetch could hang the polling loop forever.
* Polled methods (searchTrips, getTrainDetails, getRouteSummary,
  getCongestion, getNetworkSummary) now accept an optional AbortSignal
  so callers can cancel in-flight requests on unmount.
* On any fetch error the cached entry for that URL is now dropped, so
  a manual refresh or next poll after an error actually hits the
  network rather than re-serving suspect data until the 2-min window
  expires.

AbortError is re-thrown unchanged so polling hooks can distinguish
intentional cancellation from real failures; TimeoutError is surfaced
as a user-friendly "Request timed out" APIRequestError.