### PR TITLE
[codex] restore train details station label sizing

### DIFF
--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -48,6 +48,13 @@ struct SubwayLineChips: View {
     }
 }
 
+enum StationNameTextBehavior {
+    /// Search and picker rows should stay compact beside trailing controls.
+    case protectedSingleLine
+    /// Train detail stop rows should match plain `Text` sizing and wrapping.
+    case natural
+}
+
 /// Station labels with their transit badges. The badge area is constrained to
 /// half of the available width and wraps, so the station name keeps priority.
 struct StationNameWithBadges: View {
@@ -59,42 +66,60 @@ struct StationNameWithBadges: View {
     var chipSize: CGFloat = 14
     var badgeOpacity: Double = 1
     var includeSystemChips: Bool = true
+    var textBehavior: StationNameTextBehavior = .protectedSingleLine
 
-    var body: some View {
-        // Don't wrap the Text in `.frame(maxWidth: .infinity)`: that makes its
-        // ideal-width report `.infinity`, which collapses the layout's resolved
-        // nameWidth to 0 and erases the station name whenever there are no
-        // badges (e.g. non-subway stops in TrainDetailsView).
-        StationNameBadgesLayout(spacing: 6) {
-            Text(name)
-                .font(font)
-                .foregroundColor(foregroundColor)
-                .textProtected()
-
-            StationBadges(
-                stationCode: stationCode,
-                subwayLines: subwayLines,
-                size: chipSize,
-                includeSystemChips: includeSystemChips
-            )
-            .opacity(badgeOpacity)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct StationBadges: View {
-    let stationCode: String?
-    let subwayLines: [String]
-    var size: CGFloat
-    var includeSystemChips: Bool
-
-    private var systems: [TrainSystem] {
+    private var systemBadges: [TrainSystem] {
         guard includeSystemChips, let stationCode else { return [] }
         return Stations.systemsForStation(stationCode)
             .filter { $0 != .subway }
             .sorted { $0.chipLabel < $1.chipLabel }
     }
+
+    private var hasBadges: Bool {
+        !subwayLines.isEmpty || !systemBadges.isEmpty
+    }
+
+    @ViewBuilder
+    var body: some View {
+        if hasBadges {
+            StationNameBadgesLayout(spacing: 6) {
+                stationText
+
+                StationBadges(
+                    subwayLines: subwayLines,
+                    systems: systemBadges,
+                    size: chipSize
+                )
+                .opacity(badgeOpacity)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            // Keep plain station labels out of the badge layout entirely.
+            stationText
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var stationText: some View {
+        switch textBehavior {
+        case .protectedSingleLine:
+            Text(name)
+                .font(font)
+                .foregroundColor(foregroundColor)
+                .textProtected()
+        case .natural:
+            Text(name)
+                .font(font)
+                .foregroundColor(foregroundColor)
+        }
+    }
+}
+
+private struct StationBadges: View {
+    let subwayLines: [String]
+    let systems: [TrainSystem]
+    var size: CGFloat
 
     var body: some View {
         if !subwayLines.isEmpty || !systems.isEmpty {

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -755,7 +755,8 @@ struct StopRowV2: View {
                         font: .subheadline,
                         foregroundColor: textColor,
                         chipSize: 14,
-                        includeSystemChips: false
+                        includeSystemChips: false,
+                        textBehavior: .natural
                     )
 
                     if isCancelled {

--- a/ios/TrackRatTests/BuildTests.swift
+++ b/ios/TrackRatTests/BuildTests.swift
@@ -121,4 +121,44 @@ class StationNameWithBadgesLayoutTests: XCTestCase {
         let fitted = host.sizeThatFits(in: CGSize(width: 320, height: .greatestFiniteMagnitude))
         XCTAssertGreaterThan(fitted.height, 10, "Subway stop with chips must also render with positive height")
     }
+
+    func testNaturalTextBehaviorKeepsTrainDetailsStationNamesUnscaled() {
+        let stationName = "Princeton Junction Station With A Long Display Name"
+        let width: CGFloat = 120
+
+        let protected = StationNameWithBadges(
+            name: stationName,
+            subwayLines: [],
+            font: .subheadline,
+            chipSize: 14,
+            includeSystemChips: false
+        )
+        .frame(width: width)
+
+        let natural = StationNameWithBadges(
+            name: stationName,
+            subwayLines: [],
+            font: .subheadline,
+            chipSize: 14,
+            includeSystemChips: false,
+            textBehavior: .natural
+        )
+        .frame(width: width)
+
+        let protectedHeight = fittedHeight(for: protected, width: width)
+        let naturalHeight = fittedHeight(for: natural, width: width)
+
+        XCTAssertGreaterThan(
+            naturalHeight,
+            protectedHeight + 6,
+            "TrainDetailsView station names should keep the old natural Text behavior instead of shrinking like protected picker rows"
+        )
+    }
+
+    private func fittedHeight<V: View>(for view: V, width: CGFloat) -> CGFloat {
+        let host = UIHostingController(rootView: view)
+        host.view.frame = CGRect(x: 0, y: 0, width: width, height: 200)
+        host.view.layoutIfNeeded()
+        return host.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude)).height
+    }
 }


### PR DESCRIPTION
## Summary

- Add an explicit station-name text behavior for labels with badges.
- Keep search, picker, and favorite station rows on the existing protected single-line behavior.
- Restore TrainDetailsView stop names to natural plain-Text sizing across all train systems.
- Skip the custom badge layout entirely when a station label has no badges, so non-subway stop labels no longer flow through badge-specific measurement logic.
- Add a regression test covering natural Train Details label behavior versus protected picker behavior.

## Root Cause

The station badge wrapping change migrated TrainDetailsView stop names from plain `Text(...).font(.subheadline)` into `StationNameWithBadges`. That shared component applies `textProtected()`, which adds a one-line limit and minimum scale factor. After the zero-width non-subway regression was fixed, those stop names became visible again but could render at a smaller scaled size than before.

## Impact

Train detail stop names now use the same natural text sizing for subway and non-subway systems, while station search and picker surfaces keep their compact protected labels.

## Validation

- `git diff --check`
- `swiftc -parse ios/TrackRat/Views/Components/SubwayLineChips.swift`
- `swiftc -parse ios/TrackRat/Views/Screens/TrainDetailsView.swift`
- `swiftc -parse ios/TrackRatTests/BuildTests.swift`

Could not run full `xcodebuild` locally because the active developer directory is Command Line Tools rather than full Xcode.