### PR TITLE
ios: add train system details view from Settings

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		A1BA60F32DFC73650002FB39 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BA60EB2DFC73650002FB39 /* XCTestCase+Extensions.swift */; };
 		A1CB28302E3D6189004A49E6 /* AdvancedConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CB282E2E3D6189004A49E6 /* AdvancedConfigurationView.swift */; };
 		A1CB28312E3D6189004A49E6 /* CongestionMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CB282F2E3D6189004A49E6 /* CongestionMapView.swift */; };
+		A1CB28512E3D6189004A49E6 /* TrainSystemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CB28502E3D6189004A49E6 /* TrainSystemDetailView.swift */; };
 		A1D88F612F27083000111466 /* RouteTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D88F602F27083000111466 /* RouteTopology.swift */; };
 		A1D88F622F27083000111466 /* RouteTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D88F602F27083000111466 /* RouteTopology.swift */; };
 		A1D88F632F27083000111466 /* RouteTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D88F602F27083000111466 /* RouteTopology.swift */; };
@@ -288,6 +289,7 @@
 		A1BA60EB2DFC73650002FB39 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		A1CB282E2E3D6189004A49E6 /* AdvancedConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AdvancedConfigurationView.swift; path = Views/Screens/AdvancedConfigurationView.swift; sourceTree = "<group>"; };
 		A1CB282F2E3D6189004A49E6 /* CongestionMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CongestionMapView.swift; path = Views/Screens/CongestionMapView.swift; sourceTree = "<group>"; };
+		A1CB28502E3D6189004A49E6 /* TrainSystemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TrainSystemDetailView.swift; path = Views/Screens/TrainSystemDetailView.swift; sourceTree = "<group>"; };
 		A1CB28322E3D634C004A49E6 /* JourneyCongestionMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JourneyCongestionMapView.swift; path = Views/Components/JourneyCongestionMapView.swift; sourceTree = "<group>"; };
 		A1D88F602F27083000111466 /* RouteTopology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RouteTopology.swift; path = TrackRat/Shared/RouteTopology.swift; sourceTree = "<group>"; };
 		B11DC1018BF600000001 /* RouteShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RouteShapes.swift; path = TrackRat/Shared/RouteShapes.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 				A1AA1BB42DEF00CC001FA904 /* TrackRatLoadingView.swift */,
 				A1CB282E2E3D6189004A49E6 /* AdvancedConfigurationView.swift */,
 				A1CB282F2E3D6189004A49E6 /* CongestionMapView.swift */,
+				A1CB28502E3D6189004A49E6 /* TrainSystemDetailView.swift */,
 				A1CB28322E3D634C004A49E6 /* JourneyCongestionMapView.swift */,
 				A183B7E02E6352E80024FADC /* LegacySheetAwareScrollView.swift */,
 				A1AA1BB82DEF00EE001FA904 /* TrackRatMascot.swift */,
@@ -783,6 +786,7 @@
 				A1CB28302E3D6189004A49E6 /* AdvancedConfigurationView.swift in Sources */,
 				A1D92A752F0AF01E0098897F /* CompletedTrip.swift in Sources */,
 				A1CB28312E3D6189004A49E6 /* CongestionMapView.swift in Sources */,
+				A1CB28512E3D6189004A49E6 /* TrainSystemDetailView.swift in Sources */,
 				A1CNFTI0012F7000000000002 /* ConfettiView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 enum SettingsDestination: Hashable {
     case tripHistory
     case advancedConfiguration
+    case trainSystem(TrainSystem)
 }
 
 struct SettingsView: View {
@@ -102,6 +103,8 @@ struct SettingsView: View {
                         TripHistoryView()
                     case .advancedConfiguration:
                         AdvancedConfigurationView()
+                    case .trainSystem(let system):
+                        TrainSystemDetailView(system: system)
                     }
                 }
             }
@@ -237,12 +240,15 @@ struct SettingsSection: View {
 
                         VStack(spacing: 0) {
                             ForEach(selectedSystems, id: \.self) { system in
-                                TrainSystemRow(
-                                    system: system,
-                                    isSelected: true,
-                                    isLast: system == selectedSystems.last,
-                                    showControls: false
-                                ) {}
+                                NavigationLink(value: SettingsDestination.trainSystem(system)) {
+                                    TrainSystemRow(
+                                        system: system,
+                                        isSelected: true,
+                                        isLast: system == selectedSystems.last,
+                                        showControls: false
+                                    ) {}
+                                }
+                                .buttonStyle(.plain)
                             }
                         }
                     }
@@ -1266,6 +1272,10 @@ private struct TrainSystemRow: View {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .font(.body)
                         .foregroundColor(isSelected ? .orange : .white.opacity(0.3))
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(.white.opacity(0.4))
                 }
             }
             .padding(.horizontal)

--- a/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
+++ b/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
@@ -1,0 +1,288 @@
+import SwiftUI
+import MapKit
+
+/// System-level details: a route map, recent network stats, and a single
+/// opt-in toggle for system-wide route alerts. Pushed from SettingsView when
+/// a TrainSystemRow is tapped outside of edit mode.
+struct TrainSystemDetailView: View {
+    let system: TrainSystem
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var mapViewModel = CongestionMapViewModel()
+    @ObservedObject private var alertService = AlertSubscriptionService.shared
+    @ObservedObject private var subscriptionService = SubscriptionService.shared
+
+    @State private var region: MKCoordinateRegion
+    @State private var serviceAlerts: [V2ServiceAlert] = []
+    @State private var showingPaywall = false
+
+    init(system: TrainSystem) {
+        self.system = system
+        self._region = State(initialValue: system.defaultMapRegion)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TrackRatNavigationHeader(
+                title: system.displayName,
+                onBackAction: { dismiss() }
+            )
+
+            ScrollView {
+                VStack(spacing: 16) {
+                    mapSection
+                    statsSection
+                    alertsSection
+                }
+                .padding()
+                .padding(.bottom, 40)
+            }
+        }
+        .navigationBarHidden(true)
+        .background(TrackRatTheme.Colors.primaryBackground.ignoresSafeArea())
+        .task {
+            mapViewModel.highlightMode = system.preferredHighlightMode
+            mapViewModel.showRoutes = true
+            mapViewModel.showStations = false
+            await mapViewModel.fetchCongestionData(dataSource: system.dataSource)
+            await loadServiceAlerts()
+        }
+        .sheet(isPresented: $showingPaywall) {
+            PaywallView(context: .routeAlerts)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var mapSection: some View {
+        ZStack(alignment: .topTrailing) {
+            // Embedded map preview. Hit-testing is disabled so vertical scroll
+            // gestures aren't stolen by MKMapView; the map serves as visual
+            // context, not as a fully interactive surface.
+            SystemCongestionMapView(
+                region: $region,
+                segments: mapViewModel.segments,
+                individualSegments: [],
+                stations: [],
+                showRoutes: mapViewModel.showRoutes,
+                selectedSystems: [system],
+                highlightMode: mapViewModel.highlightMode,
+                onSegmentTap: { _ in },
+                onIndividualSegmentTap: nil
+            )
+            .frame(height: 280)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .allowsHitTesting(false)
+
+            if mapViewModel.isLoading {
+                ProgressView()
+                    .padding(8)
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .padding(8)
+            }
+        }
+    }
+
+    private var statsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 16) {
+                Image(systemName: "chart.bar.fill")
+                    .font(.title2)
+                    .foregroundColor(.orange)
+                    .frame(width: 24, height: 24)
+
+                Text("Recent Activity")
+                    .font(.headline)
+                    .fontWeight(.medium)
+                    .foregroundColor(.white)
+
+                Spacer()
+            }
+            .padding()
+
+            Divider().background(Color.white.opacity(0.1))
+
+            statRow(icon: "clock.fill", label: "Average delay", value: averageDelayDisplay)
+            Divider().background(Color.white.opacity(0.1))
+            statRow(icon: "map.fill", label: "Routes", value: "\(systemRouteCount)")
+            Divider().background(Color.white.opacity(0.1))
+            statRow(
+                icon: "exclamationmark.triangle.fill",
+                label: "Active alerts",
+                value: activeAlertCount > 0 ? "\(activeAlertCount)" : "None"
+            )
+            Divider().background(Color.white.opacity(0.1))
+            statRow(
+                icon: "wrench.and.screwdriver.fill",
+                label: "Planned work",
+                value: plannedWorkCount > 0 ? "\(plannedWorkCount)" : "None"
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.ultraThinMaterial)
+        )
+    }
+
+    private func statRow(icon: String, label: String, value: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.body)
+                .foregroundColor(.orange.opacity(0.8))
+                .frame(width: 24)
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(.white)
+            Spacer()
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundColor(.white.opacity(0.8))
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+    }
+
+    private var alertsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 16) {
+                Image(systemName: "bell.badge.fill")
+                    .font(.title2)
+                    .foregroundColor(.orange)
+                    .frame(width: 24, height: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("System-wide Alerts")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                    Text(alertSubtitleText)
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.6))
+                }
+
+                Spacer()
+
+                if system.supportsAlerts {
+                    Toggle("", isOn: subscribedToggleBinding)
+                        .labelsHidden()
+                        .tint(.orange)
+                } else {
+                    Text("Unavailable")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.4))
+                }
+            }
+            .padding()
+
+            if isSubscribed {
+                Divider().background(Color.white.opacity(0.1))
+
+                Text("Customize delivery, days, and thresholds from Route Alerts in Settings.")
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.5))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.vertical, 12)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(.ultraThinMaterial)
+        )
+    }
+
+    // MARK: - Derived state
+
+    private var existingSystemWideSub: RouteAlertSubscription? {
+        alertService.subscriptions.first {
+            $0.isSystemWide && $0.dataSource == system.rawValue
+        }
+    }
+
+    private var isSubscribed: Bool { existingSystemWideSub != nil }
+
+    private var atFreeRouteAlertLimit: Bool {
+        !subscriptionService.isPro
+            && alertService.subscriptions.count >= SubscriptionService.freeRouteAlertLimit
+    }
+
+    /// Two-way binding for the alerts toggle. The setter never mutates state
+    /// directly — it routes through `handleToggle`, which gates on the free
+    /// route-alert limit. If the gate trips, `isSubscribed` is unchanged and
+    /// SwiftUI re-renders the Toggle in its prior state.
+    private var subscribedToggleBinding: Binding<Bool> {
+        Binding(
+            get: { isSubscribed },
+            set: { handleToggle($0) }
+        )
+    }
+
+    private var systemRouteCount: Int {
+        RouteTopology.allRoutes.filter { $0.dataSource == system.dataSource }.count
+    }
+
+    private var averageDelayDisplay: String {
+        let segments = mapViewModel.segments
+        guard !segments.isEmpty else {
+            return mapViewModel.isLoading ? "—" : "No data"
+        }
+        let avg = segments.map(\.averageDelayMinutes).reduce(0, +) / Double(segments.count)
+        if avg < 0.5 { return "On time" }
+        return String(format: "%.1f min", avg)
+    }
+
+    private var activeAlertCount: Int {
+        serviceAlerts.filter { $0.alertType == "alert" && $0.isActiveNow }.count
+    }
+
+    private var plannedWorkCount: Int {
+        serviceAlerts.filter { $0.alertType == "planned_work" && $0.isActiveNow }.count
+    }
+
+    private var alertSubtitleText: String {
+        if !system.supportsAlerts {
+            return "Real-time alerts not available for \(system.displayName)."
+        }
+        return isSubscribed
+            ? "You'll be notified about delays across \(system.displayName)."
+            : "Get notified about delays across \(system.displayName)."
+    }
+
+    // MARK: - Actions
+
+    private func handleToggle(_ newValue: Bool) {
+        if newValue {
+            if atFreeRouteAlertLimit {
+                showingPaywall = true
+                return
+            }
+            let sub = RouteAlertSubscription(dataSource: system.rawValue)
+            alertService.addSubscriptions([sub])
+            alertService.syncIfPossible()
+        } else if let sub = existingSystemWideSub {
+            alertService.removeSubscription(sub)
+            alertService.syncIfPossible()
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    private func loadServiceAlerts() async {
+        guard system.supportsAlerts else { return }
+        do {
+            serviceAlerts = try await APIService.shared.fetchServiceAlerts(dataSource: system.rawValue)
+        } catch {
+            print("TrainSystemDetailView: failed to load service alerts for \(system.rawValue): \(error)")
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TrainSystemDetailView(system: .njt)
+            .environmentObject(AppState())
+            .environmentObject(ThemeManager.shared)
+    }
+}

--- a/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
+++ b/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
@@ -198,7 +198,7 @@ struct TrainSystemDetailView: View {
 
     private var existingSystemWideSub: RouteAlertSubscription? {
         alertService.subscriptions.first {
-            $0.isSystemWide && $0.dataSource == system.rawValue
+            $0.isSystemWide && $0.dataSource == system.dataSource
         }
     }
 
@@ -259,7 +259,7 @@ struct TrainSystemDetailView: View {
                 showingPaywall = true
                 return
             }
-            let sub = RouteAlertSubscription(dataSource: system.rawValue)
+            let sub = RouteAlertSubscription(dataSource: system.dataSource)
             alertService.addSubscriptions([sub])
             alertService.syncIfPossible()
         } else if let sub = existingSystemWideSub {
@@ -272,9 +272,9 @@ struct TrainSystemDetailView: View {
     private func loadServiceAlerts() async {
         guard system.supportsAlerts else { return }
         do {
-            serviceAlerts = try await APIService.shared.fetchServiceAlerts(dataSource: system.rawValue)
+            serviceAlerts = try await APIService.shared.fetchServiceAlerts(dataSource: system.dataSource)
         } catch {
-            print("TrainSystemDetailView: failed to load service alerts for \(system.rawValue): \(error)")
+            print("TrainSystemDetailView: failed to load service alerts for \(system.dataSource): \(error)")
         }
     }
 }


### PR DESCRIPTION
Tapping a train system row in Settings (outside edit mode) now navigates
to a detail view showing the system's route map with live congestion
overlay, recent stats (avg delay, route count, active alerts, planned
work), and a single toggle to opt in to system-wide route alerts. Edit
mode behavior is preserved — taps still toggle selection.

The map embeds SystemCongestionMapView directly (hit-testing disabled to
avoid scroll-gesture conflicts) and reuses CongestionMapViewModel scoped
to the system's dataSource. Stats are derived from existing congestion
and service-alert endpoints — no new backend work. The alerts toggle
respects the existing free-vs-Pro route alert limit and routes through
RouteAlertSubscription's system-wide initializer + the existing
AlertSubscriptionService dedup/sync path; customization continues to
live in the Route Alerts section.

https://claude.ai/code/session_0113Fzig8XSFHrR4BATPd5Jn