### PR TITLE
Fix StationNameWithBadges layout collapse on non-subway stops

### DIFF
--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -61,12 +61,15 @@ struct StationNameWithBadges: View {
     var includeSystemChips: Bool = true
 
     var body: some View {
+        // Don't wrap the Text in `.frame(maxWidth: .infinity)`: that makes its
+        // ideal-width report `.infinity`, which collapses the layout's resolved
+        // nameWidth to 0 and erases the station name whenever there are no
+        // badges (e.g. non-subway stops in TrainDetailsView).
         StationNameBadgesLayout(spacing: 6) {
             Text(name)
                 .font(font)
                 .foregroundColor(foregroundColor)
                 .textProtected()
-                .frame(maxWidth: .infinity, alignment: .leading)
 
             StationBadges(
                 stationCode: stationCode,

--- a/ios/TrackRatTests/BuildTests.swift
+++ b/ios/TrackRatTests/BuildTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftUI
 @testable import TrackRat
 
 class BuildTests: XCTestCase {
@@ -65,5 +66,59 @@ class BuildTests: XCTestCase {
         // Test that LiveActivityService can be instantiated
         let liveActivityService = LiveActivityService.shared
         XCTAssertNotNil(liveActivityService)
+    }
+}
+
+/// Regression tests for `StationNameWithBadges`. The component's custom
+/// `StationNameBadgesLayout` once collapsed to zero size when the badge
+/// subview was empty — i.e. on every non-subway stop in TrainDetailsView —
+/// because the inner `Text` was wrapped in `.frame(maxWidth: .infinity)`,
+/// making its ideal width report `.infinity` and the layout's defensive
+/// `resolvedWidth` clamp return 0. These tests host the view in a flexible
+/// HStack (the same arrangement that exercises the unspecified-proposal
+/// measurement pass) and assert the rendered size is non-zero.
+@MainActor
+class StationNameWithBadgesLayoutTests: XCTestCase {
+
+    func testRendersNameWhenBadgesAreEmpty() {
+        let view = HStack(spacing: 12) {
+            StationNameWithBadges(
+                name: "Princeton Junction",
+                subwayLines: [],
+                font: .subheadline,
+                chipSize: 14,
+                includeSystemChips: false
+            )
+            Spacer()
+        }
+
+        let host = UIHostingController(rootView: view)
+        host.view.frame = CGRect(x: 0, y: 0, width: 320, height: 100)
+        host.view.layoutIfNeeded()
+
+        let fitted = host.sizeThatFits(in: CGSize(width: 320, height: .greatestFiniteMagnitude))
+        XCTAssertGreaterThan(
+            fitted.height, 10,
+            "Station name with no badges must contribute non-zero height (regression: TrainDetailsView non-subway stops rendered no station name)"
+        )
+    }
+
+    func testRendersNameWhenBadgesArePresent() {
+        let view = HStack(spacing: 12) {
+            StationNameWithBadges(
+                name: "Times Sq-42 St",
+                subwayLines: ["1", "2", "3", "N", "Q", "R"],
+                font: .subheadline,
+                chipSize: 14
+            )
+            Spacer()
+        }
+
+        let host = UIHostingController(rootView: view)
+        host.view.frame = CGRect(x: 0, y: 0, width: 320, height: 100)
+        host.view.layoutIfNeeded()
+
+        let fitted = host.sizeThatFits(in: CGSize(width: 320, height: .greatestFiniteMagnitude))
+        XCTAssertGreaterThan(fitted.height, 10, "Subway stop with chips must also render with positive height")
     }
 }


### PR DESCRIPTION
## Summary
Fixed a layout regression in `StationNameWithBadges` where the station name would disappear on non-subway stops (when badges are empty) due to incorrect frame constraints in the custom layout.

## Changes
- **Removed problematic `.frame(maxWidth: .infinity)` constraint** from the station name `Text` in `StationNameWithBadges`. This constraint was causing the text's ideal width to report `.infinity`, which made the layout's `resolvedWidth` clamp to 0, effectively erasing the station name whenever there were no badges.
- **Added comprehensive regression tests** in `StationNameWithBadgesLayoutTests` to prevent this issue from recurring:
  - `testRendersNameWhenBadgesAreEmpty()`: Verifies station names render correctly on non-subway stops
  - `testRendersNameWhenBadgesArePresent()`: Verifies station names still render correctly when badges are present
- **Added detailed code comments** explaining the layout behavior and why the frame constraint was problematic

## Implementation Details
The tests host the component in a flexible `HStack` with a `Spacer()` (the same arrangement used in `TrainDetailsView`) and measure the rendered size to ensure it's non-zero. This exercises the unspecified-proposal measurement pass that was exposing the layout bug.

https://claude.ai/code/session_01LuyRFvZQAmTCJ8o3ER7Sot