### PR TITLE
docs: weekly documentation audit (2026-05-04)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,7 +483,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - iOS views: `ios/TrackRat/Views/Screens/`, `ios/TrackRat/Views/Components/`, `ios/TrackRat/Views/Paywall/`
 - iOS services: `ios/TrackRat/Services/`
 - iOS models: `ios/TrackRat/Models/`
-- iOS shared: `ios/TrackRat/Shared/` (LiveActivityModels, Stations, StationData, StationDepartures, StationCoordinates, RouteTopology, RouteShapes)
+- iOS shared: `ios/TrackRat/Shared/` (LiveActivityModels, Stations, StationData, StationDepartures, StationCoordinates, RouteTopology, RouteShapes, SubwayLines)
 - iOS utilities: `ios/TrackRat/Utilities/` (Extensions, Logger)
 - iOS theme: `ios/TrackRat/Theme/` (TrackRatTheme)
 - iOS Live Activity: `ios/TrainLiveActivityExtension/`
@@ -493,7 +493,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 - Web components: `webpage_v2/src/components/`
 - Web services: `webpage_v2/src/services/`
 - Web store: `webpage_v2/src/store/appStore.ts`
-- Web data: `webpage_v2/src/data/` (routeTopology, stations)
+- Web data: `webpage_v2/src/data/` (routeTopology, stations, subwayLines)
 - Web utilities: `webpage_v2/src/utils/` (date, share, formatting, routes, ratsense, trainSearch)
 - Web types: `webpage_v2/src/types/`
 - Web tests: `webpage_v2/src/` (colocated `*.test.ts` and `*.test.tsx` files, Vitest + React Testing Library)
@@ -509,6 +509,7 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 ```
 # Train Operations
 /api/v2/trains/departures          # List departures for route
+/api/v2/trains/recent-departures   # Recent departures (no route filter)
 /api/v2/trains/{train_id}          # Train details with all stops
 /api/v2/trains/{train_id}/history  # Historical train performance
 
@@ -555,6 +556,10 @@ PYTHONPATH=/tmp/pylibs:$PYTHONPATH python3 .claude/scripts/gcp-logs.py --raw
 /health/ready                      # Kubernetes readiness probe
 /scheduler/status                  # APScheduler job status
 /metrics                           # Prometheus metrics
+
+# Share (link previews)
+/share/train/{train_id}            # OG meta tags HTML for link previews
+/share/train/{train_id}/image      # PNG share image generation
 ```
 
 **API Environments:**

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ npm run build                        # TypeScript compile + Vite build
 
 ```
 GET  /api/v2/trains/departures              # Departures for a route
+GET  /api/v2/trains/recent-departures       # Recent departures (no route filter)
 GET  /api/v2/trains/{train_id}              # Train details with all stops
+GET  /api/v2/trains/{train_id}/history      # Historical train performance
 GET  /api/v2/routes/congestion              # Network congestion data
 GET  /api/v2/predictions/track              # Platform predictions
 GET  /api/v2/predictions/delay              # Delay/cancellation forecasts

--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -439,6 +439,8 @@ TRACKRAT_WMATA_API_KEY=your_wmata_developer_api_key
 
 # Metra GTFS-RT API
 TRACKRAT_METRA_API_TOKEN=your_metra_api_token
+TRACKRAT_METRA_API_USERNAME=                     # Metra HTTP Basic Auth (alternative to token)
+TRACKRAT_METRA_API_PASSWORD=                     # Metra HTTP Basic Auth (alternative to token)
 
 # Note: BART uses public GTFS-RT feed - no authentication required
 
@@ -481,7 +483,8 @@ TRACKRAT_DEBUG=false                             # Enable debug mode
 TRACKRAT_API_HOST=0.0.0.0                        # API bind host
 TRACKRAT_API_PORT=8000                           # API bind port
 TRACKRAT_SKIP_MIGRATIONS=false                   # Skip auto-migrations on startup
-TRACKRAT_BACKUP_INTERVAL_SECONDS=3600            # GCS backup frequency
+TRACKRAT_BACKUP_INTERVAL_SECONDS=300             # GCS backup frequency (default 5min)
+TRACKRAT_RETENTION_DAYS=120                      # Days to retain journey data (min 30)
 
 # APNS Auth Key Content (alternative to file path)
 APNS_AUTH_KEY=                                   # Raw P8 key content (fallback if APNS_AUTH_KEY_PATH unavailable)
@@ -753,6 +756,10 @@ The backend is organized into service classes for better maintainability:
 - **TripSearchService** (`services/trip_search.py`): Multi-leg trip search across transit systems
 - **TransferPoints** (`config/transfer_points.py`): Defines transfer connections between transit systems
 - **TripsAPI** (`api/trips.py`): Trip search endpoint
+
+#### Share / Link Previews
+- **ShareAPI** (`api/share.py`): OG meta tag HTML and image endpoints for rich link previews
+- **ShareImageService** (`services/share_image.py`): PNG rendering for share card images
 
 #### Infrastructure
 - **SimpleAPNSService** (`services/apns.py`): Apple Push Notifications for Live Activities and Route Alerts

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -25,14 +25,14 @@ SwiftUI app for tracking trains across 11 transit systems: NJ Transit, Amtrak, P
 
 ```
 TrackRat/
-├── App/              # TrackRatApp.swift, AppState
+├── App/              # TrackRatApp.swift, ContentView.swift
 ├── Views/
 │   ├── Screens/      # 16 screen-level views
-│   ├── Components/   # 23 reusable UI components
+│   ├── Components/   # 25 reusable UI components
 │   └── Paywall/      # PaywallView, ProFeatureLockView
 ├── Models/           # Train, TrainV2, V2APIModels, TrainSystem, TripOption, CompletedTrip, DeepLink
 ├── Services/         # 14 singleton services
-├── Shared/           # Stations, StationData, StationCoordinates, StationDepartures, LiveActivityModels, RouteTopology, RouteShapes
+├── Shared/           # Stations, StationData, StationCoordinates, StationDepartures, LiveActivityModels, RouteTopology, RouteShapes, SubwayLines
 ├── Theme/            # TrackRatTheme.swift
 ├── Utilities/        # Extensions.swift, Logger.swift
 └── Resources/        # Assets, Info.plist

--- a/ios/README.md
+++ b/ios/README.md
@@ -139,7 +139,7 @@ TrackRat/
 │   │   ├── AddRouteAlertView.swift      # Add route alert
 │   │   └── TripHistoryView.swift        # Trip history
 │   │
-│   └── Components/              # Reusable UI components (23 files)
+│   └── Components/              # Reusable UI components (25 files)
 │       ├── ActiveTripsSection.swift     # Live Activity cards
 │       ├── AlertConfigurationSection.swift # Route alert configuration
 │       ├── ConfettiView.swift           # Confetti animation effect
@@ -156,6 +156,8 @@ TrackRat/
 │       ├── StationButton.swift          # Station selection button
 │       ├── StationPickerSheet.swift     # Station picker modal
 │       ├── StationRow.swift             # Station list row
+│       ├── SubwayLineChips.swift        # Subway line badge chips
+│       ├── SystemChips.swift            # Transit system indicator chips
 │       ├── TrackRatLoadingView.swift    # Loading animation
 │       ├── TrackRatMascot.swift         # Animated character
 │       ├── TrackRatNavigationHeader.swift # Navigation header
@@ -175,7 +177,8 @@ TrackRat/
 │   ├── StationDepartures.swift # Station departure configuration
 │   ├── LiveActivityModels.swift # Widget shared types
 │   ├── RouteTopology.swift      # Route definitions for map layers
-│   └── RouteShapes.swift        # Route shape coordinates for map rendering
+│   ├── RouteShapes.swift        # Route shape coordinates for map rendering
+│   └── SubwayLines.swift        # Subway line definitions and color mappings
 │
 ├── Theme/                       # Visual design
 │   └── TrackRatTheme.swift     # Colors and styles

--- a/webpage_v2/CLAUDE.md
+++ b/webpage_v2/CLAUDE.md
@@ -135,6 +135,7 @@ webpage_v2/
 │   │   ├── SimilarTrainsPanel.tsx # Similar trains suggestion panel
 │   │   ├── TrainDistributionChart.tsx # Track distribution chart
 │   │   ├── UpcomingTrains.tsx    # Upcoming trains widget
+│   │   ├── SubwayLineChips.tsx  # Subway line badge chips
 │   │   ├── ErrorBoundary.tsx     # React error boundary
 │   │   └── ErrorMessage.tsx
 │   ├── pages/              # Route components
@@ -154,7 +155,8 @@ webpage_v2/
 │   │   └── appStore.ts     # Zustand global state
 │   ├── data/
 │   │   ├── stations.ts     # Static station list (1500+ stations, 11 transit systems)
-│   │   └── routeTopology.ts # Route topology for smart search and filtering
+│   │   ├── routeTopology.ts # Route topology for smart search and filtering
+│   │   └── subwayLines.ts  # Subway line definitions and color mappings
 │   ├── types/
 │   │   └── index.ts        # TypeScript interfaces
 │   └── utils/

--- a/webpage_v2/README.md
+++ b/webpage_v2/README.md
@@ -62,7 +62,7 @@ src/
 ├── store/           # Zustand global state
 ├── types/           # TypeScript type definitions
 ├── utils/           # Date formatting, status badges, share helpers
-├── data/            # Station data and route topology (1,500+ stations, 11 transit systems)
+├── data/            # Station data, route topology, subway lines (1,500+ stations, 11 transit systems)
 ├── App.tsx          # Main app component with route definitions
 ├── main.tsx         # Entry point
 └── index.css        # Global styles


### PR DESCRIPTION
## Summary

Weekly documentation accuracy audit against the current codebase. Fixes documentation drift from recent additions (SubwayLineChips, SystemChips, subwayLines data, share API, env var defaults).

- Add SubwayLines.swift to iOS Shared listings and SubwayLineChips/SystemChips to iOS Components (count 23→25)
- Fix iOS CLAUDE.md App/ description: `ContentView.swift` not `AppState`
- Add `subwayLines.ts` to web data listings and `SubwayLineChips.tsx` to web components
- Add missing API endpoints to root CLAUDE.md: `/api/v2/trains/recent-departures`, `/share/train/*`
- Add `/api/v2/trains/{train_id}/history` to root README API list
- Fix `TRACKRAT_BACKUP_INTERVAL_SECONDS` default in backend CLAUDE.md (300s, not 3600s)
- Add missing env vars to backend CLAUDE.md: `TRACKRAT_METRA_API_USERNAME/PASSWORD`, `TRACKRAT_RETENTION_DAYS`
- Add Share/Link Previews section to backend Key Service Classes

## Test plan

- [ ] Verify all listed file paths exist (`SubwayLines.swift`, `SubwayLineChips.swift`, `SystemChips.swift`, `subwayLines.ts`, `SubwayLineChips.tsx`)
- [ ] Verify updated component counts match actual file counts (25 iOS components, 16 screens)
- [ ] Verify `TRACKRAT_BACKUP_INTERVAL_SECONDS` default is 300 in `settings.py`
- [ ] Spot-check API endpoint list against `main.py` router registrations

https://claude.ai/code/session_012xEDBV17MaxyenaWSXVSqS

---
_Generated by [Claude Code](https://claude.ai/code/session_012xEDBV17MaxyenaWSXVSqS)_