### PR TITLE
Issue #1017: Add screen reader support to loading spinners and refresh timestamps

### DIFF
--- a/webpage_v2/src/components/LoadingSpinner.test.tsx
+++ b/webpage_v2/src/components/LoadingSpinner.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LoadingSpinner } from './LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+  it('renders with role="status" for screen reader announcements', () => {
+    render(<LoadingSpinner />);
+    const status = screen.getByRole('status');
+    expect(status).toBeInTheDocument();
+  });
+
+  it('has default aria-label "Loading"', () => {
+    render(<LoadingSpinner />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('accepts a custom label prop', () => {
+    render(<LoadingSpinner label="Loading departures" />);
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-label', 'Loading departures');
+  });
+
+  it('includes sr-only text matching the label', () => {
+    render(<LoadingSpinner label="Loading trains" />);
+    const srText = screen.getByText('Loading trains');
+    expect(srText).toBeInTheDocument();
+    expect(srText).toHaveClass('sr-only');
+  });
+
+  it('hides the spinner animation from screen readers', () => {
+    const { container } = render(<LoadingSpinner />);
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/webpage_v2/src/components/LoadingSpinner.tsx
+++ b/webpage_v2/src/components/LoadingSpinner.tsx
@@ -1,7 +1,8 @@
-export function LoadingSpinner() {
+export function LoadingSpinner({ label = 'Loading' }: { label?: string }) {
   return (
-    <div className="flex items-center justify-center p-8">
-      <div className="w-8 h-8 border-4 border-accent border-t-transparent rounded-full animate-spin" />
+    <div className="flex items-center justify-center p-8" role="status" aria-label={label}>
+      <div className="w-8 h-8 border-4 border-accent border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+      <span className="sr-only">{label}</span>
     </div>
   );
 }

--- a/webpage_v2/src/pages/NetworkStatusPage.tsx
+++ b/webpage_v2/src/pages/NetworkStatusPage.tsx
@@ -4,7 +4,7 @@ import { SegmentCongestion, CongestionLevel, OperationsSummaryResponse } from '.
 import { apiService } from '../services/api';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { ErrorMessage } from '../components/ErrorMessage';
-import { formatTimeAgo } from '../utils/date';
+import { formatTime } from '../utils/date';
 
 const SYSTEM_LABELS: Record<string, string> = {
   NJT: 'NJ Transit',
@@ -116,7 +116,7 @@ export function NetworkStatusPage() {
         <h2 className="text-2xl font-bold text-text-primary text-center">Network Status</h2>
         {generatedAt && (
           <div className="text-sm text-text-muted mt-1 text-center">
-            Updated {formatTimeAgo(new Date(generatedAt).toISOString())}
+            Updated at {formatTime(new Date(generatedAt).toISOString())}
           </div>
         )}
       </div>

--- a/webpage_v2/src/pages/TrainDetailsPage.tsx
+++ b/webpage_v2/src/pages/TrainDetailsPage.tsx
@@ -12,7 +12,7 @@ import { ServiceAlertBanner } from '../components/ServiceAlertBanner';
 import { HistoricalPerformance } from '../components/HistoricalPerformance';
 import { SimilarTrainsPanel } from '../components/SimilarTrainsPanel';
 import { storageService } from '../services/storage';
-import { getTodayDateString, formatTimeAgo, isToday, formatDate } from '../utils/date';
+import { getTodayDateString, formatTime, isToday, formatDate } from '../utils/date';
 import { buildTrainShareData } from '../utils/share';
 
 export function TrainDetailsPage() {
@@ -233,7 +233,7 @@ export function TrainDetailsPage() {
             </span>
           )}
           {train.data_freshness?.last_updated && (
-            <span>Updated {formatTimeAgo(train.data_freshness.last_updated)}</span>
+            <span>Updated at {formatTime(train.data_freshness.last_updated)}</span>
           )}
         </div>
       </div>

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -10,7 +10,7 @@ import { TransferTripCard } from '../components/TransferTripCard';
 import { ServiceAlertBanner } from '../components/ServiceAlertBanner';
 import { TrainDistributionChart } from '../components/TrainDistributionChart';
 import { getStationByCode } from '../data/stations';
-import { formatTimeAgo, getTodayDateString } from '../utils/date';
+import { formatTime, getTodayDateString } from '../utils/date';
 import { buildRouteStatusUrl, buildTrainUrl, buildTripUrl } from '../utils/routes';
 
 const RouteMap = lazy(() => import('../components/RouteMap').then((m) => ({ default: m.RouteMap })));
@@ -186,7 +186,7 @@ export function TrainListPage() {
         <div className="flex items-center justify-center gap-4 mt-2">
           {lastUpdated && (
             <span className="text-sm text-text-muted">
-              Updated {formatTimeAgo(lastUpdated.toISOString())}
+              Updated at {formatTime(lastUpdated.toISOString())}
             </span>
           )}
           {directRouteDataSource && !isTransferSearch && (

--- a/webpage_v2/src/pages/TripDetailsPage.tsx
+++ b/webpage_v2/src/pages/TripDetailsPage.tsx
@@ -7,7 +7,7 @@ import { ErrorMessage } from '../components/ErrorMessage';
 import { StopCard } from '../components/StopCard';
 import { ServiceAlertBanner } from '../components/ServiceAlertBanner';
 import { TransferIndicator } from '../components/TransferTripCard';
-import { formatTime, formatTimeAgo } from '../utils/date';
+import { formatTime } from '../utils/date';
 import { buildTrainUrl, parseTripParam } from '../utils/routes';
 import { storageService } from '../services/storage';
 
@@ -84,7 +84,7 @@ function LegDetail({ leg, train, loading, navigate }: { leg: TripLeg; train: Tra
 
         {train?.data_freshness?.last_updated && (
           <div className="text-xs text-text-muted mt-2">
-            {train.data_source} • Updated {formatTimeAgo(train.data_freshness.last_updated)}
+            {train.data_source} • Updated at {formatTime(train.data_freshness.last_updated)}
           </div>
         )}
       </div>

--- a/webpage_v2/src/utils/date.ts
+++ b/webpage_v2/src/utils/date.ts
@@ -1,18 +1,9 @@
-import { format, formatDistance, parseISO, isToday as fnsIsToday } from 'date-fns';
+import { format, parseISO, isToday as fnsIsToday } from 'date-fns';
 
 export function formatTime(dateString: string): string {
   try {
     const date = parseISO(dateString);
     return format(date, 'h:mm a');
-  } catch {
-    return 'N/A';
-  }
-}
-
-export function formatTimeAgo(dateString: string): string {
-  try {
-    const date = parseISO(dateString);
-    return formatDistance(date, new Date(), { addSuffix: true });
   } catch {
     return 'N/A';
   }


### PR DESCRIPTION
## Summary\n\n- **LoadingSpinner ARIA**: Added `role=\"status\"`, `aria-label`, `aria-hidden=\"true\"` on the spinner animation, and sr-only text. Accepts an optional `label` prop for contextual messages (defaults to \"Loading\").\n- **Absolute timestamps**: Replaced \"Updated 2 minutes ago\" (which froze between 30s poll intervals, misleading users) with \"Updated at 3:45 PM\" using the existing `formatTime` helper. Applied consistently across TrainListPage, TrainDetailsPage, NetworkStatusPage, and TripDetailsPage.\n- **Dead code removal**: Removed `formatTimeAgo` and the `formatDistance` import from `date-fns` since they are no longer used.\n\n## Files modified\n\n| File | Change |\n|------|--------|\n| `webpage_v2/src/components/LoadingSpinner.tsx` | Added ARIA attributes, optional `label` prop, sr-only text |\n| `webpage_v2/src/components/LoadingSpinner.test.tsx` | **New** — 5 tests covering role, aria-label, custom label, sr-only text, aria-hidden |\n| `webpage_v2/src/utils/date.ts` | Removed `formatTimeAgo` and `formatDistance` import |\n| `webpage_v2/src/pages/TrainListPage.tsx` | `formatTimeAgo` → `formatTime`, \"Updated\" → \"Updated at\" |\n| `webpage_v2/src/pages/TrainDetailsPage.tsx` | Same |\n| `webpage_v2/src/pages/NetworkStatusPage.tsx` | Same |\n| `webpage_v2/src/pages/TripDetailsPage.tsx` | Same |\n\n## Design decisions\n\n- **Option A (absolute time) over Option B (ticking relative time)**: Absolute time is always accurate, requires no extra hooks or per-second re-renders, and is a smaller diff. The issue author also expressed preference for Option A.\n- **No new dependencies**: The existing `formatTime` utility and Tailwind's built-in `sr-only` class cover everything needed.\n\n## Test coverage\n\n- 5 new tests in `LoadingSpinner.test.tsx`\n- All 188 tests pass, build clean\n\nCloses #1017\n\nhttps://claude.ai/code/session_01PusHnpz8LNL8H4ddXB1eaf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PusHnpz8LNL8H4ddXB1eaf)_