### PR TITLE
Remove operations summary section from route details view

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -53,7 +53,6 @@ struct RouteStatusView: View {
                     if viewModel.filterLoaded {
                         lineSelectionSection
                     }
-                    operationsSummarySection
                     historySections
                     alertSubscriptionSection
                     departuresSection
@@ -428,16 +427,6 @@ struct RouteStatusView: View {
                     .frame(height: 200)
             }
         }
-    }
-
-    // MARK: - Operations Summary Section
-
-    private var operationsSummarySection: some View {
-        OperationsSummaryView(
-            scope: isSystemWideContext ? .network : .route,
-            fromStation: context.effectiveFromStation,
-            toStation: context.effectiveToStation
-        )
     }
 
     // MARK: - Service Alerts Section

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -53,6 +53,7 @@ struct RouteStatusView: View {
                     if viewModel.filterLoaded {
                         lineSelectionSection
                     }
+                    operationsSummarySection
                     historySections
                     alertSubscriptionSection
                     departuresSection
@@ -426,6 +427,22 @@ struct RouteStatusView: View {
                 ContentUnavailableView("Map Unavailable", systemImage: "map", description: Text("Could not load congestion data"))
                     .frame(height: 200)
             }
+        }
+    }
+
+    // MARK: - Operations Summary Section
+
+    /// Hidden for frequency-first systems (Subway, PATH, PATCO, WMATA, BART)
+    /// where the body degenerates to a headway sentence already shown by the
+    /// Frequency stat in Route Performance below.
+    @ViewBuilder
+    private var operationsSummarySection: some View {
+        if preferredMode != .health {
+            OperationsSummaryView(
+                scope: isSystemWideContext ? .network : .route,
+                fromStation: context.effectiveFromStation,
+                toStation: context.effectiveToStation
+            )
         }
     }
 


### PR DESCRIPTION
The natural-language summary (e.g. "Trains running every 15 minutes.")
duplicated the headway shown by the Frequency stat in the Route
Performance section directly below. Drop it from RouteStatusView to
simplify the view; OperationsSummaryView is still used in
MapContainerView and TrainListView.

https://claude.ai/code/session_016RbRorePYLUM5iA9vvZj5M