### PR TITLE
Issue #1062: Fix direction-dependent trip search asymmetry

### DIFF
--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -39,7 +39,7 @@ from trackrat.utils.time import now_et
 logger = get_logger(__name__)
 
 # Maximum number of departure queries per transfer search to keep response fast
-MAX_TRANSFER_QUERIES = 6
+MAX_TRANSFER_QUERIES = 12
 
 # Minimum number of minutes after arrival to allow for catching the next train
 # (in addition to the transfer point's walk_minutes)
@@ -167,6 +167,39 @@ def _find_relevant_transfer_points(
     return transfers
 
 
+def _rank_transfer_points(
+    transfers: list[TransferPoint],
+    from_station: str,
+    to_station: str,
+    from_systems: set[str],
+    to_systems: set[str],
+) -> list[TransferPoint]:
+    """Rank transfer points so truncation is deterministic and direction-symmetric.
+
+    Sorting keys (ascending = better):
+    1. same_station transfers first (in-station is faster than walking)
+    2. walk_minutes ascending (shorter walks preferred)
+    3. stable tiebreaker on station/system codes (ensures identical ordering
+       regardless of which direction the search runs)
+    """
+
+    def _sort_key(tp: TransferPoint) -> tuple[int, int, str, str, str, str]:
+        # Canonical alphabetical order of the two sides for direction symmetry
+        side_a = (tp.station_a, tp.system_a)
+        side_b = (tp.station_b, tp.system_b)
+        canonical = tuple(sorted([side_a, side_b]))
+        return (
+            0 if tp.same_station else 1,
+            tp.walk_minutes,
+            canonical[0][0],
+            canonical[0][1],
+            canonical[1][0],
+            canonical[1][1],
+        )
+
+    return sorted(transfers, key=_sort_key)
+
+
 def _orient_transfer(
     tp: TransferPoint,
     from_systems: set[str],
@@ -287,6 +320,12 @@ async def search_trips(
     )
     if not transfer_points:
         return _empty_response(from_station, to_station, "no_transfer_points")
+
+    # Rank transfer points deterministically so that truncation produces the
+    # same result regardless of search direction (A→B vs B→A).
+    transfer_points = _rank_transfer_points(
+        transfer_points, from_station, to_station, from_systems, to_systems
+    )
 
     # Prepare transfer point queries — orient each transfer point up front
     # Limit to MAX_TRANSFER_QUERIES / 2 transfer points (each needs 2 queries)

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -11,12 +11,16 @@ Tests the pure logic functions used in trip composition:
 - _empty_response: empty response construction
 """
 
-from datetime import date, datetime, timedelta
-
-import pytest
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from trackrat.config.transfer_points import get_transfer_points
+import pytest
+
+from trackrat.config.transfer_points import (
+    TransferPoint,
+    get_systems_serving_station,
+    get_transfer_points,
+)
 from trackrat.models.api import (
     DataFreshness,
     LineInfo,
@@ -27,10 +31,9 @@ from trackrat.models.api import (
     TransferInfo,
     TripLeg,
     TripOption,
-    TripSearchResponse,
 )
-from trackrat.config.transfer_points import get_systems_serving_station
 from trackrat.services.trip_search import (
+    MAX_TRANSFER_QUERIES,
     _departure_to_leg,
     _empty_response,
     _filter_unreasonable_durations,
@@ -38,6 +41,7 @@ from trackrat.services.trip_search import (
     _get_best_time,
     _make_direct_trip,
     _orient_transfer,
+    _rank_transfer_points,
 )
 
 ET = ZoneInfo("America/New_York")
@@ -891,7 +895,6 @@ class TestDirectTripFallthroughBehavior:
                 continue
 
             # Find all `if` guards that lead to a return with search_type="direct"
-            source_lines = source.splitlines()
             for child in ast.walk(node):
                 if not isinstance(child, ast.If):
                     continue
@@ -911,3 +914,161 @@ class TestDirectTripFallthroughBehavior:
                     )
                     break
             break
+
+
+class TestRankTransferPoints:
+    """Test transfer point ranking for deterministic, direction-symmetric truncation."""
+
+    def _make_tp(
+        self,
+        station_a: str = "NY",
+        system_a: str = "NJT",
+        station_b: str = "PWC",
+        system_b: str = "PATH",
+        walk_minutes: int = 5,
+        same_station: bool = False,
+    ) -> TransferPoint:
+        return TransferPoint(
+            station_a=station_a,
+            system_a=system_a,
+            station_b=station_b,
+            system_b=system_b,
+            walk_meters=walk_minutes * 80.0,
+            walk_minutes=walk_minutes,
+            same_station=same_station,
+        )
+
+    def test_same_station_preferred_over_walk(self):
+        """same_station transfers should rank before walk transfers."""
+        walk = self._make_tp(station_a="HB", station_b="PHO", walk_minutes=5, same_station=False)
+        same = self._make_tp(station_a="NP", station_b="PNK", walk_minutes=5, same_station=True)
+        ranked = _rank_transfer_points(
+            [walk, same], "TR", "PWC", {"NJT"}, {"PATH"}
+        )
+        assert ranked[0].same_station is True
+        assert ranked[1].same_station is False
+
+    def test_shorter_walk_preferred(self):
+        """Shorter walk_minutes should rank before longer."""
+        long_walk = self._make_tp(station_a="AA", station_b="BB", walk_minutes=10, same_station=False)
+        short_walk = self._make_tp(station_a="CC", station_b="DD", walk_minutes=3, same_station=False)
+        ranked = _rank_transfer_points(
+            [long_walk, short_walk], "TR", "PWC", {"NJT"}, {"PATH"}
+        )
+        assert ranked[0].walk_minutes == 3
+        assert ranked[1].walk_minutes == 10
+
+    def test_direction_symmetric_ordering(self):
+        """Ranking must produce identical order regardless of search direction.
+
+        This is the core property that fixes issue #1062: reversing from/to
+        stations and their system sets must not change which TPs survive truncation.
+        """
+        tp1 = self._make_tp(station_a="NP", system_a="NJT", station_b="PNK", system_b="PATH",
+                            walk_minutes=5, same_station=True)
+        tp2 = self._make_tp(station_a="HB", system_a="NJT", station_b="PHO", system_b="PATH",
+                            walk_minutes=7, same_station=False)
+        tp3 = self._make_tp(station_a="NY", system_a="NJT", station_b="S128", system_b="SUBWAY",
+                            walk_minutes=5, same_station=False)
+
+        forward = _rank_transfer_points(
+            [tp1, tp2, tp3], "TR", "PWC", {"NJT", "AMTRAK"}, {"PATH", "SUBWAY"}
+        )
+        reverse = _rank_transfer_points(
+            [tp1, tp2, tp3], "PWC", "TR", {"PATH", "SUBWAY"}, {"NJT", "AMTRAK"}
+        )
+        # Exact same ordering regardless of direction
+        assert [tp.station_a for tp in forward] == [tp.station_a for tp in reverse]
+        assert [tp.station_b for tp in forward] == [tp.station_b for tp in reverse]
+
+    def test_stable_tiebreaker_on_station_codes(self):
+        """When same_station and walk_minutes are equal, sort by canonical station/system codes."""
+        tp_a = self._make_tp(station_a="BB", system_a="X", station_b="AA", system_b="Y",
+                             walk_minutes=5, same_station=False)
+        tp_b = self._make_tp(station_a="AA", system_a="X", station_b="CC", system_b="Y",
+                             walk_minutes=5, same_station=False)
+        ranked = _rank_transfer_points(
+            [tp_a, tp_b], "Z1", "Z2", {"X"}, {"Y"}
+        )
+        # Canonical order: tp_a has sorted pair (AA,Y),(BB,X); tp_b has (AA,X),(CC,Y)
+        # (AA,X) < (AA,Y) so tp_b comes first
+        assert ranked[0] is tp_b
+        assert ranked[1] is tp_a
+
+    def test_empty_input(self):
+        """Ranking an empty list should return an empty list."""
+        assert _rank_transfer_points([], "A", "B", {"NJT"}, {"PATH"}) == []
+
+    def test_single_element(self):
+        """Single-element list is returned unchanged."""
+        tp = self._make_tp()
+        result = _rank_transfer_points([tp], "A", "B", {"NJT"}, {"PATH"})
+        assert len(result) == 1
+        assert result[0] is tp
+
+
+class TestMaxTransferQueriesIncreased:
+    """Verify MAX_TRANSFER_QUERIES is large enough to avoid aggressive truncation."""
+
+    def test_max_transfer_queries_at_least_12(self):
+        """Issue #1062: cap of 6 (3 TPs) was too aggressive. Must be >= 12."""
+        assert MAX_TRANSFER_QUERIES >= 12
+
+    def test_max_transfer_points_at_least_6(self):
+        """With MAX_TRANSFER_QUERIES=12, at least 6 transfer points are evaluated."""
+        assert MAX_TRANSFER_QUERIES // 2 >= 6
+
+
+class TestTransferPointSymmetryIntegration:
+    """Integration test using real transfer point data to verify direction symmetry.
+
+    Uses the actual route topology to confirm that _find_relevant_transfer_points
+    followed by _rank_transfer_points produces the same ranked list regardless
+    of which direction the search runs.
+    """
+
+    @pytest.mark.parametrize(
+        "station_a,station_b",
+        [
+            ("TR", "PWC"),   # NJT → PATH (Trenton to World Trade Center)
+            ("HB", "P33"),   # NJT/PATH hub → PATH (Hoboken area)
+            ("NP", "PHO"),   # NJT Newark → PATH Hoboken
+        ],
+        ids=["trenton-to-wtc", "hoboken-to-33rd", "newark-to-hoboken-path"],
+    )
+    def test_ranked_transfer_points_are_direction_symmetric(self, station_a: str, station_b: str):
+        """Forward and reverse searches must produce identically ranked TPs.
+
+        This catches the root cause of issue #1062: set iteration order in
+        _find_relevant_transfer_points changes with direction, but after ranking
+        the order must be identical.
+        """
+        from trackrat.config.transfer_points import get_systems_serving_station
+
+        sys_a = get_systems_serving_station(station_a)
+        sys_b = get_systems_serving_station(station_b)
+
+        if not sys_a or not sys_b:
+            pytest.skip(f"No systems found for {station_a} or {station_b}")
+
+        fwd_tps = _find_relevant_transfer_points(sys_a, sys_b, station_a, station_b)
+        rev_tps = _find_relevant_transfer_points(sys_b, sys_a, station_b, station_a)
+
+        fwd_ranked = _rank_transfer_points(fwd_tps, station_a, station_b, sys_a, sys_b)
+        rev_ranked = _rank_transfer_points(rev_tps, station_b, station_a, sys_b, sys_a)
+
+        # Both directions should find the same transfer points (possibly in different
+        # initial order), and after ranking they must be in identical order.
+        fwd_keys = [
+            frozenset({(tp.station_a, tp.system_a), (tp.station_b, tp.system_b)})
+            for tp in fwd_ranked
+        ]
+        rev_keys = [
+            frozenset({(tp.station_a, tp.system_a), (tp.station_b, tp.system_b)})
+            for tp in rev_ranked
+        ]
+        assert fwd_keys == rev_keys, (
+            f"Direction-dependent ordering detected for {station_a}↔{station_b}.\n"
+            f"Forward:  {[(tp.station_a, tp.system_a, tp.station_b, tp.system_b) for tp in fwd_ranked]}\n"
+            f"Reverse:  {[(tp.station_a, tp.system_a, tp.station_b, tp.system_b) for tp in rev_ranked]}"
+        )


### PR DESCRIPTION
## Summary

- **Root cause**: `_find_relevant_transfer_points` iterates over `from_systems` and `to_systems` (both `set[str]`), producing direction-dependent ordering. Combined with a hard cap of 3 transfer points, different TPs survived truncation for A→B vs B→A searches.
- **Fix A**: Add `_rank_transfer_points()` that sorts by same_station preference, walk_minutes, then canonical alphabetical station/system codes. The canonical key is direction-invariant, so truncation always selects the same TPs regardless of direction.
- **Fix B**: Raise `MAX_TRANSFER_QUERIES` from 6→12 (3→6 transfer points evaluated), reducing the impact of truncation for routes with many viable transfers. Leg queries already run in parallel via `asyncio.gather`, so wall-clock impact is minimal.

## Files modified

| File | Change |
|------|--------|
| `backend_v2/src/trackrat/services/trip_search.py` | Added `_rank_transfer_points()` function; bumped `MAX_TRANSFER_QUERIES` from 6 to 12; call ranking before truncation in `search_trips()` |
| `backend_v2/tests/unit/services/test_trip_search.py` | Added `TestRankTransferPoints` (6 tests), `TestMaxTransferQueriesIncreased` (2 tests), `TestTransferPointSymmetryIntegration` (3 parametrized tests using real route topology); fixed pre-existing lint issues |

## Test coverage

- **`TestRankTransferPoints`**: same_station preference, walk_minutes ordering, direction symmetry with swapped from/to systems, stable tiebreaker on canonical codes, empty/single inputs
- **`TestMaxTransferQueriesIncreased`**: guards that cap stays ≥12 (≥6 TPs)
- **`TestTransferPointSymmetryIntegration`**: uses real route topology for TR↔PWC, HB↔P33, NP↔PHO — asserts forward and reverse ranking produce identical TP ordering

All 61 tests pass.

## Design decisions

- Ranking uses a pure sort-key function with no external state, making it easy to reason about and test
- The canonical key (`sorted([side_a, side_b])`) ensures the sort is a function of the TP alone, not the search direction
- No changes to `_find_relevant_transfer_points` itself — the ranking layer is additive, keeping the existing discovery logic untouched

Closes #1062

https://claude.ai/code/session_01CoSZ6aYW1qmaw4ZqXeSoyN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSZ6aYW1qmaw4ZqXeSoyN)_