### PR TITLE
Add feedback button to route status view

### DIFF
--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -58,6 +58,13 @@ struct RouteStatusView: View {
                     departuresSection
                     serviceAlertsSection
                     alertSubscriptionSection
+                    FeedbackButton(
+                        screen: "route_status",
+                        trainId: nil,
+                        originCode: context.fromStationCode,
+                        destinationCode: context.toStationCode
+                    )
+                    .padding(.top, 8)
                 }
                 .padding()
                 .animation(.easeInOut(duration: 0.3), value: viewModel.filterLoaded)


### PR DESCRIPTION
## Summary
Added a feedback button to the RouteStatusView screen to allow users to provide feedback about their route experience.

## Key Changes
- Added `FeedbackButton` component to the RouteStatusView below the alert subscription section
- Configured the button with route-specific context:
  - Screen identifier: "route_status"
  - Origin and destination station codes from the current route context
  - Train ID set to nil (not applicable for route status view)
- Applied top padding (8pt) for proper spacing from the section above

## Implementation Details
The feedback button is positioned at the bottom of the scrollable content stack and uses the existing route context (`context.fromStationCode` and `context.toStationCode`) to provide relevant information when users submit feedback about their journey.

https://claude.ai/code/session_01EKFA6Q2myH9gFEFRvb3L7f