### PR TITLE
Fix subway boarding detection to always return false

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -421,10 +421,15 @@ struct CombinedDetailsCard: View {
     
     /// Check if train is boarding specifically at the user's origin station
     private var isBoardingAtOrigin: Bool {
+        // Subway has no track assignments and no meaningful boarding window
+        if train.dataSource == "SUBWAY" {
+            return false
+        }
+
         guard let departureCode = appState.departureStationCode else {
             return false
         }
-        
+
         // Simple track-based boarding detection
         return train.isBoardingAtStation(departureCode)
     }


### PR DESCRIPTION
## Summary
Updated the `isBoardingAtOrigin` computed property in `CombinedDetailsCard` to explicitly handle subway trains by returning `false`, since subway data lacks track assignments and meaningful boarding windows.

## Key Changes
- Added early return for subway trains (`train.dataSource == "SUBWAY"`) in the `isBoardingAtOrigin` property
- This prevents incorrect boarding detection logic from being applied to subway data, which doesn't have the same track-based boarding information as other transit types

## Implementation Details
The subway check is performed before the existing departure station code validation, ensuring that subway trains are handled correctly regardless of other conditions. This aligns with the reality that subway systems don't use track-based boarding assignments in the same way as other transit modes.

https://claude.ai/code/session_01FohGtGyS6TpgBgGYB2SH2M