### PR TITLE
fix: stop premature Live Activity termination on transient is_expired flips

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -937,6 +937,11 @@ class JourneyCollector(BaseJourneyCollector):
             # the row valid for the next collection cycle. (`_is_same_journey`
             # has already logged the detailed `journey_mismatch_departure_time`
             # warning with full context.)
+            #
+            # Advance freshness metadata so the scheduler doesn't treat this
+            # journey as stale and busy-loop re-collecting it every cycle.
+            journey.last_updated_at = now_et()
+            journey.update_count = (journey.update_count or 0) + 1
             await session.flush()
             return
 

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -5,6 +5,7 @@ Collects complete journey details using the getTrainStopList API.
 """
 
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import Any, cast
 
 from sqlalchemy import and_, delete, or_, select, update
@@ -35,6 +36,19 @@ from trackrat.utils.time import (
 from trackrat.utils.train import is_njt_stop_cancelled
 
 logger = get_logger(__name__)
+
+
+class JourneyMatchResult(Enum):
+    """Outcome of validating an NJT API response against a stored journey row.
+
+    Distinguishes "definitely a different journey" from "probably the same
+    journey, just out of sync" so the caller can choose to expire the row or
+    only skip the current update.
+    """
+
+    MATCH = "match"
+    DESTINATION_MISMATCH = "destination_mismatch"
+    DEPARTURE_TIME_MISMATCH = "departure_time_mismatch"
 
 
 def _journey_eager_options() -> list[Any]:
@@ -525,13 +539,19 @@ class JourneyCollector(BaseJourneyCollector):
         session: AsyncSession,
         stored_journey: TrainJourney,
         api_train_data: NJTransitTrainData,
-    ) -> bool:
+    ) -> JourneyMatchResult:
         """
         Verify if API data represents the same journey as our stored record.
 
         Uses key signals to detect journey changes:
-        - Destination must match (after normalization)
-        - First stop departure time should be similar (±10 min tolerance)
+        - Destination must match (after normalization) — strong identity signal
+        - First stop departure time should be similar (±10 min tolerance) —
+          weak signal that flags potential journey swaps but also fires on
+          heavily delayed real-world trains
+
+        Returns a tri-state result so the caller can decide whether to expire
+        the journey row (destination mismatch) or only skip this update
+        (departure-time mismatch).
 
         NOTE: Line code validation removed as it's unreliable across different API calls
         """
@@ -563,7 +583,7 @@ class JourneyCollector(BaseJourneyCollector):
                 ),
                 has_complete_journey=stored_journey.has_complete_journey,
             )
-            return False
+            return JourneyMatchResult.DESTINATION_MISMATCH
 
         # NOTE: Line code check removed - NJT API returns inconsistent line codes
         # between discovery (e.g., "No") and journey details (e.g., "NC")
@@ -732,7 +752,7 @@ class JourneyCollector(BaseJourneyCollector):
                             api_departure_tz_info=str(api_departure.tzinfo),
                             raw_api_dep_time=dep_time,
                         )
-                        return False
+                        return JourneyMatchResult.DEPARTURE_TIME_MISMATCH
         else:
             # Journey doesn't have complete data yet - likely discovered at an intermediate station
             # The journey collector will fix the origin and departure time
@@ -757,7 +777,7 @@ class JourneyCollector(BaseJourneyCollector):
             ),
         )
 
-        return True
+        return JourneyMatchResult.MATCH
 
     async def collect_journey_details(
         self,
@@ -869,8 +889,11 @@ class JourneyCollector(BaseJourneyCollector):
         )
 
         # Verify this API data matches our stored journey
-        if not await self._is_same_journey(session, journey, train_data):
-            # API returned data for a different journey - mark this one as expired
+        match_result = await self._is_same_journey(session, journey, train_data)
+        if match_result is JourneyMatchResult.DESTINATION_MISMATCH:
+            # The API is returning a genuinely different journey under this
+            # train_id (e.g., the row was originally bound to a now-cancelled
+            # run). Mark expired so future passes stop refreshing it.
             journey.is_expired = True
             journey.api_error_count = 99  # High value to prevent retry
 
@@ -904,6 +927,16 @@ class JourneyCollector(BaseJourneyCollector):
                 api_error_count=journey.api_error_count,
             )
 
+            await session.flush()
+            return
+
+        if match_result is JourneyMatchResult.DEPARTURE_TIME_MISMATCH:
+            # Destination matches but the API's first-stop time is outside the
+            # 10-minute tolerance. This is most often a real-world delay rather
+            # than a journey swap, so we skip applying this snapshot but leave
+            # the row valid for the next collection cycle. (`_is_same_journey`
+            # has already logged the detailed `journey_mismatch_departure_time`
+            # warning with full context.)
             await session.flush()
             return
 

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -3013,21 +3013,16 @@ class SchedulerService:
                             )
                             continue
 
-                        # Check if journey is expired, completed, or cancelled
-                        # If so, send end events to all Live Activities tracking this train
-                        should_end = (
-                            journey.is_expired
-                            or journey.is_completed
-                            or journey.is_cancelled
-                        )
+                        # End the Live Activity only on actual journey termination.
+                        # `is_expired` is a collector-side bookkeeping flag (data feed
+                        # stopped, validator mismatch, yesterday's leftover) and can
+                        # flip transiently while the user's trip is still in progress,
+                        # so it must not drive end-of-activity pushes.
+                        should_end = journey.is_completed or journey.is_cancelled
 
                         if should_end:
                             end_reason = (
-                                "expired"
-                                if journey.is_expired
-                                else (
-                                    "completed" if journey.is_completed else "cancelled"
-                                )
+                                "completed" if journey.is_completed else "cancelled"
                             )
 
                             logger.info(

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -22,7 +22,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from trackrat.collectors.njt.client import NJTransitClient
-from trackrat.collectors.njt.journey import JourneyCollector
+from trackrat.collectors.njt.journey import JourneyCollector, JourneyMatchResult
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.utils.time import ET, now_et
 
@@ -139,13 +139,13 @@ class TestStaleOriginDetection:
             ],
         )
 
-        # Without the fix, this would return False (86 min > 10 min tolerance)
-        # With the fix, it should return True (uses stops table departure)
+        # Without the fix, this would return DEPARTURE_TIME_MISMATCH (86 min > 10 min tolerance)
+        # With the fix, it should return MATCH (uses stops table departure)
         result = await journey_collector._is_same_journey(
             db_session, journey, api_response
         )
 
-        assert result is True, (
+        assert result is JourneyMatchResult.MATCH, (
             "Journey should be recognized as same journey when stops table has "
             "correct origin even if journey.origin_station_code is stale"
         )
@@ -206,12 +206,14 @@ class TestStaleOriginDetection:
             ],
         )
 
-        # Should return False - different destination
+        # Should return DESTINATION_MISMATCH - different destination
         result = await journey_collector._is_same_journey(
             db_session, journey, api_response
         )
 
-        assert result is False, "Different destination should be detected as mismatch"
+        assert (
+            result is JourneyMatchResult.DESTINATION_MISMATCH
+        ), "Different destination should be detected as a destination mismatch"
 
     @pytest.mark.asyncio
     async def test_correct_origin_still_works(
@@ -267,12 +269,14 @@ class TestStaleOriginDetection:
             ],
         )
 
-        # Should return True - everything matches
+        # Should return MATCH - everything matches
         result = await journey_collector._is_same_journey(
             db_session, journey, api_response
         )
 
-        assert result is True, "Matching journey should be recognized"
+        assert (
+            result is JourneyMatchResult.MATCH
+        ), "Matching journey should be recognized"
 
     @pytest.mark.asyncio
     async def test_incomplete_journey_skips_departure_check(
@@ -318,9 +322,149 @@ class TestStaleOriginDetection:
             ],
         )
 
-        # Should return True - incomplete journey skips departure check
+        # Should return MATCH - incomplete journey skips departure check
         result = await journey_collector._is_same_journey(
             db_session, journey, api_response
         )
 
-        assert result is True, "Incomplete journey should skip departure time check"
+        assert (
+            result is JourneyMatchResult.MATCH
+        ), "Incomplete journey should skip departure time check"
+
+    @pytest.mark.asyncio
+    async def test_delayed_train_reports_departure_time_mismatch(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """A heavily delayed train (>10 min vs scheduled origin departure)
+        must surface as DEPARTURE_TIME_MISMATCH rather than a destination
+        mismatch. The caller in collect_journey_details treats this as a
+        soft skip — it must not flag the journey as expired, since that
+        would cause Live Activities for the in-progress trip to receive
+        a premature end push.
+        """
+        scheduled_departure = now_et().replace(
+            hour=15, minute=55, second=0, microsecond=0
+        )
+        api_actual_departure = scheduled_departure + timedelta(minutes=22)
+
+        journey = TrainJourney(
+            train_id="3943",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=scheduled_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # Stops table reflects the same scheduled origin time so the
+        # stale-origin recovery path is not triggered.
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=scheduled_departure,
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="3943",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_actual_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+
+        result = await journey_collector._is_same_journey(
+            db_session, journey, api_response
+        )
+
+        assert result is JourneyMatchResult.DEPARTURE_TIME_MISMATCH, (
+            "A 22-minute departure-time skew with matching destination should "
+            "be reported as DEPARTURE_TIME_MISMATCH so the caller can skip "
+            "the update without permanently expiring the journey row"
+        )
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_details_does_not_expire_on_time_mismatch(
+        self, db_session: AsyncSession, journey_collector, mock_njt_client
+    ):
+        """Regression: the journey collector must not set ``is_expired`` /
+        ``api_error_count = 99`` when ``_is_same_journey`` returns
+        DEPARTURE_TIME_MISMATCH. That false-positive expiry was what caused
+        production Live Activities to receive end pushes ~60s after
+        registration for any train running >10 min late.
+        """
+        scheduled_departure = now_et().replace(
+            hour=15, minute=55, second=0, microsecond=0
+        )
+        api_actual_departure = scheduled_departure + timedelta(minutes=22)
+
+        journey = TrainJourney(
+            train_id="3943",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=scheduled_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            is_expired=False,
+            api_error_count=0,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=scheduled_departure,
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="3943",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_actual_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        mock_njt_client.get_train_stop_list.return_value = api_response
+
+        await journey_collector.collect_journey_details(db_session, journey)
+
+        await db_session.refresh(journey)
+        assert (
+            journey.is_expired is False
+        ), "Time-only mismatch must not flag the journey as expired"
+        assert (
+            journey.api_error_count or 0
+        ) == 0, "Time-only mismatch must not bump api_error_count"

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -459,6 +459,8 @@ class TestStaleOriginDetection:
         )
         mock_njt_client.get_train_stop_list.return_value = api_response
 
+        original_last_updated = journey.last_updated_at
+
         await journey_collector.collect_journey_details(db_session, journey)
 
         await db_session.refresh(journey)
@@ -468,3 +470,10 @@ class TestStaleOriginDetection:
         assert (
             journey.api_error_count or 0
         ) == 0, "Time-only mismatch must not bump api_error_count"
+        assert journey.last_updated_at is not None and (
+            original_last_updated is None
+            or journey.last_updated_at > original_last_updated
+        ), (
+            "Time-only mismatch must advance last_updated_at so the scheduler "
+            "does not busy-loop re-collecting this journey every cycle"
+        )

--- a/backend_v2/tests/unit/collectors/njt/test_prefetched_train_data.py
+++ b/backend_v2/tests/unit/collectors/njt/test_prefetched_train_data.py
@@ -8,7 +8,7 @@ to collect_journey_details in Phase 3 to avoid a redundant API call.
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
-from trackrat.collectors.njt.journey import JourneyCollector
+from trackrat.collectors.njt.journey import JourneyCollector, JourneyMatchResult
 from trackrat.models.api import NJTransitTrainData
 from trackrat.models.database import TrainJourney
 
@@ -50,7 +50,10 @@ async def test_prefetched_data_skips_api_call():
     # We only care about whether the API call is made or skipped.
     with (
         patch.object(
-            collector, "_is_same_journey", new_callable=AsyncMock, return_value=True
+            collector,
+            "_is_same_journey",
+            new_callable=AsyncMock,
+            return_value=JourneyMatchResult.MATCH,
         ),
         patch.object(
             collector, "enhance_with_departure_board_data", new_callable=AsyncMock
@@ -96,7 +99,10 @@ async def test_without_prefetched_data_calls_api():
 
     with (
         patch.object(
-            collector, "_is_same_journey", new_callable=AsyncMock, return_value=True
+            collector,
+            "_is_same_journey",
+            new_callable=AsyncMock,
+            return_value=JourneyMatchResult.MATCH,
         ),
         patch.object(
             collector, "enhance_with_departure_board_data", new_callable=AsyncMock

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -527,6 +527,157 @@ class TestSchedulerService:
                 assert ("AMTRAK", "AMTRAK") in captured_pairs
 
     @pytest.mark.asyncio
+    async def test_update_live_activities_does_not_end_on_is_expired_alone(
+        self, scheduler_service, mock_apns_service
+    ):
+        """Regression: ``is_expired`` is a collector-side bookkeeping flag
+        (e.g., NJT journey-mismatch validator false positives, MTA missing-
+        from-feed timeouts) and can flip while the user's trip is still in
+        progress. It must NOT cause an end push — only ``is_completed`` /
+        ``is_cancelled`` should terminate a Live Activity."""
+        scheduler_service.apns_service = mock_apns_service
+
+        with patch("trackrat.services.scheduler.get_session") as mock_get_session:
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            with (
+                patch("sqlalchemy.create_engine"),
+                patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker,
+            ):
+                mock_sync_session = Mock()
+                mock_sessionmaker.return_value = Mock(return_value=mock_sync_session)
+
+                mock_token = Mock(
+                    push_token="token-expired",
+                    activity_id="activity-expired",
+                    train_number="3943",
+                    origin_code="NY",
+                    destination_code="HL",
+                    data_source="AMTRAK",  # bypass NJT track-assignment branch
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    is_active=True,
+                    track_notified_at=datetime.now(UTC),
+                )
+
+                mock_tokens_result = Mock()
+                mock_tokens_result.scalars.return_value = [mock_token]
+
+                # Journey is flagged is_expired (e.g., by validator false
+                # positive) but the trip itself is still in progress.
+                mock_journey = Mock(
+                    train_id="3943",
+                    data_source="AMTRAK",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=False,
+                    is_expired=True,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+
+                mock_sync_session.execute.return_value = mock_tokens_result
+                mock_sync_session.scalar.return_value = mock_journey
+                mock_sync_session.__enter__ = Mock(return_value=mock_sync_session)
+                mock_sync_session.__exit__ = Mock(return_value=None)
+
+                with patch.object(
+                    scheduler_service,
+                    "_calculate_live_activity_content_state",
+                    return_value={"test": "content"},
+                ):
+                    with patch(
+                        "trackrat.services.scheduler.run_with_freshness_check"
+                    ) as mock_freshness_check:
+
+                        async def execute_task_func(
+                            db, task_name, minimum_interval_seconds, task_func
+                        ):
+                            await task_func()
+                            return True
+
+                        mock_freshness_check.side_effect = execute_task_func
+
+                        await scheduler_service.update_live_activities()
+
+                # Update was sent; end was NOT sent.
+                mock_apns_service.send_live_activity_update.assert_called_once_with(
+                    "token-expired", {"test": "content"}
+                )
+                mock_apns_service.send_live_activity_end.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_live_activities_ends_on_is_completed(
+        self, scheduler_service, mock_apns_service
+    ):
+        """``is_completed`` must still terminate a Live Activity."""
+        scheduler_service.apns_service = mock_apns_service
+
+        with patch("trackrat.services.scheduler.get_session") as mock_get_session:
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            with (
+                patch("sqlalchemy.create_engine"),
+                patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker,
+            ):
+                mock_sync_session = Mock()
+                mock_sessionmaker.return_value = Mock(return_value=mock_sync_session)
+
+                mock_token = Mock(
+                    push_token="token-done",
+                    activity_id="activity-done",
+                    train_number="3943",
+                    origin_code="NY",
+                    destination_code="HL",
+                    data_source="AMTRAK",
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    is_active=True,
+                    track_notified_at=datetime.now(UTC),
+                )
+
+                mock_tokens_result = Mock()
+                mock_tokens_result.scalars.return_value = [mock_token]
+
+                mock_journey = Mock(
+                    train_id="3943",
+                    data_source="AMTRAK",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=True,
+                    is_expired=False,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+
+                mock_sync_session.execute.return_value = mock_tokens_result
+                mock_sync_session.scalar.return_value = mock_journey
+                mock_sync_session.__enter__ = Mock(return_value=mock_sync_session)
+                mock_sync_session.__exit__ = Mock(return_value=None)
+
+                with patch.object(
+                    scheduler_service,
+                    "_calculate_live_activity_content_state",
+                    return_value={"test": "content"},
+                ):
+                    with patch(
+                        "trackrat.services.scheduler.run_with_freshness_check"
+                    ) as mock_freshness_check:
+
+                        async def execute_task_func(
+                            db, task_name, minimum_interval_seconds, task_func
+                        ):
+                            await task_func()
+                            return True
+
+                        mock_freshness_check.side_effect = execute_task_func
+
+                        await scheduler_service.update_live_activities()
+
+                mock_apns_service.send_live_activity_end.assert_called_once()
+                mock_apns_service.send_live_activity_update.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_precompute_congestion_cache(self, scheduler_service):
         """Test congestion cache pre-computation."""
         with patch("trackrat.services.scheduler.get_session") as mock_get_session:


### PR DESCRIPTION
Production was sending APNS `end` events to active iOS Live Activities ~60s
after registration whenever the NJT journey-mismatch validator briefly flipped
`is_expired = True` on a delayed train. Two layers contributed:

1. SchedulerService.update_live_activities treated `is_expired` as a terminal
   state (alongside `is_completed` / `is_cancelled`). It is actually a
   collector-side bookkeeping flag (yesterday's leftovers, MTA missing-from-
   feed timeouts, NJT validator mismatches) and can flip transiently while
   the trip is still in progress.

2. The NJT JourneyCollector validator (`_is_same_journey`) returned a single
   bool, so any failure — including the 10-minute departure-time tolerance
   tripping on real-world delays of >10 min — caused the caller to set
   `is_expired = True` and `api_error_count = 99`. Production logs showed
   journeys with `update_count` in the hundreds (clearly the same journey)
   being expired every collection cycle.

Fixes:
- scheduler.py: drop `is_expired` from the LA end condition; only
  `is_completed` / `is_cancelled` terminate an activity.
- njt/journey.py: `_is_same_journey` now returns a `JourneyMatchResult`
  enum (`MATCH` / `DESTINATION_MISMATCH` / `DEPARTURE_TIME_MISMATCH`).
  The call site only flags `is_expired` on `DESTINATION_MISMATCH` (real
  journey-identity change). `DEPARTURE_TIME_MISMATCH` skips this update
  but leaves the row valid for the next collection cycle.

Tests:
- Updated existing `_is_same_journey` tests to assert against the enum.
- New: `test_delayed_train_reports_departure_time_mismatch` and
  `test_collect_journey_details_does_not_expire_on_time_mismatch` cover
  the validator change.
- New: `test_update_live_activities_does_not_end_on_is_expired_alone` and
  `test_update_live_activities_ends_on_is_completed` cover the scheduler
  change.

Full unit suite: 2679 passed, 4 skipped.

https://claude.ai/code/session_01M4pA7uDettdA7MiiBz1XZ1