### PR TITLE
Update train system brand colors for NJ Transit and NYC Subway

### DIFF
--- a/ios/TrackRat/Models/TrainSystem.swift
+++ b/ios/TrackRat/Models/TrainSystem.swift
@@ -57,13 +57,13 @@ enum TrainSystem: String, CaseIterable, Codable, Identifiable {
     /// Brand color for the system
     var color: String {
         switch self {
-        case .njt: return "#F5853E"   // NJ Transit orange
+        case .njt: return "#B61D8E"   // NJ Transit magenta
         case .amtrak: return "#004B87" // Amtrak blue
         case .path: return "#0072CE"  // PATH blue
         case .patco: return "#CC0C3B" // PATCO red
         case .lirr: return "#0039A6"  // MTA LIRR blue
         case .mnr: return "#000000"   // MTA Metro-North black
-        case .subway: return "#EE352E"  // NYC Subway red
+        case .subway: return "#00933C"  // NYC Subway green (4/5/6 Lexington Av Local/Express)
         case .metra: return "#00558A"  // Metra blue
         case .wmata: return "#004E8C"  // WMATA blue
         case .bart: return "#009BDA"   // BART blue


### PR DESCRIPTION
## Summary
Updated the brand colors for two transit systems to better reflect their official color schemes.

## Changes
- **NJ Transit (NJT)**: Changed primary color from orange (#F5853E) to magenta (#B61D8E)
- **NYC Subway**: Changed primary color from red (#EE352E) to green (#00933C), with an updated comment noting this represents the 4/5/6 Lexington Avenue Local/Express lines

## Details
These color updates improve the visual representation of the transit systems within the app, aligning with more accurate brand identity or specific line designations.

https://claude.ai/code/session_01VMSjSCsAZSc67fPSw8WW8a