### PR TITLE
[codex] Fix subway station badge wrapping

### DIFF
--- a/ios/TrackRat/Views/Components/StationPickerSheet.swift
+++ b/ios/TrackRat/Views/Components/StationPickerSheet.swift
@@ -108,13 +108,15 @@ struct StationPickerSheet: View {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 6) {
-                        Text(displayName)
-                            .font(.headline)
-                            .foregroundColor(isDisabled ? .white.opacity(0.4) : .white)
-                        SubwayLineChips(lines: lines, size: 14)
-                            .opacity(isDisabled ? 0.4 : 1)
-                        SystemChips(stationCode: station.code, size: 14)
-                            .opacity(isDisabled ? 0.4 : 1)
+                        StationNameWithBadges(
+                            name: displayName,
+                            stationCode: station.code,
+                            subwayLines: lines,
+                            font: .headline,
+                            foregroundColor: isDisabled ? .white.opacity(0.4) : .white,
+                            chipSize: 14,
+                            badgeOpacity: isDisabled ? 0.4 : 1
+                        )
                     }
 
                     if isDisabled {
@@ -148,14 +150,15 @@ struct StationPickerSheet: View {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 8) {
-                        Text(displayName)
-                            .font(.headline)
-                            .foregroundColor(.white.opacity(0.7))
-
-                        SubwayLineChips(lines: lines, size: 14)
-                            .opacity(0.7)
-                        SystemChips(stationCode: station.code, size: 14)
-                            .opacity(0.7)
+                        StationNameWithBadges(
+                            name: displayName,
+                            stationCode: station.code,
+                            subwayLines: lines,
+                            font: .headline,
+                            foregroundColor: .white.opacity(0.7),
+                            chipSize: 14,
+                            badgeOpacity: 0.7
+                        )
                     }
 
                     Text("Edit your train systems to use this station")

--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -17,30 +17,15 @@ struct SubwayLineChips: View {
 
     var body: some View {
         if !lines.isEmpty {
-            HStack(spacing: 3) {
+            WrappingHStackLayout(spacing: 3, rowSpacing: 3) {
                 ForEach(lines, id: \.self) { line in
-                    chip(for: line)
+                    SubwayLineChip(line: line, size: size)
                 }
             }
+            .fixedSize(horizontal: false, vertical: true)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(accessibilityLabel)
         }
-    }
-
-    @ViewBuilder
-    private func chip(for line: String) -> some View {
-        let hex = SubwayLines.lineColor[line] ?? "#666666"
-        let bg = Color(hex: hex)
-        let fg = Self.contrastingTextColor(forHex: hex)
-        ZStack {
-            Circle().fill(bg)
-            Text(line)
-                .font(.system(size: size * 0.62, weight: .heavy, design: .rounded))
-                .foregroundColor(fg)
-                .minimumScaleFactor(0.7)
-                .lineLimit(1)
-        }
-        .frame(width: size, height: size)
     }
 
     private var accessibilityLabel: String {
@@ -63,6 +48,229 @@ struct SubwayLineChips: View {
     }
 }
 
+/// Station labels with their transit badges. The badge area is constrained to
+/// half of the available width and wraps, so the station name keeps priority.
+struct StationNameWithBadges: View {
+    let name: String
+    var stationCode: String? = nil
+    var subwayLines: [String] = []
+    var font: Font = .body
+    var foregroundColor: Color = .white
+    var chipSize: CGFloat = 14
+    var badgeOpacity: Double = 1
+    var includeSystemChips: Bool = true
+
+    var body: some View {
+        StationNameBadgesLayout(spacing: 6) {
+            Text(name)
+                .font(font)
+                .foregroundColor(foregroundColor)
+                .textProtected()
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            StationBadges(
+                stationCode: stationCode,
+                subwayLines: subwayLines,
+                size: chipSize,
+                includeSystemChips: includeSystemChips
+            )
+            .opacity(badgeOpacity)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct StationBadges: View {
+    let stationCode: String?
+    let subwayLines: [String]
+    var size: CGFloat
+    var includeSystemChips: Bool
+
+    private var systems: [TrainSystem] {
+        guard includeSystemChips, let stationCode else { return [] }
+        return Stations.systemsForStation(stationCode)
+            .filter { $0 != .subway }
+            .sorted { $0.chipLabel < $1.chipLabel }
+    }
+
+    var body: some View {
+        if !subwayLines.isEmpty || !systems.isEmpty {
+            WrappingHStackLayout(spacing: 3, rowSpacing: 3) {
+                ForEach(subwayLines, id: \.self) { line in
+                    SubwayLineChip(line: line, size: size)
+                }
+
+                ForEach(systems) { system in
+                    SystemPill(system: system, size: size)
+                }
+            }
+            .fixedSize(horizontal: false, vertical: true)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel)
+        }
+    }
+
+    private var accessibilityLabel: String {
+        let lineLabel = subwayLines.isEmpty ? nil : "lines: \(subwayLines.joined(separator: ", "))"
+        let systemLabel = systems.isEmpty ? nil : "systems: \(systems.map(\.displayName).joined(separator: ", "))"
+        return [lineLabel, systemLabel].compactMap { $0 }.joined(separator: "; ")
+    }
+}
+
+private struct SubwayLineChip: View {
+    let line: String
+    var size: CGFloat
+
+    var body: some View {
+        let hex = SubwayLines.lineColor[line] ?? "#666666"
+        let bg = Color(hex: hex)
+        let fg = SubwayLineChips.contrastingTextColor(forHex: hex)
+        ZStack {
+            Circle().fill(bg)
+            Text(line)
+                .font(.system(size: size * 0.62, weight: .heavy, design: .rounded))
+                .foregroundColor(fg)
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+private struct StationNameBadgesLayout: Layout {
+    var spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        guard subviews.count == 2 else { return .zero }
+
+        let proposedWidth = proposal.width ?? idealWidth(for: subviews)
+        let sizes = measuredSizes(for: subviews, width: proposedWidth)
+
+        return CGSize(
+            width: proposedWidth,
+            height: max(sizes.name.height, sizes.badges.height)
+        )
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        guard subviews.count == 2 else { return }
+
+        let sizes = measuredSizes(for: subviews, width: bounds.width)
+        let nameY = bounds.minY + (bounds.height - sizes.name.height) / 2
+        let badgesY = bounds.minY + (bounds.height - sizes.badges.height) / 2
+
+        subviews[0].place(
+            at: CGPoint(x: bounds.minX, y: nameY),
+            proposal: ProposedViewSize(width: sizes.name.width, height: sizes.name.height)
+        )
+
+        subviews[1].place(
+            at: CGPoint(x: bounds.minX + sizes.name.width + sizes.spacing, y: badgesY),
+            proposal: ProposedViewSize(width: sizes.badges.width, height: sizes.badges.height)
+        )
+    }
+
+    private func measuredSizes(for subviews: Subviews, width: CGFloat) -> (name: CGSize, badges: CGSize, spacing: CGFloat) {
+        let unconstrainedBadges = subviews[1].sizeThatFits(.unspecified)
+        let hasBadges = unconstrainedBadges.width > 0 && unconstrainedBadges.height > 0
+        let activeSpacing = hasBadges ? spacing : 0
+        let contentWidth = max(0, width - activeSpacing)
+        let badgeMaxWidth = hasBadges ? contentWidth * 0.5 : 0
+        let badges = hasBadges
+            ? subviews[1].sizeThatFits(ProposedViewSize(width: badgeMaxWidth, height: nil))
+            : .zero
+        let badgeWidth = min(badges.width, badgeMaxWidth)
+        let nameWidth = hasBadges ? max(contentWidth - badgeWidth, contentWidth * 0.5) : width
+        let name = subviews[0].sizeThatFits(ProposedViewSize(width: nameWidth, height: nil))
+
+        return (
+            CGSize(width: nameWidth, height: name.height),
+            CGSize(width: badgeWidth, height: badges.height),
+            activeSpacing
+        )
+    }
+
+    private func idealWidth(for subviews: Subviews) -> CGFloat {
+        let name = subviews[0].sizeThatFits(.unspecified)
+        let badges = subviews[1].sizeThatFits(.unspecified)
+        let activeSpacing = badges.width > 0 && badges.height > 0 ? spacing : 0
+        return name.width + activeSpacing + badges.width
+    }
+}
+
+private struct WrappingHStackLayout: Layout {
+    var spacing: CGFloat
+    var rowSpacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = rows(for: subviews, maxWidth: proposal.width)
+        return CGSize(width: rows.width, height: rows.height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = rows(for: subviews, maxWidth: bounds.width)
+        var y = bounds.minY
+
+        for row in rows.items {
+            var x = bounds.minX
+            for item in row.items {
+                subviews[item.index].place(
+                    at: CGPoint(x: x, y: y),
+                    proposal: ProposedViewSize(width: item.size.width, height: item.size.height)
+                )
+                x += item.size.width + spacing
+            }
+            y += row.height + rowSpacing
+        }
+    }
+
+    private func rows(for subviews: Subviews, maxWidth: CGFloat?) -> (items: [Row], width: CGFloat, height: CGFloat) {
+        let availableWidth = maxWidth ?? .greatestFiniteMagnitude
+        var rows: [Row] = []
+        var current = Row()
+
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let nextWidth = current.items.isEmpty ? size.width : current.width + spacing + size.width
+
+            if !current.items.isEmpty && nextWidth > availableWidth {
+                rows.append(current)
+                current = Row()
+            }
+
+            current.append(Item(index: index, size: size), spacing: spacing)
+        }
+
+        if !current.items.isEmpty {
+            rows.append(current)
+        }
+
+        let width = min(rows.map(\.width).max() ?? 0, availableWidth)
+        let height = rows.reduce(0) { total, row in
+            total + row.height
+        } + CGFloat(max(0, rows.count - 1)) * rowSpacing
+
+        return (rows, width, height)
+    }
+
+    private struct Item {
+        let index: Int
+        let size: CGSize
+    }
+
+    private struct Row {
+        var items: [Item] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+
+        mutating func append(_ item: Item, spacing: CGFloat) {
+            width += items.isEmpty ? item.size.width : spacing + item.size.width
+            height = max(height, item.size.height)
+            items.append(item)
+        }
+    }
+}
+
 #Preview {
     VStack(alignment: .leading, spacing: 12) {
         SubwayLineChips(lines: ["N", "W"])
@@ -70,6 +278,11 @@ struct SubwayLineChips: View {
         SubwayLineChips(lines: ["A", "C", "E"])
         SubwayLineChips(lines: ["B", "D", "F", "M"])
         SubwayLineChips(lines: ["1", "2", "3", "4", "5", "6", "A", "B", "C", "D"])
+        StationNameWithBadges(
+            name: "Times Sq-42 St",
+            stationCode: "S127",
+            subwayLines: ["1", "2", "3", "7", "N", "Q", "R", "W", "S"]
+        )
         SubwayLineChips(lines: [])
     }
     .padding()

--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -143,7 +143,7 @@ private struct StationNameBadgesLayout: Layout {
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         guard subviews.count == 2 else { return .zero }
 
-        let proposedWidth = proposal.width ?? idealWidth(for: subviews)
+        let proposedWidth = resolvedWidth(proposal.width, fallback: idealWidth(for: subviews))
         let sizes = measuredSizes(for: subviews, width: proposedWidth)
 
         return CGSize(
@@ -155,7 +155,8 @@ private struct StationNameBadgesLayout: Layout {
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
         guard subviews.count == 2 else { return }
 
-        let sizes = measuredSizes(for: subviews, width: bounds.width)
+        let width = resolvedWidth(bounds.width, fallback: idealWidth(for: subviews))
+        let sizes = measuredSizes(for: subviews, width: width)
         let nameY = bounds.minY + (bounds.height - sizes.name.height) / 2
         let badgesY = bounds.minY + (bounds.height - sizes.badges.height) / 2
 
@@ -168,6 +169,13 @@ private struct StationNameBadgesLayout: Layout {
             at: CGPoint(x: bounds.minX + sizes.name.width + sizes.spacing, y: badgesY),
             proposal: ProposedViewSize(width: sizes.badges.width, height: sizes.badges.height)
         )
+    }
+
+    private func resolvedWidth(_ width: CGFloat?, fallback: CGFloat) -> CGFloat {
+        guard let width, width.isFinite else {
+            return fallback.isFinite ? max(0, fallback) : 0
+        }
+        return max(0, width)
     }
 
     private func measuredSizes(for subviews: Subviews, width: CGFloat) -> (name: CGSize, badges: CGSize, spacing: CGFloat) {

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -341,12 +341,14 @@ struct DeparturePickerView: View {
         let lines = code.map { SubwayLines.lines(forStationCode: $0) } ?? []
         HStack {
             HStack(spacing: 6) {
-                Text(displayName)
-                    .font(.body)
-                    .foregroundColor(.white)
-                    .textProtected()
-                SubwayLineChips(lines: lines, size: 14)
-                if let code { SystemChips(stationCode: code, size: 14) }
+                StationNameWithBadges(
+                    name: displayName,
+                    stationCode: code,
+                    subwayLines: lines,
+                    font: .body,
+                    foregroundColor: .white,
+                    chipSize: 14
+                )
                 Spacer()
                 Image(systemName: "chevron.right")
                     .font(TrackRatTheme.IconSize.xsmall)
@@ -398,14 +400,15 @@ struct DeparturePickerView: View {
             let lines = code.map { SubwayLines.lines(forStationCode: $0) } ?? []
             HStack {
                 HStack(spacing: 6) {
-                    Text(displayName)
-                        .font(.body)
-                        .foregroundColor(.white.opacity(0.7))
-                        .textProtected()
-
-                    SubwayLineChips(lines: lines, size: 14)
-                        .opacity(0.7)
-                    if let code { SystemChips(stationCode: code, size: 14).opacity(0.7) }
+                    StationNameWithBadges(
+                        name: displayName,
+                        stationCode: code,
+                        subwayLines: lines,
+                        font: .body,
+                        foregroundColor: .white.opacity(0.7),
+                        chipSize: 14,
+                        badgeOpacity: 0.7
+                    )
 
                     Spacer()
                     Image(systemName: "chevron.right")

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -294,14 +294,14 @@ struct DestinationPickerView: View {
         let code = Stations.getStationCode(station)
         HStack {
             HStack(spacing: 6) {
-                Text(Stations.displayName(for: station))
-                    .font(.body)
-                    .foregroundColor(.white)
-                    .textProtected()
-                if let code {
-                    SubwayLineChips(lines: SubwayLines.lines(forStationCode: code), size: 14)
-                    SystemChips(stationCode: code, size: 14)
-                }
+                StationNameWithBadges(
+                    name: Stations.displayName(for: station),
+                    stationCode: code,
+                    subwayLines: code.map { SubwayLines.lines(forStationCode: $0) } ?? [],
+                    font: .body,
+                    foregroundColor: .white,
+                    chipSize: 14
+                )
                 Spacer()
             }
 
@@ -334,20 +334,19 @@ struct DestinationPickerView: View {
     /// below the station name.
     @ViewBuilder
     private func otherSystemDestinationSearchRow(station: String, noRouteOrigin: String? = nil) -> some View {
+        let code = Stations.getStationCode(station)
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(Stations.displayName(for: station))
-                        .font(.body)
-                        .foregroundColor(.white.opacity(0.7))
-                        .textProtected()
-
-                    if let code = Stations.getStationCode(station) {
-                        SubwayLineChips(lines: SubwayLines.lines(forStationCode: code), size: 14)
-                            .opacity(0.7)
-                        SystemChips(stationCode: code, size: 14)
-                            .opacity(0.7)
-                    }
+                    StationNameWithBadges(
+                        name: Stations.displayName(for: station),
+                        stationCode: code,
+                        subwayLines: code.map { SubwayLines.lines(forStationCode: $0) } ?? [],
+                        font: .body,
+                        foregroundColor: .white.opacity(0.7),
+                        chipSize: 14,
+                        badgeOpacity: 0.7
+                    )
                 }
 
                 if let originName = noRouteOrigin {
@@ -443,15 +442,15 @@ struct FavoriteDestinationButton: View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(Stations.displayName(for: station.id))
-                        .font(.callout)
-                        .fontWeight(.medium)
-                        .foregroundColor(.white.opacity(isDimmed ? 0.7 : 1.0))
-                        .textProtected()
-                    SubwayLineChips(lines: SubwayLines.lines(forStationCode: station.id), size: 14)
-                        .opacity(isDimmed ? 0.7 : 1.0)
-                    SystemChips(stationCode: station.id, size: 14)
-                        .opacity(isDimmed ? 0.7 : 1.0)
+                    StationNameWithBadges(
+                        name: Stations.displayName(for: station.id),
+                        stationCode: station.id,
+                        subwayLines: SubwayLines.lines(forStationCode: station.id),
+                        font: .callout.weight(.medium),
+                        foregroundColor: .white.opacity(isDimmed ? 0.7 : 1.0),
+                        chipSize: 14,
+                        badgeOpacity: isDimmed ? 0.7 : 1.0
+                    )
                 }
 
                 if let originName = noRouteOrigin {

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -828,12 +828,14 @@ private struct FavoriteStationRow: View {
             }
 
             if let name = stationName, let code = stationCode {
-                Text(name)
-                    .font(.subheadline)
-                    .foregroundColor(.white)
-                    .lineLimit(1)
-                SubwayLineChips(lines: subwayLines, size: 13)
-                SystemChips(stationCode: code, size: 13)
+                StationNameWithBadges(
+                    name: name,
+                    stationCode: code,
+                    subwayLines: subwayLines,
+                    font: .subheadline,
+                    foregroundColor: .white,
+                    chipSize: 13
+                )
             } else if label != nil {
                 Text("Not set")
                     .font(.subheadline)

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -733,11 +733,14 @@ struct StopRowV2: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
-                    Text(Stations.displayName(for: stop.stationName))
-                        .font(.subheadline)
-                        .foregroundColor(textColor)
-
-                    SubwayLineChips(lines: stationLineBullets, size: 14)
+                    StationNameWithBadges(
+                        name: Stations.displayName(for: stop.stationName),
+                        subwayLines: stationLineBullets,
+                        font: .subheadline,
+                        foregroundColor: textColor,
+                        chipSize: 14,
+                        includeSystemChips: false
+                    )
 
                     if isCancelled {
                         Text("🚫")

--- a/ios/TrackRat/Views/Screens/TripSelectionView.swift
+++ b/ios/TrackRat/Views/Screens/TripSelectionView.swift
@@ -433,12 +433,14 @@ struct TripSelectionView: View {
         let lines = code.map { SubwayLines.lines(forStationCode: $0) } ?? []
         HStack {
             HStack(spacing: 6) {
-                Text(displayName)
-                    .font(.body)
-                    .foregroundColor(.white)
-                    .textProtected()
-                SubwayLineChips(lines: lines, size: 14)
-                if let code { SystemChips(stationCode: code, size: 14) }
+                StationNameWithBadges(
+                    name: displayName,
+                    stationCode: code,
+                    subwayLines: lines,
+                    font: .body,
+                    foregroundColor: .white,
+                    chipSize: 14
+                )
                 Spacer()
             }
 
@@ -473,14 +475,15 @@ struct TripSelectionView: View {
         let lines = code.map { SubwayLines.lines(forStationCode: $0) } ?? []
         HStack {
             HStack(spacing: 6) {
-                Text(displayName)
-                    .font(.body)
-                    .foregroundColor(.white.opacity(0.7))
-                    .textProtected()
-
-                SubwayLineChips(lines: lines, size: 14)
-                    .opacity(0.7)
-                if let code { SystemChips(stationCode: code, size: 14).opacity(0.7) }
+                StationNameWithBadges(
+                    name: displayName,
+                    stationCode: code,
+                    subwayLines: lines,
+                    font: .body,
+                    foregroundColor: .white.opacity(0.7),
+                    chipSize: 14,
+                    badgeOpacity: 0.7
+                )
 
                 Spacer()
             }
@@ -762,13 +765,14 @@ struct FavoriteStationButton: View {
             onTap()
         } label: {
             HStack {
-                Text(Stations.displayName(for: station.id))
-                    .font(.callout)
-                    .fontWeight(.medium)
-                    .foregroundColor(.white)
-
-                SubwayLineChips(lines: SubwayLines.lines(forStationCode: station.id), size: 14)
-                SystemChips(stationCode: station.id, size: 14)
+                StationNameWithBadges(
+                    name: Stations.displayName(for: station.id),
+                    stationCode: station.id,
+                    subwayLines: SubwayLines.lines(forStationCode: station.id),
+                    font: .callout.weight(.medium),
+                    foregroundColor: .white,
+                    chipSize: 14
+                )
 
                 Spacer()
 


### PR DESCRIPTION
## Summary

- Add a shared station name + badge SwiftUI layout that reserves at least half of the available row width for the station name.
- Wrap subway line and system badges inside a capped badge area so long subway bullet sets cannot squash the station label.
- Apply the shared layout across the iOS station picker, departure/destination search rows, favorite station rows, settings favorites, and train stop rows.

## Root Cause

Subway line bullets were rendered as a single unbreakable `HStack` beside the station label. In rows with many subway lines, that chip row could claim most of the horizontal space and force the station name to compress or collapse.

## Validation

- `git diff --check`
- Attempted iOS simulator build, but `xcodebuild` could not run because the active developer directory is Command Line Tools rather than a full Xcode install:
  `xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`