### PR TITLE
Remove SystemPill from OnboardingView and SettingsView

### DIFF
--- a/ios/TrackRat/Views/Screens/OnboardingView.swift
+++ b/ios/TrackRat/Views/Screens/OnboardingView.swift
@@ -632,7 +632,6 @@ struct SystemSelectionCard: View {
             HStack(spacing: 12) {
                 // System info
                 HStack(spacing: 6) {
-                    SystemPill(system: system, size: 22)
                     Text(system.displayName)
                         .font(.headline)
                         .foregroundColor(.white)

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -1251,7 +1251,6 @@ private struct TrainSystemRow: View {
     private var rowContent: some View {
         VStack(spacing: 0) {
             HStack(spacing: 8) {
-                SystemPill(system: system, size: 22)
                 Text(system.displayName)
                     .font(.subheadline)
                     .foregroundColor(.white)


### PR DESCRIPTION
## Summary
Removed the `SystemPill` component from two locations in the UI where system information is displayed alongside the system display name.

## Key Changes
- Removed `SystemPill(system: system, size: 22)` from `SystemSelectionCard` in OnboardingView.swift
- Removed `SystemPill(system: system, size: 22)` from `TrainSystemRow` in SettingsView.swift

## Details
Both removals maintain the `Text(system.displayName)` component, keeping the system name visible while eliminating the visual pill indicator. This simplifies the UI layout in both the onboarding flow and settings screens.

https://claude.ai/code/session_01UVXtAoP4TfszH5pvTxNaHC