### PR TITLE
Show all subway lines at station, not just transfer options

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -567,14 +567,11 @@ struct StopRowV2: View {
         return stop.rawStatus?.amtrakStatus == "CANCELLED"
     }
 
-    /// Subway bullets for lines a rider can transfer to at this stop —
-    /// every line serving the station's complex except the one currently riding.
-    /// Empty for non-subway trains and stops where no transfers are available.
-    private var transferLineBullets: [String] {
+    /// Subway bullets for every line serving this stop's station complex.
+    /// Empty for non-subway trains.
+    private var stationLineBullets: [String] {
         guard train.dataSource == "SUBWAY" else { return [] }
-        let allLines = SubwayLines.lines(forStationCode: stop.stationCode)
-        let currentBullet = SubwayLines.displayBullet(forLineCode: train.line.code)
-        return allLines.filter { $0 != currentBullet }
+        return SubwayLines.lines(forStationCode: stop.stationCode)
     }
     
     // Helper to determine if this is the origin station (first stop)
@@ -715,7 +712,7 @@ struct StopRowV2: View {
                         .font(.subheadline)
                         .foregroundColor(textColor)
 
-                    SubwayLineChips(lines: transferLineBullets, size: 14)
+                    SubwayLineChips(lines: stationLineBullets, size: 14)
 
                     if isCancelled {
                         Text("🚫")


### PR DESCRIPTION
## Summary
Updated the subway line display logic in `StopRowV2` to show all lines serving a station's complex, rather than filtering out the current line being ridden.

## Key Changes
- Renamed `transferLineBullets` to `stationLineBullets` to better reflect the new behavior
- Removed the filtering logic that excluded the current train's line from the display
- Simplified the computed property to directly return all lines for the station without filtering
- Updated the view to use the renamed property

## Implementation Details
The previous implementation filtered out the current line (`train.line.code`) from the list of all lines serving the station, assuming users only needed to see transfer options. The new implementation displays all available lines at the station, providing more complete transit information regardless of which line the user is currently on.

https://claude.ai/code/session_01FyUFNtmU31ajregnnAXVcu