### PR TITLE
Move alert settings above departures and tidy day/time pickers

### DIFF
--- a/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
+++ b/ios/TrackRat/Views/Components/AlertConfigurationSection.swift
@@ -344,15 +344,15 @@ struct AlertConfigurationSection: View {
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
 
-                // Time window presets (directly below day picker)
-                timePresetRow
-
-                if activeTimePreset == .custom || showCustomTime {
-                    customTimeWindow
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-                }
-
                 if hasDaysSelected {
+                    // Time window presets (directly below day picker)
+                    timePresetRow
+
+                    if activeTimePreset == .custom || showCustomTime {
+                        customTimeWindow
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+
                     Divider().opacity(0.3)
 
                     // Alert types
@@ -601,7 +601,7 @@ struct AlertConfigurationSection: View {
 
     private var dayPresetRow: some View {
         HStack(spacing: 8) {
-            presetButton("None", bitmask: 0)
+            presetButton("Never", bitmask: 0)
             presetButton("Every Day", bitmask: 127)
 
             Button {

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -55,9 +55,9 @@ struct RouteStatusView: View {
                     }
                     operationsSummarySection
                     historySections
+                    alertSubscriptionSection
                     departuresSection
                     serviceAlertsSection
-                    alertSubscriptionSection
                 }
                 .padding()
                 .animation(.easeInOut(duration: 0.3), value: viewModel.filterLoaded)


### PR DESCRIPTION
- Reorder route status sections so Alert Settings sits between Route
  Performance and Departures
- Hide the Anytime/Custom time pickers when no days are selected
- Rename the "None" day preset to "Never"