### PR TITLE
Issue #1018: Optimize station search performance

### DIFF
--- a/webpage_v2/src/data/stations.test.ts
+++ b/webpage_v2/src/data/stations.test.ts
@@ -41,6 +41,16 @@ describe('getStationByCode', () => {
     expect(getStationByCode('ZZZZZ_NONEXISTENT')).toBeUndefined();
   });
 
+  it('returns first STATIONS entry for duplicate codes (BOS, BBY, PVD)', () => {
+    for (const code of ['BOS', 'BBY', 'PVD']) {
+      const byMap = getStationByCode(code);
+      const byFind = STATIONS.find(s => s.code === code);
+      expect(byMap).toBeDefined();
+      expect(byFind).toBeDefined();
+      expect(byMap!.system).toBe(byFind!.system);
+    }
+  });
+
   it('returns correct station for each system', () => {
     const cases: [string, string][] = [
       ['NP', 'NJT'],

--- a/webpage_v2/src/data/stations.test.ts
+++ b/webpage_v2/src/data/stations.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STATIONS,
+  getStationByCode,
+  searchStations,
+  searchStationsPartitioned,
+  getGroupedPrimaryStations,
+  SYSTEM_ORDER,
+  PRIMARY_STATIONS,
+} from './stations';
+
+describe('STATIONS', () => {
+  it('contains stations sorted alphabetically by name', () => {
+    for (let i = 1; i < STATIONS.length; i++) {
+      expect(
+        STATIONS[i - 1].name.localeCompare(STATIONS[i].name),
+      ).toBeLessThanOrEqual(0);
+    }
+  });
+
+  it('has no more than 5 duplicate station codes', () => {
+    const codes = STATIONS.map(s => s.code);
+    const dupes = codes.length - new Set(codes).size;
+    expect(dupes).toBeLessThanOrEqual(5);
+  });
+
+  it('contains more than 1000 stations', () => {
+    expect(STATIONS.length).toBeGreaterThan(1000);
+  });
+});
+
+describe('getStationByCode', () => {
+  it('returns NY Penn Station for code "NY"', () => {
+    const station = getStationByCode('NY');
+    expect(station).toBeDefined();
+    expect(station!.name).toContain('Penn');
+    expect(station!.code).toBe('NY');
+  });
+
+  it('returns undefined for unknown code', () => {
+    expect(getStationByCode('ZZZZZ_NONEXISTENT')).toBeUndefined();
+  });
+
+  it('returns correct station for each system', () => {
+    const cases: [string, string][] = [
+      ['NP', 'NJT'],
+      ['PHO', 'PATH'],
+      ['MANS', 'MNR'],
+      ['JAM', 'LIRR'],
+      ['CUS', 'METRA'],
+    ];
+    for (const [code, expectedSystem] of cases) {
+      const station = getStationByCode(code);
+      expect(station).toBeDefined();
+      expect(station!.system).toBe(expectedSystem);
+    }
+  });
+});
+
+describe('searchStations', () => {
+  it('returns empty array for empty query', () => {
+    expect(searchStations('')).toEqual([]);
+    expect(searchStations('   ')).toEqual([]);
+  });
+
+  it('finds stations by name substring (case-insensitive)', () => {
+    const results = searchStations('penn');
+    expect(results.length).toBeGreaterThan(0);
+    for (const station of results) {
+      const match =
+        station.name.toLowerCase().includes('penn') ||
+        station.code.toLowerCase().includes('penn');
+      expect(match).toBe(true);
+    }
+  });
+
+  it('finds stations by code', () => {
+    const results = searchStations('NY');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some(s => s.code === 'NY')).toBe(true);
+  });
+
+  it('limits results to 15 by default', () => {
+    const results = searchStations('a');
+    expect(results.length).toBeLessThanOrEqual(15);
+  });
+
+  it('respects custom limit', () => {
+    const results = searchStations('a', undefined, 5);
+    expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  it('filters by transit system', () => {
+    const results = searchStations('new', ['PATH']);
+    for (const station of results) {
+      expect(station.system).toBe('PATH');
+    }
+  });
+
+  it('returns same matches regardless of query case', () => {
+    const lower = searchStations('trenton');
+    const upper = searchStations('TRENTON');
+    const mixed = searchStations('TreNtOn');
+    expect(lower.map(s => s.code)).toEqual(upper.map(s => s.code));
+    expect(lower.map(s => s.code)).toEqual(mixed.map(s => s.code));
+  });
+
+  it('finds stations across multiple systems when no filter', () => {
+    const results = searchStations('penn', undefined, 100);
+    const systems = new Set(results.map(s => s.system));
+    expect(systems.size).toBeGreaterThan(1);
+  });
+});
+
+describe('searchStationsPartitioned', () => {
+  it('returns empty arrays for empty query', () => {
+    const { matched, other } = searchStationsPartitioned('', ['NJT']);
+    expect(matched).toEqual([]);
+    expect(other).toEqual([]);
+  });
+
+  it('returns empty arrays when systems is empty', () => {
+    const { matched, other } = searchStationsPartitioned('penn', []);
+    expect(matched).toEqual([]);
+    expect(other).toEqual([]);
+  });
+
+  it('partitions results into matched and other systems', () => {
+    const { matched, other } = searchStationsPartitioned('new', ['NJT'], 100);
+    for (const station of matched) {
+      expect(station.system).toBe('NJT');
+    }
+    for (const station of other) {
+      expect(station.system).not.toBe('NJT');
+    }
+  });
+
+  it('does not duplicate stations between matched and other', () => {
+    const { matched, other } = searchStationsPartitioned('penn', ['NJT'], 100);
+    const matchedCodes = new Set(matched.map(s => s.code));
+    for (const station of other) {
+      expect(matchedCodes.has(station.code)).toBe(false);
+    }
+  });
+
+  it('combined results match unfiltered searchStations', () => {
+    const query = 'new';
+    const systems: ('NJT' | 'AMTRAK')[] = ['NJT', 'AMTRAK'];
+    const { matched, other } = searchStationsPartitioned(query, systems, 100);
+    const all = searchStations(query, undefined, 100);
+    const partitionedCodes = new Set([...matched, ...other].map(s => s.code));
+    for (const station of all) {
+      expect(partitionedCodes.has(station.code)).toBe(true);
+    }
+  });
+
+  it('limits each partition independently', () => {
+    const { matched, other } = searchStationsPartitioned('a', ['NJT'], 5);
+    expect(matched.length).toBeLessThanOrEqual(5);
+    expect(other.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('getGroupedPrimaryStations', () => {
+  it('returns groups for all systems when no filter', () => {
+    const groups = getGroupedPrimaryStations();
+    const systems = groups.map(g => g.system);
+    for (const system of SYSTEM_ORDER) {
+      if (PRIMARY_STATIONS[system].length > 0) {
+        expect(systems).toContain(system);
+      }
+    }
+  });
+
+  it('respects system filter', () => {
+    const groups = getGroupedPrimaryStations(['PATH']);
+    expect(groups.length).toBe(1);
+    expect(groups[0].system).toBe('PATH');
+  });
+
+  it('returns only valid Station objects', () => {
+    const groups = getGroupedPrimaryStations();
+    for (const group of groups) {
+      for (const station of group.stations) {
+        expect(station.code).toBeTruthy();
+        expect(station.name).toBeTruthy();
+      }
+    }
+  });
+
+  it('uses SYSTEM_NAMES for group names', () => {
+    const groups = getGroupedPrimaryStations(['NJT']);
+    expect(groups[0].name).toBe('NJ Transit');
+  });
+});

--- a/webpage_v2/src/data/stations.ts
+++ b/webpage_v2/src/data/stations.ts
@@ -1611,7 +1611,12 @@ const _searchIndex: StationSearchEntry[] = STATIONS.map(s => ({
   haystack: `${s.code.toLowerCase()} ${s.name.toLowerCase()}`,
 }));
 
-const _stationsByCode = new Map<string, Station>(STATIONS.map(s => [s.code, s]));
+const _stationsByCode = new Map<string, Station>();
+for (const s of STATIONS) {
+  if (!_stationsByCode.has(s.code)) {
+    _stationsByCode.set(s.code, s);
+  }
+}
 
 // Primary stations per system (shown in grouped view when not searching)
 export const PRIMARY_STATIONS: Record<TransitSystem, string[]> = {
@@ -1674,13 +1679,19 @@ export function searchStationsPartitioned(
   const q = query.toLowerCase();
   const matched: Station[] = [];
   const other: Station[] = [];
+  const matchedCodes = new Set<string>();
   for (const entry of _searchIndex) {
     if (matched.length >= limit && other.length >= limit) break;
     if (!entry.haystack.includes(q)) continue;
     if (entry.station.system && systems.includes(entry.station.system)) {
-      if (matched.length < limit) matched.push(entry.station);
+      if (matched.length < limit) {
+        matched.push(entry.station);
+        matchedCodes.add(entry.station.code);
+      }
     } else {
-      if (other.length < limit) other.push(entry.station);
+      if (other.length < limit && !matchedCodes.has(entry.station.code)) {
+        other.push(entry.station);
+      }
     }
   }
   return { matched, other };

--- a/webpage_v2/src/data/stations.ts
+++ b/webpage_v2/src/data/stations.ts
@@ -1600,6 +1600,19 @@ const _STATIONS_RAW: any[] = [
 ];
 export const STATIONS: Station[] = _STATIONS_RAW.sort((a, b) => a.name.localeCompare(b.name));
 
+// Pre-computed search index: lowercase name+code built once at module load
+interface StationSearchEntry {
+  station: Station;
+  haystack: string; // `${code_lower} ${name_lower}`
+}
+
+const _searchIndex: StationSearchEntry[] = STATIONS.map(s => ({
+  station: s,
+  haystack: `${s.code.toLowerCase()} ${s.name.toLowerCase()}`,
+}));
+
+const _stationsByCode = new Map<string, Station>(STATIONS.map(s => [s.code, s]));
+
 // Primary stations per system (shown in grouped view when not searching)
 export const PRIMARY_STATIONS: Record<TransitSystem, string[]> = {
   NJT: ['NY', 'NP', 'HB', 'SE', 'MP', 'PJ', 'HL', 'TR', 'LB', 'PF', 'DN', 'RA'],
@@ -1635,19 +1648,42 @@ export const SYSTEM_ORDER: TransitSystem[] = ['NJT', 'PATH', 'LIRR', 'MNR', 'SUB
 
 // Helper functions
 export function getStationByCode(code: string): Station | undefined {
-  return STATIONS.find(s => s.code === code);
+  return _stationsByCode.get(code);
 }
 
-export function searchStations(query: string, systems?: TransitSystem[]): Station[] {
-  if (!query) return [];
+export function searchStations(query: string, systems?: TransitSystem[], limit = 15): Station[] {
+  if (!query.trim()) return [];
   const q = query.toLowerCase();
   const hasFilter = systems && systems.length > 0;
-  return STATIONS
-    .filter(s =>
-      (s.name.toLowerCase().includes(q) || s.code.toLowerCase().includes(q)) &&
-      (!hasFilter || (s.system && systems!.includes(s.system)))
-    )
-    .slice(0, 15);
+  const results: Station[] = [];
+  for (const entry of _searchIndex) {
+    if (results.length >= limit) break;
+    if (!entry.haystack.includes(q)) continue;
+    if (hasFilter && (!entry.station.system || !systems!.includes(entry.station.system))) continue;
+    results.push(entry.station);
+  }
+  return results;
+}
+
+export function searchStationsPartitioned(
+  query: string,
+  systems: TransitSystem[],
+  limit = 15,
+): { matched: Station[]; other: Station[] } {
+  if (!query.trim() || systems.length === 0) return { matched: [], other: [] };
+  const q = query.toLowerCase();
+  const matched: Station[] = [];
+  const other: Station[] = [];
+  for (const entry of _searchIndex) {
+    if (matched.length >= limit && other.length >= limit) break;
+    if (!entry.haystack.includes(q)) continue;
+    if (entry.station.system && systems.includes(entry.station.system)) {
+      if (matched.length < limit) matched.push(entry.station);
+    } else {
+      if (other.length < limit) other.push(entry.station);
+    }
+  }
+  return { matched, other };
 }
 
 export function getGroupedPrimaryStations(systems?: TransitSystem[]): { system: TransitSystem; name: string; stations: Station[] }[] {

--- a/webpage_v2/src/pages/TripSelectionPage.tsx
+++ b/webpage_v2/src/pages/TripSelectionPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../store/appStore';
 import { StationPicker } from '../components/StationPicker';
-import { getStationByCode, searchStations, SYSTEM_NAMES, SYSTEM_ORDER } from '../data/stations';
+import { getStationByCode, searchStations, searchStationsPartitioned, SYSTEM_NAMES, SYSTEM_ORDER } from '../data/stations';
 import { Station, TransitSystem } from '../types';
 import { storageService } from '../services/storage';
 import { getSuggestedRoute } from '../utils/ratsense';
@@ -54,16 +54,12 @@ export function TripSelectionPage() {
     recentTrips,
   }), [homeStation, workStation, recentTrips]);
   const activeSystems = preferredSystems.length > 0 ? preferredSystems : undefined;
-  const stationResults = useMemo(
-    () => searchStations(searchQuery, activeSystems),
-    [searchQuery, activeSystems]
-  );
-  const otherSystemStationResults = useMemo(() => {
-    if (!searchQuery.trim() || !activeSystems) return [];
-
-    const primaryCodes = new Set(stationResults.map((station) => station.code));
-    return searchStations(searchQuery).filter((station) => !primaryCodes.has(station.code));
-  }, [searchQuery, activeSystems, stationResults]);
+  const { stationResults, otherSystemStationResults } = useMemo(() => {
+    if (!searchQuery.trim()) return { stationResults: [], otherSystemStationResults: [] };
+    if (!activeSystems) return { stationResults: searchStations(searchQuery), otherSystemStationResults: [] };
+    const { matched, other } = searchStationsPartitioned(searchQuery, activeSystems);
+    return { stationResults: matched, otherSystemStationResults: other };
+  }, [searchQuery, activeSystems]);
   const favoriteStationCodes = useMemo(
     () => new Set(favoriteStations.map((station) => station.id)),
     [favoriteStations]


### PR DESCRIPTION
## Summary

- **Pre-normalized search index**: Build lowercase `code + name` haystack once at module load, eliminating ~3,000 `.toLowerCase()` string allocations per keystroke across 1,500+ stations
- **O(1) station lookup**: Replace `getStationByCode()` linear scan (`STATIONS.find()`) with a pre-built `Map<string, Station>`
- **Early-exit search**: Replace `.filter().slice(15)` with a manual loop that breaks after 15 matches — best-case drops from O(n) to O(k)
- **Single-pass partitioned search**: New `searchStationsPartitioned()` returns both system-filtered and "other system" results in one iteration, replacing TripSelectionPage's double `searchStations()` calls

## Files modified

| File | Change |
|------|--------|
| `webpage_v2/src/data/stations.ts` | Added `_searchIndex` (pre-lowercased), `_stationsByCode` Map, rewrote `searchStations` with early-exit, added `searchStationsPartitioned` |
| `webpage_v2/src/pages/TripSelectionPage.tsx` | Replaced two `searchStations()` calls + Set dedup with single `searchStationsPartitioned()` call |
| `webpage_v2/src/data/stations.test.ts` | **New** — 24 tests covering `searchStations`, `getStationByCode`, `getGroupedPrimaryStations`, `searchStationsPartitioned` |

## Design decisions

- **Approach A (pre-normalized array) over Approach B (trie)**: As suggested in the issue, the simpler pre-normalized approach was chosen. With N≈1,500 stations and a 15-result limit with early exit, the performance is more than sufficient. A trie would add complexity for marginal gain.
- **`searchStationsPartitioned`** avoids the previous pattern of calling `searchStations` twice (once filtered, once unfiltered) and then deduplicating via a Set. The new function collects both buckets in a single pass with independent limits.
- **No debouncing added**: The data-structure optimizations eliminate the per-keystroke allocation overhead that was the primary bottleneck. Debouncing could be added later if needed but would be a UI-level concern separate from this data optimization.

## Test coverage

All 24 new tests pass. Full suite: 207 tests passing. Build succeeds.

Closes #1018

https://claude.ai/code/session_01SiA1GHYjpD7vNasPH9uKD3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiA1GHYjpD7vNasPH9uKD3)_