### PR TITLE
[codex] Fix rail-subway station equivalences for trip search

### DIFF
--- a/backend_v2/src/trackrat/config/stations/common.py
+++ b/backend_v2/src/trackrat/config/stations/common.py
@@ -106,6 +106,8 @@ STATION_EQUIVALENCE_GROUPS: list[set[str]] = [
     *SUBWAY_STATION_COMPLEXES,
     # PATH ↔ Subway cross-system equivalences (must be after SUBWAY_STATION_COMPLEXES
     # so the larger group overwrites the subway-only group for shared codes)
+    {"NY", "S128", "SA28"},  # Penn Station / 34 St-Penn Station
+    {"GCT", "S631", "S723", "S901"},  # Grand Central Terminal / Grand Central-42 St
     {"PWC", "S138", "S228", "SA36", "SE01", "SR25"},  # World Trade Center / Oculus
     # WMATA transfer stations (dual-platform codes for the same physical station)
     *[{a, b} for a, b in WMATA_TRANSFER_STATIONS],

--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -14,7 +14,7 @@ from datetime import date, datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
-from trackrat.config.stations import get_station_name
+from trackrat.config.stations import expand_station_codes, get_station_name
 from trackrat.config.transfer_points import (
     TransferPoint,
     get_intra_system_transfers,
@@ -107,6 +107,14 @@ def _filter_unreasonable_durations(trips: list[TripOption]) -> list[TripOption]:
     return [t for t in trips if t.total_duration_minutes <= max_reasonable]
 
 
+def _get_station_lines_expanded(station_code: str, system: str) -> frozenset[str]:
+    """Get line codes for a station and its physical-equivalent codes."""
+    lines: set[str] = set()
+    for code in expand_station_codes(station_code):
+        lines.update(get_station_lines(code, system))
+    return frozenset(lines)
+
+
 def _find_relevant_transfer_points(
     from_systems: set[str],
     to_systems: set[str],
@@ -144,8 +152,8 @@ def _find_relevant_transfer_points(
     if from_station and to_station:
         common_systems = from_systems & to_systems
         for system in common_systems:
-            origin_lines = get_station_lines(from_station, system)
-            dest_lines = get_station_lines(to_station, system)
+            origin_lines = _get_station_lines_expanded(from_station, system)
+            dest_lines = _get_station_lines_expanded(to_station, system)
             if origin_lines and dest_lines:
                 for tp in get_intra_system_transfers(system):
                     # One side must share lines with origin, other with dest
@@ -217,7 +225,7 @@ def _orient_transfer(
     """
     # Intra-system transfer: orient by line overlap with origin/destination
     if tp.system_a == tp.system_b and tp.lines_a and tp.lines_b and from_station:
-        origin_lines = get_station_lines(from_station, tp.system_a)
+        origin_lines = _get_station_lines_expanded(from_station, tp.system_a)
         if tp.lines_a & origin_lines:
             return tp.station_a, tp.system_a, tp.station_b, tp.system_b
         return tp.station_b, tp.system_b, tp.station_a, tp.system_a

--- a/backend_v2/tests/unit/config/test_stations.py
+++ b/backend_v2/tests/unit/config/test_stations.py
@@ -685,8 +685,8 @@ class TestStationEquivalences:
                 f"expected all of {sorted(expected_ts)}"
             )
 
-        # Grand Central-42 St: includes S901/GS shuttle
-        expected_gc = {"S631", "S723", "S901"}
+        # Grand Central-42 St: includes GCT commuter rail and S901/GS shuttle
+        expected_gc = {"GCT", "S631", "S723", "S901"}
         for code in expected_gc:
             result = expand_station_codes(code)
             assert set(result) == expected_gc, (
@@ -713,7 +713,7 @@ class TestStationEquivalences:
             ({"S119", "SA18"}, "103 St West Side (1 + A/B/C)"),
             ({"S120", "SA19"}, "96 St West Side (1/2/3 + A/B/C)"),
             ({"S126", "SA25"}, "50 St (1/2 + A/C/E)"),
-            ({"S128", "SA28"}, "34 St-Penn Station (1/2/3 + A/C/E)"),
+            ({"NY", "S128", "SA28"}, "Penn Station / 34 St-Penn Station"),
             (
                 {"S135", "S639", "SA34", "SM20", "SQ01", "SR23"},
                 "Canal St (1/2 + 4/6 + A/C/E + J/Z + Q + N/R/W)",
@@ -788,6 +788,32 @@ class TestStationEquivalences:
             f"Expected WTC cross-system complex {sorted(wtc_expected)} not found in "
             f"STATION_EQUIVALENCE_GROUPS"
         )
+
+    @pytest.mark.parametrize(
+        "expected_codes,description",
+        [
+            ({"NY", "S128", "SA28"}, "Penn Station / 34 St-Penn Station"),
+            (
+                {"GCT", "S631", "S723", "S901"},
+                "Grand Central Terminal / Grand Central-42 St",
+            ),
+        ],
+    )
+    def test_cross_system_rail_subway_complexes_in_equivalence_groups(
+        self, expected_codes, description
+    ):
+        """Major rail hubs should expand to connected subway complexes."""
+        found = False
+        for group in STATION_EQUIVALENCE_GROUPS:
+            if expected_codes.issubset(group):
+                found = True
+                break
+        assert found, (
+            f"Expected {description} complex {sorted(expected_codes)} not found in "
+            f"STATION_EQUIVALENCE_GROUPS"
+        )
+        for code in expected_codes:
+            assert set(expand_station_codes(code)) == expected_codes
 
     def test_unified_complexes_canonical_code_deterministic(self):
         """canonical_station_code is the same for all members of unified complexes."""

--- a/backend_v2/tests/unit/config/test_transfer_points.py
+++ b/backend_v2/tests/unit/config/test_transfer_points.py
@@ -447,6 +447,16 @@ class TestGetSubwayLinesAtStation:
         assert "L" in lines, "S635 is equivalent to SL03 which is on L"
         assert "N" in lines, "S635 is equivalent to SR20 which is on N/Q/R/W"
 
+    def test_penn_station_subway_lines_from_rail_code(self):
+        """NY should include 34 St-Penn subway lines through station equivalence."""
+        lines = get_subway_lines_at_station("NY")
+        assert {"1", "2", "3", "A", "C", "E"} <= set(lines)
+
+    def test_grand_central_subway_lines_from_rail_code(self):
+        """GCT should include Grand Central-42 St subway lines through equivalence."""
+        lines = get_subway_lines_at_station("GCT")
+        assert {"4", "5", "6", "7", "GS"} <= set(lines)
+
     def test_unknown_station_returns_empty(self):
         """Unknown station returns empty frozenset."""
         lines = get_subway_lines_at_station("ZZZZZ")
@@ -454,5 +464,5 @@ class TestGetSubwayLinesAtStation:
 
     def test_non_subway_station_returns_empty(self):
         """Non-subway station (NJT) returns empty frozenset."""
-        lines = get_subway_lines_at_station("NY")
+        lines = get_subway_lines_at_station("TR")
         assert lines == frozenset()

--- a/backend_v2/tests/unit/services/test_has_direct_route.py
+++ b/backend_v2/tests/unit/services/test_has_direct_route.py
@@ -70,6 +70,20 @@ class TestHasDirectRoute:
         Searching PNK to TR on NJT should find NJT NEC via the NP equivalence."""
         assert _has_direct_route("PNK", "TR", ["NJT"]) is True
 
+    def test_penn_subway_equivalence_finds_njt_route(self):
+        """34 St-Penn subway platforms should resolve to NY for NJT routes."""
+        assert _has_direct_route("TR", "S128", ["NJT"]) is True
+        assert _has_direct_route("TR", "SA28", ["NJT"]) is True
+
+    def test_grand_central_subway_equivalence_finds_mnr_route(self):
+        """Grand Central subway platforms should resolve to GCT for MNR routes."""
+        assert _has_direct_route("MSTM", "S631", ["MNR"]) is True
+        assert _has_direct_route("MSTM", "S723", ["MNR"]) is True
+
+    def test_union_square_is_not_grand_central_equivalent(self):
+        """S635 is 14 St-Union Sq, not Grand Central."""
+        assert _has_direct_route("MSTM", "S635", ["MNR"]) is False
+
     def test_lirr_route(self):
         """JAM (Jamaica) and BTA (Babylon) are on the LIRR Babylon branch."""
         assert _has_direct_route("JAM", "BTA", ["LIRR"]) is True

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -39,6 +39,7 @@ from trackrat.services.trip_search import (
     _filter_unreasonable_durations,
     _find_relevant_transfer_points,
     _get_best_time,
+    _get_station_lines_expanded,
     _make_direct_trip,
     _orient_transfer,
     _rank_transfer_points,
@@ -226,6 +227,37 @@ class TestFindRelevantTransferPoints:
             for tp in transfers
         ]
         assert len(keys) == len(set(keys)), "Duplicate transfers found"
+
+    def test_penn_station_rail_to_subway_transfer_found(self):
+        """NJT should transfer to the 34 St-Penn subway complex at NY Penn."""
+        transfers = _find_relevant_transfer_points(
+            {"NJT"}, {"SUBWAY"}, from_station="TR", to_station="S128"
+        )
+        station_pairs = {frozenset({tp.station_a, tp.station_b}) for tp in transfers}
+        assert frozenset({"NY", "S128"}) in station_pairs
+        assert frozenset({"NY", "SA28"}) in station_pairs
+
+    def test_grand_central_rail_to_subway_transfer_found(self):
+        """MNR should transfer to the Grand Central-42 St subway complex at GCT."""
+        transfers = _find_relevant_transfer_points(
+            {"MNR"}, {"SUBWAY"}, from_station="MSTM", to_station="S631"
+        )
+        station_pairs = {frozenset({tp.station_a, tp.station_b}) for tp in transfers}
+        assert frozenset({"GCT", "S631"}) in station_pairs
+        assert frozenset({"GCT", "S723"}) in station_pairs
+        assert frozenset({"GCT", "S901"}) in station_pairs
+
+
+class TestStationLinesExpanded:
+    """Test line lookup across physical station equivalences."""
+
+    def test_penn_station_rail_code_expands_to_subway_lines(self):
+        lines = _get_station_lines_expanded("NY", "SUBWAY")
+        assert {"1", "2", "3", "A", "C", "E"} <= set(lines)
+
+    def test_grand_central_rail_code_expands_to_subway_lines(self):
+        lines = _get_station_lines_expanded("GCT", "SUBWAY")
+        assert {"4", "5", "6", "7", "GS"} <= set(lines)
 
 
 class TestOrientTransfer:


### PR DESCRIPTION
## Summary

- Add corrected cross-system equivalence groups for Penn Station (`NY` ↔ `S128`/`SA28`) and Grand Central (`GCT` ↔ `S631`/`S723`/`S901`).
- Teach trip-search intra-system line lookup to consider expanded station codes, so rail hub codes can expose their connected subway lines where needed.
- Add focused regression coverage for direct-route detection, transfer discovery, station expansion, and subway line lookup.

## Notes

This is stacked on #1069 / issue #1062 because the remaining #1063 transfer-route failures depend on that branch's transfer-point ranking and higher transfer-query cap. I intentionally did not use the station-code guesses from the issue body where they conflict with the current backend config: `S125/S126/S127` are not Penn Station, and `S634/S635` are not Grand Central.

Closes #1063

## Validation

- `python3 -m py_compile` for the touched backend source/test files using the bundled Python 3.12 runtime.
- `git diff --check`

Tests were skipped at user request. Earlier test setup was blocked because local `poetry`, pytest, Black, Python 3.11, and Docker are not installed, and network dependency installation was not approved.