### PR TITLE
Push time_from filter into SQL for high-frequency GTFS providers

### DIFF
--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -764,6 +764,29 @@ class GTFSService:
         tz = PROVIDER_TIMEZONE.get(data_source, ET) if data_source else ET
         return tz.localize(base_dt)
 
+    @staticmethod
+    def _gtfs_time_cutoff(
+        time_from: datetime, target_date: date, data_source: str
+    ) -> str | None:
+        """Convert a `time_from` datetime into a GTFS HH:MM:SS cutoff string.
+
+        GTFS departure_time values are zero-padded local clock times, with
+        hours possibly >= 24 for overnight trips. They sort lexicographically
+        in the same order as the wall-clock times they represent, so a string
+        comparison `departure_time >= cutoff` filters correctly.
+
+        Returns None when time_from is at or before the start of target_date
+        in the provider's timezone (no rows on target_date can be excluded).
+        """
+        tz = PROVIDER_TIMEZONE.get(data_source, ET)
+        target_midnight = tz.localize(datetime.combine(target_date, time(0, 0)))
+        delta_seconds = int((time_from - target_midnight).total_seconds())
+        if delta_seconds <= 0:
+            return None
+        hours, rem = divmod(delta_seconds, 3600)
+        minutes, seconds = divmod(rem, 60)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
     async def get_active_service_ids(
         self, db: AsyncSession, data_source: str, target_date: date
     ) -> set[str]:
@@ -1310,23 +1333,19 @@ class GTFSService:
 
         for data_source, service_ids in all_services.items():
             source_departures = await self._query_departures_for_source(
-                db, data_source, service_ids, from_station, to_station, target_date
+                db,
+                data_source,
+                service_ids,
+                from_station,
+                to_station,
+                target_date,
+                time_from,
             )
             departures.extend(source_departures)
 
         # Sort by departure time
         # Use timezone-aware constant for safe comparison with ET-localized times
         departures.sort(key=lambda d: d.departure.scheduled_time or DATETIME_MAX_ET)
-
-        # Drop departures before time_from so `limit` counts trains from the
-        # requested window rather than always from the start of the day.
-        if time_from is not None:
-            departures = [
-                d
-                for d in departures
-                if d.departure.scheduled_time is not None
-                and d.departure.scheduled_time >= time_from
-            ]
 
         # Apply limit
         departures = departures[:limit]
@@ -1359,9 +1378,26 @@ class GTFSService:
         from_station: str,
         to_station: str | None,
         target_date: date,
+        time_from: datetime | None = None,
     ) -> list[TrainDeparture]:
         """Query GTFS tables for departures from a specific data source."""
         departures: list[TrainDeparture] = []
+
+        # Translate time_from into a GTFS HH:MM:SS cutoff so we can filter in
+        # SQL. Without this, the LIMIT below truncates high-frequency providers
+        # (SUBWAY) to overnight-only departures sorted by clock time.
+        time_from_cutoff = (
+            self._gtfs_time_cutoff(time_from, target_date, data_source)
+            if time_from is not None
+            else None
+        )
+        where_clauses = [
+            GTFSTrip.data_source == data_source,
+            GTFSTrip.service_id.in_(service_ids),
+            GTFSStopTime.station_code.in_(expand_station_codes(from_station)),
+        ]
+        if time_from_cutoff is not None:
+            where_clauses.append(GTFSStopTime.departure_time >= time_from_cutoff)
 
         # Find trips that have the from_station
         # We need to join trips -> stop_times to find matching trips
@@ -1381,13 +1417,7 @@ class GTFSService:
             )
             .join(GTFSRoute, GTFSTrip.route_id == GTFSRoute.id)
             .join(GTFSStopTime, GTFSTrip.id == GTFSStopTime.trip_id)
-            .where(
-                and_(
-                    GTFSTrip.data_source == data_source,
-                    GTFSTrip.service_id.in_(service_ids),
-                    GTFSStopTime.station_code.in_(expand_station_codes(from_station)),
-                )
-            )
+            .where(and_(*where_clauses))
             .order_by(GTFSStopTime.departure_time)
             # Cap results to avoid fetching hundreds of trips for high-volume
             # providers like SUBWAY. Callers apply their own limit (typically

--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -780,11 +780,13 @@ class GTFSService:
         """
         tz = PROVIDER_TIMEZONE.get(data_source, ET)
         target_midnight = tz.localize(datetime.combine(target_date, time(0, 0)))
-        delta_seconds = int((time_from - target_midnight).total_seconds())
-        if delta_seconds <= 0:
+        if time_from <= target_midnight:
             return None
-        hours, rem = divmod(delta_seconds, 3600)
-        minutes, seconds = divmod(rem, 60)
+        local_time = time_from.astimezone(tz)
+        day_offset = (local_time.date() - target_date).days
+        hours = local_time.hour + day_offset * 24
+        minutes = local_time.minute
+        seconds = local_time.second
         return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
     async def get_active_service_ids(

--- a/backend_v2/tests/unit/services/test_gtfs.py
+++ b/backend_v2/tests/unit/services/test_gtfs.py
@@ -1381,3 +1381,29 @@ class TestGetScheduledDeparturesTimeFrom:
         target_date = date(2026, 4, 23)
         cutoff = PT.localize(datetime.combine(target_date, time(8, 0)))
         assert GTFSService._gtfs_time_cutoff(cutoff, target_date, "BART") == "08:00:00"
+
+    def test_gtfs_time_cutoff_spring_forward_uses_wall_clock(self):
+        """On spring-forward day, 08:00 EDT must produce 08:00:00, not 07:00:00.
+
+        Spring forward 2026: March 8. Midnight is EST (-05:00), but 08:00 is
+        EDT (-04:00). Physical elapsed time is 7 hours, but the GTFS wall-clock
+        time is 08:00:00.
+        """
+        target_date = date(2026, 3, 8)
+        cutoff = ET.localize(datetime.combine(target_date, time(8, 0)))
+        assert (
+            GTFSService._gtfs_time_cutoff(cutoff, target_date, "SUBWAY") == "08:00:00"
+        )
+
+    def test_gtfs_time_cutoff_fall_back_uses_wall_clock(self):
+        """On fall-back day, 08:00 EST must produce 08:00:00, not 09:00:00.
+
+        Fall back 2026: November 1. Midnight is EDT (-04:00), but 08:00 is
+        EST (-05:00). Physical elapsed time is 9 hours, but the GTFS wall-clock
+        time is 08:00:00.
+        """
+        target_date = date(2026, 11, 1)
+        cutoff = ET.localize(datetime.combine(target_date, time(8, 0)))
+        assert (
+            GTFSService._gtfs_time_cutoff(cutoff, target_date, "SUBWAY") == "08:00:00"
+        )

--- a/backend_v2/tests/unit/services/test_gtfs.py
+++ b/backend_v2/tests/unit/services/test_gtfs.py
@@ -1305,63 +1305,29 @@ class TestGetScheduledDeparturesTimeFrom:
     """Tests for `time_from` filtering in get_scheduled_departures().
 
     High-frequency providers like SUBWAY would otherwise return only the
-    overnight sliver of the day because the first `limit` trains sorted by
-    departure time are all pre-dawn. `time_from` moves the limit window to
-    the caller's time of interest.
+    overnight sliver of the day because the per-source SQL caps at 250 rows
+    sorted by departure clock time. The fix pushes the cutoff into SQL via
+    `_query_departures_for_source(..., time_from=...)`.
     """
 
     def setup_method(self):
         self.service = GTFSService()
 
-    def _make_departure(self, train_id: str, dt: datetime):
-        from trackrat.models.api import (
-            DataFreshness,
-            LineInfo,
-            StationInfo,
-            TrainDeparture,
-            TrainPosition,
-        )
-
-        return TrainDeparture(
-            train_id=train_id,
-            journey_date=dt.date(),
-            line=LineInfo(code="1", name="1", color="#EE352E"),
-            destination="South Ferry",
-            departure=StationInfo(code="S127", name="Times Sq", scheduled_time=dt),
-            arrival=None,
-            train_position=TrainPosition(),
-            data_freshness=DataFreshness(last_updated=dt, age_seconds=0),
-            data_source="SUBWAY",
-            observation_type="SCHEDULED",
-        )
-
     @pytest.mark.asyncio
-    async def test_time_from_shifts_limit_window(self):
-        """Setting time_from should skip earlier departures before applying limit."""
+    async def test_time_from_passed_to_query(self):
+        """get_scheduled_departures must thread time_from down to the SQL query."""
         target_date = date(2026, 4, 23)
-        # 10 hourly SUBWAY departures from 00:30 to 09:30 ET
-        mock_deps = [
-            self._make_departure(
-                f"S{i:03d}",
-                ET.localize(datetime.combine(target_date, time(i, 30))),
-            )
-            for i in range(10)
-        ]
-
-        mock_db = AsyncMock()
         cutoff = ET.localize(datetime.combine(target_date, time(8, 0)))
+        mock_db = AsyncMock()
+        query_mock = AsyncMock(return_value=[])
 
         with (
             patch.object(
                 self.service, "get_active_service_ids", return_value={"WD_SUBWAY"}
             ),
-            patch.object(
-                self.service,
-                "_query_departures_for_source",
-                AsyncMock(return_value=mock_deps),
-            ),
+            patch.object(self.service, "_query_departures_for_source", query_mock),
         ):
-            response = await self.service.get_scheduled_departures(
+            await self.service.get_scheduled_departures(
                 db=mock_db,
                 from_station="S127",
                 to_station=None,
@@ -1371,42 +1337,47 @@ class TestGetScheduledDeparturesTimeFrom:
                 time_from=cutoff,
             )
 
-        # Only 08:30 and 09:30 departures survive the cutoff
-        returned_ids = [d.train_id for d in response.departures]
-        assert returned_ids == ["S008", "S009"]
+        assert query_mock.await_count == 1
+        # time_from is the 7th positional arg
+        assert query_mock.await_args.args[6] == cutoff
 
-    @pytest.mark.asyncio
-    async def test_no_time_from_returns_first_limit_of_day(self):
-        """Without time_from, behavior matches pre-fix: earliest N departures."""
+    def test_gtfs_time_cutoff_returns_none_before_target_midnight(self):
+        """Cutoff at or before target_date midnight means no SQL filter is needed."""
         target_date = date(2026, 4, 23)
-        mock_deps = [
-            self._make_departure(
-                f"S{i:03d}",
-                ET.localize(datetime.combine(target_date, time(i, 30))),
-            )
-            for i in range(10)
-        ]
+        # Cutoff one second before midnight ET — entire target_date is >= cutoff.
+        cutoff = ET.localize(datetime.combine(target_date, time(0, 0))) - timedelta(
+            seconds=1
+        )
+        assert GTFSService._gtfs_time_cutoff(cutoff, target_date, "SUBWAY") is None
 
-        mock_db = AsyncMock()
+    def test_gtfs_time_cutoff_formats_local_time_of_day(self):
+        """Cutoff during target_date returns zero-padded HH:MM:SS in agency tz."""
+        target_date = date(2026, 4, 23)
+        cutoff = ET.localize(datetime.combine(target_date, time(8, 5, 30)))
+        assert (
+            GTFSService._gtfs_time_cutoff(cutoff, target_date, "SUBWAY") == "08:05:30"
+        )
 
-        with (
-            patch.object(
-                self.service, "get_active_service_ids", return_value={"WD_SUBWAY"}
-            ),
-            patch.object(
-                self.service,
-                "_query_departures_for_source",
-                AsyncMock(return_value=mock_deps),
-            ),
-        ):
-            response = await self.service.get_scheduled_departures(
-                db=mock_db,
-                from_station="S127",
-                to_station=None,
-                target_date=target_date,
-                limit=5,
-                data_sources=["SUBWAY"],
-            )
+    def test_gtfs_time_cutoff_overnight_uses_24_plus_hours(self):
+        """Cutoff after midnight on the next day yields a >24:00:00 GTFS time.
 
-        returned_ids = [d.train_id for d in response.departures]
-        assert returned_ids == ["S000", "S001", "S002", "S003", "S004"]
+        GTFS represents 1:30 AM the day after a service date as 25:30:00, and
+        the cutoff string must use the same convention so lexicographic
+        comparison against stored departure_time values works.
+        """
+        target_date = date(2026, 4, 23)
+        # 1:30 AM ET on the day after target_date.
+        cutoff = ET.localize(
+            datetime.combine(target_date + timedelta(days=1), time(1, 30))
+        )
+        assert (
+            GTFSService._gtfs_time_cutoff(cutoff, target_date, "SUBWAY") == "25:30:00"
+        )
+
+    def test_gtfs_time_cutoff_uses_provider_timezone(self):
+        """A BART cutoff at 08:00 PT must produce 08:00:00, not the ET equivalent."""
+        from trackrat.utils.time import PT
+
+        target_date = date(2026, 4, 23)
+        cutoff = PT.localize(datetime.combine(target_date, time(8, 0)))
+        assert GTFSService._gtfs_time_cutoff(cutoff, target_date, "BART") == "08:00:00"


### PR DESCRIPTION
## Summary
Moves the `time_from` filtering logic from Python post-processing into the SQL query layer for GTFS departures. This fixes an issue where high-frequency providers like SUBWAY would return only overnight departures because the per-source SQL LIMIT was applied before filtering by time.

## Key Changes
- Added `_gtfs_time_cutoff()` static method to convert a `time_from` datetime into a GTFS-compatible HH:MM:SS cutoff string that works with lexicographic comparison
- Updated `_query_departures_for_source()` to accept an optional `time_from` parameter and apply it as a SQL WHERE clause on `GTFSStopTime.departure_time`
- Removed the post-query Python filtering logic from `get_scheduled_departures()` that was previously dropping departures before `time_from`
- Updated the call to `_query_departures_for_source()` to pass through the `time_from` parameter

## Implementation Details
- The `_gtfs_time_cutoff()` method handles:
  - Returning `None` when the cutoff is at or before the target date's midnight (no filtering needed)
  - Converting wall-clock times to GTFS format with zero-padded hours
  - Supporting overnight times (>24:00:00) using GTFS convention (e.g., 1:30 AM next day = "25:30:00")
  - Using the provider's timezone (via `PROVIDER_TIMEZONE`) for accurate local time calculations
- The SQL filter now prevents the LIMIT from truncating results before the requested time window, ensuring high-frequency providers return departures from the caller's time of interest rather than just the start of the day

https://claude.ai/code/session_01GKGkTvd6sjoEvsafY55EP8