### PR TITLE
Add status_code logging to WMATA API errors

### DIFF
--- a/backend_v2/src/trackrat/collectors/wmata/collector.py
+++ b/backend_v2/src/trackrat/collectors/wmata/collector.py
@@ -124,7 +124,12 @@ class WMATACollector:
         try:
             predictions = await self.client.get_all_predictions()
         except Exception as e:
-            logger.error("wmata_predictions_api_failed", error=str(e))
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            logger.error(
+                "wmata_predictions_api_failed",
+                error=str(e),
+                status_code=status_code,
+            )
             return {
                 "data_source": "WMATA",
                 "error": str(e),
@@ -202,10 +207,12 @@ class WMATACollector:
         try:
             predictions = await self.client.get_all_predictions()
         except Exception as e:
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
             logger.warning(
                 "wmata_jit_api_failed",
                 train_id=journey.train_id,
                 error=str(e),
+                status_code=status_code,
             )
             journey.api_error_count = (journey.api_error_count or 0) + 1
             if journey.api_error_count >= 3:

--- a/infra_v2/terraform/metrics.tf
+++ b/infra_v2/terraform/metrics.tf
@@ -144,9 +144,13 @@ resource "google_logging_metric" "provider_auth_failures" {
     "jsonPayload.level=~\"(error|warning)\"",
     format("(%s)", join(" OR ", [
       "(jsonPayload.event=\"njt_api_http_error\" AND (jsonPayload.status_code=401 OR jsonPayload.status_code=403))",
+      # NJT returns HTTP 200 with a null body when the API token is invalid (see
+      # collectors/njt/client.py:345). The daily getStationSchedule call is the
+      # canonical authenticated request and its non-list response surfaces here.
+      "(jsonPayload.event=\"invalid_schedule_response_type\" AND jsonPayload.response_type=\"NoneType\")",
       "(jsonPayload.event=\"metra_feed_http_error\" AND (jsonPayload.status_code=401 OR jsonPayload.status_code=403))",
       "(jsonPayload.event=\"mbta_feed_http_error\" AND (jsonPayload.status_code=401 OR jsonPayload.status_code=403))",
-      "(jsonPayload.event=~\"wmata_(predictions|jit)_api_failed\" AND jsonPayload.error=~\"(401|403|Unauthorized|Forbidden)\")",
+      "(jsonPayload.event=~\"wmata_(predictions|jit)_api_failed\" AND (jsonPayload.status_code=401 OR jsonPayload.status_code=403 OR jsonPayload.error=~\"(401|403|Unauthorized|Forbidden)\"))",
       "(jsonPayload.event=\"task_execution_failed\" AND jsonPayload.task=~\"(metra|wmata|mbta)_collection\" AND jsonPayload.error=~\"(401|403|Unauthorized|Forbidden|Invalid token|authentication failed)\")",
     ])),
   ])


### PR DESCRIPTION
## Summary
Enhanced error logging for WMATA API failures by extracting and logging HTTP status codes from exceptions, and updated the provider authentication failure metric to use the new status_code field for more reliable detection.

## Key Changes
- **WMATA Collector**: Modified exception handling in `collect()` and `_collect_journey_details_locked()` methods to extract and log the HTTP status code from API errors alongside the error message
- **Metrics Configuration**: Updated the `provider_auth_failures` logging metric to:
  - Use the new `status_code` field for WMATA API failures instead of relying on error message pattern matching
  - Added detection for NJT authentication failures (HTTP 200 with null body response)
  - Improved reliability of authentication failure detection across all providers

## Implementation Details
- Status code extraction uses safe attribute access (`getattr`) to handle cases where the exception may not have a response object
- The metric now checks for both `status_code=401/403` and legacy error message patterns for WMATA to maintain backward compatibility during transition
- Added explanatory comment in metrics.tf documenting NJT's non-standard authentication failure behavior

https://claude.ai/code/session_01RfuP6643gLipiNUZ5P1Moj