### PR TITLE
Improve subway line chips layout alignment and positioning

### DIFF
--- a/ios/TrackRat/Views/Components/SubwayLineChips.swift
+++ b/ios/TrackRat/Views/Components/SubwayLineChips.swift
@@ -140,7 +140,12 @@ private struct StationBadges: View {
 
     var body: some View {
         if !subwayLines.isEmpty || !systems.isEmpty {
-            WrappingHStackLayout(spacing: 3, rowSpacing: 3) {
+            WrappingHStackLayout(
+                spacing: 3,
+                rowSpacing: 3,
+                rowAlignment: .trailing,
+                rowDistribution: .balanced
+            ) {
                 ForEach(subwayLines, id: \.self) { line in
                     SubwayLineChip(line: line, size: size)
                 }
@@ -211,7 +216,7 @@ private struct StationNameBadgesLayout: Layout {
         )
 
         subviews[1].place(
-            at: CGPoint(x: bounds.minX + sizes.name.width + sizes.spacing, y: badgesY),
+            at: CGPoint(x: bounds.maxX - sizes.badges.width, y: badgesY),
             proposal: ProposedViewSize(width: sizes.badges.width, height: sizes.badges.height)
         )
     }


### PR DESCRIPTION
## Summary
This PR improves the layout and alignment of subway line chips in the station badges view by adding explicit layout parameters and fixing the horizontal positioning logic.

## Key Changes
- **Enhanced WrappingHStackLayout configuration**: Added `rowAlignment: .trailing` and `rowDistribution: .balanced` parameters to the `WrappingHStackLayout` in `StationBadges` for better visual alignment and distribution of subway line chips across rows
- **Fixed badge positioning logic**: Changed the x-coordinate calculation in `StationNameBadgesLayout` from a left-aligned approach (`bounds.minX + sizes.name.width + sizes.spacing`) to a right-aligned approach (`bounds.maxX - sizes.badges.width`), ensuring badges are properly positioned at the trailing edge of the available space

## Implementation Details
The positioning fix ensures that badges maintain consistent right alignment regardless of the name width, providing a more predictable and visually balanced layout. The layout distribution parameters help optimize how chips wrap across multiple rows.

https://claude.ai/code/session_018Wv7hj5FnX6NFRLs7YB4Wt