### PR TITLE
Fix double-logging and improve error handling in scheduler and JIT refresh

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -68,6 +68,14 @@ _refreshing_stations: set[str] = set()
 # can be silently garbage collected. See: https://docs.python.org/3/library/asyncio-task.html#creating-tasks
 _background_tasks: set[asyncio.Task[None]] = set()
 
+# Cap concurrent JIT refresh tasks. Each refresh holds a DB session for the
+# duration of an upstream HTTP call; without a ceiling, an NJT slowdown can
+# spawn one task per discoverable station (~21) and exhaust the connection
+# pool, cascading into 503s on unrelated endpoints. Sized to leave headroom
+# for collectors and API handlers in the 30-connection pool.
+_BACKGROUND_REFRESH_CONCURRENCY = 4
+_background_refresh_semaphore = asyncio.Semaphore(_BACKGROUND_REFRESH_CONCURRENCY)
+
 # NJT line code normalization for deduplication.
 # Canonical codes are uppercase (NE, NC, GL, MO, MA, etc.) matching route_topology.py.
 # This map handles old mixed-case codes from pre-2026-03 collectors and DB records.
@@ -1743,16 +1751,20 @@ async def _background_refresh_station(
     Errors are logged but never propagated — the caller already served
     whatever data was in the DB, matching the existing graceful-degradation
     behavior when JIT fails.
+
+    Acquires _background_refresh_semaphore so concurrent refreshes can't
+    monopolize the DB connection pool during NJT slowdowns.
     """
     try:
-        async with get_session() as db:
-            await service._ensure_fresh_station_data(
-                db,
-                station_code,
-                target_date,
-                skip_individual_refresh,
-                hide_departed,
-            )
+        async with _background_refresh_semaphore:
+            async with get_session() as db:
+                await service._ensure_fresh_station_data(
+                    db,
+                    station_code,
+                    target_date,
+                    skip_individual_refresh,
+                    hide_departed,
+                )
         logger.info("background_jit_refresh_complete", station_code=station_code)
     except Exception as e:
         logger.warning(

--- a/backend_v2/src/trackrat/utils/scheduler_utils.py
+++ b/backend_v2/src/trackrat/utils/scheduler_utils.py
@@ -101,6 +101,9 @@ async def run_with_freshness_check(
     now = datetime.now(UTC)
     instance_id = os.getenv("K_REVISION", "local")  # Cloud Run revision ID
 
+    # Phase 1: acquire lock, check freshness, claim the task.
+    # Errors here are database-level (connection lost, statement timeout, etc.)
+    # and are reported as task_freshness_check_error.
     try:
         # Ensure the task record exists atomically (idempotent upsert).
         # This prevents UniqueViolationError when multiple replicas
@@ -193,68 +196,8 @@ async def run_with_freshness_check(
         task_run.last_attempt = now
         task_run.last_instance_id = instance_id
 
-        # Execute the task while holding the database lock
-        # This prevents other replicas from running the same task simultaneously
-        start_time = time.time()
-        try:
-            if timeout_seconds is not None:
-                await asyncio.wait_for(task_func(), timeout=timeout_seconds)
-            else:
-                await task_func()
-            duration_ms = int((time.time() - start_time) * 1000)
-
-            # Update success metrics in the same transaction
-            task_run.last_successful_run = now
-            current_count = task_run.run_count or 0  # Handle None case gracefully
-            task_run.run_count = current_count + 1
-            task_run.last_duration_ms = duration_ms
-
-            # Update rolling average (90% old, 10% new)
-            if task_run.average_duration_ms:
-                task_run.average_duration_ms = int(
-                    task_run.average_duration_ms * 0.9 + duration_ms * 0.1
-                )
-            else:
-                task_run.average_duration_ms = duration_ms
-
-            # Commit the entire transaction (releases the lock)
-            await db.commit()
-
-            logger.info(
-                "task_completed_successfully",
-                task=task_name,
-                duration_ms=duration_ms,
-                instance=instance_id,
-            )
-            return True
-
-        except TimeoutError:
-            duration_ms = int((time.time() - start_time) * 1000)
-            await db.rollback()
-            logger.error(
-                "task_execution_timed_out",
-                task=task_name,
-                timeout_seconds=timeout_seconds,
-                duration_ms=duration_ms,
-                instance=instance_id,
-            )
-            raise
-
-        except Exception as e:
-            await db.rollback()
-            logger.error(
-                "task_execution_failed",
-                task=task_name,
-                error=str(e) or repr(e),
-                error_type=type(e).__name__,
-                instance=instance_id,
-                exc_info=True,
-            )
-            # Re-raise so the scheduler knows the task failed
-            raise
-
     except Exception as e:
-        # Catch any database-level errors
+        # Database-level errors during lock acquisition / freshness check.
         await db.rollback()
         logger.error(
             "task_freshness_check_error",
@@ -269,6 +212,72 @@ async def run_with_freshness_check(
     except BaseException:
         # CancelledError, KeyboardInterrupt, SystemExit bypass except Exception.
         # Rollback to release the FOR UPDATE lock and avoid idle-in-transaction.
+        with contextlib.suppress(Exception):
+            await db.rollback()
+        raise
+
+    # Phase 2: execute the task while holding the database lock.
+    # Errors here are task-level (timeout, task_func raised) and are reported
+    # exactly once via task_execution_timed_out or task_execution_failed.
+    start_time = time.time()
+    try:
+        if timeout_seconds is not None:
+            await asyncio.wait_for(task_func(), timeout=timeout_seconds)
+        else:
+            await task_func()
+        duration_ms = int((time.time() - start_time) * 1000)
+
+        # Update success metrics in the same transaction
+        task_run.last_successful_run = now
+        current_count = task_run.run_count or 0  # Handle None case gracefully
+        task_run.run_count = current_count + 1
+        task_run.last_duration_ms = duration_ms
+
+        # Update rolling average (90% old, 10% new)
+        if task_run.average_duration_ms:
+            task_run.average_duration_ms = int(
+                task_run.average_duration_ms * 0.9 + duration_ms * 0.1
+            )
+        else:
+            task_run.average_duration_ms = duration_ms
+
+        # Commit the entire transaction (releases the lock)
+        await db.commit()
+
+        logger.info(
+            "task_completed_successfully",
+            task=task_name,
+            duration_ms=duration_ms,
+            instance=instance_id,
+        )
+        return True
+
+    except TimeoutError:
+        duration_ms = int((time.time() - start_time) * 1000)
+        await db.rollback()
+        logger.error(
+            "task_execution_timed_out",
+            task=task_name,
+            timeout_seconds=timeout_seconds,
+            duration_ms=duration_ms,
+            instance=instance_id,
+        )
+        return False
+
+    except Exception as e:
+        await db.rollback()
+        logger.error(
+            "task_execution_failed",
+            task=task_name,
+            error=str(e) or repr(e),
+            error_type=type(e).__name__,
+            instance=instance_id,
+            exc_info=True,
+        )
+        return False
+
+    except BaseException:
+        # CancelledError, KeyboardInterrupt, SystemExit bypass except Exception.
         with contextlib.suppress(Exception):
             await db.rollback()
         raise

--- a/backend_v2/tests/unit/services/test_jit_promotion.py
+++ b/backend_v2/tests/unit/services/test_jit_promotion.py
@@ -17,7 +17,9 @@ import pytest
 
 from trackrat.models.database import TrainJourney
 from trackrat.services.departure import (
+    _BACKGROUND_REFRESH_CONCURRENCY,
     DepartureService,
+    _background_refresh_station,
     _refreshing_stations,
 )
 from trackrat.utils.time import now_et
@@ -303,3 +305,78 @@ class TestRunInlineJitRefresh:
         # _run_inline_jit_refresh should not be called due to guard,
         # but verify the guard condition works
         assert "SO" in _refreshing_stations
+
+
+class TestBackgroundRefreshSemaphore:
+    """The module-level semaphore caps concurrent JIT refreshes so an NJT
+    slowdown cannot exhaust the DB connection pool by spawning one
+    in-flight refresh per discoverable station."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_refreshes_capped_at_semaphore_limit(self):
+        """Launching many concurrent refreshes must never run more than
+        _BACKGROUND_REFRESH_CONCURRENCY at the same time.
+
+        Regression guard for issue #1040: previously _background_refresh_station
+        had no global concurrency cap and could spawn ~21 concurrent NJT
+        refreshes during an upstream slowdown.
+        """
+        in_flight = 0
+        peak_in_flight = 0
+        gate = asyncio.Event()
+
+        async def fake_ensure_fresh(*args, **kwargs):
+            nonlocal in_flight, peak_in_flight
+            in_flight += 1
+            peak_in_flight = max(peak_in_flight, in_flight)
+            try:
+                await gate.wait()
+            finally:
+                in_flight -= 1
+
+        # get_session is an async context manager; provide a stub that yields
+        # any object since _ensure_fresh_station_data is fully mocked.
+        class _FakeSessionCtx:
+            async def __aenter__(self):
+                return Mock()
+
+            async def __aexit__(self, *exc):
+                return None
+
+        service = DepartureService.__new__(DepartureService)
+        service._ensure_fresh_station_data = AsyncMock(side_effect=fake_ensure_fresh)
+        target_date = now_et().date()
+        # Fire 3x the cap to ensure contention.
+        n_tasks = _BACKGROUND_REFRESH_CONCURRENCY * 3
+
+        with patch(
+            "trackrat.services.departure.get_session",
+            return_value=_FakeSessionCtx(),
+        ):
+            tasks = [
+                asyncio.create_task(
+                    _background_refresh_station(
+                        service,
+                        f"S{i:02d}",
+                        target_date,
+                        skip_individual_refresh=True,
+                        hide_departed=False,
+                    )
+                )
+                for i in range(n_tasks)
+            ]
+            # Let the tasks reach the gate. A short sleep is enough; the
+            # semaphore-allowed ones will be inside fake_ensure_fresh, the
+            # rest will be parked on the semaphore.
+            for _ in range(20):
+                await asyncio.sleep(0)
+            # Confirm the cap is honored before releasing.
+            assert peak_in_flight == _BACKGROUND_REFRESH_CONCURRENCY, (
+                f"expected peak {_BACKGROUND_REFRESH_CONCURRENCY}, "
+                f"saw {peak_in_flight} after {n_tasks} concurrent launches"
+            )
+            gate.set()
+            await asyncio.gather(*tasks)
+
+        # All tasks eventually run.
+        assert service._ensure_fresh_station_data.await_count == n_tasks

--- a/backend_v2/tests/unit/test_scheduler_utils.py
+++ b/backend_v2/tests/unit/test_scheduler_utils.py
@@ -210,7 +210,7 @@ class TestRunWithFreshnessCheckSimplified:
                 tzinfo=timezone.utc
             )
 
-            # Task function fails, but function should return False (current behavior)
+            # Task function fails, function returns False
             result = await run_with_freshness_check(
                 db=mock_db,
                 task_name="test_task",
@@ -218,17 +218,13 @@ class TestRunWithFreshnessCheckSimplified:
                 task_func=mock_task_func,
             )
 
-            # Current implementation returns False on task failures
             assert result is False
 
         # Verify task was attempted
         mock_task_func.assert_called_once()
 
-        # Verify database was rolled back due to failure
-        # Note: Current implementation calls rollback twice:
-        # 1. Inner handler (task execution failure)
-        # 2. Outer handler (re-raised as freshness check error)
-        assert mock_db.rollback.call_count == 2
+        # Verify database was rolled back exactly once (task execution failure)
+        assert mock_db.rollback.call_count == 1
         mock_db.commit.assert_not_called()
 
         # Verify success metrics were NOT updated
@@ -444,8 +440,7 @@ class TestRunWithFreshnessCheckTimeout:
                 tzinfo=timezone.utc
             )
 
-            # The inner except catches TimeoutError but re-raises it.
-            # The outer except catches it and returns False.
+            # TimeoutError is caught and converted to return False.
             result = await run_with_freshness_check(
                 db=mock_db,
                 task_name="test_task",
@@ -456,8 +451,8 @@ class TestRunWithFreshnessCheckTimeout:
 
         # Task should not succeed
         assert result is False
-        # DB should be rolled back (inner handler + outer handler)
-        assert mock_db.rollback.call_count == 2
+        # DB should be rolled back exactly once (timeout handler)
+        assert mock_db.rollback.call_count == 1
         mock_db.commit.assert_not_called()
 
     @pytest.mark.asyncio
@@ -519,6 +514,82 @@ class TestRunWithFreshnessCheckTimeout:
         assert result is True
         task_func.assert_called_once()
         mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_double_log_as_freshness_error(self, mock_db):
+        """A timed-out task must log task_execution_timed_out exactly once
+        and must NOT also log task_freshness_check_error.
+
+        Regression guard for issue #1040: previously the inner TimeoutError
+        handler logged + raised, and the outer Exception handler caught the
+        re-raised TimeoutError and logged a misleading second event.
+        """
+        import asyncio
+
+        self._setup_stale_task(mock_db)
+
+        async def slow_task():
+            await asyncio.sleep(10)
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            with patch("trackrat.utils.scheduler_utils.logger") as mock_logger:
+                await run_with_freshness_check(
+                    db=mock_db,
+                    task_name="test_task",
+                    minimum_interval_seconds=60,
+                    task_func=slow_task,
+                    timeout_seconds=1,
+                )
+
+                logged_events = [
+                    call.args[0] for call in mock_logger.error.call_args_list
+                ]
+                assert logged_events.count("task_execution_timed_out") == 1
+                assert "task_freshness_check_error" not in logged_events
+
+    @pytest.mark.asyncio
+    async def test_task_failure_does_not_double_log_as_freshness_error(self, mock_db):
+        """A failing task must log task_execution_failed exactly once and
+        must NOT also log task_freshness_check_error.
+
+        Regression guard for issue #1040.
+        """
+        self._setup_stale_task(mock_db)
+
+        async def failing_task():
+            raise RuntimeError("boom")
+
+        with patch("trackrat.utils.scheduler_utils.datetime") as mock_datetime:
+            from datetime import timezone
+
+            current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = current_time
+            mock_datetime.min.replace.return_value = datetime.min.replace(
+                tzinfo=timezone.utc
+            )
+
+            with patch("trackrat.utils.scheduler_utils.logger") as mock_logger:
+                result = await run_with_freshness_check(
+                    db=mock_db,
+                    task_name="test_task",
+                    minimum_interval_seconds=60,
+                    task_func=failing_task,
+                )
+
+                assert result is False
+                logged_events = [
+                    call.args[0] for call in mock_logger.error.call_args_list
+                ]
+                assert logged_events.count("task_execution_failed") == 1
+                assert "task_freshness_check_error" not in logged_events
 
     @pytest.mark.asyncio
     async def test_timeout_logs_duration(self, mock_db):


### PR DESCRIPTION
Refs #1040.

## Summary
This PR fixes error handling and logging issues in the task scheduler and JIT refresh mechanisms, and adds concurrency controls to prevent resource exhaustion. It implements two of the three follow-up recommendations from the issue #1040 triage; the third (HTTP backoff on collectors) was deliberately skipped — see the design discussion on the issue.

## Key Changes

### Scheduler Error Handling (scheduler_utils.py)
- **Restructured exception handling into two distinct phases:**
  - Phase 1: Database lock acquisition and freshness check (reports `task_freshness_check_error`)
  - Phase 2: Task execution (reports `task_execution_timed_out` or `task_execution_failed`)
- **Fixed double-logging regression:** Task execution errors (timeouts, failures) are now caught and logged exactly once in Phase 2, preventing them from being re-raised and caught again by the outer exception handler as freshness check errors
- **Changed error handling strategy:** Task execution errors now return `False` instead of re-raising, ensuring single-event logging and cleaner error semantics
- **Improved BaseException handling:** Moved outside Phase 2 to properly handle cancellation signals without interfering with task execution error handling

### JIT Refresh Concurrency Control (departure.py)
- **Added semaphore-based concurrency cap:** Introduced `_BACKGROUND_REFRESH_CONCURRENCY = 4` to limit concurrent JIT refresh tasks
- **Prevents connection pool exhaustion:** Without the cap, an upstream slowdown could spawn one refresh task per discoverable station (~21), exhausting the 30-connection pool and cascading into 503s on unrelated endpoints
- **Wrapped refresh logic:** `_background_refresh_station` now acquires the semaphore before opening a DB session

## Test Updates (test_scheduler_utils.py, test_jit_promotion.py)
- Updated assertions to expect single rollback calls instead of double rollbacks
- Added regression tests to verify timeout and failure events are logged exactly once without spurious freshness check errors
- Added concurrency cap test to verify the semaphore limits in-flight refreshes to the configured limit

## Notable Implementation Details
- The semaphore is module-level and shared across all concurrent refresh requests, providing a global cap
- Error handling now clearly separates database-level errors (freshness check) from task-level errors (execution), improving observability
- All error paths properly clean up database transactions via rollback

https://claude.ai/code/session_01VY7w4TdhnwqFVXocgqExqr