### PR TITLE
Issue #1090: Fix digest time not respecting directionality

### DIFF
--- a/ios/TrackRat/Services/AlertSubscriptionService.swift
+++ b/ios/TrackRat/Services/AlertSubscriptionService.swift
@@ -68,8 +68,15 @@ final class AlertSubscriptionService: ObservableObject {
             if sub.isSystemWide && context.lineId == nil && context.fromStationCode == nil {
                 return true
             }
-            // Match line subscriptions
+            // Match line subscriptions (with direction check when context has a terminal destination)
             if let lineId = sub.lineId, lineId == context.lineId {
+                if let subDir = sub.direction, let ctxTo = context.toStationCode,
+                   let route = RouteTopology.allRoutes.first(where: { $0.id == lineId }) {
+                    let stations = route.stationCodes
+                    if ctxTo == stations.first || ctxTo == stations.last {
+                        return subDir == ctxTo
+                    }
+                }
                 return true
             }
             // Match station-pair subscriptions (exact direction only)

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -80,6 +80,13 @@ struct RouteStatusView: View {
                                 fromStationCode: context.toStationCode,
                                 toStationCode: context.fromStationCode
                             )
+                            // Persist pending edits before switching direction
+                            for (_, edited) in editedSubscriptions {
+                                alertService.updateSubscription(edited)
+                            }
+                            if !editedSubscriptions.isEmpty {
+                                alertService.syncIfPossible()
+                            }
                             editedSubscriptions = [:]
                             draftSubscription = nil
                             Task { await viewModel.replaceContext(reversed, historyPeriod: selectedHistoryPeriod) }
@@ -95,7 +102,7 @@ struct RouteStatusView: View {
                     }
                 }
             }
-            .task {
+            .task(id: "\(context.fromStationCode ?? "")-\(context.toStationCode ?? "")") {
                 // Initialize draft subscription for alert config if not yet subscribed
                 if matchingSubscriptions.isEmpty && draftSubscription == nil {
                     if let from = context.fromStationCode, let to = context.toStationCode {

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -120,6 +120,8 @@ struct RouteStatusView: View {
                         )
                     }
                 }
+            }
+            .task {
                 await viewModel.loadData(initialPeriod: selectedHistoryPeriod)
             }
             .onDisappear {

--- a/ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift
+++ b/ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift
@@ -350,6 +350,110 @@ class AlertSubscriptionServiceTests: XCTestCase {
                        "Zero subscriptions should be below the free limit")
     }
 
+    // MARK: - subscriptions(for:) Direction Matching
+
+    func testSubscriptionsForContext_lineSubscription_matchesCorrectDirection() {
+        // User has NEC subscriptions for both directions
+        let toNY = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "njt-nec", lineName: "Northeast Corridor",
+            direction: "NY", activeDays: 31, digestTimeMinutes: 420
+        )
+        let toTR = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "njt-nec", lineName: "Northeast Corridor",
+            direction: "TR", activeDays: 31, digestTimeMinutes: 480
+        )
+        service.addSubscriptions([toNY, toTR])
+
+        // Context for NY-bound (toStationCode = terminal "NY")
+        let contextToNY = RouteStatusContext(
+            dataSource: "NJT", lineId: "njt-nec",
+            fromStationCode: "TR", toStationCode: "NY"
+        )
+        let matchesNY = service.subscriptions(for: contextToNY)
+        XCTAssertEqual(matchesNY.count, 1, "Should only match the NY-direction subscription")
+        XCTAssertEqual(matchesNY.first?.direction, "NY", "Matched subscription should be NY-bound")
+        XCTAssertEqual(matchesNY.first?.digestTimeMinutes, 420, "Should have NY-direction's digest time")
+
+        // Context for TR-bound (toStationCode = terminal "TR")
+        let contextToTR = RouteStatusContext(
+            dataSource: "NJT", lineId: "njt-nec",
+            fromStationCode: "NY", toStationCode: "TR"
+        )
+        let matchesTR = service.subscriptions(for: contextToTR)
+        XCTAssertEqual(matchesTR.count, 1, "Should only match the TR-direction subscription")
+        XCTAssertEqual(matchesTR.first?.direction, "TR", "Matched subscription should be TR-bound")
+        XCTAssertEqual(matchesTR.first?.digestTimeMinutes, 480, "Should have TR-direction's digest time")
+    }
+
+    func testSubscriptionsForContext_lineSubscription_midRouteContextMatchesBothDirections() {
+        // When context destination is not a terminal, fall back to lineId-only match
+        let toNY = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "njt-nec", lineName: "Northeast Corridor",
+            direction: "NY", activeDays: 31
+        )
+        let toTR = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "njt-nec", lineName: "Northeast Corridor",
+            direction: "TR", activeDays: 31
+        )
+        service.addSubscriptions([toNY, toTR])
+
+        // Mid-route context: destination is NP (Newark), not a terminal
+        let midRouteContext = RouteStatusContext(
+            dataSource: "NJT", lineId: "njt-nec",
+            fromStationCode: "TR", toStationCode: "NP"
+        )
+        let matches = service.subscriptions(for: midRouteContext)
+        XCTAssertEqual(matches.count, 2,
+                       "Mid-route context should match both directions (no terminal filtering)")
+    }
+
+    func testSubscriptionsForContext_stationPair_matchesExactDirectionOnly() {
+        let subAB = RouteAlertSubscription(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR",
+            activeDays: 31, digestTimeMinutes: 420
+        )
+        let subBA = RouteAlertSubscription(
+            dataSource: "NJT", fromStationCode: "TR", toStationCode: "NY",
+            activeDays: 31, digestTimeMinutes: 480
+        )
+        service.addSubscriptions([subAB, subBA])
+
+        let contextAB = RouteStatusContext(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR"
+        )
+        let matchesAB = service.subscriptions(for: contextAB)
+        XCTAssertEqual(matchesAB.count, 1, "Should only match NY→TR subscription")
+        XCTAssertEqual(matchesAB.first?.fromStationCode, "NY")
+        XCTAssertEqual(matchesAB.first?.digestTimeMinutes, 420,
+                       "Should return the correct direction's digest time")
+
+        let contextBA = RouteStatusContext(
+            dataSource: "NJT", fromStationCode: "TR", toStationCode: "NY"
+        )
+        let matchesBA = service.subscriptions(for: contextBA)
+        XCTAssertEqual(matchesBA.count, 1, "Should only match TR→NY subscription")
+        XCTAssertEqual(matchesBA.first?.fromStationCode, "TR")
+        XCTAssertEqual(matchesBA.first?.digestTimeMinutes, 480,
+                       "Should return the correct direction's digest time")
+    }
+
+    func testSubscriptionsForContext_systemWide_matchesCorrectly() {
+        let sub = RouteAlertSubscription(dataSource: "NJT")
+        service.addSubscriptions([sub])
+
+        let context = RouteStatusContext(dataSource: "NJT")
+        let matches = service.subscriptions(for: context)
+        XCTAssertEqual(matches.count, 1, "System-wide subscription should match system context")
+
+        // System-wide should NOT match when context has specific stations
+        let stationContext = RouteStatusContext(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR"
+        )
+        let stationMatches = service.subscriptions(for: stationContext)
+        XCTAssertEqual(stationMatches.count, 0,
+                       "System-wide subscription should not match station-specific context")
+    }
+
     // MARK: - Commute Scenario: Independent Direction Configuration
 
     func testCommuteScenario_morningAndEveningDirections() {


### PR DESCRIPTION
## Summary\n\nFixes #1090 — setting digest time for A→B was also affecting B→A due to three issues in the iOS alert subscription system.\n\n### Changes\n\n**`ios/TrackRat/Services/AlertSubscriptionService.swift`**\n- `subscriptions(for:)` now checks the subscription's `direction` against the context's `toStationCode` when the destination is a route terminal. Previously, line-based subscriptions matched any context with the same `lineId` regardless of direction, causing both A→B and B→A subscriptions to match simultaneously. `alertConfigBinding` would then bind to whichever came first.\n\n**`ios/TrackRat/Views/Screens/RouteStatusView.swift`**\n- Reverse button now persists pending `editedSubscriptions` before clearing them, preventing silent data loss when switching direction.\n- `.task` modifier now uses `id:` tied to the station pair so that `draftSubscription` reinitializes correctly after a direction reversal (previously `.task` had no id and only ran once on view appear).\n\n**`ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift`**\n- Added 4 tests verifying direction-aware matching: line subscriptions match correct direction at terminals, fall back to broad match for mid-route contexts, station-pair subscriptions match exact direction only, and system-wide subscriptions match correctly.\n\n## Test plan\n\n- [x] New unit tests pass for direction-aware subscription matching\n- [ ] Manual: Create both A→B and B→A subscriptions, set different digest times, verify they remain independent\n- [ ] Manual: Reverse direction in RouteStatusView, verify edits to first direction are preserved\n- [ ] Manual: Verify mid-route navigation still shows line subscription alerts\n\nCloses #1090\n\nhttps://claude.ai/code/session_01GM7bv1pc6ciYJqidY1yXJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM7bv1pc6ciYJqidY1yXJW)_