### PR TITLE
Fix NJT trains stuck in is_expired loop from per-station schedule overwrite

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -593,50 +593,41 @@ class JourneyCollector(BaseJourneyCollector):
                 if dep_time is not None:
                     api_departure = parse_njt_time(dep_time)
 
-                    # Get stored departure, but check if journey metadata is stale
-                    # If origin_station_code doesn't match first stop in our stops table,
-                    # the journey was discovered at an intermediate station and metadata
-                    # was never properly corrected. Use stops table as source of truth.
+                    # Source stored_departure from the stops table when available.
+                    # journey.scheduled_departure is a denormalized cache that the
+                    # schedule collector overwrites for every station's schedule
+                    # item, so it can drift from the train's actual origin time
+                    # even when origin_station_code is correct. The stops table
+                    # is the authoritative schedule.
                     stored_departure = stored_journey.scheduled_departure
 
-                    if (
-                        stored_journey.origin_station_code
-                        and stored_journey.origin_station_code
-                        != first_stop.STATION_2CHAR
-                    ):
-                        # Query stops explicitly to avoid lazy-load greenlet error
-                        stops_stmt = (
-                            select(JourneyStop)
-                            .where(JourneyStop.journey_id == stored_journey.id)
-                            .order_by(JourneyStop.stop_sequence.asc().nulls_last())
-                        )
-                        stops_result = await session.execute(stops_stmt)
-                        db_stops_sorted = list(stops_result.scalars().all())
+                    stops_stmt = (
+                        select(JourneyStop)
+                        .where(JourneyStop.journey_id == stored_journey.id)
+                        .order_by(JourneyStop.stop_sequence.asc().nulls_last())
+                        .limit(1)
+                    )
+                    first_db_stop = await session.scalar(stops_stmt)
 
-                        # Check if our stored stops have a different first station
-                        if db_stops_sorted:
-                            first_db_stop = db_stops_sorted[0]
-                            if (
-                                first_db_stop.station_code
-                                != stored_journey.origin_station_code
-                                and first_db_stop.scheduled_departure
-                            ):
-                                # Stops table has correct origin, journey record is stale
-                                # Use the first stop's departure for comparison
-                                stored_departure = first_db_stop.scheduled_departure
-                                logger.info(
-                                    "using_stops_table_departure_for_comparison",
-                                    journey_id=stored_journey.id,
-                                    train_id=stored_journey.train_id,
-                                    stale_origin=stored_journey.origin_station_code,
-                                    correct_origin=first_db_stop.station_code,
-                                    stale_departure=(
-                                        stored_journey.scheduled_departure.isoformat()
-                                        if stored_journey.scheduled_departure
-                                        else None
-                                    ),
-                                    corrected_departure=stored_departure.isoformat(),
-                                )
+                    if first_db_stop and first_db_stop.scheduled_departure:
+                        if (
+                            stored_departure is None
+                            or stored_departure != first_db_stop.scheduled_departure
+                        ):
+                            logger.info(
+                                "using_stops_table_departure_for_comparison",
+                                journey_id=stored_journey.id,
+                                train_id=stored_journey.train_id,
+                                first_stop_code=first_db_stop.station_code,
+                                stored_origin=stored_journey.origin_station_code,
+                                stale_departure=(
+                                    stored_departure.isoformat()
+                                    if stored_departure
+                                    else None
+                                ),
+                                corrected_departure=first_db_stop.scheduled_departure.isoformat(),
+                            )
+                        stored_departure = first_db_stop.scheduled_departure
 
                     if stored_departure is not None:
                         # Ensure stored departure is timezone-aware for comparison

--- a/backend_v2/src/trackrat/collectors/njt/schedule.py
+++ b/backend_v2/src/trackrat/collectors/njt/schedule.py
@@ -296,8 +296,18 @@ class NJTScheduleCollector:
                 )
                 return "skipped"
 
-            # Update the scheduled journey with latest schedule data
-            existing_journey.scheduled_departure = scheduled_departure
+            # Update the scheduled journey with latest schedule data.
+            # NJT lists the same train in every stop-station's schedule (origin,
+            # intermediates, terminus). Without the earliest-wins guard below,
+            # whichever station is processed last would overwrite the journey's
+            # scheduled_departure with an intermediate/terminal time, leaving
+            # the journey row inconsistent with stops[0]. Guarantee that
+            # scheduled_departure converges on the train's actual origin time.
+            if (
+                existing_journey.scheduled_departure is None
+                or scheduled_departure < existing_journey.scheduled_departure
+            ):
+                existing_journey.scheduled_departure = scheduled_departure
             existing_journey.destination = destination
             existing_journey.line_code = parse_njt_line_code(line)
             existing_journey.line_name = line

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -275,6 +275,91 @@ class TestStaleOriginDetection:
         assert result is True, "Matching journey should be recognized"
 
     @pytest.mark.asyncio
+    async def test_self_heals_when_journey_departure_drifts_from_stops(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """
+        Test that _is_same_journey() trusts the stops table even when
+        origin_station_code is correct but journey.scheduled_departure has
+        drifted.
+
+        Scenario (the production bug seen for ~550 NJT trains/day):
+        - Schedule collector iterates per-station schedules. NJT lists the
+          same train in every stop-station's schedule, so the journey row's
+          scheduled_departure gets overwritten with whichever station was
+          processed last (e.g. the terminus arrival time, ~90 min off the
+          actual NY origin departure).
+        - origin_station_code stays correct ("NY") because schedule.py only
+          assigns it on creation, not update.
+        - Stops table is correct: stop_sequence=0 is NY at 21:35.
+        - API returns first_stop=NY at 21:35.
+        - Without fix: stored=23:05 vs api=21:35 = 5400s > 600s → falsely
+          marked is_expired=True every collection cycle → train vanishes
+          from /trains/departures.
+        - With fix: stops table provides 21:35 → matches API → journey
+          collector self-heals scheduled_departure via update_journey_metadata.
+        """
+        ny_departure = now_et().replace(hour=21, minute=35, second=0, microsecond=0)
+        # Drifted journey time (e.g. terminus arrival), origin_station_code intact
+        drifted_departure = ny_departure + timedelta(minutes=90)
+
+        journey = TrainJourney(
+            train_id="3889",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",  # CORRECT
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=drifted_departure,  # DRIFTED (the bug)
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # Stops table reflects the actual schedule
+        ny_stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=ny_departure,
+        )
+        db_session.add(ny_stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="3889",
+            line_code="NE",
+            destination="Trenton -SEC",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    ny_departure.strftime(NJT_TIME_FORMAT),
+                ),
+                builder.build_stop(
+                    "TR",
+                    "Trenton",
+                    (ny_departure + timedelta(minutes=90)).strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+
+        result = await journey_collector._is_same_journey(
+            db_session, journey, api_response
+        )
+
+        assert result is True, (
+            "Journey should self-heal via stops table when journey.scheduled_departure "
+            "has drifted (the per-station schedule overwrite bug)"
+        )
+
+    @pytest.mark.asyncio
     async def test_incomplete_journey_skips_departure_check(
         self, db_session: AsyncSession, journey_collector
     ):

--- a/backend_v2/tests/unit/collectors/njt/test_schedule_departure_overwrite.py
+++ b/backend_v2/tests/unit/collectors/njt/test_schedule_departure_overwrite.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for NJT schedule collector's scheduled_departure handling.
+
+Validates that _process_schedule_item() does not overwrite an existing
+journey's scheduled_departure with a later time when the same train appears
+in multiple stations' schedules.
+
+NJT lists the same train in every stop-station's schedule. Without the
+earliest-wins guard, whichever station was processed last (often the
+terminus, with arrival-time-as-SCHED_DEP_DATE) would clobber the actual
+origin departure, leaving the journey row inconsistent with stops[0] and
+breaking _is_same_journey() in the journey collector — observable as
+~550 NJT trains/day stuck in is_expired flap loops.
+"""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from trackrat.collectors.njt.client import NJTransitClient
+from trackrat.collectors.njt.schedule import NJTScheduleCollector
+from trackrat.models.database import Base, TrainJourney
+from trackrat.utils.time import now_et
+
+
+# Reuses the same SQLite-in-memory pattern as test_schedule_duplicate_stops.py
+@pytest.fixture
+async def sqlite_engine():
+    """Create an in-memory SQLite engine for testing."""
+    import pytz
+    from sqlalchemy import DateTime as SADateTime, TypeDecorator
+
+    _ET = pytz.timezone("America/New_York")
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def set_sqlite_pragma(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    class TZDateTime(TypeDecorator):
+        impl = SADateTime
+        cache_ok = True
+
+        def process_bind_param(self, value, dialect):
+            return value
+
+        def process_result_value(self, value, dialect):
+            if value is not None:
+                return _ET.localize(value)
+            return value
+
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, SADateTime) and column.type.timezone:
+                column.type = TZDateTime()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, TZDateTime):
+                column.type = SADateTime(timezone=True)
+
+    await engine.dispose()
+
+
+@pytest.fixture
+async def sqlite_session(sqlite_engine) -> AsyncSession:
+    session_factory = async_sessionmaker(
+        sqlite_engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture
+def schedule_collector():
+    client = AsyncMock(spec=NJTransitClient)
+    return NJTScheduleCollector(client)
+
+
+def _make_item(train_id: str, dep_str: str, destination: str = "Trenton") -> dict:
+    """Build a minimal NJT schedule API item."""
+    return {
+        "TRAIN_ID": train_id,
+        "SCHED_DEP_DATE": dep_str,
+        "DESTINATION": destination,
+        "LINE": "Northeast Corridor",
+        "TRACK": None,
+    }
+
+
+class TestEarliestDepartureWins:
+    """Once a SCHEDULED journey exists, only earlier scheduled_departure values overwrite it."""
+
+    @pytest.mark.asyncio
+    async def test_later_station_does_not_overwrite_earlier_origin(
+        self, sqlite_session: AsyncSession, schedule_collector
+    ):
+        """
+        Process the same train at NY (origin, 21:35) then at TR (terminus, 23:05).
+        After both passes the journey's scheduled_departure must still be 21:35.
+        Today, without the guard, TR would clobber NY because it's processed
+        later in the schedule_data iteration — exactly the production bug.
+        """
+        journey_date = now_et().date()
+        ny_dep = now_et().replace(hour=21, minute=35, second=0, microsecond=0)
+        tr_dep = ny_dep + timedelta(minutes=90)  # 23:05 — TR-side time
+
+        ny_item = _make_item("3889", ny_dep.strftime("%d-%b-%Y %I:%M:%S %p"))
+        tr_item = _make_item("3889", tr_dep.strftime("%d-%b-%Y %I:%M:%S %p"))
+
+        # First pass: NY's schedule creates the journey
+        result = await schedule_collector._process_schedule_item(
+            sqlite_session, ny_item, "NY", "New York Penn Station", journey_date
+        )
+        assert result == "new"
+        await sqlite_session.flush()
+
+        # Second pass: TR's schedule sees the existing journey
+        result = await schedule_collector._process_schedule_item(
+            sqlite_session, tr_item, "TR", "Trenton", journey_date
+        )
+        assert result == "updated"
+        await sqlite_session.flush()
+
+        # Origin departure must survive
+        journey = await sqlite_session.scalar(
+            select(TrainJourney).where(TrainJourney.train_id == "3889")
+        )
+        assert journey is not None
+        assert journey.scheduled_departure == ny_dep, (
+            f"scheduled_departure was clobbered by the later station: "
+            f"got {journey.scheduled_departure}, expected {ny_dep}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_earlier_station_does_overwrite_later(
+        self, sqlite_session: AsyncSession, schedule_collector
+    ):
+        """
+        Inverse of the above: if a journey was first seen at TR (terminus
+        time stored), and NY's schedule is processed afterwards, the earlier
+        NY time must replace it. Without this, journeys accidentally created
+        from a non-origin station would never converge to the real origin.
+        """
+        journey_date = now_et().date()
+        ny_dep = now_et().replace(hour=21, minute=35, second=0, microsecond=0)
+        tr_dep = ny_dep + timedelta(minutes=90)
+
+        tr_item = _make_item("3889", tr_dep.strftime("%d-%b-%Y %I:%M:%S %p"))
+        ny_item = _make_item("3889", ny_dep.strftime("%d-%b-%Y %I:%M:%S %p"))
+
+        # TR processed first (creates journey with tr_dep)
+        await schedule_collector._process_schedule_item(
+            sqlite_session, tr_item, "TR", "Trenton", journey_date
+        )
+        await sqlite_session.flush()
+
+        # NY processed second (should overwrite to earlier time)
+        await schedule_collector._process_schedule_item(
+            sqlite_session, ny_item, "NY", "New York Penn Station", journey_date
+        )
+        await sqlite_session.flush()
+
+        journey = await sqlite_session.scalar(
+            select(TrainJourney).where(TrainJourney.train_id == "3889")
+        )
+        assert journey is not None
+        assert journey.scheduled_departure == ny_dep, (
+            f"Earlier station's time should overwrite the later one: "
+            f"got {journey.scheduled_departure}, expected {ny_dep}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_observed_journey_not_touched(
+        self, sqlite_session: AsyncSession, schedule_collector
+    ):
+        """
+        Once a journey is OBSERVED, schedule processing must not touch
+        scheduled_departure regardless of the new value. This pre-existing
+        behaviour is preserved by the early `return "skipped"` and is asserted
+        here so the earliest-wins guard does not accidentally subvert it.
+        """
+        journey_date = now_et().date()
+        observed_dep = now_et().replace(hour=21, minute=35, second=0, microsecond=0)
+        earlier_dep = observed_dep - timedelta(minutes=30)
+
+        # Pre-create an OBSERVED journey
+        journey = TrainJourney(
+            train_id="3889",
+            journey_date=journey_date,
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            observation_type="OBSERVED",
+            scheduled_departure=observed_dep,
+            is_cancelled=False,
+            is_expired=False,
+            is_completed=False,
+            has_complete_journey=False,
+            stops_count=0,
+            update_count=1,
+        )
+        sqlite_session.add(journey)
+        await sqlite_session.flush()
+
+        item = _make_item("3889", earlier_dep.strftime("%d-%b-%Y %I:%M:%S %p"))
+        result = await schedule_collector._process_schedule_item(
+            sqlite_session, item, "NY", "New York Penn Station", journey_date
+        )
+        assert result == "skipped"
+
+        refreshed = await sqlite_session.scalar(
+            select(TrainJourney).where(TrainJourney.train_id == "3889")
+        )
+        assert (
+            refreshed.scheduled_departure == observed_dep
+        ), "OBSERVED journey's scheduled_departure must be left alone"


### PR DESCRIPTION
The NJT schedule collector iterates over every station's schedule items.
NJT lists the same train in every stop-station's schedule, so the journey
row's scheduled_departure was overwritten on each iteration — whichever
station was processed last (often the terminus, with arrival-time-as-
SCHED_DEP_DATE) clobbered the actual origin departure. The journey
collector then permanently marked the row is_expired due to the resulting
mismatch with the API's first-stop time, before the corrective code path
in update_journey_metadata could run. Discovery un-expired it, journey
collector re-expired it, the cycle repeated, and ~550 NJT trains/day
intermittently disappeared from /trains/departures.

Two changes:

1. journey._is_same_journey: source stored_departure from the stops table
   (authoritative) instead of journey.scheduled_departure (denormalized
   cache). Generalizes the existing stale-stops branch — it previously
   only fired when origin_station_code mismatched, missing the more
   common case where origin matched but the cached departure had drifted.

2. schedule._process_schedule_item: only overwrite an existing journey's
   scheduled_departure if the new value is earlier. The origin always
   has the earliest time across stops, so this converges scheduled_departure
   on the train's actual origin departure regardless of station iteration
   order.

Tests cover both fixes including the inverse case (earlier station does
overwrite a later-time row) and verify OBSERVED journeys remain untouched
by schedule processing.

https://claude.ai/code/session_01S6DeZ97RtEm5DGcFkxdNKz