### PR TITLE
Reorder sections in RouteStatusView for better UX

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -55,9 +55,9 @@ struct RouteStatusView: View {
                     }
                     operationsSummarySection
                     historySections
-                    alertSubscriptionSection
                     departuresSection
                     serviceAlertsSection
+                    alertSubscriptionSection
                 }
                 .padding()
                 .animation(.easeInOut(duration: 0.3), value: viewModel.filterLoaded)


### PR DESCRIPTION
## Summary
Reorganized the section layout in RouteStatusView to improve the information hierarchy and user experience by moving the alert subscription section to the bottom of the view.

## Changes
- Moved `alertSubscriptionSection` from its position before `departuresSection` to after `serviceAlertsSection`
- This places the subscription prompt at the end of the view, after all primary content sections

## Details
The new section order is now:
1. Operations summary
2. History sections
3. Departures
4. Service alerts
5. Alert subscription (moved to bottom)

This change improves the logical flow by presenting actionable information (departures and alerts) before prompting users to subscribe to alerts.

https://claude.ai/code/session_01ETTtubGTBRoxqpAjzwdDuL