### PR TITLE
Fix route stats cutoff filter to use origin departure instead of destination arrival

### DIFF
--- a/backend_v2/src/trackrat/api/routes.py
+++ b/backend_v2/src/trackrat/api/routes.py
@@ -316,17 +316,17 @@ async def _calculate_route_stats_sql(
         "track_usage": {},
     }
 
-    # Build time filter clauses for sub-day windows (hours parameter).
-    # dest_time_filter: filters by arrival at destination (used for non-cancelled trains).
-    # origin_time_filter: filters by departure at origin (used for cancelled trains
-    # without destination stops, since they never arrived anywhere).
-    dest_time_filter = ""
+    # Sub-day windows (hours parameter) filter by ORIGIN DEPARTURE time.
+    # "Trains in the past hour" means "trains that departed origin in the
+    # past hour" — captures recently-departed in-transit trains and is
+    # robust to NJT's NULL scheduled_arrival at intermediate stops (NJT
+    # puts the schedule in DEP_TIME at non-terminal stops, so a destination-
+    # arrival filter silently drops every NJT route ending mid-line).
+    # Stats automatically fall back from arrival-based to departure-based
+    # metrics when arrival data is unavailable (see destination_stops vs
+    # origin_stops CTEs and the on_time_source selection below).
     origin_time_filter = ""
     if cutoff_time:
-        dest_time_filter = """
-            AND COALESCE(ts.actual_arrival, ts.scheduled_arrival) >= :cutoff_time
-            AND COALESCE(ts.actual_arrival, ts.scheduled_arrival) <= :now_time
-        """
         origin_time_filter = """
             AND COALESCE(fs.actual_departure, fs.scheduled_departure) >= :cutoff_time
             AND COALESCE(fs.actual_departure, fs.scheduled_departure) <= :now_time
@@ -340,13 +340,11 @@ async def _calculate_route_stats_sql(
     if line_codes:
         line_filter = "AND tj.line_code = ANY(:line_codes)"
 
-    # Build the route_journeys CTE SQL (reused by stats and track queries)
-    # Non-cancelled trains are time-windowed by destination arrival.
-    # Cancelled trains are time-windowed by origin departure — they never
-    # arrived, so dest arrival is NULL (and for NJT intermediate stops even
-    # scheduled_arrival is NULL, since the schedule time lives in
-    # scheduled_departure). Using dest arrival for cancelled trains silently
-    # excludes them, making cancellation_rate read 0% during disruptions.
+    # Build the route_journeys CTE SQL (reused by stats and track queries).
+    # Require an origin stop within the time window plus either a downstream
+    # destination stop (the normal case) or a cancelled journey whose stop
+    # list never finished backfilling (origin-only allowed so disruptions
+    # still register in cancellation_rate).
     route_journeys_cte = f"""
         SELECT tj.id AS journey_id, tj.is_cancelled
         FROM train_journeys tj
@@ -355,41 +353,20 @@ async def _calculate_route_stats_sql(
           AND tj.journey_date <= :end_date
           {train_filter}
           {line_filter}
-          AND (
-              -- Non-cancelled: require stops at both origin and destination,
-              -- time-windowed by destination arrival.
-              (NOT tj.is_cancelled AND EXISTS (
-                  SELECT 1 FROM journey_stops fs
-                  WHERE fs.journey_id = tj.id
-                    AND fs.station_code = ANY(:from_codes)
-                    AND EXISTS (
+          AND EXISTS (
+              SELECT 1 FROM journey_stops fs
+              WHERE fs.journey_id = tj.id
+                AND fs.station_code = ANY(:from_codes)
+                {origin_time_filter}
+                AND (
+                    EXISTS (
                         SELECT 1 FROM journey_stops ts
                         WHERE ts.journey_id = tj.id
                           AND ts.station_code = ANY(:to_codes)
                           AND ts.stop_sequence > fs.stop_sequence
-                          {dest_time_filter}
                     )
-              ))
-              OR
-              -- Cancelled: time-window by origin departure. Require a
-              -- destination stop after origin when the stop list is complete;
-              -- allow origin-only for reconciled SCHEDULED trains where stop
-              -- backfill failed.
-              (tj.is_cancelled AND EXISTS (
-                  SELECT 1 FROM journey_stops fs
-                  WHERE fs.journey_id = tj.id
-                    AND fs.station_code = ANY(:from_codes)
-                    {origin_time_filter}
-                    AND (
-                        NOT tj.has_complete_journey
-                        OR EXISTS (
-                            SELECT 1 FROM journey_stops ts
-                            WHERE ts.journey_id = tj.id
-                              AND ts.station_code = ANY(:to_codes)
-                              AND ts.stop_sequence > fs.stop_sequence
-                        )
-                    )
-              ))
+                    OR (tj.is_cancelled AND NOT tj.has_complete_journey)
+                )
           )
         ORDER BY tj.journey_date DESC
         LIMIT 5000

--- a/backend_v2/tests/unit/api/test_route_history.py
+++ b/backend_v2/tests/unit/api/test_route_history.py
@@ -1020,15 +1020,16 @@ class TestArrivalSourceFiltering:
 
 
 @pytest.mark.asyncio
-class TestCutoffTimeFiltersByArrival:
-    """Verify hours-based cutoff filters by destination ARRIVAL time, not origin departure.
+class TestCutoffTimeFiltersByOriginDeparture:
+    """Verify hours-based cutoff filters by ORIGIN DEPARTURE time.
 
-    This was a major bug: "last hour" stats filtered by scheduled_departure at the
-    origin station. Since most trains that departed in the last hour haven't arrived yet,
-    the stats would show "N/A" for on_time_percentage and average_delay_minutes.
+    "Trains in the past hour" means "trains that departed origin in the past hour":
+    in-transit trains are included even though they haven't arrived yet, and routes
+    ending at NJT intermediate stops (where scheduled_arrival is NULL) work correctly.
 
-    The fix filters by the destination stop's arrival time (actual or scheduled), so
-    "last hour" means "trains that arrived at the destination in the last hour".
+    Stats degrade gracefully when arrival data isn't yet available — the stats CTE
+    falls back from arrival-based to departure-based on-time metrics (see
+    `on_time_source` in _calculate_route_stats_sql).
     """
 
     async def _run_stats_with_cutoff(
@@ -1051,58 +1052,15 @@ class TestCutoffTimeFiltersByArrival:
             now=now,
         )
 
-    async def test_recently_arrived_train_included_in_last_hour(
+    async def test_recently_departed_in_transit_train_included(
         self, db_session: AsyncSession
     ):
-        """A train that arrived 30 minutes ago should appear in 'last hour' stats.
+        """A train that departed 30 minutes ago and is still en route is included.
 
-        Train departed 1.5 hours ago (outside the 1-hour window) but arrived
-        30 minutes ago (inside the window). With the old departure-based filter,
-        this train would be excluded. With the arrival-based filter, it's included.
-        """
-        now = BASE_TIME + timedelta(hours=3)
-        cutoff = now - timedelta(hours=1)
-
-        await _create_journey(
-            db_session,
-            train_id="train_arrived_recently",
-            stops=[
-                {
-                    "station_code": "NY",
-                    "stop_sequence": 0,
-                    "scheduled_departure": now - timedelta(hours=1, minutes=30),
-                    "actual_departure": now - timedelta(hours=1, minutes=30),
-                },
-                {
-                    "station_code": "TR",
-                    "stop_sequence": 1,
-                    "scheduled_arrival": now - timedelta(minutes=30),
-                    "actual_arrival": now - timedelta(minutes=25),
-                    "arrival_source": "api_observed",
-                },
-            ],
-        )
-        await db_session.commit()
-
-        result = await self._run_stats_with_cutoff(db_session, cutoff, now)
-
-        assert result["total_journeys"] == 1, (
-            f"Expected 1 journey (arrived 30min ago, within 1h window), "
-            f"got {result['total_journeys']}. The cutoff should filter by "
-            "destination arrival time, not origin departure time."
-        )
-        assert (
-            result["on_time_percentage"] is not None
-        ), "on_time_percentage should not be N/A for a train that already arrived"
-
-    async def test_recently_departed_but_not_arrived_excluded(
-        self, db_session: AsyncSession
-    ):
-        """A train that departed 30 minutes ago but hasn't arrived should NOT appear.
-
-        With the old filter this train would be included (departed within the hour)
-        but produce N/A stats since it has no arrival data. With the new filter,
-        it's correctly excluded because it hasn't arrived yet.
+        This is the user-visible bug: NY -> Hamilton train departed NY 40 min ago
+        but the previous arrival-based filter excluded it (arrival in the future,
+        scheduled_arrival NULL on NJT intermediate stops). Origin-departure filter
+        captures it.
         """
         now = BASE_TIME + timedelta(hours=3)
         cutoff = now - timedelta(hours=1)
@@ -1129,59 +1087,78 @@ class TestCutoffTimeFiltersByArrival:
 
         result = await self._run_stats_with_cutoff(db_session, cutoff, now)
 
-        assert result["total_journeys"] == 0, (
-            f"Expected 0 journeys (train hasn't arrived yet, scheduled_arrival "
-            f"is in the future), got {result['total_journeys']}. Trains still "
-            "en route should not be included in arrival-based stats."
+        assert result["total_journeys"] == 1, (
+            f"Expected 1 journey (departed 30min ago, in transit), got "
+            f"{result['total_journeys']}. Cutoff must filter by origin departure "
+            "so in-transit trains are visible in 'past hour' counts."
+        )
+        # No arrival yet -> stats fall back to departure-based metrics.
+        assert result["on_time_source"] == "departure", (
+            f"With no arrival data, on_time_source should fall back to 'departure'; "
+            f"got {result['on_time_source']!r}."
         )
 
-    async def test_train_arrived_before_cutoff_excluded(self, db_session: AsyncSession):
-        """A train that arrived 2 hours ago should NOT appear in 'last hour' stats."""
-        now = BASE_TIME + timedelta(hours=4)
+    async def test_njt_intermediate_destination_with_null_scheduled_arrival_included(
+        self, db_session: AsyncSession
+    ):
+        """Regression: NY -> Hamilton (NJT intermediate stop) must not silently return 0.
+
+        NJT puts the schedule for non-terminal stops in DEP_TIME (mapped to
+        scheduled_departure), leaving scheduled_arrival NULL. The previous
+        destination-arrival filter dropped every such row.
+        """
+        now = BASE_TIME + timedelta(hours=3)
         cutoff = now - timedelta(hours=1)
 
         await _create_journey(
             db_session,
-            train_id="train_arrived_long_ago",
+            train_id="njt_to_hamilton",
             stops=[
                 {
                     "station_code": "NY",
                     "stop_sequence": 0,
-                    "scheduled_departure": now - timedelta(hours=3),
-                    "actual_departure": now - timedelta(hours=3),
+                    "scheduled_departure": now - timedelta(minutes=40),
+                    "actual_departure": now - timedelta(minutes=40),
+                },
+                {
+                    # NJT intermediate stop: scheduled_arrival left NULL on purpose
+                    "station_code": "HL",
+                    "stop_sequence": 12,
+                    "scheduled_departure": now + timedelta(minutes=21),
+                    "scheduled_arrival": None,
+                    "actual_arrival": None,
                 },
                 {
                     "station_code": "TR",
-                    "stop_sequence": 1,
-                    "scheduled_arrival": now - timedelta(hours=2),
-                    "actual_arrival": now - timedelta(hours=2),
-                    "arrival_source": "api_observed",
+                    "stop_sequence": 13,
+                    "scheduled_departure": now + timedelta(minutes=34),
+                    "scheduled_arrival": None,
+                    "actual_arrival": None,
                 },
             ],
         )
         await db_session.commit()
 
-        result = await self._run_stats_with_cutoff(db_session, cutoff, now)
-
-        assert result["total_journeys"] == 0, (
-            f"Expected 0 journeys (arrived 2h ago, outside 1h window), "
-            f"got {result['total_journeys']}."
+        result = await self._run_stats_with_cutoff(
+            db_session, cutoff, now, from_codes=["NY"], to_codes=["HL"]
         )
 
-    async def test_cutoff_uses_actual_arrival_over_scheduled(
+        assert result["total_journeys"] == 1, (
+            f"Expected 1 journey for NY->HL, got {result['total_journeys']}. "
+            "NJT intermediate stops have NULL scheduled_arrival; origin-departure "
+            "filter must still match."
+        )
+
+    async def test_train_departed_before_cutoff_excluded(
         self, db_session: AsyncSession
     ):
-        """When actual_arrival exists, it should be used for the cutoff filter.
-
-        Train scheduled to arrive 70 minutes ago (outside window) but actually
-        arrived 40 minutes ago (inside window due to delay). Should be included.
-        """
+        """A train that departed 2 hours ago (outside the 1h window) is excluded."""
         now = BASE_TIME + timedelta(hours=4)
         cutoff = now - timedelta(hours=1)
 
         await _create_journey(
             db_session,
-            train_id="train_late_but_recent",
+            train_id="train_departed_long_ago",
             stops=[
                 {
                     "station_code": "NY",
@@ -1192,8 +1169,8 @@ class TestCutoffTimeFiltersByArrival:
                 {
                     "station_code": "TR",
                     "stop_sequence": 1,
-                    "scheduled_arrival": now - timedelta(minutes=70),
-                    "actual_arrival": now - timedelta(minutes=40),
+                    "scheduled_arrival": now - timedelta(hours=1),
+                    "actual_arrival": now - timedelta(hours=1),
                     "arrival_source": "api_observed",
                 },
             ],
@@ -1202,11 +1179,145 @@ class TestCutoffTimeFiltersByArrival:
 
         result = await self._run_stats_with_cutoff(db_session, cutoff, now)
 
-        assert result["total_journeys"] == 1, (
-            f"Expected 1 journey (actual_arrival 40min ago is within 1h window, "
-            f"even though scheduled_arrival was 70min ago), got {result['total_journeys']}. "
-            "COALESCE(actual_arrival, scheduled_arrival) should prefer actual."
+        assert result["total_journeys"] == 0, (
+            f"Expected 0 journeys (departed 2h ago, outside 1h window), got "
+            f"{result['total_journeys']}."
         )
+
+    async def test_cutoff_uses_actual_departure_over_scheduled(
+        self, db_session: AsyncSession
+    ):
+        """COALESCE prefers actual_departure: a late-but-recent departure is included.
+
+        Scheduled to depart 70 minutes ago (outside 1h window), actually departed
+        40 minutes ago (inside window due to upstream delay) — must match.
+        """
+        now = BASE_TIME + timedelta(hours=4)
+        cutoff = now - timedelta(hours=1)
+
+        await _create_journey(
+            db_session,
+            train_id="train_late_departure",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": now - timedelta(minutes=70),
+                    "actual_departure": now - timedelta(minutes=40),
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": now + timedelta(minutes=20),
+                    "actual_arrival": None,
+                },
+            ],
+        )
+        await db_session.commit()
+
+        result = await self._run_stats_with_cutoff(db_session, cutoff, now)
+
+        assert result["total_journeys"] == 1, (
+            f"Expected 1 journey (actual_departure 40min ago is within 1h window, "
+            f"even though scheduled_departure was 70min ago), got "
+            f"{result['total_journeys']}. "
+            "COALESCE(actual_departure, scheduled_departure) should prefer actual."
+        )
+
+    async def test_in_transit_trains_count_in_total_but_skip_arrival_stats(
+        self, db_session: AsyncSession
+    ):
+        """In-transit trains contribute to total_journeys but not to arrival metrics.
+
+        Mix of one arrived (delayed 8 min) and one in-transit train. on_time_source
+        should still be 'arrival' (one train has arrival data) and the arrival
+        average should not be polluted by the en-route train.
+        """
+        now = BASE_TIME + timedelta(hours=3)
+        cutoff = now - timedelta(hours=1)
+
+        await _create_journey(
+            db_session,
+            train_id="arrived_delayed",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": now - timedelta(minutes=50),
+                    "actual_departure": now - timedelta(minutes=50),
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": now - timedelta(minutes=10),
+                    "actual_arrival": now - timedelta(minutes=2),
+                    "arrival_source": "api_observed",
+                },
+            ],
+        )
+        await _create_journey(
+            db_session,
+            train_id="still_en_route",
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": now - timedelta(minutes=20),
+                    "actual_departure": now - timedelta(minutes=20),
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": now + timedelta(minutes=40),
+                    "actual_arrival": None,
+                },
+            ],
+        )
+        await db_session.commit()
+
+        result = await self._run_stats_with_cutoff(db_session, cutoff, now)
+
+        assert (
+            result["total_journeys"] == 2
+        ), f"Both trains should count in total_journeys; got {result['total_journeys']}."
+        assert result["on_time_source"] == "arrival"
+        assert result["average_delay_minutes"] == pytest.approx(8.0, abs=0.1), (
+            f"Average should reflect only the arrived train (8 min delay), not be "
+            f"diluted by the en-route train; got {result['average_delay_minutes']}."
+        )
+
+    async def test_cancelled_train_in_window_counts_via_origin_departure(
+        self, db_session: AsyncSession
+    ):
+        """Cancelled trains keep being filtered by origin departure (unchanged behavior)."""
+        now = BASE_TIME + timedelta(hours=3)
+        cutoff = now - timedelta(hours=1)
+
+        await _create_journey(
+            db_session,
+            train_id="cancelled_recent",
+            is_cancelled=True,
+            stops=[
+                {
+                    "station_code": "NY",
+                    "stop_sequence": 0,
+                    "scheduled_departure": now - timedelta(minutes=20),
+                    "actual_departure": None,
+                },
+                {
+                    "station_code": "TR",
+                    "stop_sequence": 1,
+                    "scheduled_arrival": None,
+                    "actual_arrival": None,
+                },
+            ],
+        )
+        await db_session.commit()
+
+        result = await self._run_stats_with_cutoff(db_session, cutoff, now)
+
+        assert result["total_journeys"] == 1
+        assert result["cancellation_rate"] == 100.0
 
     async def test_no_cutoff_includes_all_journeys(self, db_session: AsyncSession):
         """When cutoff_time is None (days-based query), all journeys are included."""


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in route statistics filtering where the "past hour" cutoff was incorrectly filtering by destination arrival time instead of origin departure time. This caused in-transit trains to be excluded from stats and made routes ending at NJT intermediate stops (which have NULL scheduled_arrival) silently return zero results.

## Key Changes

**Source Code (`backend_v2/src/trackrat/api/routes.py`)**
- Removed the `dest_time_filter` that was filtering by `COALESCE(actual_arrival, scheduled_arrival)`
- Unified the filtering logic to use `origin_time_filter` (based on `COALESCE(actual_departure, scheduled_departure)`) for all journeys, both cancelled and non-cancelled
- Simplified the `route_journeys_cte` SQL logic by removing the separate branches for cancelled vs non-cancelled trains
- Updated comments to clarify that "trains in the past hour" means "trains that departed origin in the past hour"
- Added documentation that stats gracefully fall back from arrival-based to departure-based metrics when arrival data is unavailable

**Tests (`backend_v2/tests/unit/api/test_route_history.py`)**
- Renamed test class from `TestCutoffTimeFiltersByArrival` to `TestCutoffTimeFiltersByOriginDeparture` to reflect the corrected behavior
- Updated test docstrings to document the new expected behavior
- `test_recently_arrived_train_included_in_last_hour` → `test_recently_departed_in_transit_train_included`: Now tests that in-transit trains (departed recently but not yet arrived) are included, with fallback to departure-based metrics
- `test_recently_departed_but_not_arrived_excluded` → `test_njt_intermediate_destination_with_null_scheduled_arrival_included`: Now tests the NJT intermediate stop regression case where scheduled_arrival is NULL
- `test_train_arrived_before_cutoff_excluded` → `test_train_departed_before_cutoff_excluded`: Updated to verify exclusion based on departure time
- `test_cutoff_uses_actual_arrival_over_scheduled` → `test_cutoff_uses_actual_departure_over_scheduled`: Updated to verify COALESCE prefers actual_departure
- Added `test_in_transit_trains_count_in_total_but_skip_arrival_stats`: Verifies that in-transit trains count toward total_journeys but don't pollute arrival-based metrics
- Added `test_cancelled_train_in_window_counts_via_origin_departure`: Verifies cancelled trains are still correctly filtered by origin departure

## Notable Implementation Details
- The fix maintains backward compatibility for cancelled trains, which continue to be filtered by origin departure
- Stats automatically degrade gracefully: when arrival data isn't available, the CTE falls back to departure-based on-time metrics (controlled by the `on_time_source` selection logic)
- The unified filtering approach is more robust to data quality issues like NJT's NULL scheduled_arrival at intermediate stops

https://claude.ai/code/session_01BMKpSx4m1c7JhXJ8tmwvEi