### PR TITLE
Separate subway line display from destination text in headers

### DIFF
--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -659,6 +659,13 @@ extension TrainV2 {
         return observationType == "SCHEDULED" ? "Train TBD" : "Train \(trainId)"
     }
 
+    /// User-facing label without the parenthetical line code that `displayLabel`
+    /// embeds for subway. Use this when the line is rendered separately (e.g.,
+    /// next to a `SubwayLineChips` bullet); otherwise use `displayLabel`.
+    var displayDestination: String {
+        return dataSource == "SUBWAY" ? destination : displayLabel
+    }
+
     /// True when displayLabel returns "Train TBD" — a scheduled-only train
     /// from a provider that uses public train numbers (NJT, Amtrak).
     var hasUnconfirmedTrainNumber: Bool {

--- a/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
+++ b/ios/TrackRat/Views/Components/TrackRatNavigationHeader.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 /// Reusable navigation header that replaces the system navigation bar
 /// to prevent layout shift issues on initial load.
-struct TrackRatNavigationHeader<TrailingContent: View>: View {
+///
+/// `titleAccessory` renders inline before the title (e.g., a `SubwayLineChips`
+/// bullet). It defaults to `EmptyView` so callers that don't need it can omit it.
+struct TrackRatNavigationHeader<TitleAccessory: View, TrailingContent: View>: View {
     @EnvironmentObject private var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -11,6 +14,7 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
     var showBackButton: Bool = true
     var showCloseButton: Bool = true
     var onBackAction: (() -> Void)? = nil
+    var titleAccessory: () -> TitleAccessory
     var trailingContent: (() -> TrailingContent)?
 
     init(
@@ -19,6 +23,7 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
         showBackButton: Bool = true,
         showCloseButton: Bool = true,
         onBackAction: (() -> Void)? = nil,
+        @ViewBuilder titleAccessory: @escaping () -> TitleAccessory,
         @ViewBuilder trailingContent: @escaping () -> TrailingContent
     ) {
         self.title = title
@@ -26,6 +31,7 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
         self.showBackButton = showBackButton
         self.showCloseButton = showCloseButton
         self.onBackAction = onBackAction
+        self.titleAccessory = titleAccessory
         self.trailingContent = trailingContent
     }
 
@@ -33,11 +39,14 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
         ZStack {
             // Center title - truly centered regardless of leading/trailing content
             VStack(spacing: 0) {
-                Text(title)
-                    .font(TrackRatTheme.Typography.title3)
-                    .foregroundColor(.white)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
+                HStack(spacing: 6) {
+                    titleAccessory()
+                    Text(title)
+                        .font(TrackRatTheme.Typography.title3)
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
                 if let subtitle = subtitle {
                     Text(subtitle)
                         .font(.caption2)
@@ -91,8 +100,48 @@ struct TrackRatNavigationHeader<TrailingContent: View>: View {
     }
 }
 
-// Convenience initializer for headers without trailing content
+// Convenience: trailing content only (no title accessory)
+extension TrackRatNavigationHeader where TitleAccessory == EmptyView {
+    init(
+        title: String,
+        subtitle: String? = nil,
+        showBackButton: Bool = true,
+        showCloseButton: Bool = true,
+        onBackAction: (() -> Void)? = nil,
+        @ViewBuilder trailingContent: @escaping () -> TrailingContent
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.showBackButton = showBackButton
+        self.showCloseButton = showCloseButton
+        self.onBackAction = onBackAction
+        self.titleAccessory = { EmptyView() }
+        self.trailingContent = trailingContent
+    }
+}
+
+// Convenience: title accessory only (no trailing content)
 extension TrackRatNavigationHeader where TrailingContent == EmptyView {
+    init(
+        title: String,
+        subtitle: String? = nil,
+        showBackButton: Bool = true,
+        showCloseButton: Bool = true,
+        onBackAction: (() -> Void)? = nil,
+        @ViewBuilder titleAccessory: @escaping () -> TitleAccessory
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.showBackButton = showBackButton
+        self.showCloseButton = showCloseButton
+        self.onBackAction = onBackAction
+        self.titleAccessory = titleAccessory
+        self.trailingContent = nil
+    }
+}
+
+// Convenience: neither title accessory nor trailing content
+extension TrackRatNavigationHeader where TitleAccessory == EmptyView, TrailingContent == EmptyView {
     init(
         title: String,
         subtitle: String? = nil,
@@ -105,6 +154,7 @@ extension TrackRatNavigationHeader where TrailingContent == EmptyView {
         self.showBackButton = showBackButton
         self.showCloseButton = showCloseButton
         self.onBackAction = onBackAction
+        self.titleAccessory = { EmptyView() }
         self.trailingContent = nil
     }
 }

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -59,7 +59,17 @@ struct TrainDetailsView: View {
 
     private var trainNavigationTitle: String {
         guard let train = viewModel.train else { return "Loading..." }
-        return train.displayLabel
+        return train.displayDestination
+    }
+
+    @ViewBuilder
+    private var trainTitleAccessory: some View {
+        if let train = viewModel.train, train.dataSource == "SUBWAY" {
+            SubwayLineChips(
+                lines: [SubwayLines.displayBullet(forLineCode: train.line.code)],
+                size: 22
+            )
+        }
     }
 
     var body: some View {
@@ -70,6 +80,7 @@ struct TrainDetailsView: View {
                 title: trainNavigationTitle,
                 showBackButton: !isSheet,
                 showCloseButton: false,
+                titleAccessory: { trainTitleAccessory },
                 trailingContent: {
                     HStack(alignment: .center, spacing: 12) {
                         if let train = viewModel.train,

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -413,8 +413,16 @@ struct TrainCard: View {
                         .font(.caption)
                 }
 
-                HStack(spacing: 4) {
-                    Text(train.displayLabel)
+                HStack(spacing: 6) {
+                    if train.dataSource == "SUBWAY" {
+                        SubwayLineChips(
+                            lines: [SubwayLines.displayBullet(forLineCode: train.line.code)],
+                            size: 20
+                        )
+                        .opacity(isCancelled || hasDeparted ? 0.5 : 1.0)
+                    }
+
+                    Text(train.displayDestination)
                         .font(.headline)
                         .foregroundColor(isCancelled || hasDeparted ? .black.opacity(0.5) : (isBoardingAtOrigin ? .white : .black))
                         .strikethrough(isCancelled)

--- a/ios/TrackRatTests/Models/TrainV2Tests.swift
+++ b/ios/TrackRatTests/Models/TrainV2Tests.swift
@@ -20,6 +20,7 @@ class TrainV2Tests: XCTestCase {
         isCompleted: Bool = false,
         observationType: String? = nil,
         dataSource: String = "NJT",
+        lineCode: String = "NEC",
         stops: [StopV2]? = nil
     ) -> TrainV2 {
         let departure = StationTiming(
@@ -40,7 +41,7 @@ class TrainV2Tests: XCTestCase {
             track: nil
         )
 
-        let line = LineInfo(code: "NEC", name: "Northeast Corridor", color: "#FF6B00")
+        let line = LineInfo(code: lineCode, name: "Northeast Corridor", color: "#FF6B00")
 
         return TrainV2(
             trainId: trainId,
@@ -748,5 +749,81 @@ class TrainV2Tests: XCTestCase {
             "Banner must only appear for explicitly SCHEDULED trains")
 
         print("  ✅ nil observationType hides banner")
+    }
+
+    // MARK: - displayDestination
+
+    func testDisplayDestination_subway_stripsLineParenthetical() {
+        print("🚇 Testing displayDestination for SUBWAY drops the embedded '(line)' prefix")
+
+        let train = createTestTrainV2(
+            destinationName: "Astoria-Ditmars Blvd",
+            dataSource: "SUBWAY",
+            lineCode: "N"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - displayDestination: \(train.displayDestination)")
+        XCTAssertEqual(train.displayLabel, "(N) Astoria-Ditmars Blvd",
+            "Sanity check: displayLabel still embeds the line for callers that need a flat string")
+        XCTAssertEqual(train.displayDestination, "Astoria-Ditmars Blvd",
+            "displayDestination must omit '(line)' so the chip can render the bullet separately")
+    }
+
+    func testDisplayDestination_subwayExpress_chipNormalizationIsOrthogonal() {
+        print("🚇 Testing displayDestination for SUBWAY express line (e.g., 7X) preserves destination only")
+
+        // The chip layer normalizes "7X" → "7" via SubwayLines.displayBullet(forLineCode:);
+        // the destination string itself should not depend on that.
+        let train = createTestTrainV2(
+            destinationName: "Flushing-Main St",
+            dataSource: "SUBWAY",
+            lineCode: "7X"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - displayDestination: \(train.displayDestination)")
+        XCTAssertEqual(train.displayDestination, "Flushing-Main St",
+            "displayDestination is just the destination regardless of express variant code")
+    }
+
+    func testDisplayDestination_njt_matchesDisplayLabel() {
+        print("🚆 Testing displayDestination for NJT mirrors displayLabel ('Train N')")
+
+        let train = createTestTrainV2(
+            trainId: "3838",
+            observationType: "OBSERVED",
+            dataSource: "NJT"
+        )
+
+        print("  - displayLabel: \(train.displayLabel)")
+        print("  - displayDestination: \(train.displayDestination)")
+        XCTAssertEqual(train.displayDestination, train.displayLabel,
+            "Non-subway providers don't embed a parenthetical line, so displayDestination == displayLabel")
+        XCTAssertEqual(train.displayDestination, "Train 3838",
+            "Sanity check: OBSERVED NJT renders as 'Train {id}'")
+    }
+
+    func testDisplayDestination_syntheticIdSources_matchDisplayLabel() {
+        print("🚉 Testing displayDestination for synthetic-ID providers mirrors displayLabel (the destination)")
+
+        // PATH/PATCO/LIRR/MNR show just the destination from displayLabel, so
+        // displayDestination should be identical — there's no parenthetical to strip.
+        let syntheticSources = ["PATH", "PATCO", "LIRR", "MNR"]
+
+        for source in syntheticSources {
+            let train = createTestTrainV2(
+                trainId: "TRIP-1",
+                destinationName: "World Trade Center",
+                observationType: "OBSERVED",
+                dataSource: source
+            )
+
+            print("  - \(source): displayLabel=\"\(train.displayLabel)\" displayDestination=\"\(train.displayDestination)\"")
+            XCTAssertEqual(train.displayDestination, train.displayLabel,
+                "\(source) has no parenthetical to strip; displayDestination must equal displayLabel")
+            XCTAssertEqual(train.displayDestination, "World Trade Center",
+                "Sanity check: \(source) shows the destination name")
+        }
     }
 }


### PR DESCRIPTION
## Summary
Refactors how train destinations are displayed to separate the subway line indicator (rendered as a visual chip) from the destination text. This improves layout flexibility and allows the line code to be rendered as a distinct visual element rather than embedded in the text.

## Key Changes

- **TrainV2 model**: Added `displayDestination` property that returns the destination without the parenthetical line code for subway trains. For non-subway providers, it mirrors `displayLabel`.

- **TrackRatNavigationHeader**: Extended to support a `titleAccessory` generic parameter (e.g., for rendering `SubwayLineChips`). Added three convenience initializers to handle combinations of title accessory and trailing content, with sensible defaults using `EmptyView`.

- **TrainDetailsView**: Updated to use `displayDestination` for the header title and render the subway line as a separate `SubwayLineChips` bullet via the new `titleAccessory` parameter.

- **TrainListView (TrainCard)**: Modified to display subway line codes as a `SubwayLineChips` bullet separate from the destination text, using `displayDestination` instead of `displayLabel`.

- **Test coverage**: Added comprehensive tests for `displayDestination` across different data sources (SUBWAY, NJT, PATH, PATCO, LIRR, MNR) and edge cases (express lines like "7X").

## Implementation Details

- The `displayDestination` property strips the "(line)" parenthetical only for SUBWAY data source, preserving the full `displayLabel` for other providers.
- The `TrackRatNavigationHeader` refactor maintains backward compatibility through extension-based convenience initializers, allowing callers to opt-in to the new `titleAccessory` feature without breaking existing code.
- Subway line normalization (e.g., "7X" → "7") remains orthogonal and handled by the chip layer, not the destination string itself.

https://claude.ai/code/session_01McZ6JWEtZPFmgJM1vMRAJf