### PR TITLE
Improve TR matching logic to prefer same train_id over nearest-by-time

### DIFF
--- a/scripts/ground-truth-validate.py
+++ b/scripts/ground-truth-validate.py
@@ -941,16 +941,49 @@ def run_validation_loop(
                 time_str = gt.expected_time.astimezone(et).strftime("%H:%M")
                 detail = ""
                 if verbose and tr_departures:
-                    nearest = min(
-                        tr_departures,
-                        key=lambda tr: abs((tr.departure_time - gt.expected_time).total_seconds()),
+                    # If GT has a trip_id, prefer reporting the TR record with the
+                    # same train_id (even if outside tolerance) — that's the actually
+                    # comparable train. Falling back to nearest-by-time alone is
+                    # misleading when frequencies are short, since the "nearest" may
+                    # be a completely different physical train.
+                    id_matched = (
+                        [tr for tr in tr_departures if gt.train_id and tr.train_id == gt.train_id]
+                        if gt.train_id
+                        else []
                     )
-                    nearest_delta = int((nearest.departure_time - gt.expected_time).total_seconds())
-                    nearest_time = nearest.departure_time.astimezone(et).strftime("%H:%M:%S")
-                    detail = (
-                        f"Nearest TR: {nearest.train_id} @ {nearest_time} "
-                        f"({chr(0x394)} {format_delta(abs(nearest_delta))}, {nearest.observation_type})"
-                    )
+                    if id_matched:
+                        match = min(
+                            id_matched,
+                            key=lambda tr: abs(
+                                (tr.departure_time - gt.expected_time).total_seconds()
+                            ),
+                        )
+                        match_delta = int((match.departure_time - gt.expected_time).total_seconds())
+                        match_time = match.departure_time.astimezone(et).strftime("%H:%M:%S")
+                        detail = (
+                            f"Same-trip TR: {match.train_id} @ {match_time} "
+                            f"({chr(0x394)} {format_delta(abs(match_delta))}, "
+                            f"{match.observation_type})"
+                        )
+                    else:
+                        nearest = min(
+                            tr_departures,
+                            key=lambda tr: abs(
+                                (tr.departure_time - gt.expected_time).total_seconds()
+                            ),
+                        )
+                        nearest_delta = int(
+                            (nearest.departure_time - gt.expected_time).total_seconds()
+                        )
+                        nearest_time = nearest.departure_time.astimezone(et).strftime("%H:%M:%S")
+                        # Label clearly: this is closest-by-time on the route, NOT
+                        # necessarily the same train. The trip_id didn't match (or GT
+                        # has no trip_id), so the delta is the gap to a different train.
+                        detail = (
+                            f"Closest-by-time TR (different train): {nearest.train_id} "
+                            f"@ {nearest_time} ({chr(0x394)} {format_delta(abs(nearest_delta))}, "
+                            f"{nearest.observation_type})"
+                        )
                 # Downgrade far-future trains to WARN: the collector may not have
                 # discovered them yet (e.g. PATH collects every 4 min).
                 if gt.minutes_away > far_future_minutes:


### PR DESCRIPTION
## Summary
Enhanced the ground truth validation reporting to intelligently match transit records (TR) with ground truth (GT) entries. When a GT record has a `train_id`, the validation now prefers reporting the TR record with the matching `train_id` rather than always falling back to the nearest-by-time match, which can be misleading on high-frequency routes.

## Key Changes
- **Smart TR matching**: When GT has a `trip_id`, filter TR departures to find records with matching `train_id` first
- **Fallback behavior**: Only use nearest-by-time matching when no same-train match exists or GT lacks a `train_id`
- **Improved labeling**: Distinguish between "Same-trip TR" (matched by ID) and "Closest-by-time TR (different train)" (fallback case) in verbose output
- **Better context**: Added clarifying comments explaining why same-train matching is preferred and why nearest-by-time alone can be misleading on short-frequency routes

## Implementation Details
- The logic now performs two-tier matching: first attempts to find TR records with matching `train_id`, then falls back to nearest-by-time if no match is found
- Output labels clearly indicate whether the reported TR is the same physical train or just the closest departure time-wise
- Maintains backward compatibility by gracefully handling cases where GT lacks a `train_id`

https://claude.ai/code/session_01JQsm5cqKZK1uzRDrhHGv1q