### PR TITLE
[codex] Fix phantom stop propagation

### DIFF
--- a/backend_v2/src/trackrat/collectors/bart/collector.py
+++ b/backend_v2/src/trackrat/collectors/bart/collector.py
@@ -17,6 +17,7 @@ from trackrat.collectors.mta_common import (
     JOURNEY_UPDATE_LOAD_OPTIONS,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     select_matching_trip,
     update_journey_metadata,
     update_stop_departure_status,
@@ -453,14 +454,9 @@ class BARTCollector:
         # Find arrivals that match this journey's stops
         journey_station_codes = {s.station_code for s in journey.stops}
 
-        # Group by trip_id
-        matching_trips: dict[str, list[BartArrival]] = {}
-        for arr in arrivals:
-            if arr.station_code not in journey_station_codes:
-                continue
-            if arr.trip_id not in matching_trips:
-                matching_trips[arr.trip_id] = []
-            matching_trips[arr.trip_id].append(arr)
+        matching_trips = group_candidate_trips_by_overlap(
+            arrivals, journey_station_codes
+        )
 
         best_trip = select_matching_trip(
             matching_trips,

--- a/backend_v2/src/trackrat/collectors/bart/collector.py
+++ b/backend_v2/src/trackrat/collectors/bart/collector.py
@@ -17,6 +17,7 @@ from trackrat.collectors.mta_common import (
     JOURNEY_UPDATE_LOAD_OPTIONS,
     build_complete_stops,
     check_journey_completed,
+    select_matching_trip,
     update_journey_metadata,
     update_stop_departure_status,
 )
@@ -379,7 +380,7 @@ class BARTCollector:
             await session.flush()
             now = now_et()
             update_stop_departure_status(created_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, created_stops)
             check_journey_completed(journey, created_stops)
 
             # Analyze segments for congestion data
@@ -421,7 +422,7 @@ class BARTCollector:
             )
             journey_stops = list(stop_result.scalars().all())
             update_stop_departure_status(journey_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, journey_stops)
             check_journey_completed(journey, journey_stops)
 
             # Analyze segments for congestion data
@@ -461,37 +462,13 @@ class BARTCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Exact match: regenerate train_id from each candidate trip_id
-        best_trip: list[BartArrival] | None = None
-        for trip_id_candidate, trip_arrivals in matching_trips.items():
-            if _generate_train_id(trip_id_candidate) == journey.train_id:
-                best_trip = trip_arrivals
-                break
-
-        # Fuzzy fallback: station overlap + time proximity
-        if best_trip is None:
-            best_overlap = 0
-            best_time_diff = float("inf")
-
-            for trip_arrivals in matching_trips.values():
-                trip_stations = {a.station_code for a in trip_arrivals}
-                overlap = len(trip_stations & journey_station_codes)
-
-                time_diff = float("inf")
-                if journey.scheduled_departure:
-                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                    time_diff = abs(
-                        (
-                            first_arr.arrival_time - journey.scheduled_departure
-                        ).total_seconds()
-                    )
-
-                if overlap > best_overlap or (
-                    overlap == best_overlap and time_diff < best_time_diff
-                ):
-                    best_overlap = overlap
-                    best_time_diff = time_diff
-                    best_trip = trip_arrivals
+        best_trip = select_matching_trip(
+            matching_trips,
+            journey,
+            journey_station_codes,
+            _generate_train_id,
+            "BART",
+        )
 
         if not best_trip:
             logger.debug(f"No matching BART trip found for journey {journey.train_id}")
@@ -531,7 +508,7 @@ class BARTCollector:
         )
         journey_stops = list(stop_result.scalars().all())
         update_stop_departure_status(journey_stops, now)
-        update_journey_metadata(journey, now)
+        update_journey_metadata(journey, now, journey_stops)
         check_journey_completed(journey, journey_stops)
 
         logger.debug(f"JIT updated BART journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -20,6 +20,7 @@ from trackrat.collectors.mta_common import (
     build_complete_stops,
     check_journey_completed,
     infer_missing_origin,
+    select_matching_trip,
     set_stop_track,
     update_journey_metadata,
     update_stop_departure_status,
@@ -487,7 +488,7 @@ class LIRRCollector:
             await session.flush()
             now = now_et()
             update_stop_departure_status(created_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, created_stops)
             check_journey_completed(journey, created_stops)
 
             logger.debug(f"Discovered LIRR train {train_id}")
@@ -520,7 +521,7 @@ class LIRRCollector:
             now = now_et()
             journey_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
             update_stop_departure_status(journey_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, journey_stops)
             check_journey_completed(journey, journey_stops)
 
             logger.debug(f"Updated LIRR train {train_id}")
@@ -558,41 +559,13 @@ class LIRRCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Exact match: regenerate train_id from each candidate trip_id
-        # and compare against the stored train_id. This avoids the fuzzy
-        # matching bug where trains on the same branch with identical
-        # station sets and close departure times get swapped.
-        best_trip: list[LirrArrival] | None = None
-        for trip_id_candidate, trip_arrivals in matching_trips.items():
-            if _generate_train_id(trip_id_candidate) == journey.train_id:
-                best_trip = trip_arrivals
-                break
-
-        # Fuzzy fallback: if the trip_id changed (rare), fall back to
-        # station overlap + time proximity.
-        if best_trip is None:
-            best_overlap = 0
-            best_time_diff = float("inf")
-
-            for trip_arrivals in matching_trips.values():
-                trip_stations = {a.station_code for a in trip_arrivals}
-                overlap = len(trip_stations & journey_station_codes)
-
-                time_diff = float("inf")
-                if journey.scheduled_departure:
-                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                    time_diff = abs(
-                        (
-                            first_arr.arrival_time - journey.scheduled_departure
-                        ).total_seconds()
-                    )
-
-                if overlap > best_overlap or (
-                    overlap == best_overlap and time_diff < best_time_diff
-                ):
-                    best_overlap = overlap
-                    best_time_diff = time_diff
-                    best_trip = trip_arrivals
+        best_trip = select_matching_trip(
+            matching_trips,
+            journey,
+            journey_station_codes,
+            _generate_train_id,
+            "LIRR",
+        )
 
         if not best_trip:
             logger.debug(f"No matching LIRR trip found for journey {journey.train_id}")
@@ -633,7 +606,7 @@ class LIRRCollector:
         )
         journey_stops = list(stop_result.scalars().all())
         update_stop_departure_status(journey_stops, now)
-        update_journey_metadata(journey, now)
+        update_journey_metadata(journey, now, journey_stops)
         check_journey_completed(journey, journey_stops)
 
         logger.debug(f"JIT updated LIRR journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/lirr/collector.py
+++ b/backend_v2/src/trackrat/collectors/lirr/collector.py
@@ -19,6 +19,7 @@ from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     infer_missing_origin,
     select_matching_trip,
     set_stop_track,
@@ -548,16 +549,9 @@ class LIRRCollector:
         # Find arrivals that match this journey's stops
         journey_station_codes = {s.station_code for s in journey.stops}
 
-        # Find arrivals that might be part of this journey
-        # Match by origin station and approximate departure time
-        matching_trips: dict[str, list[LirrArrival]] = {}
-
-        for arr in arrivals:
-            if arr.station_code not in journey_station_codes:
-                continue
-            if arr.trip_id not in matching_trips:
-                matching_trips[arr.trip_id] = []
-            matching_trips[arr.trip_id].append(arr)
+        matching_trips = group_candidate_trips_by_overlap(
+            arrivals, journey_station_codes
+        )
 
         best_trip = select_matching_trip(
             matching_trips,

--- a/backend_v2/src/trackrat/collectors/mbta/collector.py
+++ b/backend_v2/src/trackrat/collectors/mbta/collector.py
@@ -19,6 +19,7 @@ from trackrat.collectors.mta_common import (
     build_complete_stops,
     check_journey_completed,
     infer_missing_origin,
+    select_matching_trip,
     update_journey_metadata,
     update_stop_departure_status,
 )
@@ -441,7 +442,7 @@ class MBTACollector:
             await session.flush()
             now = now_et()
             update_stop_departure_status(created_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, created_stops)
             check_journey_completed(journey, created_stops)
 
             # Analyze segments for congestion data
@@ -486,7 +487,7 @@ class MBTACollector:
             )
             journey_stops = list(stop_result.scalars().all())
             update_stop_departure_status(journey_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, journey_stops)
             check_journey_completed(journey, journey_stops)
 
             transit_analyzer = TransitAnalyzer()
@@ -517,37 +518,13 @@ class MBTACollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Exact match by train_id
-        best_trip: list[MbtaArrival] | None = None
-        for trip_id_candidate, trip_arrivals in matching_trips.items():
-            if _generate_train_id(trip_id_candidate) == journey.train_id:
-                best_trip = trip_arrivals
-                break
-
-        # Fuzzy fallback
-        if best_trip is None:
-            best_overlap = 0
-            best_time_diff = float("inf")
-
-            for trip_arrivals in matching_trips.values():
-                trip_stations = {a.station_code for a in trip_arrivals}
-                overlap = len(trip_stations & journey_station_codes)
-
-                time_diff = float("inf")
-                if journey.scheduled_departure:
-                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                    time_diff = abs(
-                        (
-                            first_arr.arrival_time - journey.scheduled_departure
-                        ).total_seconds()
-                    )
-
-                if overlap > best_overlap or (
-                    overlap == best_overlap and time_diff < best_time_diff
-                ):
-                    best_overlap = overlap
-                    best_time_diff = time_diff
-                    best_trip = trip_arrivals
+        best_trip = select_matching_trip(
+            matching_trips,
+            journey,
+            journey_station_codes,
+            _generate_train_id,
+            "MBTA",
+        )
 
         if not best_trip:
             logger.debug(f"No matching MBTA trip found for journey {journey.train_id}")
@@ -588,7 +565,7 @@ class MBTACollector:
         )
         journey_stops = list(stop_result.scalars().all())
         update_stop_departure_status(journey_stops, now)
-        update_journey_metadata(journey, now)
+        update_journey_metadata(journey, now, journey_stops)
         check_journey_completed(journey, journey_stops)
 
         logger.debug(f"JIT updated MBTA journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/mbta/collector.py
+++ b/backend_v2/src/trackrat/collectors/mbta/collector.py
@@ -18,6 +18,7 @@ from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     infer_missing_origin,
     select_matching_trip,
     update_journey_metadata,
@@ -510,13 +511,9 @@ class MBTACollector:
         arrivals = await self.client.get_all_arrivals()
         journey_station_codes = {s.station_code for s in journey.stops}
 
-        matching_trips: dict[str, list[MbtaArrival]] = {}
-        for arr in arrivals:
-            if arr.station_code not in journey_station_codes:
-                continue
-            if arr.trip_id not in matching_trips:
-                matching_trips[arr.trip_id] = []
-            matching_trips[arr.trip_id].append(arr)
+        matching_trips = group_candidate_trips_by_overlap(
+            arrivals, journey_station_codes
+        )
 
         best_trip = select_matching_trip(
             matching_trips,

--- a/backend_v2/src/trackrat/collectors/metra/collector.py
+++ b/backend_v2/src/trackrat/collectors/metra/collector.py
@@ -18,6 +18,7 @@ from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     infer_missing_origin,
     select_matching_trip,
     update_journey_metadata,
@@ -555,14 +556,9 @@ class MetraCollector:
 
         journey_station_codes = {s.station_code for s in journey.stops}
 
-        # Find arrivals that might be part of this journey
-        matching_trips: dict[str, list[MetraArrival]] = {}
-        for arr in arrivals:
-            if arr.station_code not in journey_station_codes:
-                continue
-            if arr.trip_id not in matching_trips:
-                matching_trips[arr.trip_id] = []
-            matching_trips[arr.trip_id].append(arr)
+        matching_trips = group_candidate_trips_by_overlap(
+            arrivals, journey_station_codes
+        )
 
         best_trip = select_matching_trip(
             matching_trips,

--- a/backend_v2/src/trackrat/collectors/metra/collector.py
+++ b/backend_v2/src/trackrat/collectors/metra/collector.py
@@ -19,6 +19,7 @@ from trackrat.collectors.mta_common import (
     build_complete_stops,
     check_journey_completed,
     infer_missing_origin,
+    select_matching_trip,
     update_journey_metadata,
     update_stop_departure_status,
 )
@@ -477,7 +478,7 @@ class MetraCollector:
             await session.flush()
             now = now_for_provider(DATA_SOURCE)
             update_stop_departure_status(created_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, created_stops)
             check_journey_completed(journey, created_stops)
 
             # Analyze segments for congestion data
@@ -519,7 +520,7 @@ class MetraCollector:
             )
             journey_stops = list(stop_result.scalars().all())
             update_stop_departure_status(journey_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, journey_stops)
             check_journey_completed(journey, journey_stops)
 
             # Analyze segments for congestion data
@@ -563,37 +564,13 @@ class MetraCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Exact match: regenerate train_id from each candidate trip_id
-        best_trip: list[MetraArrival] | None = None
-        for trip_id_candidate, trip_arrivals in matching_trips.items():
-            if _generate_train_id(trip_id_candidate) == journey.train_id:
-                best_trip = trip_arrivals
-                break
-
-        # Fuzzy fallback: station overlap + time proximity
-        if best_trip is None:
-            best_overlap = 0
-            best_time_diff = float("inf")
-
-            for trip_arrivals in matching_trips.values():
-                trip_stations = {a.station_code for a in trip_arrivals}
-                overlap = len(trip_stations & journey_station_codes)
-
-                time_diff = float("inf")
-                if journey.scheduled_departure:
-                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                    time_diff = abs(
-                        (
-                            first_arr.arrival_time - journey.scheduled_departure
-                        ).total_seconds()
-                    )
-
-                if overlap > best_overlap or (
-                    overlap == best_overlap and time_diff < best_time_diff
-                ):
-                    best_overlap = overlap
-                    best_time_diff = time_diff
-                    best_trip = trip_arrivals
+        best_trip = select_matching_trip(
+            matching_trips,
+            journey,
+            journey_station_codes,
+            _generate_train_id,
+            DATA_SOURCE,
+        )
 
         if not best_trip:
             logger.debug(f"No matching Metra trip found for journey {journey.train_id}")
@@ -633,7 +610,7 @@ class MetraCollector:
         )
         journey_stops = list(stop_result.scalars().all())
         update_stop_departure_status(journey_stops, now)
-        update_journey_metadata(journey, now)
+        update_journey_metadata(journey, now, journey_stops)
         check_journey_completed(journey, journey_stops)
 
         logger.debug(f"JIT updated Metra journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -19,6 +19,7 @@ from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     infer_direction_from_terminals,
     infer_missing_origin,
     select_matching_trip,
@@ -539,15 +540,9 @@ class MNRCollector:
         # Find arrivals that match this journey's stops
         journey_station_codes = {s.station_code for s in journey.stops}
 
-        # Find arrivals that might be part of this journey
-        matching_trips: dict[str, list[MnrArrival]] = {}
-
-        for arr in arrivals:
-            if arr.station_code not in journey_station_codes:
-                continue
-            if arr.trip_id not in matching_trips:
-                matching_trips[arr.trip_id] = []
-            matching_trips[arr.trip_id].append(arr)
+        matching_trips = group_candidate_trips_by_overlap(
+            arrivals, journey_station_codes
+        )
 
         best_trip = select_matching_trip(
             matching_trips,

--- a/backend_v2/src/trackrat/collectors/mnr/collector.py
+++ b/backend_v2/src/trackrat/collectors/mnr/collector.py
@@ -21,6 +21,7 @@ from trackrat.collectors.mta_common import (
     check_journey_completed,
     infer_direction_from_terminals,
     infer_missing_origin,
+    select_matching_trip,
     set_stop_track,
     update_journey_metadata,
     update_stop_departure_status,
@@ -478,7 +479,7 @@ class MNRCollector:
             await session.flush()
             now = now_et()
             update_stop_departure_status(created_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, created_stops)
             check_journey_completed(journey, created_stops)
 
             logger.debug(f"Discovered MNR train {train_id}")
@@ -511,7 +512,7 @@ class MNRCollector:
             now = now_et()
             journey_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
             update_stop_departure_status(journey_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, journey_stops)
             check_journey_completed(journey, journey_stops)
 
             logger.debug(f"Updated MNR train {train_id}")
@@ -548,41 +549,13 @@ class MNRCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Exact match: regenerate train_id from each candidate trip_id
-        # and compare against the stored train_id. This avoids the fuzzy
-        # matching bug where trains on the same line with identical
-        # station sets and close departure times get swapped.
-        best_trip: list[MnrArrival] | None = None
-        for trip_id_candidate, trip_arrivals in matching_trips.items():
-            if _generate_train_id(trip_id_candidate) == journey.train_id:
-                best_trip = trip_arrivals
-                break
-
-        # Fuzzy fallback: if the trip_id changed (rare), fall back to
-        # station overlap + time proximity.
-        if best_trip is None:
-            best_overlap = 0
-            best_time_diff = float("inf")
-
-            for trip_arrivals in matching_trips.values():
-                trip_stations = {a.station_code for a in trip_arrivals}
-                overlap = len(trip_stations & journey_station_codes)
-
-                time_diff = float("inf")
-                if journey.scheduled_departure:
-                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                    time_diff = abs(
-                        (
-                            first_arr.arrival_time - journey.scheduled_departure
-                        ).total_seconds()
-                    )
-
-                if overlap > best_overlap or (
-                    overlap == best_overlap and time_diff < best_time_diff
-                ):
-                    best_overlap = overlap
-                    best_time_diff = time_diff
-                    best_trip = trip_arrivals
+        best_trip = select_matching_trip(
+            matching_trips,
+            journey,
+            journey_station_codes,
+            _generate_train_id,
+            "MNR",
+        )
 
         if not best_trip:
             logger.debug(f"No matching MNR trip found for journey {journey.train_id}")
@@ -623,7 +596,7 @@ class MNRCollector:
         )
         journey_stops = list(stop_result.scalars().all())
         update_stop_departure_status(journey_stops, now)
-        update_journey_metadata(journey, now)
+        update_journey_metadata(journey, now, journey_stops)
         check_journey_completed(journey, journey_stops)
 
         logger.debug(f"JIT updated MNR journey {journey.train_id}")

--- a/backend_v2/src/trackrat/collectors/mta_common.py
+++ b/backend_v2/src/trackrat/collectors/mta_common.py
@@ -9,6 +9,7 @@ Follows the patterns established in the PATH collector.
 """
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -338,6 +339,76 @@ def set_stop_track(
     )
 
 
+def select_matching_trip(
+    matching_trips: dict[str, list[Any]],
+    journey: TrainJourney,
+    journey_station_codes: set[str],
+    make_train_id: Callable[[str], str],
+    data_source: str,
+) -> list[Any] | None:
+    """Select the live trip that should refresh an existing GTFS-RT journey.
+
+    Exact train-id matches are trusted even when the feed only contains a
+    subset of the route. Fuzzy matches are intentionally stricter: if the
+    candidate stop set differs from the existing journey, we reject it and let
+    the normal collector path create/update the new trip row instead.
+    """
+    for trip_id_candidate, trip_arrivals in matching_trips.items():
+        if make_train_id(trip_id_candidate) == journey.train_id:
+            return trip_arrivals
+
+    best_trip: list[Any] | None = None
+    best_overlap = 0
+    best_time_diff = float("inf")
+    scheduled_departure = getattr(journey, "scheduled_departure", None)
+
+    for trip_arrivals in matching_trips.values():
+        trip_stations = {a.station_code for a in trip_arrivals}
+        overlap = len(trip_stations & journey_station_codes)
+
+        time_diff = float("inf")
+        if isinstance(scheduled_departure, datetime):
+            first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
+            time_diff = abs(
+                (first_arr.arrival_time - scheduled_departure).total_seconds()
+            )
+
+        if overlap > best_overlap or (
+            overlap == best_overlap and time_diff < best_time_diff
+        ):
+            best_overlap = overlap
+            best_time_diff = time_diff
+            best_trip = trip_arrivals
+
+    if not best_trip:
+        return None
+
+    trip_station_codes = {a.station_code for a in best_trip}
+    if trip_station_codes != journey_station_codes:
+        logger.warning(
+            "mta_fuzzy_trip_rejected_stop_set_mismatch",
+            extra={
+                "data_source": data_source,
+                "train_id": journey.train_id,
+                "journey_stations": sorted(journey_station_codes),
+                "candidate_stations": sorted(trip_station_codes),
+                "overlap": len(trip_station_codes & journey_station_codes),
+            },
+        )
+        return None
+
+    logger.info(
+        "mta_fuzzy_trip_matched",
+        extra={
+            "data_source": data_source,
+            "train_id": journey.train_id,
+            "station_count": len(trip_station_codes),
+            "time_diff_seconds": best_time_diff,
+        },
+    )
+    return best_trip
+
+
 def update_stop_departure_status(stops: list[JourneyStop], now: datetime) -> None:
     """Infer departure status for MTA stops based on actual/scheduled times.
 
@@ -409,15 +480,20 @@ def update_stop_departure_status(stops: list[JourneyStop], now: datetime) -> Non
                 )
 
 
-def update_journey_metadata(journey: TrainJourney, now: datetime) -> None:
+def update_journey_metadata(
+    journey: TrainJourney, now: datetime, stops: list[JourneyStop] | None = None
+) -> None:
     """Update journey freshness tracking fields.
 
     Args:
         journey: The journey to update.
         now: Current time (timezone-aware, Eastern).
+        stops: Current stop collection, if available.
     """
     journey.last_updated_at = now
     journey.update_count = (journey.update_count or 0) + 1
+    if stops is not None:
+        journey.stops_count = len(stops)
 
 
 def check_journey_completed(journey: TrainJourney, stops: list[JourneyStop]) -> None:

--- a/backend_v2/src/trackrat/collectors/mta_common.py
+++ b/backend_v2/src/trackrat/collectors/mta_common.py
@@ -339,6 +339,27 @@ def set_stop_track(
     )
 
 
+def group_candidate_trips_by_overlap(
+    arrivals: list[Any], journey_station_codes: set[str]
+) -> dict[str, list[Any]]:
+    """Group full live trips that share at least one station with a journey.
+
+    Callers use this before fuzzy matching so candidate stop-set comparison sees
+    the entire visible trip, including stops that are not on the stored journey.
+    """
+    trips: dict[str, list[Any]] = {}
+    for arrival in arrivals:
+        if arrival.trip_id not in trips:
+            trips[arrival.trip_id] = []
+        trips[arrival.trip_id].append(arrival)
+
+    return {
+        trip_id: trip_arrivals
+        for trip_id, trip_arrivals in trips.items()
+        if {arrival.station_code for arrival in trip_arrivals} & journey_station_codes
+    }
+
+
 def select_matching_trip(
     matching_trips: dict[str, list[Any]],
     journey: TrainJourney,
@@ -349,13 +370,18 @@ def select_matching_trip(
     """Select the live trip that should refresh an existing GTFS-RT journey.
 
     Exact train-id matches are trusted even when the feed only contains a
-    subset of the route. Fuzzy matches are intentionally stricter: if the
-    candidate stop set differs from the existing journey, we reject it and let
-    the normal collector path create/update the new trip row instead.
+    subset of the route, and only stored journey stops are returned for update.
+    Fuzzy matches are intentionally stricter: if the candidate stop set differs
+    from the existing journey, we reject it and let the normal collector path
+    create/update the new trip row instead.
     """
     for trip_id_candidate, trip_arrivals in matching_trips.items():
         if make_train_id(trip_id_candidate) == journey.train_id:
-            return trip_arrivals
+            return [
+                arrival
+                for arrival in trip_arrivals
+                if arrival.station_code in journey_station_codes
+            ]
 
     best_trip: list[Any] | None = None
     best_overlap = 0

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -1509,27 +1509,30 @@ class JourneyCollector(BaseJourneyCollector):
         # Flush changes so newly created/updated stops are visible in the database
         await session.flush()
 
-        # Delete phantom stops that don't appear in API response
-        # This removes schedule-generated placeholder stops that don't match reality
+        # Delete phantom stops that don't appear in the API response.
+        # This removes schedule-generated placeholder stops that don't match reality.
         api_station_codes = {stop_data.STATION_2CHAR for stop_data in stops_data}
-        stmt = select(JourneyStop).where(JourneyStop.journey_id == journey.id)
-        result = await session.execute(stmt)
-        all_stops = list(result.scalars().all())
-
-        for stop in all_stops:
-            if stop.station_code not in api_station_codes:
+        if api_station_codes:
+            deleted = cast(
+                CursorResult[tuple[()]],
+                await session.execute(
+                    delete(JourneyStop).where(
+                        and_(
+                            JourneyStop.journey_id == journey.id,
+                            JourneyStop.station_code.notin_(api_station_codes),
+                        )
+                    ).execution_options(synchronize_session="fetch")
+                ),
+            )
+            phantom_count = deleted.rowcount or 0
+            if phantom_count:
                 logger.warning(
-                    "deleting_phantom_stop",
+                    "deleted_phantom_stops",
                     journey_id=journey.id,
                     train_id=journey.train_id,
-                    station_code=stop.station_code,
-                    stop_sequence=stop.stop_sequence,
-                    had_scheduled_times=bool(
-                        stop.scheduled_arrival or stop.scheduled_departure
-                    ),
-                    had_actual_times=bool(stop.actual_departure or stop.actual_arrival),
+                    count=phantom_count,
+                    api_station_codes=sorted(api_station_codes),
                 )
-                await session.delete(stop)
 
         # Re-sequence all stops for this journey to ensure consistency
         await self._resequence_stops(session, journey)

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -25,6 +25,7 @@ from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     infer_subway_origin,
     select_matching_trip,
     set_stop_track,
@@ -520,14 +521,9 @@ class SubwayCollector:
         arrivals = await self.client.get_feed_arrivals(journey.line_code or "")
 
         journey_station_codes = {s.station_code for s in journey.stops}
-        matching_trips: dict[str, list[SubwayArrival]] = {}
-
-        for arr in arrivals:
-            if arr.station_code not in journey_station_codes:
-                continue
-            if arr.trip_id not in matching_trips:
-                matching_trips[arr.trip_id] = []
-            matching_trips[arr.trip_id].append(arr)
+        matching_trips = group_candidate_trips_by_overlap(
+            arrivals, journey_station_codes
+        )
 
         route_id = journey.line_code or ""
         best_trip = select_matching_trip(

--- a/backend_v2/src/trackrat/collectors/subway/collector.py
+++ b/backend_v2/src/trackrat/collectors/subway/collector.py
@@ -26,6 +26,7 @@ from trackrat.collectors.mta_common import (
     build_complete_stops,
     check_journey_completed,
     infer_subway_origin,
+    select_matching_trip,
     set_stop_track,
     update_journey_metadata,
     update_stop_departure_status,
@@ -473,7 +474,7 @@ class SubwayCollector:
             await session.flush()
             now = now_et()
             update_stop_departure_status(created_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, created_stops)
             check_journey_completed(journey, created_stops)
 
             logger.debug(f"Discovered subway train {train_id}")
@@ -502,7 +503,7 @@ class SubwayCollector:
             now = now_et()
             journey_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
             update_stop_departure_status(journey_stops, now)
-            update_journey_metadata(journey, now)
+            update_journey_metadata(journey, now, journey_stops)
             check_journey_completed(journey, journey_stops)
 
             logger.debug(f"Updated subway train {train_id}")
@@ -528,42 +529,14 @@ class SubwayCollector:
                 matching_trips[arr.trip_id] = []
             matching_trips[arr.trip_id].append(arr)
 
-        # Exact match: re-hash each candidate trip_id and compare against
-        # the stored train_id. This avoids the fuzzy matching bug where
-        # non-branching lines (e.g., L) have identical station sets for
-        # every trip, causing the fuzzy matcher to pick the wrong train.
-        best_trip: list[SubwayArrival] | None = None
         route_id = journey.line_code or ""
-        for trip_id_candidate, trip_arrivals in matching_trips.items():
-            if _generate_train_id(trip_id_candidate, route_id) == journey.train_id:
-                best_trip = trip_arrivals
-                break
-
-        # Fuzzy fallback: if the trip_id changed (rare), fall back to
-        # station overlap + time proximity.
-        if best_trip is None:
-            best_overlap = 0
-            best_time_diff = float("inf")
-
-            for trip_arrivals in matching_trips.values():
-                trip_stations = {a.station_code for a in trip_arrivals}
-                overlap = len(trip_stations & journey_station_codes)
-
-                time_diff = float("inf")
-                if journey.scheduled_departure:
-                    first_arr = min(trip_arrivals, key=lambda a: a.arrival_time)
-                    time_diff = abs(
-                        (
-                            first_arr.arrival_time - journey.scheduled_departure
-                        ).total_seconds()
-                    )
-
-                if overlap > best_overlap or (
-                    overlap == best_overlap and time_diff < best_time_diff
-                ):
-                    best_overlap = overlap
-                    best_time_diff = time_diff
-                    best_trip = trip_arrivals
+        best_trip = select_matching_trip(
+            matching_trips,
+            journey,
+            journey_station_codes,
+            lambda trip_id: _generate_train_id(trip_id, route_id),
+            "SUBWAY",
+        )
 
         if not best_trip:
             logger.debug(
@@ -592,7 +565,7 @@ class SubwayCollector:
         now = now_et()
         journey_stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
         update_stop_departure_status(journey_stops, now)
-        update_journey_metadata(journey, now)
+        update_journey_metadata(journey, now, journey_stops)
         check_journey_completed(journey, journey_stops)
 
         logger.debug(f"JIT updated subway journey {journey.train_id}")

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -38,6 +38,8 @@ class AmtrakPatternScheduler:
     MIN_OCCURRENCES = 2  # Train must appear at least 2 times in the past 3 weeks
     EXPECTED_WEEKS = 3  # Number of weeks we expect to see in lookback period
     TIME_VARIANCE_THRESHOLD = 35  # Minutes - if times vary by more, don't schedule
+    STOP_CONSENSUS_RUNS = 5  # Recent matching runs used to infer scheduled stops
+    MIN_STOP_CONSENSUS_RUNS = 2  # Avoid trusting a one-off route variant
 
     async def generate_daily_schedules(self, target_date: date) -> dict[str, Any]:
         """
@@ -374,43 +376,162 @@ class AmtrakPatternScheduler:
 
         return patterns
 
-    async def _get_recent_journey_stops(
-        self, session: "AsyncSession", train_number: str
-    ) -> list[JourneyStop] | None:
-        """Fetch stops from the most recent complete OBSERVED journey for a train.
-
-        Used to populate SCHEDULED records with full route stops instead of
-        just the origin station, so they appear in departure queries from
-        any station on the route.
-
-        Args:
-            session: Database session
-            train_number: Base train number (e.g., "2150")
-
-        Returns:
-            Sorted list of stops from the most recent journey, or None
-        """
+    async def _get_recent_matching_journeys(
+        self,
+        session: "AsyncSession",
+        pattern: dict[str, Any],
+        target_date: date,
+    ) -> list[TrainJourney]:
+        """Fetch recent complete OBSERVED journeys for the same train and route."""
+        target_dow = (target_date.weekday() + 1) % 7
+        lookback_start = target_date - timedelta(days=self.LOOKBACK_DAYS)
         stmt = (
             select(TrainJourney)
             .options(selectinload(TrainJourney.stops))
             .where(
                 and_(
-                    TrainJourney.train_id == train_number,
+                    TrainJourney.train_id == pattern["train_number"],
                     TrainJourney.data_source == "AMTRAK",
                     TrainJourney.observation_type == "OBSERVED",
                     TrainJourney.has_complete_journey.is_(True),
+                    TrainJourney.is_cancelled.is_(False),
+                    TrainJourney.origin_station_code == pattern["origin"],
+                    TrainJourney.terminal_station_code == pattern["terminal"],
+                    TrainJourney.journey_date >= lookback_start,
+                    TrainJourney.journey_date < target_date,
+                    func.extract("dow", TrainJourney.journey_date) == target_dow,
                 )
             )
             .order_by(TrainJourney.journey_date.desc())
-            .limit(1)
+            .limit(self.STOP_CONSENSUS_RUNS)
         )
 
         result = await session.execute(stmt)
-        recent_journey = result.scalar_one_or_none()
+        return list(result.scalars().all())
 
-        if recent_journey and recent_journey.stops:
-            return sorted(recent_journey.stops, key=lambda s: s.stop_sequence or 0)
-        return None
+    @staticmethod
+    def _scheduled_time_for_order(stop: JourneyStop) -> datetime | None:
+        """Return the best scheduled time for ordering and offsets."""
+        return stop.scheduled_departure or stop.scheduled_arrival
+
+    def _build_consensus_stop_templates(
+        self,
+        journeys: list[TrainJourney],
+        required_station_codes: set[str] | None = None,
+    ) -> list[dict[str, Any]] | None:
+        """Build route stop templates from stations present in every sample run."""
+        if len(journeys) < self.MIN_STOP_CONSENSUS_RUNS:
+            return None
+
+        runs: list[list[JourneyStop]] = []
+        for journey in journeys:
+            stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
+            if stops and self._scheduled_time_for_order(stops[0]):
+                runs.append(stops)
+
+        if len(runs) < self.MIN_STOP_CONSENSUS_RUNS:
+            return None
+
+        common_station_codes = set(stop.station_code for stop in runs[0])
+        for stops in runs[1:]:
+            common_station_codes &= {stop.station_code for stop in stops}
+
+        if not common_station_codes:
+            return None
+
+        required_station_codes = required_station_codes or set()
+        if not required_station_codes <= common_station_codes:
+            return None
+
+        templates = []
+        for station_code in common_station_codes:
+            sequence_values = []
+            arrival_offsets = []
+            departure_offsets = []
+            station_name = get_station_name(station_code)
+
+            for stops in runs:
+                origin_time = self._scheduled_time_for_order(stops[0])
+                if origin_time is None:
+                    continue
+
+                stop = next(s for s in stops if s.station_code == station_code)
+                sequence_values.append(stop.stop_sequence or 0)
+                station_name = stop.station_name or station_name
+                if stop.scheduled_arrival:
+                    arrival_offsets.append(stop.scheduled_arrival - origin_time)
+                if stop.scheduled_departure:
+                    departure_offsets.append(stop.scheduled_departure - origin_time)
+
+            templates.append(
+                {
+                    "station_code": station_code,
+                    "station_name": station_name,
+                    "sequence": self._median_number(sequence_values),
+                    "arrival_offset": self._median_timedelta(arrival_offsets),
+                    "departure_offset": self._median_timedelta(departure_offsets),
+                }
+            )
+
+        templates.sort(key=lambda s: (s["sequence"], s["station_code"]))
+        return templates
+
+    @staticmethod
+    def _median_number(values: list[int]) -> float:
+        """Calculate median for numeric stop sequence values."""
+        if not values:
+            return 0
+        sorted_values = sorted(values)
+        mid = len(sorted_values) // 2
+        if len(sorted_values) % 2:
+            return float(sorted_values[mid])
+        return (sorted_values[mid - 1] + sorted_values[mid]) / 2
+
+    @staticmethod
+    def _median_timedelta(values: list[timedelta]) -> timedelta | None:
+        """Calculate median for stop time offsets."""
+        if not values:
+            return None
+        sorted_values = sorted(values)
+        mid = len(sorted_values) // 2
+        if len(sorted_values) % 2:
+            return sorted_values[mid]
+        return sorted_values[mid - 1] + (
+            sorted_values[mid] - sorted_values[mid - 1]
+        ) / 2
+
+    def _origin_only_stop(
+        self,
+        journey: TrainJourney,
+        pattern: dict[str, Any],
+        scheduled_departure: datetime,
+    ) -> list[JourneyStop]:
+        """Build the safe fallback stop list when no stable route is known."""
+        return [
+            JourneyStop(
+                journey=journey,
+                station_code=pattern["origin"],
+                station_name=get_station_name(pattern["origin"]),
+                stop_sequence=0,
+                scheduled_departure=scheduled_departure,
+                scheduled_arrival=scheduled_departure,
+                has_departed_station=False,
+            )
+        ]
+
+    @staticmethod
+    def _normalize_stop_sequences(stops: list[JourneyStop]) -> list[JourneyStop]:
+        """Return stops with contiguous sequences before inserting scheduled rows."""
+        ordered_stops = sorted(
+            stops,
+            key=lambda s: (
+                s.stop_sequence if s.stop_sequence is not None else 10**9,
+                s.station_code,
+            ),
+        )
+        for sequence, stop in enumerate(ordered_stops):
+            stop.stop_sequence = sequence
+        return ordered_stops
 
     async def _build_scheduled_stops(
         self,
@@ -419,11 +540,11 @@ class AmtrakPatternScheduler:
         pattern: dict[str, Any],
         scheduled_departure: datetime,
     ) -> list[JourneyStop]:
-        """Build stops for a SCHEDULED journey from the most recent OBSERVED journey.
+        """Build stops for a SCHEDULED journey from recent OBSERVED consensus.
 
-        Copies the full stop list from a recent OBSERVED journey and adjusts
-        all times to the target date using the pattern's median departure.
-        Falls back to a single origin stop if no recent journey is available.
+        Uses stations present across recent matching OBSERVED journeys rather
+        than copying one run. This prevents one-off stops from appearing in
+        future SCHEDULED rows before the train is live and reconciled.
 
         Args:
             session: Database session
@@ -434,63 +555,37 @@ class AmtrakPatternScheduler:
         Returns:
             List of JourneyStop objects for the scheduled journey
         """
-        recent_stops = await self._get_recent_journey_stops(
-            session, pattern["train_number"]
+        recent_journeys = await self._get_recent_matching_journeys(
+            session, pattern, scheduled_departure.date()
+        )
+        stop_templates = self._build_consensus_stop_templates(
+            recent_journeys,
+            {pattern["origin"], pattern["terminal"]},
         )
 
-        if not recent_stops:
+        if not stop_templates:
             logger.debug(
-                "no_recent_stops_for_pattern",
+                "no_consensus_stops_for_pattern",
                 train_number=pattern["train_number"],
+                sample_count=len(recent_journeys),
             )
-            return [
-                JourneyStop(
-                    journey=journey,
-                    station_code=pattern["origin"],
-                    station_name=get_station_name(pattern["origin"]),
-                    stop_sequence=0,
-                    scheduled_departure=scheduled_departure,
-                    scheduled_arrival=scheduled_departure,
-                    has_departed_station=False,
-                )
-            ]
-
-        # Calculate time offset: shift from recent journey's origin to target departure
-        ref_departure = recent_stops[0].scheduled_departure
-        if not ref_departure:
-            logger.debug(
-                "no_reference_departure_time",
-                train_number=pattern["train_number"],
-            )
-            return [
-                JourneyStop(
-                    journey=journey,
-                    station_code=pattern["origin"],
-                    station_name=get_station_name(pattern["origin"]),
-                    stop_sequence=0,
-                    scheduled_departure=scheduled_departure,
-                    scheduled_arrival=scheduled_departure,
-                    has_departed_station=False,
-                )
-            ]
-
-        time_offset = scheduled_departure - ref_departure
+            return self._origin_only_stop(journey, pattern, scheduled_departure)
 
         stops = []
-        for i, ref_stop in enumerate(recent_stops):
+        for i, template in enumerate(stop_templates):
             stop = JourneyStop(
                 journey=journey,
-                station_code=ref_stop.station_code,
-                station_name=ref_stop.station_name,
+                station_code=template["station_code"],
+                station_name=template["station_name"],
                 stop_sequence=i,
                 scheduled_departure=(
-                    ref_stop.scheduled_departure + time_offset
-                    if ref_stop.scheduled_departure
+                    scheduled_departure + template["departure_offset"]
+                    if template["departure_offset"] is not None
                     else None
                 ),
                 scheduled_arrival=(
-                    ref_stop.scheduled_arrival + time_offset
-                    if ref_stop.scheduled_arrival
+                    scheduled_departure + template["arrival_offset"]
+                    if template["arrival_offset"] is not None
                     else None
                 ),
                 has_departed_station=False,
@@ -498,9 +593,10 @@ class AmtrakPatternScheduler:
             stops.append(stop)
 
         logger.debug(
-            "built_scheduled_stops_from_recent",
+            "built_scheduled_stops_from_consensus",
             train_number=pattern["train_number"],
             stop_count=len(stops),
+            sample_count=len(recent_journeys),
             stations=[s.station_code for s in stops],
         )
 
@@ -580,7 +676,7 @@ class AmtrakPatternScheduler:
                     update_count=1,
                 )
 
-                # Build stops from most recent OBSERVED journey for full route coverage
+                # Build stops from recent OBSERVED consensus for route coverage
                 stops = await self._build_scheduled_stops(
                     session, journey, pattern, scheduled_departure
                 )
@@ -624,7 +720,7 @@ class AmtrakPatternScheduler:
         async with get_session() as session:
             for item in scheduled_journeys:
                 journey = item["journey"]
-                stops = item["stops"]
+                stops = self._normalize_stop_sequences(item["stops"])
 
                 try:
                     # Check for existing SCHEDULED record

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -13,7 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
-from trackrat.config.stations import get_station_name, map_amtrak_station_code
+from trackrat.config.stations import (
+    get_station_name,
+    map_amtrak_station_code,
+    map_internal_to_amtrak_code,
+)
 from trackrat.db.engine import get_session
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.settings import get_settings
@@ -385,6 +389,8 @@ class AmtrakPatternScheduler:
         """Fetch recent complete OBSERVED journeys for the same train and route."""
         target_dow = (target_date.weekday() + 1) % 7
         lookback_start = target_date - timedelta(days=self.LOOKBACK_DAYS)
+        origin_codes = sorted(self._station_code_aliases(pattern["origin"]))
+        terminal_codes = sorted(self._station_code_aliases(pattern["terminal"]))
         stmt = (
             select(TrainJourney)
             .options(selectinload(TrainJourney.stops))
@@ -395,8 +401,8 @@ class AmtrakPatternScheduler:
                     TrainJourney.observation_type == "OBSERVED",
                     TrainJourney.has_complete_journey.is_(True),
                     TrainJourney.is_cancelled.is_(False),
-                    TrainJourney.origin_station_code == pattern["origin"],
-                    TrainJourney.terminal_station_code == pattern["terminal"],
+                    TrainJourney.origin_station_code.in_(origin_codes),
+                    TrainJourney.terminal_station_code.in_(terminal_codes),
                     TrainJourney.journey_date >= lookback_start,
                     TrainJourney.journey_date < target_date,
                     func.extract("dow", TrainJourney.journey_date) == target_dow,
@@ -483,13 +489,22 @@ class AmtrakPatternScheduler:
     ) -> bool:
         """Check required stops while tolerating raw/internal Amtrak aliases."""
         for required_code in required_station_codes:
-            aliases = {required_code}
-            internal_code = map_amtrak_station_code(required_code)
-            if internal_code:
-                aliases.add(internal_code)
+            aliases = AmtrakPatternScheduler._station_code_aliases(required_code)
             if not aliases & station_codes:
                 return False
         return True
+
+    @staticmethod
+    def _station_code_aliases(station_code: str) -> set[str]:
+        """Return raw/internal Amtrak aliases for a station code."""
+        aliases = {station_code}
+        internal_code = map_amtrak_station_code(station_code)
+        if internal_code:
+            aliases.add(internal_code)
+        amtrak_code = map_internal_to_amtrak_code(station_code)
+        if amtrak_code:
+            aliases.add(amtrak_code)
+        return aliases
 
     @staticmethod
     def _median_number(values: list[int]) -> float:

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
-from trackrat.config.stations import get_station_name
+from trackrat.config.stations import get_station_name, map_amtrak_station_code
 from trackrat.db.engine import get_session
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.settings import get_settings
@@ -439,8 +439,9 @@ class AmtrakPatternScheduler:
         if not common_station_codes:
             return None
 
-        required_station_codes = required_station_codes or set()
-        if not required_station_codes <= common_station_codes:
+        if not self._has_required_station_codes(
+            common_station_codes, required_station_codes or set()
+        ):
             return None
 
         templates = []
@@ -475,6 +476,20 @@ class AmtrakPatternScheduler:
 
         templates.sort(key=lambda s: (s["sequence"], s["station_code"]))
         return templates
+
+    @staticmethod
+    def _has_required_station_codes(
+        station_codes: set[str], required_station_codes: set[str]
+    ) -> bool:
+        """Check required stops while tolerating raw/internal Amtrak aliases."""
+        for required_code in required_station_codes:
+            aliases = {required_code}
+            internal_code = map_amtrak_station_code(required_code)
+            if internal_code:
+                aliases.add(internal_code)
+            if not aliases & station_codes:
+                return False
+        return True
 
     @staticmethod
     def _median_number(values: list[int]) -> float:

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -429,18 +429,28 @@ class AmtrakPatternScheduler:
         if len(journeys) < self.MIN_STOP_CONSENSUS_RUNS:
             return None
 
-        runs: list[list[JourneyStop]] = []
+        runs: list[list[tuple[str, JourneyStop]]] = []
         for journey in journeys:
             stops = sorted(journey.stops, key=lambda s: s.stop_sequence or 0)
             if stops and self._scheduled_time_for_order(stops[0]):
-                runs.append(stops)
+                canonical_stops = []
+                seen_station_codes = set()
+                for stop in stops:
+                    station_code = self._canonical_amtrak_station_code(
+                        stop.station_code
+                    )
+                    if station_code in seen_station_codes:
+                        continue
+                    seen_station_codes.add(station_code)
+                    canonical_stops.append((station_code, stop))
+                runs.append(canonical_stops)
 
         if len(runs) < self.MIN_STOP_CONSENSUS_RUNS:
             return None
 
-        common_station_codes = set(stop.station_code for stop in runs[0])
+        common_station_codes = set(station_code for station_code, _stop in runs[0])
         for stops in runs[1:]:
-            common_station_codes &= {stop.station_code for stop in stops}
+            common_station_codes &= {station_code for station_code, _stop in stops}
 
         if not common_station_codes:
             return None
@@ -458,11 +468,11 @@ class AmtrakPatternScheduler:
             station_name = get_station_name(station_code)
 
             for stops in runs:
-                origin_time = self._scheduled_time_for_order(stops[0])
+                origin_time = self._scheduled_time_for_order(stops[0][1])
                 if origin_time is None:
                     continue
 
-                stop = next(s for s in stops if s.station_code == station_code)
+                stop = next(s for code, s in stops if code == station_code)
                 sequence_values.append(stop.stop_sequence or 0)
                 station_name = stop.station_name or station_name
                 if stop.scheduled_arrival:
@@ -482,6 +492,11 @@ class AmtrakPatternScheduler:
 
         templates.sort(key=lambda s: (s["sequence"], s["station_code"]))
         return templates
+
+    @staticmethod
+    def _canonical_amtrak_station_code(station_code: str) -> str:
+        """Canonicalize raw Amtrak station codes to TrackRat internal codes."""
+        return map_amtrak_station_code(station_code) or station_code
 
     @staticmethod
     def _has_required_station_codes(

--- a/backend_v2/tests/unit/collectors/test_mta_common.py
+++ b/backend_v2/tests/unit/collectors/test_mta_common.py
@@ -14,6 +14,7 @@ from trackrat.collectors.mta_common import (
     infer_direction_from_terminals,
     infer_missing_origin,
     infer_subway_origin,
+    select_matching_trip,
     set_stop_track,
     update_journey_metadata,
     update_stop_departure_status,
@@ -310,6 +311,90 @@ class TestUpdateJourneyMetadata:
         update_journey_metadata(journey, now)
 
         assert journey.update_count == 1
+
+    def test_refreshes_stops_count_when_stops_are_provided(self):
+        """Should keep journey metadata aligned with the current stop collection."""
+        now = datetime.now(timezone.utc)
+        journey = MagicMock(spec=TrainJourney)
+        journey.update_count = 0
+        journey.stops_count = 99
+
+        update_journey_metadata(journey, now, [MagicMock(), MagicMock()])
+
+        assert journey.stops_count == 2
+
+
+class TestSelectMatchingTrip:
+    """Tests for GTFS-RT exact/fuzzy trip selection."""
+
+    def test_exact_match_allows_partial_live_stop_set(self):
+        """Exact trip-id matches can refresh even when RT omits passed stops."""
+        now = datetime.now(timezone.utc)
+        journey = MagicMock(spec=TrainJourney)
+        journey.train_id = "L123"
+        journey.scheduled_departure = now
+
+        candidate = [
+            _make_arrival("JAM", now + timedelta(minutes=5)),
+            _make_arrival("NY", now + timedelta(minutes=20)),
+        ]
+        matching_trips = {"trip_123": candidate}
+
+        result = select_matching_trip(
+            matching_trips,
+            journey,
+            {"GCT", "JAM", "NY"},
+            lambda trip_id: "L123" if trip_id == "trip_123" else "L999",
+            "LIRR",
+        )
+
+        assert result is candidate
+
+    def test_rejects_fuzzy_match_with_different_stop_set(self):
+        """Fuzzy trip-id fallback must not mutate a journey for another variant."""
+        now = datetime.now(timezone.utc)
+        journey = MagicMock(spec=TrainJourney)
+        journey.train_id = "L999"
+        journey.scheduled_departure = now
+
+        candidate = [
+            _make_arrival("JAM", now + timedelta(seconds=30)),
+            _make_arrival("ATL", now + timedelta(minutes=10)),
+        ]
+        matching_trips = {"new_trip": candidate}
+
+        result = select_matching_trip(
+            matching_trips,
+            journey,
+            {"JAM", "NY"},
+            lambda _trip_id: "L123",
+            "LIRR",
+        )
+
+        assert result is None
+
+    def test_accepts_fuzzy_match_with_same_stop_set(self):
+        """Fuzzy fallback remains available for true trip-id reassignment."""
+        now = datetime.now(timezone.utc)
+        journey = MagicMock(spec=TrainJourney)
+        journey.train_id = "L999"
+        journey.scheduled_departure = now
+
+        candidate = [
+            _make_arrival("JAM", now + timedelta(seconds=30)),
+            _make_arrival("NY", now + timedelta(minutes=10)),
+        ]
+        matching_trips = {"new_trip": candidate}
+
+        result = select_matching_trip(
+            matching_trips,
+            journey,
+            {"JAM", "NY"},
+            lambda _trip_id: "L123",
+            "LIRR",
+        )
+
+        assert result is candidate
 
 
 class TestCheckJourneyCompleted:

--- a/backend_v2/tests/unit/collectors/test_mta_common.py
+++ b/backend_v2/tests/unit/collectors/test_mta_common.py
@@ -11,6 +11,7 @@ from trackrat.collectors.mta_common import (
     ORIGIN_TRAVEL_BUFFER,
     build_complete_stops,
     check_journey_completed,
+    group_candidate_trips_by_overlap,
     infer_direction_from_terminals,
     infer_missing_origin,
     infer_subway_origin,
@@ -327,6 +328,49 @@ class TestUpdateJourneyMetadata:
 class TestSelectMatchingTrip:
     """Tests for GTFS-RT exact/fuzzy trip selection."""
 
+    def test_grouping_preserves_candidate_extra_stops(self):
+        """Candidate trip grouping must keep stops outside the stored journey."""
+        now = datetime.now(timezone.utc)
+        arrivals = [
+            _make_arrival("JAM", now, trip_id="new_trip"),
+            _make_arrival("NY", now + timedelta(minutes=10), trip_id="new_trip"),
+            _make_arrival("ATL", now + timedelta(minutes=20), trip_id="new_trip"),
+            _make_arrival("GCT", now, trip_id="other_trip"),
+        ]
+
+        matching_trips = group_candidate_trips_by_overlap(arrivals, {"JAM", "NY"})
+
+        assert set(matching_trips) == {"new_trip"}
+        assert [a.station_code for a in matching_trips["new_trip"]] == [
+            "JAM",
+            "NY",
+            "ATL",
+        ]
+
+    def test_rejects_fuzzy_match_with_extra_candidate_stop(self):
+        """Fuzzy fallback must see and reject added route-variant stops."""
+        now = datetime.now(timezone.utc)
+        journey = MagicMock(spec=TrainJourney)
+        journey.train_id = "L999"
+        journey.scheduled_departure = now
+
+        arrivals = [
+            _make_arrival("JAM", now + timedelta(seconds=30), trip_id="new_trip"),
+            _make_arrival("NY", now + timedelta(minutes=10), trip_id="new_trip"),
+            _make_arrival("ATL", now + timedelta(minutes=20), trip_id="new_trip"),
+        ]
+        matching_trips = group_candidate_trips_by_overlap(arrivals, {"JAM", "NY"})
+
+        result = select_matching_trip(
+            matching_trips,
+            journey,
+            {"JAM", "NY"},
+            lambda _trip_id: "L123",
+            "LIRR",
+        )
+
+        assert result is None
+
     def test_exact_match_allows_partial_live_stop_set(self):
         """Exact trip-id matches can refresh even when RT omits passed stops."""
         now = datetime.now(timezone.utc)
@@ -348,7 +392,31 @@ class TestSelectMatchingTrip:
             "LIRR",
         )
 
-        assert result is candidate
+        assert [arrival.station_code for arrival in result or []] == ["JAM", "NY"]
+
+    def test_exact_match_ignores_extra_live_stops_when_updating(self):
+        """Exact matches should not widen the stored journey during updates."""
+        now = datetime.now(timezone.utc)
+        journey = MagicMock(spec=TrainJourney)
+        journey.train_id = "L123"
+        journey.scheduled_departure = now
+
+        candidate = [
+            _make_arrival("JAM", now + timedelta(minutes=5)),
+            _make_arrival("NY", now + timedelta(minutes=20)),
+            _make_arrival("ATL", now + timedelta(minutes=35)),
+        ]
+        matching_trips = {"trip_123": candidate}
+
+        result = select_matching_trip(
+            matching_trips,
+            journey,
+            {"JAM", "NY"},
+            lambda trip_id: "L123" if trip_id == "trip_123" else "L999",
+            "LIRR",
+        )
+
+        assert [arrival.station_code for arrival in result or []] == ["JAM", "NY"]
 
     def test_rejects_fuzzy_match_with_different_stop_set(self):
         """Fuzzy trip-id fallback must not mutate a journey for another variant."""
@@ -502,9 +570,11 @@ def _make_arrival(
     departure_time: datetime | None = None,
     delay_seconds: int = 0,
     track: str | None = None,
+    trip_id: str = "trip",
 ) -> MagicMock:
     """Create a mock GTFS-RT arrival (LirrArrival/MnrArrival compatible)."""
     arr = MagicMock()
+    arr.trip_id = trip_id
     arr.station_code = station_code
     arr.arrival_time = arrival_time
     arr.departure_time = departure_time

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -174,7 +174,7 @@ async def test_high_variance_filter(pattern_scheduler):
 
 @pytest.mark.asyncio
 async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
-    """Test that SCHEDULED journeys copy full stop list from recent OBSERVED journey."""
+    """SCHEDULED journeys use a stable stop list from multiple recent runs."""
     target_date = date(2024, 1, 25)
 
     patterns = [
@@ -191,56 +191,64 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         }
     ]
 
-    # Build a mock recent OBSERVED journey with full stops
-    recent_journey = MagicMock()
-    recent_journey.stops = [
-        MagicMock(
-            station_code="NYP",
-            station_name="New York Penn Station",
-            stop_sequence=0,
-            scheduled_departure=ET.localize(datetime(2024, 1, 22, 15, 3)),
-            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 15, 3)),
-        ),
-        MagicMock(
-            station_code="NWK",
-            station_name="Newark Penn Station",
-            stop_sequence=1,
-            scheduled_departure=ET.localize(datetime(2024, 1, 22, 15, 22)),
-            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 15, 20)),
-        ),
-        MagicMock(
-            station_code="TRE",
-            station_name="Trenton",
-            stop_sequence=2,
-            scheduled_departure=ET.localize(datetime(2024, 1, 22, 15, 55)),
-            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 15, 53)),
-        ),
-        MagicMock(
-            station_code="PH",
-            station_name="Philadelphia 30th Street",
-            stop_sequence=3,
-            scheduled_departure=ET.localize(datetime(2024, 1, 22, 16, 25)),
-            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 16, 22)),
-        ),
-        MagicMock(
-            station_code="WS",
-            station_name="Washington Union Station",
-            stop_sequence=4,
-            scheduled_departure=None,
-            scheduled_arrival=ET.localize(datetime(2024, 1, 22, 18, 30)),
-        ),
+    def make_recent_journey(journey_date: date, origin_minute: int) -> MagicMock:
+        origin_departure = ET.localize(
+            datetime.combine(journey_date, time(15, origin_minute))
+        )
+        recent_journey = MagicMock()
+        recent_journey.journey_date = journey_date
+        recent_journey.stops = [
+            MagicMock(
+                station_code="NYP",
+                station_name="New York Penn Station",
+                stop_sequence=0,
+                scheduled_departure=origin_departure,
+                scheduled_arrival=origin_departure,
+            ),
+            MagicMock(
+                station_code="NWK",
+                station_name="Newark Penn Station",
+                stop_sequence=1,
+                scheduled_departure=origin_departure + timedelta(minutes=19),
+                scheduled_arrival=origin_departure + timedelta(minutes=17),
+            ),
+            MagicMock(
+                station_code="TRE",
+                station_name="Trenton",
+                stop_sequence=2,
+                scheduled_departure=origin_departure + timedelta(minutes=52),
+                scheduled_arrival=origin_departure + timedelta(minutes=50),
+            ),
+            MagicMock(
+                station_code="PH",
+                station_name="Philadelphia 30th Street",
+                stop_sequence=3,
+                scheduled_departure=origin_departure + timedelta(minutes=82),
+                scheduled_arrival=origin_departure + timedelta(minutes=79),
+            ),
+            MagicMock(
+                station_code="WS",
+                station_name="Washington Union Station",
+                stop_sequence=4,
+                scheduled_departure=None,
+                scheduled_arrival=origin_departure + timedelta(minutes=207),
+            ),
+        ]
+        return recent_journey
+
+    recent_journeys = [
+        make_recent_journey(date(2024, 1, 18), 3),
+        make_recent_journey(date(2024, 1, 11), 7),
     ]
 
     with patch(
         "trackrat.services.amtrak_pattern_scheduler.get_session"
     ) as mock_session:
-        # First execute call: check for existing journey (returns None)
-        # Second execute call: fetch recent journey with stops
         mock_no_existing = MagicMock()
         mock_no_existing.scalars.return_value.first.return_value = None
 
         mock_recent_result = MagicMock()
-        mock_recent_result.scalar_one_or_none.return_value = recent_journey
+        mock_recent_result.scalars.return_value.all.return_value = recent_journeys
 
         mock_execute = AsyncMock(side_effect=[mock_no_existing, mock_recent_result])
         mock_session.return_value.__aenter__.return_value.execute = mock_execute
@@ -268,7 +276,7 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
             datetime.combine(target_date, time(15, 5))
         )
 
-        # Should have all 5 stops from the recent journey, not just origin
+        # Should have all 5 stops from the stable route, not just origin
         assert len(stops) == 5
         assert journey.stops_count == 5
 
@@ -277,8 +285,6 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         assert station_codes == ["NYP", "NWK", "TRE", "PH", "WS"]
 
         # Verify time offset was applied correctly
-        # Recent origin departed at 15:03, pattern median is 15:05 -> offset = +2 min
-        # (plus 3-day date shift from Jan 22 to Jan 25)
         assert stops[0].scheduled_departure == ET.localize(datetime(2024, 1, 25, 15, 5))
         assert stops[1].scheduled_departure == ET.localize(
             datetime(2024, 1, 25, 15, 24)
@@ -294,6 +300,70 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         # Verify arrivals also shifted
         assert stops[0].scheduled_arrival == ET.localize(datetime(2024, 1, 25, 15, 5))
         assert stops[4].scheduled_arrival == ET.localize(datetime(2024, 1, 25, 18, 32))
+
+
+@pytest.mark.asyncio
+async def test_create_scheduled_journeys_excludes_one_off_stop(pattern_scheduler):
+    """A stop from only one historical run should not leak into SCHEDULED rows."""
+    target_date = date(2024, 1, 25)
+    patterns = [
+        {
+            "train_number": "2107",
+            "median_departure": time(7, 35),
+            "occurrence_count": 2,
+            "origin": "NY",
+            "destination": "Washington Union Station",
+            "terminal": "WS",
+            "line_name": "Acela",
+            "time_variance": 1.0,
+            "sample_dates": ["2024-01-11", "2024-01-18"],
+        }
+    ]
+
+    def stop(code: str, seq: int, journey_date: date, minutes: int) -> MagicMock:
+        base_time = ET.localize(datetime.combine(journey_date, time(7, 35)))
+        return MagicMock(
+            station_code=code,
+            station_name=code,
+            stop_sequence=seq,
+            scheduled_departure=base_time + timedelta(minutes=minutes),
+            scheduled_arrival=base_time + timedelta(minutes=minutes),
+        )
+
+    one_off = MagicMock()
+    one_off.journey_date = date(2024, 1, 18)
+    one_off.stops = [
+        stop("NY", 0, one_off.journey_date, 0),
+        stop("MP", 1, one_off.journey_date, 21),
+        stop("PH", 2, one_off.journey_date, 66),
+        stop("WS", 3, one_off.journey_date, 175),
+    ]
+
+    normal = MagicMock()
+    normal.journey_date = date(2024, 1, 11)
+    normal.stops = [
+        stop("NY", 0, normal.journey_date, 0),
+        stop("PH", 1, normal.journey_date, 66),
+        stop("WS", 2, normal.journey_date, 175),
+    ]
+
+    with patch(
+        "trackrat.services.amtrak_pattern_scheduler.get_session"
+    ) as mock_session:
+        mock_no_existing = MagicMock()
+        mock_no_existing.scalars.return_value.first.return_value = None
+        mock_recent_result = MagicMock()
+        mock_recent_result.scalars.return_value.all.return_value = [one_off, normal]
+        mock_session.return_value.__aenter__.return_value.execute = AsyncMock(
+            side_effect=[mock_no_existing, mock_recent_result]
+        )
+
+        scheduled_journeys = await pattern_scheduler.create_scheduled_journeys(
+            patterns, target_date
+        )
+
+    stops = scheduled_journeys[0]["stops"]
+    assert [s.station_code for s in stops] == ["NY", "PH", "WS"]
 
 
 @pytest.mark.asyncio
@@ -318,12 +388,11 @@ async def test_create_scheduled_journeys_fallback_no_recent(pattern_scheduler):
     with patch(
         "trackrat.services.amtrak_pattern_scheduler.get_session"
     ) as mock_session:
-        # First: no existing journey; Second: no recent journey found
         mock_no_existing = MagicMock()
         mock_no_existing.scalars.return_value.first.return_value = None
 
         mock_no_recent = MagicMock()
-        mock_no_recent.scalar_one_or_none.return_value = None
+        mock_no_recent.scalars.return_value.all.return_value = []
 
         mock_execute = AsyncMock(side_effect=[mock_no_existing, mock_no_recent])
         mock_session.return_value.__aenter__.return_value.execute = mock_execute

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -307,9 +307,9 @@ async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
         assert len(stops) == 5
         assert journey.stops_count == 5
 
-        # Verify station codes match the full route
+        # Verify station codes match the canonicalized full route
         station_codes = [s.station_code for s in stops]
-        assert station_codes == ["NYP", "NWK", "TRE", "PH", "WS"]
+        assert station_codes == ["NY", "NP", "TR", "PH", "WS"]
 
         # Verify time offset was applied correctly
         assert stops[0].scheduled_departure == ET.localize(datetime(2024, 1, 25, 15, 5))

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -393,6 +393,47 @@ async def test_create_scheduled_journeys_excludes_one_off_stop(pattern_scheduler
     assert [s.station_code for s in stops] == ["NY", "PH", "WS"]
 
 
+def test_consensus_stop_templates_canonicalize_amtrak_station_aliases(
+    pattern_scheduler,
+):
+    """Raw/internal Amtrak stop aliases should intersect as the same route."""
+    raw_base = ET.localize(datetime(2024, 1, 18, 7, 35))
+    internal_base = ET.localize(datetime(2024, 1, 11, 7, 35))
+
+    def stop(
+        code: str, name: str, sequence: int, base_time: datetime, minutes: int
+    ) -> MagicMock:
+        return MagicMock(
+            station_code=code,
+            station_name=name,
+            stop_sequence=sequence,
+            scheduled_departure=base_time + timedelta(minutes=minutes),
+            scheduled_arrival=base_time + timedelta(minutes=minutes),
+        )
+
+    raw_journey = MagicMock()
+    raw_journey.stops = [
+        stop("NYP", "New York Penn Station", 0, raw_base, 0),
+        stop("PHL", "Philadelphia 30th Street", 1, raw_base, 66),
+        stop("WAS", "Washington Union Station", 2, raw_base, 175),
+    ]
+
+    internal_journey = MagicMock()
+    internal_journey.stops = [
+        stop("NY", "New York Penn Station", 0, internal_base, 0),
+        stop("PH", "Philadelphia 30th Street", 1, internal_base, 66),
+        stop("WS", "Washington Union Station", 2, internal_base, 175),
+    ]
+
+    templates = pattern_scheduler._build_consensus_stop_templates(
+        [raw_journey, internal_journey],
+        {"NYP", "WAS"},
+    )
+
+    assert templates is not None
+    assert [t["station_code"] for t in templates] == ["NY", "PH", "WS"]
+
+
 @pytest.mark.asyncio
 async def test_create_scheduled_journeys_fallback_no_recent(pattern_scheduler):
     """Test fallback to origin-only stop when no recent OBSERVED journey exists."""

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -173,6 +173,33 @@ async def test_high_variance_filter(pattern_scheduler):
 
 
 @pytest.mark.asyncio
+async def test_recent_matching_journeys_filters_amtrak_station_aliases(
+    pattern_scheduler,
+):
+    """Historical route samples should match raw/internal Amtrak station aliases."""
+    session = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=mock_result)
+
+    await pattern_scheduler._get_recent_matching_journeys(
+        session,
+        {
+            "train_number": "2150",
+            "origin": "NYP",
+            "terminal": "WAS",
+        },
+        date(2024, 1, 25),
+    )
+
+    stmt = session.execute.await_args.args[0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+    assert "origin_station_code IN ('NY', 'NYP')" in compiled
+    assert "terminal_station_code IN ('WAS', 'WS')" in compiled
+
+
+@pytest.mark.asyncio
 async def test_create_scheduled_journeys_with_recent_stops(pattern_scheduler):
     """SCHEDULED journeys use a stable stop list from multiple recent runs."""
     target_date = date(2024, 1, 25)


### PR DESCRIPTION
## Summary

Fixes phantom stop propagation across scheduled and live journey update paths.

This PR addresses the backend root cause behind pre-departure Amtrak phantom stops and hardens the related GTFS-RT fuzzy-trip update behavior across the MTA-family collectors. It also converts NJT phantom-stop cleanup to the safer bulk-delete pattern and keeps `stops_count` aligned with the current stop collection.

## Root Cause

Amtrak scheduled journeys were seeded by copying the full stop list from a single recent `OBSERVED` journey and shifting timestamps. If that one observed run included an unusual one-off stop, every future `SCHEDULED` record for that train number inherited the phantom stop until live Amtrak reconciliation corrected it.

The MTA-family collectors had a latent version of the same orphan-stop risk: their exact train-id updates are safe, but their fuzzy trip-id fallback could accept a different live trip with a different stop set and then leave old stops attached to the existing journey.

The follow-up test failure exposed a mixed station-code edge case in the new Amtrak consensus guard: patterns can carry raw Amtrak codes such as `WAS`, while journey stops may carry TrackRat internal codes such as `WS`. The required origin/terminal check now accepts either raw or mapped internal aliases.

PR feedback also caught that alias handling must happen before consensus construction: the recent observed-journey query itself was still filtering route samples with strict origin/terminal equality, so alias-equivalent historical rows could be dropped before they reached the consensus step.

A later review pass found two remaining edge cases: MTA-family fuzzy candidates were being pre-filtered before stop-set comparison, hiding extra candidate stops, and Amtrak stop consensus still compared raw/internal stop aliases as distinct stations.

## What Changed

### Amtrak pattern scheduler

- Replaced single-run scheduled stop seeding with recent same-weekday, same-route consensus.
- Requires at least two complete observed samples before trusting a scheduled route stop list.
- Intersects canonicalized Amtrak station codes across sample runs so one-off stops are excluded while raw/internal aliases still agree.
- Queries recent route samples using raw/internal Amtrak origin and terminal aliases.
- Requires origin and terminal to be present in the consensus before using it, while tolerating raw/internal Amtrak station-code aliases.
- Falls back to the origin-only scheduled stop when a stable route cannot be proven.
- Uses median stop sequence and median time offsets to build scheduled stop templates.
- Normalizes stop sequences before saving scheduled rows.

### MTA-family collectors

- Added shared `select_matching_trip` helper for LIRR, MNR, Subway, BART, MBTA, and Metra.
- Added shared candidate grouping that preserves full live trips before fuzzy stop-set comparison.
- Preserves exact train-id matching behavior, including partial live-feed stop sets, while applying exact updates only to stored journey stops.
- Makes fuzzy fallback stricter by rejecting candidates whose full visible station set differs from the stored journey.
- Keeps `journey.stops_count` refreshed whenever callers have the current stop list.

### NJT journey collector

- Replaced select-then-per-row phantom stop deletion with a single bulk `DELETE` scoped to stops not present in the live API response.
- Leaves existing resequencing and duplicate-sequence validation in place after cleanup.

### Tests

- Updated Amtrak scheduler tests to cover consensus-built scheduled stops.
- Added coverage that a one-off Amtrak stop is excluded from scheduled rows.
- Added coverage that the recent observed-journey query includes alias-equivalent Amtrak origin/terminal station codes.
- Added coverage that raw/internal Amtrak stop aliases intersect during consensus.
- Added MTA common tests for exact match tolerance, exact match scoping, fuzzy mismatch rejection, fuzzy extra-stop rejection, fuzzy same-stop-set acceptance, candidate grouping, and `stops_count` refresh.

## Safety Notes

- The Amtrak change is intentionally conservative: if there is not enough agreement among recent complete observed runs, scheduled journeys keep only the origin stop instead of inventing a full route.
- The route-sample query, required-stop check, and stop-consensus intersection now handle mixed raw/internal Amtrak station codes like `WAS`/`WS`.
- Exact GTFS-RT trip matches remain permissive for partial feeds, so normal updates are not blocked when passed stops disappear from live data.
- Exact GTFS-RT update application remains scoped to stops that already exist on the stored journey.
- Fuzzy GTFS-RT matches now only update an existing journey when the full visible stop set is the same, avoiding cross-variant mutation.
- NJT still resequences and validates after deleting phantom stops.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/trackrat_pycache /Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile ...` on all modified source and test files.
- `git diff --check`.
- Focused pytest could not be run locally because this environment does not have `pytest`, `poetry`, or `uv` installed.

## Commits

`f56f0bf Fix phantom stop propagation`

- Build Amtrak scheduled stop lists from recent same-route consensus instead of copying a single observed run, with origin-only fallback when the stable route cannot be proven.
- Centralize GTFS-RT exact/fuzzy trip selection so MTA-family collectors reject fuzzy matches whose stop sets differ from the stored journey, while keeping exact train-id matches tolerant of partial live feeds.
- Refresh `stops_count` from the current stop collection and convert NJT phantom-stop cleanup to a bulk delete before resequencing.
- Validation: py_compile on modified backend/test files; git diff --check. Pytest intentionally skipped per request.

`9b42045 Handle Amtrak station aliases in stop consensus`

- Allow required scheduler origin and terminal codes to match either raw Amtrak station codes or mapped internal TrackRat station codes.
- Keeps the consensus safety check intact while fixing mixed-code historical data such as `WAS` versus `WS`.
- Validation: py_compile for the scheduler and related test file; git diff --check. Focused pytest could not run locally because pytest/poetry/uv are not installed in this environment.

`9113bea Query Amtrak route samples by station aliases`

- Expand the recent observed-journey query to match raw Amtrak and internal TrackRat origin/terminal aliases before building scheduled-stop consensus.
- Addresses PR feedback where strict `WAS` versus `WS` route filters could drop otherwise valid historical samples and force origin-only scheduled journeys.
- Validation: py_compile for the scheduler and related scheduler test file; git diff --check.

`a85c2b8 Tighten stop-set reconciliation edge cases`

- Group full GTFS-RT candidate trips before fuzzy matching so added route-variant stops remain visible to the stop-set comparison.
- Keep exact train-id updates scoped to stored journey stops to preserve existing update behavior while still tolerating partial live feeds.
- Canonicalize Amtrak raw station codes to TrackRat internal codes before stop-consensus intersection so mixed raw/internal historical stops still agree.
- Validation: py_compile for modified backend and test files; git diff --check.