### PR TITLE
Fix Live Activity push updates for trains with colliding IDs across transit systems

### DIFF
--- a/backend_v2/src/trackrat/api/live_activities.py
+++ b/backend_v2/src/trackrat/api/live_activities.py
@@ -31,6 +31,10 @@ class RegisterRequest(BaseModel):
     train_number: str
     origin_code: str
     destination_code: str
+    # Disambiguates journeys when train_number collides across transit systems
+    # (e.g. NJT and Amtrak both running 1989). Optional for back-compat with
+    # older iOS clients that don't send it.
+    data_source: str | None = None
 
 
 class RegisterResponse(BaseModel):
@@ -65,6 +69,7 @@ async def register_live_activity(
         token.train_number = request.train_number
         token.origin_code = request.origin_code
         token.destination_code = request.destination_code
+        token.data_source = request.data_source
         token.expires_at = expires_at
         token.is_active = True
     else:
@@ -75,6 +80,7 @@ async def register_live_activity(
             train_number=request.train_number,
             origin_code=request.origin_code,
             destination_code=request.destination_code,
+            data_source=request.data_source,
             expires_at=expires_at,
             is_active=True,
         )
@@ -87,6 +93,7 @@ async def register_live_activity(
         train_number=request.train_number,
         origin=request.origin_code,
         destination=request.destination_code,
+        data_source=request.data_source,
     )
 
     return RegisterResponse(expires_at=expires_at)

--- a/backend_v2/src/trackrat/db/migrations/versions/20260429_1226-896c9fb11394_add_data_source_to_live_activity_tokens.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260429_1226-896c9fb11394_add_data_source_to_live_activity_tokens.py
@@ -1,0 +1,36 @@
+"""add data_source to live_activity_tokens
+
+Revision ID: 896c9fb11394
+Revises: 062a92685e12
+Create Date: 2026-04-29 12:26:57.009719
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "896c9fb11394"
+down_revision = "062a92685e12"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply migration.
+
+    Adds data_source to live_activity_tokens so the push-update scheduler can
+    disambiguate train_journeys when a train_id is shared across transit
+    systems (e.g. NJT and Amtrak both running 1989 today). Nullable: tokens
+    registered by older iOS clients that don't send data_source must keep
+    working.
+    """
+    op.add_column(
+        "live_activity_tokens",
+        sa.Column("data_source", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    op.drop_column("live_activity_tokens", "data_source")

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -295,6 +295,10 @@ class LiveActivityToken(Base):
     train_number = Column(String(30), nullable=False)  # PATH IDs are ~21 chars
     origin_code = Column(String(10), nullable=False)  # e.g., "NY"
     destination_code = Column(String(10), nullable=False)  # e.g., "WAS"
+    # Disambiguates journeys when train_number collides across systems.
+    # Nullable so older clients that never sent it still receive updates
+    # (with the legacy "first-match wins" behavior).
+    data_source = Column(String(20), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     expires_at = Column(DateTime(timezone=True))  # Auto-expire after journey
     is_active = Column(Boolean, default=True, nullable=False)

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2944,16 +2944,19 @@ class SchedulerService:
                         logger.debug("no_active_live_activity_tokens")
                         return
 
-                    # Group by train number for efficiency
-                    trains_to_update: dict[str, list[Any]] = {}
+                    # Group by (train_number, data_source). When a train_id
+                    # collides across systems (e.g. NJT and Amtrak), grouping
+                    # only by train_number routes both groups' updates to
+                    # whichever journey the unfiltered query happens to return.
+                    # data_source is None for tokens registered by older iOS
+                    # clients that never sent it; those keep the legacy
+                    # unfiltered behavior.
+                    trains_to_update: dict[tuple[str, str | None], list[Any]] = {}
                     for token in active_tokens:
-                        if (
-                            token.train_number
-                            and token.train_number not in trains_to_update
-                        ):
-                            trains_to_update[token.train_number] = []
-                        if token.train_number:
-                            trains_to_update[token.train_number].append(token)
+                        if not token.train_number:
+                            continue
+                        key = (token.train_number, token.data_source)
+                        trains_to_update.setdefault(key, []).append(token)
 
                     logger.info(
                         "live_activity_tokens_found",
@@ -2970,16 +2973,21 @@ class SchedulerService:
                         return
 
                     # Update each train's Live Activities
-                    for train_number, tokens in trains_to_update.items():
-                        # Get latest journey for this train
+                    for (train_number, data_source), tokens in trains_to_update.items():
+                        # Get latest journey for this train. Filter by
+                        # data_source when the token has one to avoid picking
+                        # the wrong journey on cross-system train_id collisions.
+                        journey_filters = [
+                            TrainJourney.train_id == train_number,
+                            TrainJourney.journey_date == now_et().date(),
+                        ]
+                        if data_source:
+                            journey_filters.append(
+                                TrainJourney.data_source == data_source
+                            )
                         journey_stmt = (
                             select(TrainJourney)
-                            .where(
-                                and_(
-                                    TrainJourney.train_id == train_number,
-                                    TrainJourney.journey_date == now_et().date(),
-                                )
-                            )
+                            .where(and_(*journey_filters))
                             .options(
                                 # Live Activity status calc reads journey.stops
                                 # and journey.snapshots[-1].train_status; the
@@ -3129,6 +3137,7 @@ class SchedulerService:
                                                 train_number,
                                                 journey.journey_date,
                                                 force_refresh=True,
+                                                data_source=data_source,
                                             )
                                         )
 

--- a/backend_v2/tests/unit/api/test_live_activities.py
+++ b/backend_v2/tests/unit/api/test_live_activities.py
@@ -1,0 +1,99 @@
+"""Tests for the Live Activity registration endpoint.
+
+Specifically covers issue #1050: when train_ids collide across transit
+systems, the Live Activity must carry data_source so backend push updates
+target the right journey.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.orm import sessionmaker
+from starlette.testclient import TestClient
+
+from trackrat.models.database import LiveActivityToken
+
+
+def test_register_persists_data_source(e2e_client: TestClient, sync_engine):
+    """data_source on the request body must be saved on the token row."""
+    resp = e2e_client.post(
+        "/api/v2/live-activities/register",
+        json={
+            "push_token": "tok-issue-1050-amtrak",
+            "activity_id": "act-1",
+            "train_number": "1989",
+            "origin_code": "NYP",
+            "destination_code": "WAS",
+            "data_source": "AMTRAK",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    Session = sessionmaker(bind=sync_engine)
+    with Session() as session:
+        token = session.scalar(
+            select(LiveActivityToken).where(
+                LiveActivityToken.push_token == "tok-issue-1050-amtrak"
+            )
+        )
+        assert token is not None
+        assert token.data_source == "AMTRAK"
+
+
+def test_register_accepts_missing_data_source_for_legacy_clients(
+    e2e_client: TestClient, sync_engine
+):
+    """Older iOS clients omit data_source entirely; we must still accept them."""
+    resp = e2e_client.post(
+        "/api/v2/live-activities/register",
+        json={
+            "push_token": "tok-legacy-client",
+            "activity_id": "act-legacy",
+            "train_number": "1989",
+            "origin_code": "NYP",
+            "destination_code": "WAS",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    Session = sessionmaker(bind=sync_engine)
+    with Session() as session:
+        token = session.scalar(
+            select(LiveActivityToken).where(
+                LiveActivityToken.push_token == "tok-legacy-client"
+            )
+        )
+        assert token is not None
+        assert token.data_source is None
+
+
+def test_register_updates_existing_token_data_source(
+    e2e_client: TestClient, sync_engine
+):
+    """Re-registering the same push_token must overwrite data_source so users
+    who restart a Live Activity for a different system pick up the new value."""
+    payload = {
+        "push_token": "tok-reregister",
+        "activity_id": "act-reregister",
+        "train_number": "1989",
+        "origin_code": "NYP",
+        "destination_code": "WAS",
+        "data_source": "AMTRAK",
+    }
+    assert (
+        e2e_client.post("/api/v2/live-activities/register", json=payload).status_code
+        == 200
+    )
+    payload["data_source"] = "NJT"
+    assert (
+        e2e_client.post("/api/v2/live-activities/register", json=payload).status_code
+        == 200
+    )
+
+    Session = sessionmaker(bind=sync_engine)
+    with Session() as session:
+        token = session.scalar(
+            select(LiveActivityToken).where(
+                LiveActivityToken.push_token == "tok-reregister"
+            )
+        )
+        assert token is not None
+        assert token.data_source == "NJT"

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -413,6 +413,120 @@ class TestSchedulerService:
                             )
 
     @pytest.mark.asyncio
+    async def test_update_live_activities_groups_by_data_source(
+        self, scheduler_service, mock_apns_service
+    ):
+        """Issue #1050: tokens with the same train_number but different
+        data_source must each get their own journey lookup. Otherwise the
+        unfiltered journey query returns whichever row sorts first and both
+        users get push updates for the wrong train."""
+        scheduler_service.apns_service = mock_apns_service
+
+        with patch("trackrat.services.scheduler.get_session") as mock_get_session:
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            with (
+                patch("sqlalchemy.create_engine") as mock_create_engine,
+                patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker,
+            ):
+                mock_sync_session = Mock()
+                mock_create_engine.return_value = Mock()
+                mock_sessionmaker.return_value = Mock(return_value=mock_sync_session)
+
+                # Two tokens, same train_number, different transit systems.
+                njt_token = Mock(
+                    push_token="njt-tok",
+                    activity_id="njt-act",
+                    train_number="1989",
+                    origin_code="NY",
+                    destination_code="MP",
+                    data_source="NJT",
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    is_active=True,
+                    track_notified_at=None,
+                )
+                amtrak_token = Mock(
+                    push_token="amtrak-tok",
+                    activity_id="amtrak-act",
+                    train_number="1989",
+                    origin_code="NYP",
+                    destination_code="WAS",
+                    data_source="AMTRAK",
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    is_active=True,
+                    track_notified_at=None,
+                )
+
+                mock_tokens_result = Mock()
+                mock_tokens_result.scalars.return_value = [njt_token, amtrak_token]
+
+                # Each scalar() call returns a journey shaped to the matching
+                # data_source, so we can verify the right token gets the right
+                # journey (verifying grouping AND filtering both worked).
+                njt_journey = Mock(
+                    train_id="1989",
+                    data_source="NJT",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=False,
+                    is_expired=False,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+                amtrak_journey = Mock(
+                    train_id="1989",
+                    data_source="AMTRAK",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=False,
+                    is_expired=False,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+
+                mock_sync_session.execute.return_value = mock_tokens_result
+                # First call (NJT group) returns NJT journey, second (AMTRAK) returns AMTRAK
+                mock_sync_session.scalar.side_effect = [njt_journey, amtrak_journey]
+                mock_sync_session.__enter__ = Mock(return_value=mock_sync_session)
+                mock_sync_session.__exit__ = Mock(return_value=None)
+
+                # Capture which (token, journey) pair the content-state calc sees.
+                captured_pairs = []
+
+                def capture_pair(journey, token, _session):
+                    captured_pairs.append((token.data_source, journey.data_source))
+                    return {"test": "content"}
+
+                with patch.object(
+                    scheduler_service,
+                    "_calculate_live_activity_content_state",
+                    side_effect=capture_pair,
+                ):
+                    with patch(
+                        "trackrat.services.scheduler.run_with_freshness_check"
+                    ) as mock_freshness_check:
+
+                        async def execute_task_func(
+                            db, task_name, minimum_interval_seconds, task_func
+                        ):
+                            await task_func()
+                            return True
+
+                        mock_freshness_check.side_effect = execute_task_func
+
+                        await scheduler_service.update_live_activities()
+
+                # Two groups => two journey lookups (the bug was a single lookup).
+                assert mock_sync_session.scalar.call_count == 2
+
+                # NJT token paired with NJT journey, AMTRAK with AMTRAK.
+                # If grouping by data_source had been removed, both tokens
+                # would share whichever journey was returned first.
+                assert ("NJT", "NJT") in captured_pairs
+                assert ("AMTRAK", "AMTRAK") in captured_pairs
+
+    @pytest.mark.asyncio
     async def test_precompute_congestion_cache(self, scheduler_service):
         """Test congestion cache pre-computation."""
         with patch("trackrat.services.scheduler.get_session") as mock_get_session:

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -828,28 +828,32 @@ final class APIService: ObservableObject {
     
     // MARK: - Live Activity Token Registration (V2)
     
-    func registerLiveActivityToken(pushToken: String, activityId: String, trainNumber: String, originCode: String, destinationCode: String) async throws {
+    func registerLiveActivityToken(pushToken: String, activityId: String, trainNumber: String, originCode: String, destinationCode: String, dataSource: String? = nil) async throws {
         // Create V2 endpoint
         let endpoint = "/v2/live-activities/register"
         guard let url = URL(string: "\(baseURL)\(endpoint)") else {
             throw APIError.invalidURL
         }
-        
-        // Create request body matching new backend
+
+        // Create request body matching new backend.
+        // data_source disambiguates trains that share an ID across transit systems.
         struct RegisterRequest: Encodable {
             let push_token: String
             let activity_id: String
             let train_number: String
             let origin_code: String
             let destination_code: String
+            let data_source: String?
         }
-        
+
+        let normalizedDataSource = (dataSource?.isEmpty ?? true) ? nil : dataSource
         let body = RegisterRequest(
             push_token: pushToken,
             activity_id: activityId,
             train_number: trainNumber,
             origin_code: originCode,
-            destination_code: destinationCode
+            destination_code: destinationCode,
+            data_source: normalizedDataSource
         )
         
         // Create request

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -89,7 +89,8 @@ class LiveActivityService: ObservableObject {
             destinationStationCode: destinationCode,
             departureTime: train.getDepartureTime(fromStationCode: originCode) ?? train.departureTime,
             scheduledArrivalTime: scheduledArrivalTime,
-            theme: "black"
+            theme: "black",
+            dataSource: train.dataSource
         )
         
         // Determine if train has departed user's origin
@@ -247,10 +248,12 @@ class LiveActivityService: ObservableObject {
         guard let activity = currentActivity else { return }
 
         do {
-            // Fetch train details
+            // Fetch train details. Pass dataSource so the backend can
+            // disambiguate when train IDs collide across transit systems.
             let train = try await APIService.shared.fetchTrainDetails(
                 id: activity.attributes.trainId,
-                fromStationCode: activity.attributes.originStationCode
+                fromStationCode: activity.attributes.originStationCode,
+                dataSource: activity.attributes.dataSource
             )
 
             // Cache the fresh train data for instant loading in TrainDetailsView
@@ -428,7 +431,8 @@ class LiveActivityService: ObservableObject {
                         activityId: activity.id,
                         trainNumber: train.trainId,
                         originCode: originCode,
-                        destinationCode: destinationCode
+                        destinationCode: destinationCode,
+                        dataSource: train.dataSource
                     )
                     print("✅ Live Activity token registration successful")
                 } catch {

--- a/ios/TrackRat/Shared/LiveActivityModels.swift
+++ b/ios/TrackRat/Shared/LiveActivityModels.swift
@@ -182,6 +182,8 @@ struct TrainActivityAttributes: ActivityAttributes {
     let departureTime: Date
     let scheduledArrivalTime: Date?
     let theme: String // Theme name as string (blue, black, white)
+    // Optional so Activities started before this field was added can still decode
+    let dataSource: String?
 }
 
 // MARK: - Supporting Data Models


### PR DESCRIPTION
Closes #1050.

## Summary
When multiple transit systems run trains with the same train number on the same day (e.g., NJT and Amtrak both have a 1989), the Live Activity push update path could resolve to the wrong journey because neither the iOS poll nor the backend push scheduler filtered by `data_source`. This PR threads `data_source` through both paths.

## Key Changes

**Backend:**
- Added nullable `data_source` column to `live_activity_tokens` (migration `896c9fb11394`). Nullable so older iOS clients that never sent it keep working with legacy "first-match wins" behavior.
- Updated the per-minute push scheduler to group tokens by `(train_number, data_source)` instead of `train_number` alone, and to add `TrainJourney.data_source == data_source` to the journey lookup when set.
- Pass `data_source` to `JIT.ensure_fresh_data` in the scheduler's staleness refresh so the right journey is refreshed.

**API:**
- Extended `RegisterRequest` to accept optional `data_source` field; persisted on both new and re-registered tokens.

**iOS Client:**
- Added `dataSource` (optional, for back-compat with in-flight Activities) to `TrainActivityAttributes`.
- `LiveActivityService.fetchAndUpdateTrain` passes it to `APIService.fetchTrainDetails` (the 30s polling loop).
- `registerLiveActivityToken` accepts and sends `dataSource` to the backend.

## Test Coverage

- New `tests/unit/api/test_live_activities.py`: register persists `data_source`, accepts legacy clients without it, overwrites on re-registration.
- New scheduler test: two tokens with the same `train_number` but different `data_source` values each get their own journey lookup, and the right token is paired with the right journey.
- Full unit suite: 2628 passed, 0 failures.

## Test plan
- [ ] Build iOS app on a device, start a Live Activity for an NJT train, confirm 30s polls hit `/v2/trains/{id}?data_source=NJT`.
- [ ] After deploy, verify `live_activity_tokens.data_source` is populated for new registrations.
- [ ] Confirm in-flight Live Activities from older app builds still receive push updates (legacy null `data_source` path).

https://claude.ai/code/session_01D7fjNkxCaHbFBeR7oVDdBw