### PR TITLE
Issue #1046: Show paywall when adding alerts at free tier limit

### DIFF
--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -202,11 +202,6 @@ struct AddRouteAlertView: View {
     }
 
     private func openSystemAlertSheet(for system: TrainSystem) {
-        if atAlertLimit {
-            showingPaywall = true
-            return
-        }
-
         let alreadyExists = alertService.subscriptions.contains {
             $0.isSystemWide && $0.dataSource == system.rawValue
         }
@@ -214,6 +209,11 @@ struct AddRouteAlertView: View {
         if alreadyExists {
             UINotificationFeedbackGenerator().notificationOccurred(.warning)
             showConfirmation("Already subscribed")
+            return
+        }
+
+        if atAlertLimit {
+            showingPaywall = true
             return
         }
 

--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -29,6 +29,9 @@ struct AddRouteAlertView: View {
     @ObservedObject private var alertService = AlertSubscriptionService.shared
     @ObservedObject private var subscriptionService = SubscriptionService.shared
 
+    // Paywall
+    @State private var showingPaywall = false
+
     // Mode selection
     @State private var alertMode: AlertMode = .route
 
@@ -60,6 +63,9 @@ struct AddRouteAlertView: View {
                 }
         }
         .preferredColorScheme(.dark)
+        .sheet(isPresented: $showingPaywall) {
+            PaywallView(context: .routeAlerts)
+        }
         .sheet(item: $activeSheet) { sheet in
             switch sheet {
             case .directional(let data):
@@ -86,7 +92,11 @@ struct AddRouteAlertView: View {
     }
 
     private func saveDirectionalSubscriptions(_ subs: [RouteAlertSubscription]) {
-        guard !atAlertLimit else { return }
+        guard !atAlertLimit else {
+            activeSheet = nil
+            showingPaywall = true
+            return
+        }
         alertService.addSubscriptions(subs)
         alertService.syncIfPossible()
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
@@ -98,7 +108,11 @@ struct AddRouteAlertView: View {
     }
 
     private func saveSystemSubscription(_ subs: [RouteAlertSubscription]) {
-        guard !atAlertLimit else { return }
+        guard !atAlertLimit else {
+            activeSheet = nil
+            showingPaywall = true
+            return
+        }
         alertService.addSubscriptions(subs)
         alertService.syncIfPossible()
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
@@ -188,6 +202,11 @@ struct AddRouteAlertView: View {
     }
 
     private func openSystemAlertSheet(for system: TrainSystem) {
+        if atAlertLimit {
+            showingPaywall = true
+            return
+        }
+
         let alreadyExists = alertService.subscriptions.contains {
             $0.isSystemWide && $0.dataSource == system.rawValue
         }
@@ -254,6 +273,10 @@ struct AddRouteAlertView: View {
             // Add button
             if let from = fromStation, let to = toStation {
                 Button {
+                    if atAlertLimit {
+                        showingPaywall = true
+                        return
+                    }
                     let fromCode = from.code
                     let toCode = to.code
                     let fromSystems = Stations.systemStringsForStation(fromCode)

--- a/ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift
+++ b/ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift
@@ -296,6 +296,60 @@ class AlertSubscriptionServiceTests: XCTestCase {
         XCTAssertEqual(service.subscriptions.count, 1, "Subscription should still exist")
     }
 
+    // MARK: - addSubscriptions: System-Wide Subscriptions
+
+    func testAddSystemSubscription_addsSuccessfully() {
+        let sub = RouteAlertSubscription(dataSource: "NJT")
+        service.addSubscriptions([sub])
+
+        XCTAssertEqual(service.subscriptions.count, 1, "Should have one system-wide subscription")
+        XCTAssertTrue(service.subscriptions.first!.isSystemWide,
+                      "Subscription should be system-wide")
+        XCTAssertEqual(service.subscriptions.first!.dataSource, "NJT",
+                       "System-wide subscription should have correct dataSource")
+    }
+
+    func testAddSystemSubscription_deduplicatesSameSystem() {
+        let sub1 = RouteAlertSubscription(dataSource: "SUBWAY")
+        service.addSubscriptions([sub1])
+
+        let sub2 = RouteAlertSubscription(dataSource: "SUBWAY")
+        service.addSubscriptions([sub2])
+
+        XCTAssertEqual(service.subscriptions.count, 1,
+                       "Duplicate system-wide subscription should be skipped")
+    }
+
+    func testAddSystemSubscription_allowsDifferentSystems() {
+        let sub1 = RouteAlertSubscription(dataSource: "NJT")
+        let sub2 = RouteAlertSubscription(dataSource: "SUBWAY")
+        service.addSubscriptions([sub1, sub2])
+
+        XCTAssertEqual(service.subscriptions.count, 2,
+                       "Different systems should both be added")
+    }
+
+    // MARK: - Free Tier Limit Behavior
+
+    func testSubscriptionCount_atFreeLimit_afterOneSubscription() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "NEC", lineName: "Northeast Corridor", direction: "NY"
+        )
+        service.addSubscriptions([sub])
+
+        XCTAssertEqual(service.subscriptions.count, 1,
+                       "Should have exactly one subscription")
+        XCTAssertTrue(service.subscriptions.count >= SubscriptionService.freeRouteAlertLimit,
+                      "One subscription should meet or exceed the free limit of \(SubscriptionService.freeRouteAlertLimit)")
+    }
+
+    func testSubscriptionCount_belowFreeLimit_whenEmpty() {
+        XCTAssertEqual(service.subscriptions.count, 0,
+                       "Should have zero subscriptions")
+        XCTAssertFalse(service.subscriptions.count >= SubscriptionService.freeRouteAlertLimit,
+                       "Zero subscriptions should be below the free limit")
+    }
+
     // MARK: - Commute Scenario: Independent Direction Configuration
 
     func testCommuteScenario_morningAndEveningDirections() {

--- a/ios/TrackRatTests/Views/AlertConfigurationTests.swift
+++ b/ios/TrackRatTests/Views/AlertConfigurationTests.swift
@@ -208,6 +208,47 @@ class AlertConfigurationTests: XCTestCase {
         }
     }
 
+    // MARK: - Free Tier Alert Limit
+
+    func testFreeRouteAlertLimit_isOne() {
+        XCTAssertEqual(SubscriptionService.freeRouteAlertLimit, 1,
+                       "Free tier should allow exactly 1 route alert subscription")
+    }
+
+    func testIsSystemWide_trueWhenNoLineOrStationOrTrain() {
+        let sub = RouteAlertSubscription(dataSource: "NJT")
+        XCTAssertTrue(sub.isSystemWide,
+                      "Subscription with only dataSource should be system-wide")
+        XCTAssertNil(sub.lineId, "System-wide subscription should have nil lineId")
+        XCTAssertNil(sub.fromStationCode, "System-wide subscription should have nil fromStationCode")
+        XCTAssertNil(sub.toStationCode, "System-wide subscription should have nil toStationCode")
+        XCTAssertNil(sub.trainId, "System-wide subscription should have nil trainId")
+    }
+
+    func testIsSystemWide_falseWhenLineIdSet() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "NEC", lineName: "Northeast Corridor", direction: "NY"
+        )
+        XCTAssertFalse(sub.isSystemWide,
+                       "Subscription with lineId should not be system-wide")
+    }
+
+    func testIsSystemWide_falseWhenStationPairSet() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR"
+        )
+        XCTAssertFalse(sub.isSystemWide,
+                       "Subscription with station pair should not be system-wide")
+    }
+
+    func testIsSystemWide_falseWhenTrainIdSet() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", trainId: "3254", trainName: "NJT 3254"
+        )
+        XCTAssertFalse(sub.isSystemWide,
+                       "Subscription with trainId should not be system-wide")
+    }
+
     // MARK: - Copy Settings
 
     func testCommuteScenario_copySettingsPreservesTimePreset() {


### PR DESCRIPTION
## Summary

- **Fix:** Free users adding route alerts beyond the limit now see the paywall instead of a silent failure
- **Gate points added:** `openSystemAlertSheet()` and the route "Add Alert" button now check `atAlertLimit` before opening the configuration sheet
- **Safety net:** `saveDirectionalSubscriptions()` and `saveSystemSubscription()` now dismiss the active sheet and present the paywall instead of silently returning

## Files Modified

| File | Change |
|------|--------|
| `ios/TrackRat/Views/Screens/AddRouteAlertView.swift` | Added `showingPaywall` state, paywall sheet, limit checks at gate points, and paywall presentation in save guards |
| `ios/TrackRatTests/Views/AlertConfigurationTests.swift` | Added tests for `freeRouteAlertLimit` constant and `isSystemWide` computed property |
| `ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift` | Added tests for system-wide subscription CRUD and free tier limit behavior |

## Design Decisions

- Followed the existing paywall pattern from `SettingsView` (line ~318) and `RouteStatusView` (line ~204)
- Check at gate points (before opening config sheet) is the primary fix — prevents users from configuring an alert they can't save
- Save-function guards are a safety net for race conditions (e.g., limit changes while editing)
- Used `PaywallView(context: .routeAlerts)` for consistent paywall messaging

## Test Coverage

- `testFreeRouteAlertLimit_isOne` — verifies the limit constant
- `testIsSystemWide_*` (4 tests) — verifies the `isSystemWide` computed property used in duplicate detection
- `testAddSystemSubscription_*` (3 tests) — verifies system-wide subscription add/dedup behavior
- `testSubscriptionCount_*` (2 tests) — verifies the count-based limit check logic

Closes #1046

https://claude.ai/code/session_01Tfav3CKiXuuHD8Futwjs1N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tfav3CKiXuuHD8Futwjs1N)_