### PR TITLE
Issue #1064: per-source stale-filter thresholds for SCHEDULED trains

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -98,12 +98,22 @@ REAL_TIME_DATA_SOURCES: frozenset[str] = frozenset(
     {"NJT", "AMTRAK", "PATH", "LIRR", "MNR", "SUBWAY", "METRA", "WMATA", "BART", "MBTA"}
 )
 
-# Minutes before departure to hide SCHEDULED trains that weren't discovered.
-# If a train hasn't been OBSERVED by this point, it's likely not running
-# or we can't provide reliable information about it.
-# Must be less than the discovery interval (30min) so SCHEDULED trains remain
-# visible for at least one discovery cycle before being filtered out.
-SCHEDULED_VISIBILITY_THRESHOLD_MINUTES: int = 15
+# Per-source minutes before departure to hide SCHEDULED trains that weren't discovered.
+# Sized to each provider's discovery cadence — must be less than the discovery interval
+# so SCHEDULED trains remain visible for at least one cycle before being filtered out.
+SCHEDULED_VISIBILITY_THRESHOLDS: dict[str, int] = {
+    "NJT": 15,  # 30-min discovery
+    "AMTRAK": 15,  # 30-min discovery
+    "PATH": 5,  # 4-min discovery
+    "LIRR": 5,  # 4-min discovery
+    "MNR": 5,  # 4-min discovery
+    "SUBWAY": 5,  # 4-min discovery
+    "BART": 5,  # 4-min discovery
+    "MBTA": 5,  # 4-min discovery
+    "METRA": 5,  # 4-min discovery
+    "WMATA": 4,  # 3-min discovery
+}
+DEFAULT_SCHEDULED_VISIBILITY_THRESHOLD_MINUTES: int = 15
 
 # All supported data sources for departure queries.
 ALL_DATA_SOURCES: list[str] = [
@@ -924,7 +934,9 @@ class DepartureService:
         """
         current_time = now_et()
         threshold = current_time + timedelta(
-            minutes=SCHEDULED_VISIBILITY_THRESHOLD_MINUTES
+            minutes=SCHEDULED_VISIBILITY_THRESHOLDS.get(
+                "NJT", DEFAULT_SCHEDULED_VISIBILITY_THRESHOLD_MINUTES
+            )
         )
         cutoff_time = current_time - timedelta(seconds=60)
         from_codes = expand_station_codes(from_station)
@@ -1696,12 +1708,9 @@ class DepartureService:
         Returns:
             Filtered list with stale SCHEDULED trains removed
         """
-        threshold = current_time + timedelta(
-            minutes=SCHEDULED_VISIBILITY_THRESHOLD_MINUTES
-        )
-
         result = []
         filtered_count = 0
+        filtered_by_source: dict[str, int] = {}
 
         for dep in departures:
             # Always show OBSERVED trains - we have real-time data
@@ -1714,16 +1723,26 @@ class DepartureService:
                 result.append(dep)
                 continue
 
+            # Per-source threshold sized to the provider's discovery cadence
+            threshold_minutes = SCHEDULED_VISIBILITY_THRESHOLDS.get(
+                dep.data_source, DEFAULT_SCHEDULED_VISIBILITY_THRESHOLD_MINUTES
+            )
+            threshold = current_time + timedelta(minutes=threshold_minutes)
+
             # For real-time systems: hide SCHEDULED trains if departure is imminent
             scheduled_time = dep.departure.scheduled_time
             if scheduled_time and scheduled_time < threshold:
                 filtered_count += 1
+                filtered_by_source[dep.data_source] = (
+                    filtered_by_source.get(dep.data_source, 0) + 1
+                )
                 logger.debug(
                     "filtering_stale_scheduled_train",
                     train_id=dep.train_id,
                     data_source=dep.data_source,
                     scheduled_time=scheduled_time.isoformat(),
                     threshold=threshold.isoformat(),
+                    threshold_minutes=threshold_minutes,
                 )
                 continue
 
@@ -1733,7 +1752,7 @@ class DepartureService:
             logger.info(
                 "filtered_stale_scheduled_trains",
                 count=filtered_count,
-                threshold_minutes=SCHEDULED_VISIBILITY_THRESHOLD_MINUTES,
+                by_source=filtered_by_source,
             )
 
         return result

--- a/backend_v2/tests/unit/services/test_departure_filtering.py
+++ b/backend_v2/tests/unit/services/test_departure_filtering.py
@@ -1013,9 +1013,11 @@ class TestDepartureFilterQuery:
 class TestStaleScheduledFiltering:
     """Tests for filtering SCHEDULED trains close to departure time.
 
-    SCHEDULED trains from systems with real-time data (NJT, Amtrak, PATH)
-    should be hidden when they're within 15 minutes of departure and
-    haven't been upgraded to OBSERVED by the discovery system.
+    SCHEDULED trains from systems with real-time data are hidden when within
+    their per-source threshold of departure and haven't been upgraded to
+    OBSERVED by discovery. Thresholds are sized to each provider's discovery
+    cadence: 15 min for NJT/Amtrak (30-min discovery), 5 min for PATH/LIRR/
+    MNR/SUBWAY/BART/MBTA/METRA (4-min discovery), 4 min for WMATA (3-min).
 
     PATCO trains (schedule-only) should never be filtered since there's
     no real-time system to discover them.
@@ -1106,7 +1108,7 @@ class TestStaleScheduledFiltering:
         ), "SCHEDULED Amtrak train within threshold should be filtered"
 
     def test_filter_scheduled_path_within_threshold(self):
-        """SCHEDULED PATH train within 15 min of departure should be filtered."""
+        """SCHEDULED PATH train within 5-min threshold should be filtered."""
         service = DepartureService()
         now = now_et()
 
@@ -1115,7 +1117,7 @@ class TestStaleScheduledFiltering:
                 train_id="PATH-123",
                 data_source="PATH",
                 observation_type="SCHEDULED",
-                minutes_until_departure=10,  # Within threshold
+                minutes_until_departure=3,  # Within PATH threshold (5 min)
             )
         ]
 
@@ -1123,7 +1125,28 @@ class TestStaleScheduledFiltering:
 
         assert (
             len(result) == 0
-        ), "SCHEDULED PATH train within threshold should be filtered"
+        ), "SCHEDULED PATH train within 5-min threshold should be filtered"
+
+    def test_keep_scheduled_path_outside_threshold(self):
+        """SCHEDULED PATH train at 6 min (outside 5-min threshold) should be kept."""
+        service = DepartureService()
+        now = now_et()
+
+        departures = [
+            self._create_departure(
+                train_id="PATH-456",
+                data_source="PATH",
+                observation_type="SCHEDULED",
+                minutes_until_departure=6,  # Outside PATH threshold (5 min)
+            )
+        ]
+
+        result = service._filter_stale_scheduled_trains(departures, now)
+
+        assert len(result) == 1, (
+            "SCHEDULED PATH train at 6 min should be kept (PATH threshold is 5 min)"
+        )
+        assert result[0].train_id == "PATH-456"
 
     def test_keep_scheduled_patco_within_threshold(self):
         """SCHEDULED PATCO train within 15 min should NOT be filtered (no real-time API)."""
@@ -1183,31 +1206,34 @@ class TestStaleScheduledFiltering:
         assert result[0].train_id == "1234"
 
     def test_mixed_departures_filtering(self):
-        """Test filtering with a mix of different departure types."""
+        """Test filtering with a mix of different departure types and per-source thresholds."""
         service = DepartureService()
         now = now_et()
 
         departures = [
-            # Should be filtered: SCHEDULED NJT within threshold (15 min)
+            # Should be filtered: SCHEDULED NJT within 15-min threshold
             self._create_departure("1001", "NJT", "SCHEDULED", 5),
             # Should be kept: OBSERVED NJT within threshold
             self._create_departure("1002", "NJT", "OBSERVED", 5),
-            # Should be filtered: SCHEDULED AMTRAK within threshold
+            # Should be filtered: SCHEDULED AMTRAK within 15-min threshold
             self._create_departure("A1003", "AMTRAK", "SCHEDULED", 10),
             # Should be kept: SCHEDULED NJT outside threshold
             self._create_departure("1004", "NJT", "SCHEDULED", 60),
-            # Should be kept: SCHEDULED PATCO within threshold (no real-time)
+            # Should be kept: SCHEDULED PATCO (no real-time API)
             self._create_departure("P1005", "PATCO", "SCHEDULED", 5),
-            # Should be filtered: SCHEDULED PATH within threshold
+            # Should be kept: SCHEDULED PATH at 10 min, outside 5-min threshold
             self._create_departure("PATH-1006", "PATH", "SCHEDULED", 10),
+            # Should be filtered: SCHEDULED PATH at 3 min, within 5-min threshold
+            self._create_departure("PATH-1007", "PATH", "SCHEDULED", 3),
         ]
 
         result = service._filter_stale_scheduled_trains(departures, now)
 
-        # Should keep: 1002 (observed), 1004 (outside threshold), P1005 (PATCO)
-        assert len(result) == 3
+        # Should keep: 1002 (observed), 1004 (outside NJT threshold),
+        #   P1005 (PATCO), PATH-1006 (outside PATH 5-min threshold)
+        assert len(result) == 4
         result_ids = {d.train_id for d in result}
-        assert result_ids == {"1002", "1004", "P1005"}
+        assert result_ids == {"1002", "1004", "P1005", "PATH-1006"}
 
     def test_boundary_at_exactly_threshold(self):
         """Train departing exactly at threshold boundary should be kept."""
@@ -1248,3 +1274,120 @@ class TestStaleScheduledFiltering:
         result = service._filter_stale_scheduled_trains(departures, now)
 
         assert len(result) == 0, "Train just under threshold should be filtered"
+
+    def test_njt_threshold_unchanged_at_14_min(self):
+        """Regression: NJT still uses 15-min threshold — 14 min is filtered."""
+        service = DepartureService()
+        now = now_et()
+
+        departures = [
+            self._create_departure("NJT-1", "NJT", "SCHEDULED", 14),
+        ]
+
+        result = service._filter_stale_scheduled_trains(departures, now)
+        assert len(result) == 0, "NJT SCHEDULED at 14 min should be filtered (threshold=15)"
+
+    def test_path_boundary_at_exactly_5_min(self):
+        """PATH train at exactly 5-min threshold should be kept (< not <=)."""
+        service = DepartureService()
+        now = now_et()
+
+        departures = [
+            self._create_departure("PATH-B", "PATH", "SCHEDULED", 5),
+        ]
+
+        result = service._filter_stale_scheduled_trains(departures, now)
+        assert len(result) == 1, "PATH at exactly 5 min should be kept"
+
+    def test_path_boundary_at_4_min(self):
+        """PATH train at 4 min (under 5-min threshold) should be filtered."""
+        service = DepartureService()
+        now = now_et()
+
+        departures = [
+            self._create_departure("PATH-C", "PATH", "SCHEDULED", 4),
+        ]
+
+        result = service._filter_stale_scheduled_trains(departures, now)
+        assert len(result) == 0, "PATH at 4 min should be filtered (threshold=5)"
+
+    def test_wmata_uses_4_min_threshold(self):
+        """WMATA uses 4-min threshold (3-min discovery cycle)."""
+        service = DepartureService()
+        now = now_et()
+
+        kept = [self._create_departure("WMATA-K", "WMATA", "SCHEDULED", 4)]
+        filtered = [self._create_departure("WMATA-F", "WMATA", "SCHEDULED", 3)]
+
+        result_kept = service._filter_stale_scheduled_trains(kept, now)
+        assert len(result_kept) == 1, "WMATA at 4 min should be kept (threshold=4)"
+
+        result_filtered = service._filter_stale_scheduled_trains(filtered, now)
+        assert len(result_filtered) == 0, "WMATA at 3 min should be filtered (threshold=4)"
+
+    def test_subway_uses_5_min_threshold(self):
+        """SUBWAY uses 5-min threshold (4-min discovery cycle)."""
+        service = DepartureService()
+        now = now_et()
+
+        kept = [self._create_departure("SUB-K", "SUBWAY", "SCHEDULED", 6)]
+        filtered = [self._create_departure("SUB-F", "SUBWAY", "SCHEDULED", 3)]
+
+        result_kept = service._filter_stale_scheduled_trains(kept, now)
+        assert len(result_kept) == 1, "SUBWAY at 6 min should be kept (threshold=5)"
+
+        result_filtered = service._filter_stale_scheduled_trains(filtered, now)
+        assert len(result_filtered) == 0, "SUBWAY at 3 min should be filtered (threshold=5)"
+
+    def test_lirr_uses_5_min_threshold(self):
+        """LIRR uses 5-min threshold (4-min discovery cycle)."""
+        service = DepartureService()
+        now = now_et()
+
+        kept = [self._create_departure("LIRR-K", "LIRR", "SCHEDULED", 6)]
+        filtered = [self._create_departure("LIRR-F", "LIRR", "SCHEDULED", 4)]
+
+        result_kept = service._filter_stale_scheduled_trains(kept, now)
+        assert len(result_kept) == 1, "LIRR at 6 min should be kept (threshold=5)"
+
+        result_filtered = service._filter_stale_scheduled_trains(filtered, now)
+        assert len(result_filtered) == 0, "LIRR at 4 min should be filtered (threshold=5)"
+
+    def test_mnr_uses_5_min_threshold(self):
+        """MNR uses 5-min threshold (4-min discovery cycle)."""
+        service = DepartureService()
+        now = now_et()
+
+        kept = [self._create_departure("MNR-K", "MNR", "SCHEDULED", 7)]
+        filtered = [self._create_departure("MNR-F", "MNR", "SCHEDULED", 4)]
+
+        result_kept = service._filter_stale_scheduled_trains(kept, now)
+        assert len(result_kept) == 1, "MNR at 7 min should be kept (threshold=5)"
+
+        result_filtered = service._filter_stale_scheduled_trains(filtered, now)
+        assert len(result_filtered) == 0, "MNR at 4 min should be filtered (threshold=5)"
+
+    def test_per_source_thresholds_in_single_batch(self):
+        """Different providers apply their own thresholds in the same filter call."""
+        service = DepartureService()
+        now = now_et()
+
+        departures = [
+            # PATH at 6 min: kept (threshold=5)
+            self._create_departure("PATH-1", "PATH", "SCHEDULED", 6),
+            # NJT at 6 min: filtered (threshold=15)
+            self._create_departure("NJT-1", "NJT", "SCHEDULED", 6),
+            # WMATA at 6 min: kept (threshold=4)
+            self._create_departure("WMATA-1", "WMATA", "SCHEDULED", 6),
+            # AMTRAK at 6 min: filtered (threshold=15)
+            self._create_departure("AMT-1", "AMTRAK", "SCHEDULED", 6),
+            # SUBWAY at 6 min: kept (threshold=5)
+            self._create_departure("SUB-1", "SUBWAY", "SCHEDULED", 6),
+        ]
+
+        result = service._filter_stale_scheduled_trains(departures, now)
+        result_ids = {d.train_id for d in result}
+
+        assert result_ids == {"PATH-1", "WMATA-1", "SUB-1"}, (
+            f"Expected PATH/WMATA/SUBWAY kept at 6 min, NJT/AMTRAK filtered. Got: {result_ids}"
+        )


### PR DESCRIPTION
## Summary

- Replace global 15-min `SCHEDULED_VISIBILITY_THRESHOLD_MINUTES` with per-source `SCHEDULED_VISIBILITY_THRESHOLDS` map, sized to each provider's discovery cadence: 15 min for NJT/Amtrak (30-min discovery), 5 min for PATH/LIRR/MNR/SUBWAY/BART/MBTA/METRA (4-min discovery), 4 min for WMATA (3-min discovery)
- Improve filter observability: the INFO log now includes a `by_source` dict so regressions are detectable from logs alone
- Update the NJT-specific JIT check (`_has_imminent_scheduled_njt`) to use the new per-source lookup

## Files modified

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/services/departure.py` | Replace global constant with per-source threshold map; update `_filter_stale_scheduled_trains` to compute threshold per-departure; update `_has_imminent_scheduled_njt` to use the map; improve INFO log with `by_source` breakdown |
| `backend_v2/tests/unit/services/test_departure_filtering.py` | Update existing PATH/mixed tests for new 5-min threshold; add 9 new tests covering per-source thresholds for PATH, WMATA, SUBWAY, LIRR, MNR, NJT regression, boundary conditions, and a multi-provider batch test |

## Test coverage

- 18 tests in `TestStaleScheduledFiltering` (9 existing updated + 9 new), all passing
- Full test file (38 tests) passes with no regressions
- New tests cover: PATH boundary at exactly 5 min (kept) and 4 min (filtered), WMATA 4-min threshold, SUBWAY/LIRR/MNR 5-min thresholds, NJT 15-min regression check, mixed-provider batch verifying each source applies its own threshold

## Design decisions

- Per-source thresholds are 1 min above the discovery interval (e.g., 5 min for 4-min discovery) to keep one cycle of buffer — a SCHEDULED train that genuinely won't run gets filtered after one missed discovery cycle
- Used a simple `dict[str, int]` with a default fallback rather than an enum or config object — keeps the change minimal and the constants easy to audit at a glance
- Did not touch JIT refresh generalization (item C in the issue) — that's a larger change best shipped separately

Closes #1064

https://claude.ai/code/session_01KQRnQ6A26cZAZPcFpBd2eU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQRnQ6A26cZAZPcFpBd2eU)_