### PR TITLE
Issue #1016: Add accessibility to StationPicker modal

### DIFF
--- a/webpage_v2/src/components/StationPicker.test.tsx
+++ b/webpage_v2/src/components/StationPicker.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { StationPicker } from './StationPicker';
+
+describe('StationPicker', () => {
+  let onSelect: ReturnType<typeof vi.fn>;
+  let onClose: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onSelect = vi.fn();
+    onClose = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  function renderPicker(title = 'Select Station') {
+    return render(
+      <StationPicker title={title} onSelect={onSelect} onClose={onClose} />
+    );
+  }
+
+  describe('dialog semantics', () => {
+    it('renders with role="dialog" and aria-modal="true"', () => {
+      renderPicker();
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('has aria-labelledby pointing to the title', () => {
+      renderPicker('Pick a Station');
+      const dialog = screen.getByRole('dialog');
+      const titleId = dialog.getAttribute('aria-labelledby');
+      expect(titleId).toBe('stationpicker-title');
+      const heading = document.getElementById(titleId!);
+      expect(heading).toHaveTextContent('Pick a Station');
+    });
+
+    it('close button has aria-label', () => {
+      renderPicker();
+      const closeBtn = screen.getByRole('button', { name: 'Close' });
+      expect(closeBtn).toBeInTheDocument();
+    });
+  });
+
+  describe('Escape-to-close', () => {
+    it('calls onClose when Escape is pressed', () => {
+      renderPicker();
+      const dialog = screen.getByRole('dialog');
+      fireEvent.keyDown(dialog, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose for other keys', () => {
+      renderPicker();
+      const dialog = screen.getByRole('dialog');
+      fireEvent.keyDown(dialog, { key: 'Enter' });
+      fireEvent.keyDown(dialog, { key: 'a' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('body scroll lock', () => {
+    it('sets body overflow to hidden on mount', () => {
+      renderPicker();
+      expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('restores previous body overflow on unmount', () => {
+      document.body.style.overflow = 'auto';
+      const { unmount } = renderPicker();
+      expect(document.body.style.overflow).toBe('hidden');
+      unmount();
+      expect(document.body.style.overflow).toBe('auto');
+    });
+
+    it('restores empty string when body had no overflow set', () => {
+      document.body.style.overflow = '';
+      const { unmount } = renderPicker();
+      expect(document.body.style.overflow).toBe('hidden');
+      unmount();
+      expect(document.body.style.overflow).toBe('');
+    });
+  });
+
+  describe('focus trap', () => {
+    it('wraps focus from last to first element on Tab', () => {
+      renderPicker();
+      const dialog = screen.getByRole('dialog');
+      const focusableElements = dialog.querySelectorAll<HTMLElement>('button, input');
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      lastElement.focus();
+      expect(document.activeElement).toBe(lastElement);
+
+      fireEvent.keyDown(dialog, { key: 'Tab' });
+      expect(document.activeElement).toBe(focusableElements[0]);
+    });
+
+    it('wraps focus from first to last element on Shift+Tab', () => {
+      renderPicker();
+      const dialog = screen.getByRole('dialog');
+      const focusableElements = dialog.querySelectorAll<HTMLElement>('button, input');
+      const firstElement = focusableElements[0];
+
+      firstElement.focus();
+      expect(document.activeElement).toBe(firstElement);
+
+      fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(focusableElements[focusableElements.length - 1]);
+    });
+  });
+
+  describe('auto-focus', () => {
+    it('focuses the search input on mount', () => {
+      renderPicker();
+      const searchInput = screen.getByPlaceholderText('Search stations...');
+      expect(document.activeElement).toBe(searchInput);
+    });
+  });
+
+  describe('close button', () => {
+    it('calls onClose when close button is clicked', () => {
+      renderPicker();
+      fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/webpage_v2/src/components/StationPicker.tsx
+++ b/webpage_v2/src/components/StationPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Station } from '../types';
 import { searchStations, getGroupedPrimaryStations, SYSTEM_ORDER, SYSTEM_NAMES } from '../data/stations';
 import { useAppStore } from '../store/appStore';
@@ -13,10 +13,47 @@ export function StationPicker({ title, onSelect, onClose }: StationPickerProps) 
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Station[]>([]);
   const { preferredSystems, toggleSystem, loadPreferredSystems } = useAppStore();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     loadPreferredSystems();
   }, [loadPreferredSystems]);
+
+  // Body scroll lock
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
+  // Escape-to-close and focus trap
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+      return;
+    }
+    if (e.key === 'Tab' && dialogRef.current) {
+      const focusable = dialogRef.current.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }, [onClose]);
+
+  // Auto-focus search input
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
 
   const activeFilter = preferredSystems.length > 0 ? preferredSystems : undefined;
 
@@ -45,12 +82,20 @@ export function StationPicker({ title, onSelect, onClose }: StationPickerProps) 
   const isSearching = query.trim().length > 0;
 
   return (
-    <div className="fixed inset-0 bg-text-primary/50 backdrop-blur-sm z-50 flex items-end md:items-center justify-center">
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="stationpicker-title"
+      onKeyDown={handleKeyDown}
+      className="fixed inset-0 bg-text-primary/50 backdrop-blur-sm z-50 flex items-end md:items-center justify-center"
+    >
       <div className="bg-surface w-full md:max-w-2xl md:rounded-2xl rounded-t-2xl max-h-[80vh] flex flex-col">
         <div className="p-4 border-b border-text-muted/20 flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-text-primary">{title}</h2>
+          <h2 id="stationpicker-title" className="text-xl font-semibold text-text-primary">{title}</h2>
           <button
             onClick={onClose}
+            aria-label="Close"
             className="text-text-secondary hover:text-text-primary text-2xl leading-none"
           >
             ×
@@ -59,11 +104,11 @@ export function StationPicker({ title, onSelect, onClose }: StationPickerProps) 
 
         <div className="p-4 border-b border-text-muted/20">
           <input
+            ref={searchInputRef}
             type="text"
             value={query}
             onChange={(e) => handleSearch(e.target.value)}
             placeholder="Search stations..."
-            autoFocus
             className="w-full px-4 py-3 bg-background border border-text-muted/30 rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:ring-2 focus:ring-accent mb-3"
           />
           {/* System filter chips */}


### PR DESCRIPTION
## Summary

- Add `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the modal overlay so screen readers announce it as a dialog
- Add Escape-to-close via `onKeyDown` handler on the dialog container
- Add focus trap that cycles Tab/Shift+Tab between first and last focusable elements within the dialog
- Add body scroll lock (`overflow: hidden`) on mount with proper cleanup to restore previous value on unmount
- Add `aria-label="Close"` to the close button (previously just the `×` character, invisible to screen readers)
- Replace `autoFocus` attribute with ref-based `.focus()` in a `useEffect` for more reliable cross-browser behavior

## Files modified

- **`webpage_v2/src/components/StationPicker.tsx`** — All accessibility improvements (ARIA attributes, keyboard handling, scroll lock, focus management)
- **`webpage_v2/src/components/StationPicker.test.tsx`** — New test file with 12 tests covering dialog semantics, Escape-to-close, body scroll lock, focus trap, auto-focus, and close button behavior

## Test coverage

12 new tests across 6 describe blocks:
- Dialog semantics: `role="dialog"`, `aria-modal`, `aria-labelledby`, close button `aria-label`
- Escape-to-close: fires `onClose`, ignores other keys
- Body scroll lock: sets `overflow: hidden`, restores previous value on unmount
- Focus trap: wraps forward Tab and backward Shift+Tab
- Auto-focus: search input receives focus on mount
- Close button: click calls `onClose`

Full test suite passes (195 tests, 0 failures). TypeScript type check passes.

## Design decisions

- Used `onKeyDown` on the dialog `div` (React synthetic event) rather than a `document.addEventListener` to keep the handler scoped to the dialog lifecycle without manual cleanup
- Focus trap queries focusable elements dynamically on each Tab press (not cached) because the set of focusable elements changes as search results appear/disappear
- No new dependencies added — focus trap is ~15 lines of vanilla DOM code, consistent with the project's minimal-dependencies philosophy

Closes #1016

https://claude.ai/code/session_0195PMWUuiJrEUscrMw2X24x

---
_Generated by [Claude Code](https://claude.ai/code/session_0195PMWUuiJrEUscrMw2X24x)_