### PR TITLE
Add info banner for unconfirmed scheduled train numbers

### DIFF
--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -658,4 +658,12 @@ extension TrainV2 {
         }
         return observationType == "SCHEDULED" ? "Train TBD" : "Train \(trainId)"
     }
+
+    /// True when displayLabel returns "Train TBD" — a scheduled-only train
+    /// from a provider that uses public train numbers (NJT, Amtrak).
+    var hasUnconfirmedTrainNumber: Bool {
+        return observationType == "SCHEDULED"
+            && dataSource != "SUBWAY"
+            && !usesSyntheticTrainId
+    }
 }

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -170,6 +170,12 @@ struct TrainDetailsView: View {
                         }
                     } else if let train = viewModel.train {
                         VStack(spacing: 16) {
+                            // Explain "Train TBD" — scheduled-only NJT/Amtrak trains not yet
+                            // seen in the live feed. Self-clears once observationType flips.
+                            if train.hasUnconfirmedTrainNumber {
+                                ScheduledTrainInfoBanner()
+                            }
+
                             // Train performance summary (similar trains + historical)
                             // Hide after train departs from user's origin station
                             if let originCode = appState.departureStationCode,
@@ -547,6 +553,25 @@ struct CombinedDetailsCard: View {
 }
 
 // Note: StatusV2 functionality is now integrated directly into TrainV2 model
+
+// MARK: - Scheduled Train Info Banner
+struct ScheduledTrainInfoBanner: View {
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .foregroundColor(.white.opacity(0.6))
+            Text("This train is on the published schedule but hasn't appeared in the live feed yet. The train number will be confirmed once it becomes active.")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.8))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.08))
+        .cornerRadius(8)
+    }
+}
 
 // MARK: - Stop Row V2
 struct StopRowV2: View {

--- a/ios/TrackRatTests/Models/TrainV2Tests.swift
+++ b/ios/TrackRatTests/Models/TrainV2Tests.swift
@@ -19,6 +19,7 @@ class TrainV2Tests: XCTestCase {
         isCancelled: Bool = false,
         isCompleted: Bool = false,
         observationType: String? = nil,
+        dataSource: String = "NJT",
         stops: [StopV2]? = nil
     ) -> TrainV2 {
         let departure = StationTiming(
@@ -53,7 +54,7 @@ class TrainV2Tests: XCTestCase {
             observationType: observationType,
             isCancelled: isCancelled,
             isCompleted: isCompleted,
-            dataSource: "NJT",
+            dataSource: dataSource,
             stops: stops
         )
     }
@@ -643,5 +644,109 @@ class TrainV2Tests: XCTestCase {
         XCTAssertTrue(hasAlreadyDeparted, "Train that departed 30 minutes ago should be detected as departed")
 
         print("  ✅ Already departed detection test passed")
+    }
+
+    // MARK: - hasUnconfirmedTrainNumber
+
+    func testHasUnconfirmedTrainNumber_scheduledNJT_isTrue() {
+        print("📋 Testing hasUnconfirmedTrainNumber for SCHEDULED NJT train (the 'Train TBD' case)")
+
+        let train = createTestTrainV2(
+            trainId: "3838",
+            observationType: "SCHEDULED",
+            dataSource: "NJT"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - hasUnconfirmedTrainNumber: \(train.hasUnconfirmedTrainNumber)")
+        XCTAssertEqual(train.displayLabel, "Train TBD",
+            "Sanity check: SCHEDULED NJT train should render as 'Train TBD'")
+        XCTAssertTrue(train.hasUnconfirmedTrainNumber,
+            "SCHEDULED NJT train must trigger the info banner")
+
+        print("  ✅ SCHEDULED NJT triggers banner")
+    }
+
+    func testHasUnconfirmedTrainNumber_observedNJT_isFalse() {
+        print("✅ Testing hasUnconfirmedTrainNumber for OBSERVED NJT train (banner must clear)")
+
+        let train = createTestTrainV2(
+            trainId: "3838",
+            observationType: "OBSERVED",
+            dataSource: "NJT"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - hasUnconfirmedTrainNumber: \(train.hasUnconfirmedTrainNumber)")
+        XCTAssertEqual(train.displayLabel, "Train 3838",
+            "Sanity check: OBSERVED NJT train shows confirmed number")
+        XCTAssertFalse(train.hasUnconfirmedTrainNumber,
+            "Banner must self-clear once train flips to OBSERVED")
+
+        print("  ✅ OBSERVED NJT hides banner")
+    }
+
+    func testHasUnconfirmedTrainNumber_syntheticIdSources_isFalse() {
+        print("🚇 Testing hasUnconfirmedTrainNumber suppressed for synthetic-ID providers")
+
+        // PATH/PATCO/LIRR/MNR/SUBWAY/etc. never render "Train TBD" so the banner
+        // would be off-topic — verify it stays hidden even when SCHEDULED.
+        let syntheticSources = ["PATH", "PATCO", "LIRR", "MNR", "SUBWAY", "BART", "MBTA", "METRA", "WMATA"]
+
+        for source in syntheticSources {
+            let train = createTestTrainV2(
+                trainId: "TRIP-1",
+                observationType: "SCHEDULED",
+                dataSource: source
+            )
+
+            print("  - \(source): displayLabel=\"\(train.displayLabel)\", hasUnconfirmedTrainNumber=\(train.hasUnconfirmedTrainNumber)")
+            XCTAssertNotEqual(train.displayLabel, "Train TBD",
+                "Sanity check: \(source) does not use 'Train TBD' label")
+            XCTAssertFalse(train.hasUnconfirmedTrainNumber,
+                "\(source) is synthetic-ID — banner must not appear")
+        }
+
+        print("  ✅ All synthetic-ID sources suppress banner")
+    }
+
+    func testHasUnconfirmedTrainNumber_scheduledAmtrak_isTrue() {
+        print("🚆 Testing hasUnconfirmedTrainNumber for SCHEDULED Amtrak train")
+
+        let train = createTestTrainV2(
+            trainId: "172",
+            observationType: "SCHEDULED",
+            dataSource: "AMTRAK"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - hasUnconfirmedTrainNumber: \(train.hasUnconfirmedTrainNumber)")
+        XCTAssertEqual(train.displayLabel, "Train TBD",
+            "Sanity check: Amtrak shares NJT-style numeric IDs and shows 'Train TBD' when scheduled")
+        XCTAssertTrue(train.hasUnconfirmedTrainNumber,
+            "SCHEDULED Amtrak train must trigger the banner")
+
+        print("  ✅ SCHEDULED Amtrak triggers banner")
+    }
+
+    func testHasUnconfirmedTrainNumber_nilObservationType_isFalse() {
+        print("⚠️  Testing hasUnconfirmedTrainNumber when observationType is nil")
+
+        // Older / partial records with no observationType should not trigger the banner;
+        // displayLabel falls through to "Train \(trainId)" so the explanation would be misleading.
+        let train = createTestTrainV2(
+            trainId: "3838",
+            observationType: nil,
+            dataSource: "NJT"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - hasUnconfirmedTrainNumber: \(train.hasUnconfirmedTrainNumber)")
+        XCTAssertEqual(train.displayLabel, "Train 3838",
+            "Sanity check: nil observationType shows the trainId, not 'TBD'")
+        XCTAssertFalse(train.hasUnconfirmedTrainNumber,
+            "Banner must only appear for explicitly SCHEDULED trains")
+
+        print("  ✅ nil observationType hides banner")
     }
 }


### PR DESCRIPTION
Closes #1044.

## Summary
Adds a user-facing info banner that explains why certain trains display "Train TBD" on the details screen. The banner appears only for scheduled trains from providers that use public train numbers (NJT, Amtrak) and automatically clears once the train appears in the live feed.

## Changes
- **TrainV2.swift**: Added `hasUnconfirmedTrainNumber` computed property that returns `true` when a train is in SCHEDULED state and from a provider that uses public train numbers (excludes synthetic-ID providers like PATH, PATCO, LIRR, MNR, SUBWAY, etc.)
- **TrainDetailsView.swift**: Integrated `ScheduledTrainInfoBanner` component that displays contextual help text explaining the "Train TBD" label and when it will be confirmed
- **TrainV2Tests.swift**: Added comprehensive test coverage with 5 test cases:
  - SCHEDULED NJT trains trigger the banner
  - OBSERVED NJT trains hide the banner (self-clearing behavior)
  - Synthetic-ID providers (PATH, PATCO, LIRR, MNR, SUBWAY, BART, MBTA, METRA, WMATA) never show the banner
  - SCHEDULED Amtrak trains trigger the banner
  - Nil observationType hides the banner
- **Test helper**: Updated `createTestTrainV2()` to accept `dataSource` parameter for flexible test scenarios

## Implementation Details
The banner only appears when all conditions are met:
- `observationType == "SCHEDULED"` (train is on published schedule but not yet live)
- `dataSource` is not "SUBWAY" (explicit exclusion)
- `!usesSyntheticTrainId` (excludes all synthetic-ID providers)

This ensures the banner is contextually relevant and doesn't appear for providers that never use the "Train TBD" label.

https://claude.ai/code/session_012tLBdb37rXR9H3N38iMXtE