### PR TITLE
Add SystemChips component for displaying transit systems

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		B1SUBLNS02000000000000A1 /* SubwayLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SUBLNS01000000000000A1 /* SubwayLines.swift */; };
 		B1SUBCHP01000000000000A1 /* SubwayLineChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SUBCHP01000000000000A1 /* SubwayLineChips.swift */; };
 		B1SUBCHP02000000000000A1 /* SubwayLineChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SUBCHP01000000000000A1 /* SubwayLineChips.swift */; };
+		B1SYSCHP01000000000000A1 /* SystemChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SYSCHP01000000000000A1 /* SystemChips.swift */; };
+		B1SYSCHP02000000000000A1 /* SystemChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SYSCHP01000000000000A1 /* SystemChips.swift */; };
 		B1SHIMR001000000000000A1 /* ShimmerRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SHIMR001000000000000A1 /* ShimmerRect.swift */; };
 		B1SHIMR002000000000000A1 /* ShimmerRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SHIMR001000000000000A1 /* ShimmerRect.swift */; };
 		B1LINTST01000000000000A1 /* LineSelectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1LINTST01000000000000A1 /* LineSelectionViewTests.swift */; };
@@ -248,6 +250,7 @@
 		F1SHIMR001000000000000A1 /* ShimmerRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShimmerRect.swift; path = TrackRat/Views/Components/ShimmerRect.swift; sourceTree = "<group>"; };
 		F1SUBLNS01000000000000A1 /* SubwayLines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SubwayLines.swift; path = TrackRat/Shared/SubwayLines.swift; sourceTree = "<group>"; };
 		F1SUBCHP01000000000000A1 /* SubwayLineChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SubwayLineChips.swift; path = TrackRat/Views/Components/SubwayLineChips.swift; sourceTree = "<group>"; };
+		F1SYSCHP01000000000000A1 /* SystemChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SystemChips.swift; path = TrackRat/Views/Components/SystemChips.swift; sourceTree = "<group>"; };
 		F1LINTST01000000000000A1 /* LineSelectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LineSelectionViewTests.swift; path = TrackRatTests/Views/LineSelectionViewTests.swift; sourceTree = "<group>"; };
 		A18E54392DEB88E500AB2B74 /* LiveActivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LiveActivityService.swift; path = Services/LiveActivityService.swift; sourceTree = "<group>"; };
 		A18E54412DEB893100AB2B74 /* LiveActivityControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LiveActivityControls.swift; path = Views/Components/LiveActivityControls.swift; sourceTree = "<group>"; };
@@ -379,6 +382,7 @@
 				F1SHIMR001000000000000A1 /* ShimmerRect.swift */,
 				F1SUBLNS01000000000000A1 /* SubwayLines.swift */,
 				F1SUBCHP01000000000000A1 /* SubwayLineChips.swift */,
+				F1SYSCHP01000000000000A1 /* SystemChips.swift */,
 				A1D88F602F27083000111466 /* RouteTopology.swift */,
 				B11DC1018BF600000001 /* RouteShapes.swift */,
 				A12C31402F1DA61700CAF76D /* PaywallView.swift */,
@@ -743,6 +747,7 @@
 				B11DC1018BF600000004 /* RouteShapes.swift in Sources */,
 				B1SUBLNS01000000000000A1 /* SubwayLines.swift in Sources */,
 				B1SUBCHP01000000000000A1 /* SubwayLineChips.swift in Sources */,
+				B1SYSCHP01000000000000A1 /* SystemChips.swift in Sources */,
 				A18D98D72F1D2F3700F5D22F /* DateSelectorSheet.swift in Sources */,
 				728970FFA08F441C994FCA1C /* AlertConfigurationSection.swift in Sources */,
 				B1LINSEL01000000000000A1 /* LineSelectionView.swift in Sources */,
@@ -798,6 +803,7 @@
 				B1SHIMR002000000000000A1 /* ShimmerRect.swift in Sources */,
 				B1SUBLNS02000000000000A1 /* SubwayLines.swift in Sources */,
 				B1SUBCHP02000000000000A1 /* SubwayLineChips.swift in Sources */,
+				B1SYSCHP02000000000000A1 /* SystemChips.swift in Sources */,
 				B1LINTST01000000000000A1 /* LineSelectionViewTests.swift in Sources */,
 				A16C81EF2EEEFFEE00F34F00 /* FeedbackButton.swift in Sources */,
 				A198994A2E8063F90079E596 /* HistoricalDataViewModelTests.swift in Sources */,

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -90,6 +90,23 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
         }
     }
 
+    /// Short label for compact station chips (analogous to subway line letters).
+    var chipLabel: String {
+        switch self {
+        case .njt: return "NJT"
+        case .amtrak: return "AMK"
+        case .path: return "PATH"
+        case .patco: return "PATCO"
+        case .lirr: return "LIRR"
+        case .mnr: return "MNR"
+        case .subway: return "SUB"
+        case .metra: return "MTR"
+        case .wmata: return "DC"
+        case .bart: return "BART"
+        case .mbta: return "MBTA"
+        }
+    }
+
     /// Whether this system is in beta (shown as label in UI)
     var isBeta: Bool {
         switch self {

--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -231,11 +231,6 @@ extension Stations {
         guard !originSystems.isEmpty else { return true }
         return !originSystems.isDisjoint(with: systemStringsForStation(stationCode))
     }
-
-    /// Returns the primary train system for a station (for badge display).
-    static func primarySystem(forStationCode code: String) -> TrainSystem? {
-        systemsForStation(code).min(by: { $0.displayName < $1.displayName })
-    }
 }
 
 // MARK: - Per-System Default Map Regions

--- a/ios/TrackRat/Views/Components/StationPickerSheet.swift
+++ b/ios/TrackRat/Views/Components/StationPickerSheet.swift
@@ -113,6 +113,8 @@ struct StationPickerSheet: View {
                             .foregroundColor(isDisabled ? .white.opacity(0.4) : .white)
                         SubwayLineChips(lines: lines, size: 14)
                             .opacity(isDisabled ? 0.4 : 1)
+                        SystemChips(stationCode: station.code, size: 14)
+                            .opacity(isDisabled ? 0.4 : 1)
                     }
 
                     if isDisabled {
@@ -152,10 +154,8 @@ struct StationPickerSheet: View {
 
                         SubwayLineChips(lines: lines, size: 14)
                             .opacity(0.7)
-
-                        if let system = Stations.primarySystem(forStationCode: station.code) {
-                            SystemBadge(system: system)
-                        }
+                        SystemChips(stationCode: station.code, size: 14)
+                            .opacity(0.7)
                     }
 
                     Text("Edit your train systems to use this station")

--- a/ios/TrackRat/Views/Components/SystemChips.swift
+++ b/ios/TrackRat/Views/Components/SystemChips.swift
@@ -60,7 +60,7 @@ struct SystemChips: View {
         HStack(spacing: 6) {
             Text("Times Sq-42 St")
             SubwayLineChips(lines: ["1", "2", "3", "7", "N", "Q", "R", "W", "S"])
-            SystemChips(stationCode: "TSQ")
+            SystemChips(stationCode: "S127")
         }
     }
     .padding()

--- a/ios/TrackRat/Views/Components/SystemChips.swift
+++ b/ios/TrackRat/Views/Components/SystemChips.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Renders compact colored pills showing which non-subway transit systems
+/// serve a station (e.g., "NJT", "AMK", "PATH"). Analogous to
+/// `SubwayLineChips` but for commuter/intercity rail systems.
+///
+/// Empty when the station has no non-subway systems, so callers can use
+/// this unconditionally alongside `SubwayLineChips`.
+struct SystemChips: View {
+    let stationCode: String
+    var size: CGFloat = 14
+
+    private var systems: [TrainSystem] {
+        Stations.systemsForStation(stationCode)
+            .filter { $0 != .subway }
+            .sorted { $0.chipLabel < $1.chipLabel }
+    }
+
+    var body: some View {
+        if !systems.isEmpty {
+            HStack(spacing: 3) {
+                ForEach(systems) { system in
+                    chip(for: system)
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("systems: \(systems.map(\.displayName).joined(separator: ", "))")
+        }
+    }
+
+    @ViewBuilder
+    private func chip(for system: TrainSystem) -> some View {
+        let bg = Color(hex: system.color) ?? .gray
+        Text(system.chipLabel)
+            .font(.system(size: size * 0.55, weight: .heavy, design: .rounded))
+            .foregroundColor(.white)
+            .padding(.horizontal, size * 0.28)
+            .frame(height: size)
+            .background(
+                RoundedRectangle(cornerRadius: size * 0.25)
+                    .fill(bg)
+            )
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 12) {
+        HStack(spacing: 6) {
+            Text("Penn Station")
+            SystemChips(stationCode: "NY")
+        }
+        HStack(spacing: 6) {
+            Text("Newark Penn")
+            SystemChips(stationCode: "NP")
+        }
+        HStack(spacing: 6) {
+            Text("Jamaica")
+            SystemChips(stationCode: "JAM")
+        }
+        HStack(spacing: 6) {
+            Text("Times Sq-42 St")
+            SubwayLineChips(lines: ["1", "2", "3", "7", "N", "Q", "R", "W", "S"])
+            SystemChips(stationCode: "TSQ")
+        }
+    }
+    .padding()
+    .background(Color.black)
+    .foregroundColor(.white)
+}

--- a/ios/TrackRat/Views/Components/SystemChips.swift
+++ b/ios/TrackRat/Views/Components/SystemChips.swift
@@ -1,5 +1,27 @@
 import SwiftUI
 
+/// A single compact colored pill identifying one transit system.
+/// Currently renders the short `chipLabel` over the system's brand color;
+/// designed so a future logo asset can replace the text without touching
+/// callers.
+struct SystemPill: View {
+    let system: TrainSystem
+    var size: CGFloat = 14
+
+    var body: some View {
+        let bg = Color(hex: system.color) ?? .gray
+        Text(system.chipLabel)
+            .font(.system(size: size * 0.55, weight: .heavy, design: .rounded))
+            .foregroundColor(.white)
+            .padding(.horizontal, size * 0.28)
+            .frame(height: size)
+            .background(
+                RoundedRectangle(cornerRadius: size * 0.25)
+                    .fill(bg)
+            )
+    }
+}
+
 /// Renders compact colored pills showing which non-subway transit systems
 /// serve a station (e.g., "NJT", "AMK", "PATH"). Analogous to
 /// `SubwayLineChips` but for commuter/intercity rail systems.
@@ -20,26 +42,12 @@ struct SystemChips: View {
         if !systems.isEmpty {
             HStack(spacing: 3) {
                 ForEach(systems) { system in
-                    chip(for: system)
+                    SystemPill(system: system, size: size)
                 }
             }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("systems: \(systems.map(\.displayName).joined(separator: ", "))")
         }
-    }
-
-    @ViewBuilder
-    private func chip(for system: TrainSystem) -> some View {
-        let bg = Color(hex: system.color) ?? .gray
-        Text(system.chipLabel)
-            .font(.system(size: size * 0.55, weight: .heavy, design: .rounded))
-            .foregroundColor(.white)
-            .padding(.horizontal, size * 0.28)
-            .frame(height: size)
-            .background(
-                RoundedRectangle(cornerRadius: size * 0.25)
-                    .fill(bg)
-            )
     }
 }
 
@@ -61,6 +69,10 @@ struct SystemChips: View {
             Text("Times Sq-42 St")
             SubwayLineChips(lines: ["1", "2", "3", "7", "N", "Q", "R", "W", "S"])
             SystemChips(stationCode: "S127")
+        }
+        HStack(spacing: 6) {
+            Text("NJ Transit")
+            SystemPill(system: .njt, size: 22)
         }
     }
     .padding()

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -1,24 +1,5 @@
 import SwiftUI
 
-/// Small colored pill showing which transit system a station belongs to.
-/// Used in search results to identify stations from non-active systems.
-struct SystemBadge: View {
-    let system: TrainSystem
-
-    var body: some View {
-        Text(system.displayName)
-            .font(.caption2)
-            .fontWeight(.medium)
-            .foregroundColor(.white.opacity(0.9))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill((Color(hex: system.color) ?? .gray).opacity(0.7))
-            )
-    }
-}
-
 /// A view that displays the appropriate icon for a station based on whether it's a home station, work station, or regular favorite
 struct StationIconView: View {
     let stationCode: String
@@ -365,6 +346,7 @@ struct DeparturePickerView: View {
                     .foregroundColor(.white)
                     .textProtected()
                 SubwayLineChips(lines: lines, size: 14)
+                if let code { SystemChips(stationCode: code, size: 14) }
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(TrackRatTheme.IconSize.xsmall)
@@ -423,10 +405,7 @@ struct DeparturePickerView: View {
 
                     SubwayLineChips(lines: lines, size: 14)
                         .opacity(0.7)
-
-                    if let code, let system = Stations.primarySystem(forStationCode: code) {
-                        SystemBadge(system: system)
-                    }
+                    if let code { SystemChips(stationCode: code, size: 14).opacity(0.7) }
 
                     Spacer()
                     Image(systemName: "chevron.right")

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -291,16 +291,21 @@ struct DestinationPickerView: View {
 
     @ViewBuilder
     private func destinationSearchRow(station: String) -> some View {
+        let code = Stations.getStationCode(station)
         HStack {
-            HStack {
+            HStack(spacing: 6) {
                 Text(Stations.displayName(for: station))
                     .font(.body)
                     .foregroundColor(.white)
                     .textProtected()
+                if let code {
+                    SubwayLineChips(lines: SubwayLines.lines(forStationCode: code), size: 14)
+                    SystemChips(stationCode: code, size: 14)
+                }
                 Spacer()
             }
 
-            if let code = Stations.getStationCode(station) {
+            if let code {
                 StationIconView(
                     stationCode: code,
                     isStationFavorited: appState.isStationFavorited(code: code)
@@ -324,10 +329,9 @@ struct DestinationPickerView: View {
         )
     }
 
-    /// Demoted search row. When `noRouteOrigin` is provided, shows
-    /// "No route from {origin}" below the station name in place of the
-    /// SystemBadge — used when the destination doesn't share a system with
-    /// the selected origin (a state the user can't fix in settings).
+    /// Demoted search row for stations on systems the user hasn't activated.
+    /// When `noRouteOrigin` is provided, shows "No route from {origin}"
+    /// below the station name.
     @ViewBuilder
     private func otherSystemDestinationSearchRow(station: String, noRouteOrigin: String? = nil) -> some View {
         HStack {
@@ -338,10 +342,11 @@ struct DestinationPickerView: View {
                         .foregroundColor(.white.opacity(0.7))
                         .textProtected()
 
-                    if noRouteOrigin == nil,
-                       let code = Stations.getStationCode(station),
-                       let system = Stations.primarySystem(forStationCode: code) {
-                        SystemBadge(system: system)
+                    if let code = Stations.getStationCode(station) {
+                        SubwayLineChips(lines: SubwayLines.lines(forStationCode: code), size: 14)
+                            .opacity(0.7)
+                        SystemChips(stationCode: code, size: 14)
+                            .opacity(0.7)
                     }
                 }
 
@@ -444,6 +449,8 @@ struct FavoriteDestinationButton: View {
                         .foregroundColor(.white.opacity(isDimmed ? 0.7 : 1.0))
                         .textProtected()
                     SubwayLineChips(lines: SubwayLines.lines(forStationCode: station.id), size: 14)
+                        .opacity(isDimmed ? 0.7 : 1.0)
+                    SystemChips(stationCode: station.id, size: 14)
                         .opacity(isDimmed ? 0.7 : 1.0)
                 }
 

--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -640,6 +640,7 @@ struct SystemSelectionCard: View {
             HStack(spacing: 12) {
                 // System info
                 HStack(spacing: 6) {
+                    SystemPill(system: system, size: 22)
                     Text(system.displayName)
                         .font(.headline)
                         .foregroundColor(.white)

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -821,12 +821,13 @@ private struct FavoriteStationRow: View {
                     .frame(width: 24)
             }
 
-            if let name = stationName {
+            if let name = stationName, let code = stationCode {
                 Text(name)
                     .font(.subheadline)
                     .foregroundColor(.white)
                     .lineLimit(1)
                 SubwayLineChips(lines: subwayLines, size: 13)
+                SystemChips(stationCode: code, size: 13)
             } else if label != nil {
                 Text("Not set")
                     .font(.subheadline)

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -438,6 +438,7 @@ struct TripSelectionView: View {
                     .foregroundColor(.white)
                     .textProtected()
                 SubwayLineChips(lines: lines, size: 14)
+                if let code { SystemChips(stationCode: code, size: 14) }
                 Spacer()
             }
 
@@ -479,10 +480,7 @@ struct TripSelectionView: View {
 
                 SubwayLineChips(lines: lines, size: 14)
                     .opacity(0.7)
-
-                if let code, let system = Stations.primarySystem(forStationCode: code) {
-                    SystemBadge(system: system)
-                }
+                if let code { SystemChips(stationCode: code, size: 14).opacity(0.7) }
 
                 Spacer()
             }
@@ -770,6 +768,7 @@ struct FavoriteStationButton: View {
                     .foregroundColor(.white)
 
                 SubwayLineChips(lines: SubwayLines.lines(forStationCode: station.id), size: 14)
+                SystemChips(stationCode: station.id, size: 14)
 
                 Spacer()
 

--- a/ios/TrackRatTests/Models/TrainSystemTests.swift
+++ b/ios/TrackRatTests/Models/TrainSystemTests.swift
@@ -405,4 +405,84 @@ class TrainSystemTests: XCTestCase {
         XCTAssertFalse(Stations.isStationVisible("ALT", withSystems: [.njt]),
                       "Unmapped Amtrak station should NOT be visible when only NJT selected")
     }
+
+    // MARK: - chipLabel
+
+    func testChipLabel_allCasesHaveNonEmptyLabel() {
+        for system in TrainSystem.allCases {
+            XCTAssertFalse(system.chipLabel.isEmpty,
+                          "\(system.rawValue) should have a non-empty chipLabel")
+        }
+    }
+
+    func testChipLabel_compactLength() {
+        for system in TrainSystem.allCases {
+            XCTAssertLessThanOrEqual(system.chipLabel.count, 5,
+                                    "\(system.rawValue).chipLabel should be ≤5 chars for compact display, got: '\(system.chipLabel)' (\(system.chipLabel.count) chars)")
+        }
+    }
+
+    func testChipLabel_knownValues() {
+        XCTAssertEqual(TrainSystem.njt.chipLabel, "NJT")
+        XCTAssertEqual(TrainSystem.amtrak.chipLabel, "AMK")
+        XCTAssertEqual(TrainSystem.path.chipLabel, "PATH")
+        XCTAssertEqual(TrainSystem.patco.chipLabel, "PATCO")
+        XCTAssertEqual(TrainSystem.lirr.chipLabel, "LIRR")
+        XCTAssertEqual(TrainSystem.mnr.chipLabel, "MNR")
+        XCTAssertEqual(TrainSystem.subway.chipLabel, "SUB")
+        XCTAssertEqual(TrainSystem.metra.chipLabel, "MTR")
+        XCTAssertEqual(TrainSystem.wmata.chipLabel, "DC")
+        XCTAssertEqual(TrainSystem.bart.chipLabel, "BART")
+        XCTAssertEqual(TrainSystem.mbta.chipLabel, "MBTA")
+    }
+
+    func testChipLabel_uniqueAcrossSystems() {
+        let labels = TrainSystem.allCases.map(\.chipLabel)
+        let uniqueLabels = Set(labels)
+        XCTAssertEqual(labels.count, uniqueLabels.count,
+                      "All chipLabels should be unique, duplicates found: \(labels)")
+    }
+
+    // MARK: - SystemChips logic (non-subway filtering)
+
+    func testSystemChips_multiSystemStation_excludesSubway() {
+        // NY Penn serves NJT, AMTRAK, LIRR (no subway) — all should appear
+        let systems = Stations.systemsForStation("NY").filter { $0 != .subway }
+        XCTAssertFalse(systems.isEmpty,
+                      "NY Penn should have non-subway systems, got empty")
+        XCTAssertFalse(systems.contains(.subway),
+                      "SystemChips should filter out subway")
+        XCTAssertTrue(systems.contains(.njt),
+                     "NY Penn non-subway systems should include NJT, got: \(systems)")
+        XCTAssertTrue(systems.contains(.amtrak),
+                     "NY Penn non-subway systems should include AMTRAK, got: \(systems)")
+    }
+
+    func testSystemChips_pureSubwayStation_isEmpty() {
+        // A pure subway station should have no non-subway systems
+        let subwayCode = "TSQ"  // Times Sq-42 St
+        let systems = Stations.systemsForStation(subwayCode).filter { $0 != .subway }
+        XCTAssertTrue(systems.isEmpty,
+                     "Pure subway station \(subwayCode) should have no non-subway systems, got: \(systems)")
+    }
+
+    func testSystemChips_singleSystemStation() {
+        // Jamaica (JAM) is LIRR-only
+        let systems = Stations.systemsForStation("JAM").filter { $0 != .subway }
+        XCTAssertEqual(systems.count, 1,
+                      "Jamaica should have exactly 1 non-subway system, got: \(systems)")
+        XCTAssertTrue(systems.contains(.lirr),
+                     "Jamaica non-subway system should be LIRR, got: \(systems)")
+    }
+
+    func testSystemChips_sortOrder_deterministic() {
+        let systems1 = Stations.systemsForStation("NP")
+            .filter { $0 != .subway }
+            .sorted { $0.chipLabel < $1.chipLabel }
+        let systems2 = Stations.systemsForStation("NP")
+            .filter { $0 != .subway }
+            .sorted { $0.chipLabel < $1.chipLabel }
+        XCTAssertEqual(systems1.map(\.chipLabel), systems2.map(\.chipLabel),
+                      "SystemChips sort order should be deterministic")
+    }
 }

--- a/ios/TrackRatTests/Models/TrainSystemTests.swift
+++ b/ios/TrackRatTests/Models/TrainSystemTests.swift
@@ -177,31 +177,6 @@ class TrainSystemTests: XCTestCase {
                             "Should have at least some results for '\(query)'")
     }
 
-    // MARK: - primarySystem
-
-    func testPrimarySystem_newarkPenn() {
-        // Newark Penn has NJT, AMTRAK, PATH — primarySystem should return one of them
-        let system = Stations.primarySystem(forStationCode: "NP")
-        XCTAssertNotNil(system, "Newark Penn should have a primary system")
-        let validSystems: Set<TrainSystem> = [.njt, .amtrak, .path]
-        XCTAssertTrue(validSystems.contains(system!),
-                     "Newark Penn primary system should be NJT, AMTRAK, or PATH, got: \(system!)")
-    }
-
-    func testPrimarySystem_lirrStation() {
-        // Jamaica (JM) is LIRR
-        let system = Stations.primarySystem(forStationCode: "JAM")
-        XCTAssertNotNil(system, "Jamaica should have a primary system")
-        XCTAssertEqual(system, .lirr, "Jamaica primary system should be LIRR, got: \(String(describing: system))")
-    }
-
-    func testPrimarySystem_deterministic() {
-        // Same station should always return the same primary system
-        let system1 = Stations.primarySystem(forStationCode: "NP")
-        let system2 = Stations.primarySystem(forStationCode: "NP")
-        XCTAssertEqual(system1, system2, "primarySystem should be deterministic")
-    }
-
     // MARK: - systemsForStation
 
     func testSystemsForStation_multiSystem() {
@@ -459,9 +434,14 @@ class TrainSystemTests: XCTestCase {
     }
 
     func testSystemChips_pureSubwayStation_isEmpty() {
-        // A pure subway station should have no non-subway systems
-        let subwayCode = "TSQ"  // Times Sq-42 St
-        let systems = Stations.systemsForStation(subwayCode).filter { $0 != .subway }
+        // S127 = Times Sq-42 St, a real subway-only station code. We assert the
+        // unfiltered set contains .subway so a future code change that returns
+        // [] for unknown codes can't make this test pass vacuously.
+        let subwayCode = "S127"
+        let unfiltered = Stations.systemsForStation(subwayCode)
+        XCTAssertTrue(unfiltered.contains(.subway),
+                     "S127 (Times Sq-42 St) should include .subway, got: \(unfiltered)")
+        let systems = unfiltered.filter { $0 != .subway }
         XCTAssertTrue(systems.isEmpty,
                      "Pure subway station \(subwayCode) should have no non-subway systems, got: \(systems)")
     }


### PR DESCRIPTION
## Summary
Introduces a new `SystemChips` component to display compact colored pills showing which non-subway transit systems serve a station, replacing the single-system `SystemBadge` approach. This provides better visual parity with `SubwayLineChips` and improves station identification across the app.

## Key Changes

- **New Component**: Added `SystemChips.swift` - a reusable SwiftUI view that renders all non-subway systems for a station as compact, colored pills (e.g., "NJT", "AMK", "PATH")
  - Filters out `.subway` system automatically
  - Sorts systems by `chipLabel` for deterministic ordering
  - Includes accessibility labels with full system names
  - Renders empty when station has no non-subway systems

- **TrainSystem Enhancement**: Added `chipLabel` property to `TrainSystem` enum
  - Provides short, compact labels (≤5 characters) for each system
  - Examples: "NJT", "AMK", "LIRR", "DC" (for WMATA), "MTR" (for Metra)
  - All labels are unique across systems

- **Removed Legacy Code**: 
  - Deleted `SystemBadge` struct from `DeparturePickerView.swift` (single-system badge)
  - Removed `primarySystem(forStationCode:)` method from `Stations` extension (no longer needed)
  - Removed 3 tests for `primarySystem` functionality

- **UI Integration**: Updated multiple views to use `SystemChips`:
  - `DestinationPickerView`: Shows systems in both active and inactive station rows
  - `DeparturePickerView`: Displays systems alongside subway line chips
  - `TripSelectionView`: Integrated into station selection rows
  - `StationPickerSheet`: Added to both enabled and disabled station options
  - `SettingsView`: Added to favorite station rows

- **Test Coverage**: Added comprehensive test suite for `SystemChips` functionality
  - Validates all systems have non-empty labels ≤5 characters
  - Verifies known label values for each system
  - Ensures label uniqueness across systems
  - Tests filtering logic (multi-system, pure-subway, single-system stations)
  - Validates deterministic sort ordering

## Implementation Details

- `SystemChips` uses the existing `TrainSystem.color` property for background colors
- Opacity is applied at the component level in dimmed contexts (inactive systems)
- Empty state is handled gracefully - component renders nothing when no non-subway systems exist
- Maintains consistent sizing with `SubwayLineChips` (14pt default, scalable)

https://claude.ai/code/session_01Vqr5XGVpN338WjuUGNdy8v