### PR TITLE
Make text protection optional in StationNameWithBadges

### DIFF
--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -59,6 +59,10 @@ struct StationNameWithBadges: View {
     var chipSize: CGFloat = 14
     var badgeOpacity: Double = 1
     var includeSystemChips: Bool = true
+    /// When true, the name uses `textProtected()` (one line, scales to 75%).
+    /// Set false to render at the full font size with no line limit, matching
+    /// callers whose original plain `Text` had neither modifier.
+    var protectText: Bool = true
 
     var body: some View {
         // Don't wrap the Text in `.frame(maxWidth: .infinity)`: that makes its
@@ -69,7 +73,8 @@ struct StationNameWithBadges: View {
             Text(name)
                 .font(font)
                 .foregroundColor(foregroundColor)
-                .textProtected()
+                .lineLimit(protectText ? 1 : nil)
+                .minimumScaleFactor(protectText ? 0.75 : 1.0)
 
             StationBadges(
                 stationCode: stationCode,

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -755,7 +755,8 @@ struct StopRowV2: View {
                         font: .subheadline,
                         foregroundColor: textColor,
                         chipSize: 14,
-                        includeSystemChips: false
+                        includeSystemChips: false,
+                        protectText: false
                     )
 
                     if isCancelled {


### PR DESCRIPTION
## Summary
Refactored `StationNameWithBadges` to make text protection behavior configurable via a new `protectText` parameter, allowing callers to choose between constrained single-line text with scaling or unrestricted multi-line text at full font size.

## Changes
- Added `protectText` parameter (default `true`) to `StationNameWithBadges` to control text rendering behavior
- Replaced hardcoded `.textProtected()` modifier with conditional logic:
  - When `protectText: true` → applies `lineLimit(1)` and `minimumScaleFactor(0.75)` (original behavior)
  - When `protectText: false` → no line limit and full font size scaling (1.0)
- Updated `StopRowV2` to pass `protectText: false` when creating `StationNameWithBadges`, matching the original plain `Text` behavior without modifiers

## Implementation Details
The change maintains backward compatibility by defaulting `protectText` to `true`, preserving existing behavior for all current callers except `StopRowV2`, which explicitly opts into the new unrestricted text rendering mode.

https://claude.ai/code/session_012DRSZbg9FM4sSQGW89eh9Y