### PR TITLE
Issue #1021: Fix TrainCard keys, RouteMap ErrorBoundary, share fallback

### DIFF
--- a/webpage_v2/src/components/ErrorBoundary.test.tsx
+++ b/webpage_v2/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('test error');
+  return <div>child rendered</div>;
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('child rendered')).toBeInTheDocument();
+  });
+
+  it('renders default error UI when child throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('Reload')).toBeInTheDocument();
+    expect(screen.queryByText('child rendered')).not.toBeInTheDocument();
+  });
+
+  it('renders custom fallback when provided and child throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary fallback={<div>custom fallback</div>}>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('custom fallback')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when fallback is null and child throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(
+      <ErrorBoundary fallback={null}>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(container.innerHTML).toBe('');
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('logs error details via componentDidCatch', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    const callArgs = errorSpy.mock.calls.flat();
+    const hasErrorBoundaryCatch = callArgs.some(
+      (arg) => typeof arg === 'string' && arg.includes('ErrorBoundary caught')
+    );
+    expect(hasErrorBoundaryCatch).toBe(true);
+  });
+});

--- a/webpage_v2/src/components/ErrorBoundary.tsx
+++ b/webpage_v2/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, ReactNode } from 'react';
 
 interface Props {
   children: ReactNode;
+  fallback?: ReactNode;
 }
 
 interface State {
@@ -24,6 +25,9 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      if (this.props.fallback !== undefined) {
+        return this.props.fallback;
+      }
       return (
         <div className="min-h-screen bg-background flex items-center justify-center p-4">
           <div className="text-center max-w-md">

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -208,7 +208,7 @@ export function TrainListPage() {
 
       {/* Route map (lazy-loaded) */}
       {fromStation && toStation && (
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary key={`${from}-${to}`} fallback={null}>
           <Suspense fallback={null}>
             <RouteMap
               fromStation={fromStation}

--- a/webpage_v2/src/pages/TrainListPage.tsx
+++ b/webpage_v2/src/pages/TrainListPage.tsx
@@ -4,6 +4,7 @@ import { Train, TripOption, OperationsSummaryResponse } from '../types';
 import { apiService } from '../services/api';
 import { useAppStore } from '../store/appStore';
 import { LoadingSpinner } from '../components/LoadingSpinner';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import { ErrorMessage } from '../components/ErrorMessage';
 import { TrainCard } from '../components/TrainCard';
 import { TransferTripCard } from '../components/TransferTripCard';
@@ -207,13 +208,15 @@ export function TrainListPage() {
 
       {/* Route map (lazy-loaded) */}
       {fromStation && toStation && (
-        <Suspense fallback={null}>
-          <RouteMap
-            fromStation={fromStation}
-            toStation={toStation}
-            lineColor={trains[0]?.line.color}
-          />
-        </Suspense>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <RouteMap
+              fromStation={fromStation}
+              toStation={toStation}
+              lineColor={trains[0]?.line.color}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
 
       {/* Route summary (direct routes only) */}
@@ -315,7 +318,7 @@ export function TrainListPage() {
         <div className="space-y-3">
           {filteredTrains.map((train) => (
             <TrainCard
-              key={train.train_id}
+              key={`direct-${train.train_id}-${train.journey_date}`}
               train={train}
               onClick={() => navigate(buildTrainUrl({
                 trainId: train.train_id,
@@ -331,7 +334,7 @@ export function TrainListPage() {
           ))}
           {filteredTransferTrips.map((trip) => (
             <TransferTripCard
-              key={trip.legs.map(l => l.train_id).join('-')}
+              key={`transfer-${trip.legs.map(l => `${l.train_id}:${l.journey_date}`).join('|')}`}
               trip={trip}
               onClick={() => navigate(buildTripUrl(trip))}
             />

--- a/webpage_v2/src/utils/share.test.ts
+++ b/webpage_v2/src/utils/share.test.ts
@@ -59,6 +59,42 @@ describe('share', () => {
     const result = await share(data);
     expect(result).toBe(false);
   });
+
+  it('uses legacy execCommand fallback when navigator.clipboard is unavailable', async () => {
+    const mockTextarea = {
+      value: '',
+      style: {} as CSSStyleDeclaration,
+      select: vi.fn(),
+    };
+    vi.stubGlobal('navigator', {});
+    vi.spyOn(document, 'createElement').mockReturnValue(mockTextarea as unknown as HTMLElement);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockTextarea as unknown as Node);
+    vi.spyOn(document.body, 'removeChild').mockImplementation(() => mockTextarea as unknown as Node);
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    const result = await share(data);
+
+    expect(result).toBe(true);
+    expect(mockTextarea.value).toBe('https://example.com');
+    expect(mockTextarea.select).toHaveBeenCalled();
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(document.body.removeChild).toHaveBeenCalled();
+  });
+
+  it('returns false when all share/clipboard methods fail', async () => {
+    vi.stubGlobal('navigator', {});
+    vi.spyOn(document, 'createElement').mockReturnValue({
+      value: '',
+      style: {} as CSSStyleDeclaration,
+      select: vi.fn(),
+    } as unknown as HTMLElement);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => {
+      throw new Error('DOM error');
+    });
+
+    const result = await share(data);
+    expect(result).toBe(false);
+  });
 });
 
 describe('buildTrainShareData', () => {

--- a/webpage_v2/src/utils/share.ts
+++ b/webpage_v2/src/utils/share.ts
@@ -36,11 +36,10 @@ export async function share(data: ShareData): Promise<boolean> {
       return true;
     }
   } catch (error) {
-    // User cancelled share or clipboard failed
     if (error instanceof Error && error.name === 'AbortError') {
-      // User cancelled, not an error
       return false;
     }
+    console.warn('Share failed:', error);
     return false;
   }
 }


### PR DESCRIPTION
## Summary

Three independent low-risk robustness fixes for `webpage_v2`, as described in #1021.

### 1. TrainCard/TransferTripCard list key collisions
- Prefixed direct train keys with `direct-` and included `journey_date` for cross-day uniqueness
- Prefixed transfer trip keys with `transfer-` and included `journey_date` per leg, using `|` separator to avoid ambiguity with `-` in train IDs

### 2. RouteMap lazy-load ErrorBoundary
- Added optional `fallback` prop to `ErrorBoundary` component — when provided, renders the fallback instead of the full-page error UI
- Wrapped `RouteMap` `<Suspense>` in `<ErrorBoundary fallback={null}>` so MapLibre chunk load failures gracefully degrade to no map rather than crashing the entire departures page

### 3. ShareButton Web Share fallback verification
- Confirmed the existing clipboard fallback chain works correctly: Web Share API → `navigator.clipboard.writeText` → `document.execCommand('copy')` on a hidden textarea
- Added `console.warn` for non-cancel share failures (was completely silent before)
- Added test coverage for the legacy `execCommand` fallback path and the complete-failure path

## Files modified
- `webpage_v2/src/pages/TrainListPage.tsx` — key prefixes + ErrorBoundary import/wrapping
- `webpage_v2/src/components/ErrorBoundary.tsx` — optional `fallback` prop
- `webpage_v2/src/utils/share.ts` — `console.warn` on failure
- `webpage_v2/src/components/ErrorBoundary.test.tsx` — new test file (5 tests)
- `webpage_v2/src/utils/share.test.ts` — 2 new tests for legacy fallback paths

## Test coverage
- All 190 web tests pass
- TypeScript compiles cleanly with `tsc --noEmit`

Closes #1021

https://claude.ai/code/session_017pz4PgYvMMZwcJXifonW1q

---
_Generated by [Claude Code](https://claude.ai/code/session_017pz4PgYvMMZwcJXifonW1q)_