### PR TITLE
Add provider API auth failure monitoring and alerting

### DIFF
--- a/infra_v2/terraform/metrics.tf
+++ b/infra_v2/terraform/metrics.tf
@@ -125,3 +125,42 @@ resource "google_logging_metric" "train_follows" {
 
   depends_on = [google_project_service.apis["logging.googleapis.com"]]
 }
+
+# =============================================================================
+# PROVIDER AUTH FAILURE METRIC
+# Tracks: upstream transit-provider responses whose body contains
+# "Invalid token" (NJT, WMATA, MBTA, Metra all surface this on bad credentials).
+# Drives the "Provider API Auth Failure" alert in monitoring.tf.
+# Scoped to this environment's GCE instances by hostname prefix so staging
+# deployments don't trigger the production alert.
+# =============================================================================
+resource "google_logging_metric" "provider_auth_failures" {
+  count = local.metrics_enabled ? 1 : 0
+
+  name        = "provider_auth_failures"
+  description = "Upstream transit-provider API auth failures (token invalid/expired)"
+  filter = join(" AND ", [
+    "logName=\"projects/${var.project_id}/logs/cos_containers\"",
+    "jsonPayload._HOSTNAME=~\"^trackrat-${var.environment}-\"",
+    "jsonPayload.level=\"error\"",
+    "jsonPayload.error=~\"Invalid token\"",
+  ])
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+
+    labels {
+      key         = "logger"
+      value_type  = "STRING"
+      description = "Module emitting the error"
+    }
+  }
+
+  label_extractors = {
+    "logger" = "EXTRACT(jsonPayload.logger)"
+  }
+
+  depends_on = [google_project_service.apis["logging.googleapis.com"]]
+}

--- a/infra_v2/terraform/metrics.tf
+++ b/infra_v2/terraform/metrics.tf
@@ -128,8 +128,7 @@ resource "google_logging_metric" "train_follows" {
 
 # =============================================================================
 # PROVIDER AUTH FAILURE METRIC
-# Tracks: upstream transit-provider responses whose body contains
-# "Invalid token" (NJT, WMATA, MBTA, Metra all surface this on bad credentials).
+# Tracks: upstream transit-provider auth failures in structured collector logs.
 # Drives the "Provider API Auth Failure" alert in monitoring.tf.
 # Scoped to this environment's GCE instances by hostname prefix so staging
 # deployments don't trigger the production alert.
@@ -142,8 +141,14 @@ resource "google_logging_metric" "provider_auth_failures" {
   filter = join(" AND ", [
     "logName=\"projects/${var.project_id}/logs/cos_containers\"",
     "jsonPayload._HOSTNAME=~\"^trackrat-${var.environment}-\"",
-    "jsonPayload.level=\"error\"",
-    "jsonPayload.error=~\"Invalid token\"",
+    "jsonPayload.level=~\"(error|warning)\"",
+    format("(%s)", join(" OR ", [
+      "(jsonPayload.event=\"njt_api_http_error\" AND (jsonPayload.status_code=401 OR jsonPayload.status_code=403))",
+      "(jsonPayload.event=\"metra_feed_http_error\" AND (jsonPayload.extra.status_code=401 OR jsonPayload.extra.status_code=403))",
+      "(jsonPayload.event=~\"wmata_(predictions|jit)_api_failed\" AND jsonPayload.error=~\"(401|403|Unauthorized|Forbidden)\")",
+      "(jsonPayload.event=~\"HTTP error fetching MBTA GTFS-RT feed.*(401|403|Unauthorized|Forbidden)\")",
+      "jsonPayload.error=~\"Invalid token|authentication failed\"",
+    ])),
   ])
 
   metric_descriptor {

--- a/infra_v2/terraform/monitoring.tf
+++ b/infra_v2/terraform/monitoring.tf
@@ -73,3 +73,38 @@ resource "google_monitoring_alert_policy" "api_unavailable" {
 
   depends_on = [google_project_service.apis["monitoring.googleapis.com"]]
 }
+
+# Alert policy - fires when upstream-provider auth failures exceed threshold.
+# Backed by google_logging_metric.provider_auth_failures (see metrics.tf).
+# Threshold of 3 failures over 5 minutes debounces against one-off blips
+# while still firing within ~5 minutes of a genuine token expiry.
+resource "google_monitoring_alert_policy" "provider_auth_failure" {
+  count = var.environment == "production" ? 1 : 0
+
+  display_name = "Provider API Auth Failure"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Invalid token errors detected"
+
+    condition_threshold {
+      filter          = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.provider_auth_failures[0].name}\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 2
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].name]
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  depends_on = [google_project_service.apis["monitoring.googleapis.com"]]
+}

--- a/infra_v2/terraform/monitoring.tf
+++ b/infra_v2/terraform/monitoring.tf
@@ -85,7 +85,7 @@ resource "google_monitoring_alert_policy" "provider_auth_failure" {
   combiner     = "OR"
 
   conditions {
-    display_name = "Invalid token errors detected"
+    display_name = "Provider auth errors detected"
 
     condition_threshold {
       filter          = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.provider_auth_failures[0].name}\""
@@ -94,8 +94,9 @@ resource "google_monitoring_alert_policy" "provider_auth_failure" {
       duration        = "0s"
 
       aggregations {
-        alignment_period   = "300s"
-        per_series_aligner = "ALIGN_SUM"
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
       }
     }
   }


### PR DESCRIPTION
## Summary
This PR adds monitoring and alerting for upstream transit-provider API authentication failures. It detects when provider credentials become invalid or expired and triggers alerts in production environments.

## Key Changes
- **New logging metric** (`provider_auth_failures` in metrics.tf):
  - Tracks structured provider auth-failure logs from COS containers
  - Matches real collector auth failure shapes: HTTP 401/403 status fields, known WMATA/MBTA HTTP error strings, and token/authentication failure text
  - Scoped to environment-specific instances via hostname prefix to prevent staging from triggering production alerts
  - Extracts the logger module name as a label for debugging while allowing the alert to aggregate across labels

- **New alert policy** (`provider_auth_failure` in monitoring.tf):
  - Fires when more than 2 auth failures occur within a 5-minute window
  - Aggregates matching series with `REDUCE_SUM`, so the threshold is evaluated across instances and logger labels
  - Production-only alert to avoid noise from staging deployments
  - Sends notifications to the email notification channel
  - Auto-closes after 30 minutes of inactivity to prevent stale alerts

## Implementation Details
- The metric uses a DELTA metric kind to count discrete log events
- The 5-minute aggregation window (300s) with a threshold of 2 failures provides a balance between responsiveness (~5 minutes to alert) and debouncing against transient blips
- Environment scoping via hostname prefix (`trackrat-${var.environment}-`) ensures staging and production alerts remain isolated
- The logger label extraction enables quick identification of which module encountered the auth failure

https://claude.ai/code/session_01E2P1pgQhvQpkYHQLzPs6YX