### PR TITLE
[codex] balance subway stop badge wrapping

### DIFF
--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -14,10 +14,17 @@ struct SubwayLineChips: View {
     /// `.subheadline` text. Use a smaller value in tight contexts (e.g. compact
     /// list rows) or larger in headers.
     var size: CGFloat = 16
+    var rowAlignment: WrappingRowAlignment = .leading
+    var rowDistribution: WrappingRowDistribution = .greedy
 
     var body: some View {
         if !lines.isEmpty {
-            WrappingHStackLayout(spacing: 3, rowSpacing: 3) {
+            WrappingHStackLayout(
+                spacing: 3,
+                rowSpacing: 3,
+                rowAlignment: rowAlignment,
+                rowDistribution: rowDistribution
+            ) {
                 ForEach(lines, id: \.self) { line in
                     SubwayLineChip(line: line, size: size)
                 }
@@ -46,6 +53,16 @@ struct SubwayLineChips: View {
         let brightness = (Double(r) * 299 + Double(g) * 587 + Double(b) * 114) / 1000
         return brightness > 150 ? .black : .white
     }
+}
+
+enum WrappingRowAlignment {
+    case leading
+    case trailing
+}
+
+enum WrappingRowDistribution {
+    case greedy
+    case balanced
 }
 
 enum StationNameTextBehavior {
@@ -237,6 +254,8 @@ private struct StationNameBadgesLayout: Layout {
 private struct WrappingHStackLayout: Layout {
     var spacing: CGFloat
     var rowSpacing: CGFloat
+    var rowAlignment: WrappingRowAlignment = .leading
+    var rowDistribution: WrappingRowDistribution = .greedy
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
         let rows = rows(for: subviews, maxWidth: proposal.width)
@@ -249,6 +268,13 @@ private struct WrappingHStackLayout: Layout {
 
         for row in rows.items {
             var x = bounds.minX
+            switch rowAlignment {
+            case .leading:
+                break
+            case .trailing:
+                x = bounds.maxX - row.width
+            }
+
             for item in row.items {
                 subviews[item.index].place(
                     at: CGPoint(x: x, y: y),
@@ -261,24 +287,17 @@ private struct WrappingHStackLayout: Layout {
     }
 
     private func rows(for subviews: Subviews, maxWidth: CGFloat?) -> (items: [Row], width: CGFloat, height: CGFloat) {
-        let availableWidth = maxWidth ?? .greatestFiniteMagnitude
-        var rows: [Row] = []
-        var current = Row()
-
-        for index in subviews.indices {
-            let size = subviews[index].sizeThatFits(.unspecified)
-            let nextWidth = current.items.isEmpty ? size.width : current.width + spacing + size.width
-
-            if !current.items.isEmpty && nextWidth > availableWidth {
-                rows.append(current)
-                current = Row()
-            }
-
-            current.append(Item(index: index, size: size), spacing: spacing)
+        let availableWidth = maxWidth.flatMap { $0.isFinite ? max(0, $0) : nil } ?? .greatestFiniteMagnitude
+        let measuredItems = subviews.indices.map { index in
+            Item(index: index, size: subviews[index].sizeThatFits(.unspecified))
         }
 
-        if !current.items.isEmpty {
-            rows.append(current)
+        let rows: [Row]
+        switch rowDistribution {
+        case .greedy:
+            rows = greedyRows(for: measuredItems, availableWidth: availableWidth)
+        case .balanced:
+            rows = balancedRows(for: measuredItems, availableWidth: availableWidth)
         }
 
         let width = min(rows.map(\.width).max() ?? 0, availableWidth)
@@ -287,6 +306,65 @@ private struct WrappingHStackLayout: Layout {
         } + CGFloat(max(0, rows.count - 1)) * rowSpacing
 
         return (rows, width, height)
+    }
+
+    private func greedyRows(for items: [Item], availableWidth: CGFloat) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+
+        for item in items {
+            let nextWidth = current.items.isEmpty ? item.size.width : current.width + spacing + item.size.width
+
+            if !current.items.isEmpty && nextWidth > availableWidth {
+                rows.append(current)
+                current = Row()
+            }
+
+            current.append(item, spacing: spacing)
+        }
+
+        if !current.items.isEmpty {
+            rows.append(current)
+        }
+
+        return rows
+    }
+
+    private func balancedRows(for items: [Item], availableWidth: CGFloat) -> [Row] {
+        let greedy = greedyRows(for: items, availableWidth: availableWidth)
+        guard greedy.count > 1 else { return greedy }
+
+        for rowCount in greedy.count...items.count {
+            let rows = rowsWithEvenCounts(for: items, rowCount: rowCount)
+            if rows.allSatisfy({ $0.width <= availableWidth }) {
+                return rows
+            }
+        }
+
+        return greedy
+    }
+
+    private func rowsWithEvenCounts(for items: [Item], rowCount: Int) -> [Row] {
+        guard rowCount > 0 else { return [] }
+
+        let baseCount = items.count / rowCount
+        let extraRows = items.count % rowCount
+        var rows: [Row] = []
+        var index = 0
+
+        for rowIndex in 0..<rowCount {
+            let count = baseCount + (rowIndex < extraRows ? 1 : 0)
+            guard count > 0 else { continue }
+
+            var row = Row()
+            for item in items[index..<(index + count)] {
+                row.append(item, spacing: spacing)
+            }
+            rows.append(row)
+            index += count
+        }
+
+        return rows
     }
 
     private struct Item {

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -740,6 +740,90 @@ struct StopRowV2: View {
         return "" // Don't show anything for on-time or 1 minute early
     }
     
+    private var stopTimes: (arrival: String?, departure: String?) {
+        let display = enhancedTimeDisplay
+        return (display.arrival, display.departure)
+    }
+
+    private var hasTimingText: Bool {
+        let times = stopTimes
+        return times.arrival != nil || times.departure != nil
+    }
+
+    @ViewBuilder
+    private var stationHeader: some View {
+        HStack(spacing: 6) {
+            Text(Stations.displayName(for: stop.stationName))
+                .font(.subheadline)
+                .foregroundColor(textColor)
+
+            if isCancelled {
+                Text("🚫")
+                    .font(.subheadline)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var timingText: some View {
+        let times = stopTimes
+
+        VStack(alignment: .leading, spacing: 2) {
+            if let arrivalText = times.arrival {
+                Text(arrivalText)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(timeColor)
+            }
+
+            if let departureText = times.departure {
+                Text(departureText)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(timeColor)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var stationAndTiming: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            stationHeader
+
+            if hasTimingText {
+                timingText
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var layoutTimingText: some View {
+        if hasTimingText {
+            timingText
+        } else {
+            Color.clear.frame(width: 0, height: 0)
+        }
+    }
+
+    @ViewBuilder
+    private var stationContent: some View {
+        if stationLineBullets.isEmpty {
+            stationAndTiming
+        } else {
+            StopTextBadgesLayout(spacing: 6) {
+                stationHeader
+                layoutTimingText
+
+                SubwayLineChips(
+                    lines: stationLineBullets,
+                    size: 14,
+                    rowAlignment: .trailing,
+                    rowDistribution: .balanced
+                )
+            }
+        }
+    }
+
     var body: some View {
         HStack(spacing: 12) {
             // Stop indicator
@@ -747,42 +831,8 @@ struct StopRowV2: View {
                 .fill(stopColor)
                 .frame(width: 12, height: 12)
             
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    StationNameWithBadges(
-                        name: Stations.displayName(for: stop.stationName),
-                        subwayLines: stationLineBullets,
-                        font: .subheadline,
-                        foregroundColor: textColor,
-                        chipSize: 14,
-                        includeSystemChips: false,
-                        textBehavior: .natural
-                    )
-
-                    if isCancelled {
-                        Text("🚫")
-                            .font(.subheadline)
-                    }
-                }
-                
-                VStack(alignment: .leading, spacing: 2) {
-                    if let arrivalText = enhancedTimeDisplay.arrival {
-                        Text(arrivalText)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundColor(timeColor)
-                    }
-                    
-                    if let departureText = enhancedTimeDisplay.departure {
-                        Text(departureText)
-                            .font(.caption)
-                            .fontWeight(.medium)
-                            .foregroundColor(timeColor)
-                    }
-                }
-            }
-            
-            Spacer()
+            stationContent
+                .frame(maxWidth: .infinity, alignment: .leading)
             
             // Show prediction if available and samples > 0
             if let predictedArrival = stop.predictedArrival,
@@ -857,6 +907,92 @@ struct StopRowV2: View {
         if isCancelled { return .clear }
         if isNextImportantStation { return Color(red: 1.0, green: 0.584, blue: 0.0).opacity(0.1) }
         return .clear
+    }
+}
+
+private struct StopTextBadgesLayout: Layout {
+    var spacing: CGFloat
+    var textSpacing: CGFloat = 4
+    var maxBadgeWidthRatio: CGFloat = 0.5
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        guard subviews.count == 3 else { return .zero }
+
+        let proposedWidth = resolvedWidth(proposal.width, fallback: idealWidth(for: subviews))
+        let sizes = measuredSizes(for: subviews, width: proposedWidth)
+
+        return CGSize(
+            width: proposedWidth,
+            height: max(sizes.textHeight, sizes.badges.height)
+        )
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        guard subviews.count == 3 else { return }
+
+        let width = resolvedWidth(bounds.width, fallback: idealWidth(for: subviews))
+        let sizes = measuredSizes(for: subviews, width: width)
+        let centeredBadgeY = bounds.minY + (sizes.header.height - sizes.badges.height) / 2
+        let badgesY = sizes.badges.height <= sizes.header.height ? centeredBadgeY : bounds.minY
+
+        subviews[0].place(
+            at: CGPoint(x: bounds.minX, y: bounds.minY),
+            proposal: ProposedViewSize(width: sizes.textWidth, height: sizes.header.height)
+        )
+
+        subviews[1].place(
+            at: CGPoint(x: bounds.minX, y: bounds.minY + sizes.header.height + sizes.textSpacing),
+            proposal: ProposedViewSize(width: sizes.textWidth, height: sizes.timing.height)
+        )
+
+        subviews[2].place(
+            at: CGPoint(x: bounds.maxX - sizes.badges.width, y: badgesY),
+            proposal: ProposedViewSize(width: sizes.badges.width, height: sizes.badges.height)
+        )
+    }
+
+    private func measuredSizes(
+        for subviews: Subviews,
+        width: CGFloat
+    ) -> (header: CGSize, timing: CGSize, badges: CGSize, textWidth: CGFloat, textHeight: CGFloat, textSpacing: CGFloat) {
+        let unconstrainedBadges = subviews[2].sizeThatFits(.unspecified)
+        let hasBadges = unconstrainedBadges.width > 0 && unconstrainedBadges.height > 0
+        let activeSpacing = hasBadges ? spacing : 0
+        let contentWidth = max(0, width - activeSpacing)
+        let badgeMaxWidth = hasBadges ? contentWidth * maxBadgeWidthRatio : 0
+        let badges = hasBadges
+            ? subviews[2].sizeThatFits(ProposedViewSize(width: badgeMaxWidth, height: nil))
+            : .zero
+        let badgeWidth = min(badges.width, badgeMaxWidth)
+        let textWidth = hasBadges ? max(0, contentWidth - badgeWidth) : width
+        let header = subviews[0].sizeThatFits(ProposedViewSize(width: textWidth, height: nil))
+        let timing = subviews[1].sizeThatFits(ProposedViewSize(width: textWidth, height: nil))
+        let activeTextSpacing = timing.width > 0 && timing.height > 0 ? textSpacing : 0
+        let textHeight = header.height + activeTextSpacing + timing.height
+
+        return (
+            CGSize(width: textWidth, height: header.height),
+            CGSize(width: textWidth, height: timing.height),
+            CGSize(width: badgeWidth, height: badges.height),
+            textWidth,
+            textHeight,
+            activeTextSpacing
+        )
+    }
+
+    private func resolvedWidth(_ width: CGFloat?, fallback: CGFloat) -> CGFloat {
+        guard let width, width.isFinite else {
+            return fallback.isFinite ? max(0, fallback) : 0
+        }
+        return max(0, width)
+    }
+
+    private func idealWidth(for subviews: Subviews) -> CGFloat {
+        let header = subviews[0].sizeThatFits(.unspecified)
+        let timing = subviews[1].sizeThatFits(.unspecified)
+        let badges = subviews[2].sizeThatFits(.unspecified)
+        let activeSpacing = badges.width > 0 && badges.height > 0 ? spacing : 0
+        return max(header.width, timing.width) + activeSpacing + badges.width
     }
 }
 


### PR DESCRIPTION
## Summary

- Add default-preserving wrapping options to `SubwayLineChips` for trailing alignment and balanced wrapped rows.
- Update Train Details stop rows so subway badges, station names, and timing text are measured together.
- Keep single-row badges aligned with the station name while allowing wrapped badges to use the station/timing block height.

## Root Cause

When a stop had enough subway bullets to wrap, the badge block lived inside the station-name layout only. That made the station-name row grow taller while the arrival/departure time row underneath stayed independent, producing uneven whitespace. The existing wrapping layout also used greedy leading rows, so wrapped subway bullets filled the first row and left-align overflow.

## Impact

Subway stop rows should look more consistent when a station serves many subway lines: wrapped bullets stay right-aligned, split more evenly across rows, and no longer inflate only the station-name line. Existing picker/search/favorite badge layouts keep their default leading greedy wrapping behavior.

## Validation

- `git diff --check`
- `swiftc -parse ios/TrackRat/Views/Components/SubwayLineChips.swift`
- `swiftc -parse ios/TrackRat/Views/Screens/TrainDetailsView.swift`

Could not run full `xcodebuild` locally because the active developer directory is Command Line Tools and the `iphoneos` SDK is unavailable.