### PR TITLE
Issue #1106: Fix future date schedule showing only trains after current time

### DIFF
--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -105,7 +105,7 @@ final class APIService: ObservableObject {
               selectedStart > todayStart else {
             return nil
         }
-        return selectedStart.addingTimeInterval(5 * 60 * 60)
+        return calendar.date(bySettingHour: 5, minute: 0, second: 0, of: selectedStart)
     }
 
     // MARK: - Train Search

--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -93,10 +93,10 @@ final class APIService: ObservableObject {
         return decoder
     }()
 
-    /// For a future `selectedDate`, project today's wall-clock time-of-day (ET)
-    /// onto it so the backend's limit-50 window lands around the user's current
-    /// commute time rather than always at midnight. Returns nil for today or
-    /// past dates so the existing today-path behavior is unchanged.
+    /// For a future `selectedDate`, anchor the backend's limit-50 window at
+    /// 5 AM ET so high-frequency providers (e.g. SUBWAY) don't fill the result
+    /// set with pre-dawn trains while still showing the full daytime schedule.
+    /// Returns nil for today or past dates so the existing behavior is unchanged.
     static func timeFromForFutureDate(_ selectedDate: Date, now: Date = Date()) -> Date? {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "America/New_York") ?? .current
@@ -105,8 +105,7 @@ final class APIService: ObservableObject {
               selectedStart > todayStart else {
             return nil
         }
-        let timeOfDay = now.timeIntervalSince(todayStart)
-        return selectedStart.addingTimeInterval(timeOfDay)
+        return selectedStart.addingTimeInterval(5 * 60 * 60)
     }
 
     // MARK: - Train Search

--- a/ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift
+++ b/ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift
@@ -208,6 +208,38 @@ class TrainListViewModelTests: XCTestCase {
                        "Future date time_from should be the same regardless of when the user checks")
     }
 
+    func testTimeFromForFutureDatePreserves5AMOnDSTSpringForward() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        // March 8, 2026 is DST spring-forward day (clocks jump 2AM → 3AM)
+        let today = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 3, day: 7, hour: 12))!
+        let dstDay = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 3, day: 8))!
+
+        let timeFrom = APIService.timeFromForFutureDate(dstDay, now: today)
+
+        XCTAssertNotNil(timeFrom)
+        let components = calendar.dateComponents([.hour, .minute], from: timeFrom!)
+        XCTAssertEqual(components.hour, 5, "Should be 5 AM local time even on spring-forward day")
+        XCTAssertEqual(components.minute, 0)
+    }
+
+    func testTimeFromForFutureDatePreserves5AMOnDSTFallBack() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        // November 1, 2026 is DST fall-back day (clocks repeat 1AM → 2AM)
+        let today = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 10, day: 31, hour: 12))!
+        let dstDay = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 11, day: 1))!
+
+        let timeFrom = APIService.timeFromForFutureDate(dstDay, now: today)
+
+        XCTAssertNotNil(timeFrom)
+        let components = calendar.dateComponents([.hour, .minute], from: timeFrom!)
+        XCTAssertEqual(components.hour, 5, "Should be 5 AM local time even on fall-back day")
+        XCTAssertEqual(components.minute, 0)
+    }
+
     func testTimeFromForFutureDateReturnsNilForToday() {
         let now = Date()
         let todayStart = Calendar.current.startOfDay(for: now)

--- a/ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift
+++ b/ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift
@@ -172,7 +172,7 @@ class TrainListViewModelTests: XCTestCase {
                        "Future-date view should not apply the 6-hour live-board filter")
     }
 
-    func testTimeFromForFutureDateProjectsTodaysTimeOfDay() {
+    func testTimeFromForFutureDateAnchorsAt5AM() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "America/New_York")!
 
@@ -182,13 +182,30 @@ class TrainListViewModelTests: XCTestCase {
 
         let timeFrom = APIService.timeFromForFutureDate(tomorrowStart, now: today)
 
-        XCTAssertNotNil(timeFrom)
+        XCTAssertNotNil(timeFrom, "Future date should return a non-nil time_from")
         let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: timeFrom!)
         XCTAssertEqual(components.year, 2026)
         XCTAssertEqual(components.month, 5)
         XCTAssertEqual(components.day, 5)
-        XCTAssertEqual(components.hour, 15)
-        XCTAssertEqual(components.minute, 30)
+        XCTAssertEqual(components.hour, 5, "Future date should anchor at 5 AM ET, not the user's current time")
+        XCTAssertEqual(components.minute, 0)
+    }
+
+    func testTimeFromForFutureDateIgnoresCurrentTimeOfDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        let morning = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 5, day: 4, hour: 8, minute: 0))!
+        let evening = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 5, day: 4, hour: 21, minute: 45))!
+        let tomorrowStart = calendar.date(from: DateComponents(timeZone: calendar.timeZone, year: 2026, month: 5, day: 5))!
+
+        let timeFromMorning = APIService.timeFromForFutureDate(tomorrowStart, now: morning)
+        let timeFromEvening = APIService.timeFromForFutureDate(tomorrowStart, now: evening)
+
+        XCTAssertNotNil(timeFromMorning)
+        XCTAssertNotNil(timeFromEvening)
+        XCTAssertEqual(timeFromMorning, timeFromEvening,
+                       "Future date time_from should be the same regardless of when the user checks")
     }
 
     func testTimeFromForFutureDateReturnsNilForToday() {


### PR DESCRIPTION
## Summary\n\n- **Bug:** When viewing scheduled trains for a future day, the list only showed trains after the current wall-clock time (e.g., checking tomorrow at 3pm hid all morning trains)\n- **Root cause:** `APIService.timeFromForFutureDate` projected today's time-of-day onto the selected future date as the `time_from` query parameter, causing the backend to filter out earlier trains\n- **Fix:** Changed the anchor from \"user's current time\" to a fixed 5:00 AM ET. This preserves the original intent (skip overnight/pre-dawn subway trains that fill the 50-result limit) while showing the complete daytime schedule\n\n## Files Changed\n\n| File | Change |\n|------|--------|\n| `ios/TrackRat/Services/APIService.swift` | Changed `timeFromForFutureDate` to use fixed 5 AM anchor instead of current time-of-day |\n| `ios/TrackRatTests/ViewModels/TrainListViewModelTests.swift` | Updated test to verify 5 AM anchor; added new test confirming time_from is independent of when user checks |\n\n## Test Coverage\n\n- `testTimeFromForFutureDateAnchorsAt5AM` — verifies future date returns 5:00 AM on the selected day\n- `testTimeFromForFutureDateIgnoresCurrentTimeOfDay` — verifies the result is the same whether checked at 8 AM or 9:45 PM\n- `testTimeFromForFutureDateReturnsNilForToday` — existing test, unchanged (today still uses existing behavior)\n\n## Design Decision\n\nThe web app never sends `time_from` for future dates, but it likely has the inverse problem (subway schedules showing only pre-dawn trains due to LIMIT truncation). The 5 AM anchor is a targeted iOS fix that balances both concerns.\n\nCloses #1106\n\nhttps://claude.ai/code/session_0154r3XYJw4M8xMLxBAsKhi2

---
_Generated by [Claude Code](https://claude.ai/code/session_0154r3XYJw4M8xMLxBAsKhi2)_