### PR TITLE
ios: add station details view

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		A1STNPK0012F6000000000002 /* StationPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1STNPK0012F6000000000001 /* StationPickerSheet.swift */; };
 		A1ROUTE0012F5000000000002 /* RouteStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ROUTE0012F5000000000001 /* RouteStatusView.swift */; };
 		A11A0DC12F4B840B00C96DA1 /* AddRouteAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0DBC2F4B840B00C96DA1 /* AddRouteAlertView.swift */; };
+		F1TRNROW01000000000000A2 /* TrainRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1TRNROW01000000000000A1 /* TrainRow.swift */; };
+		F1STDETAIL00000000000000A2 /* StationDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1STDETAIL00000000000000A1 /* StationDetailsView.swift */; };
 		A11A2C332E27C1A400B74BB5 /* StaticTrackDistributionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A2C322E27C1A400B74BB5 /* StaticTrackDistributionService.swift */; };
 		A126E5582E25BBC700958ABA /* TrainV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = A126E5562E25BBC700958ABA /* TrainV2.swift */; };
 		A1TRIP0012F60000000000001 /* TripOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1TRIP0012F60000000000002 /* TripOption.swift */; };
@@ -212,6 +214,8 @@
 		A11A0DB62F4B83CF00C96DA1 /* AlertSubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AlertSubscriptionService.swift; path = TrackRat/Services/AlertSubscriptionService.swift; sourceTree = "<group>"; };
 		A11A0DB72F4B83CF00C96DA1 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = APIService.swift; path = TrackRat/Services/APIService.swift; sourceTree = "<group>"; };
 		A11A0DBC2F4B840B00C96DA1 /* AddRouteAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddRouteAlertView.swift; path = Views/Screens/AddRouteAlertView.swift; sourceTree = "<group>"; };
+		F1TRNROW01000000000000A1 /* TrainRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TrainRow.swift; path = Views/Components/TrainRow.swift; sourceTree = "<group>"; };
+		F1STDETAIL00000000000000A1 /* StationDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StationDetailsView.swift; path = Views/Screens/StationDetailsView.swift; sourceTree = "<group>"; };
 		A1STNPK0012F6000000000001 /* StationPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StationPickerSheet.swift; path = Views/Components/StationPickerSheet.swift; sourceTree = "<group>"; };
 		A1ROUTE0012F5000000000001 /* RouteStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RouteStatusView.swift; path = Views/Screens/RouteStatusView.swift; sourceTree = "<group>"; };
 		A11A0DBE2F4B840B00C96DA1 /* TripHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TripHistoryView.swift; path = Views/Screens/TripHistoryView.swift; sourceTree = "<group>"; };
@@ -435,6 +439,8 @@
 				A11A0DBC2F4B840B00C96DA1 /* AddRouteAlertView.swift */,
 				A1STNPK0012F6000000000001 /* StationPickerSheet.swift */,
 				A1ROUTE0012F5000000000001 /* RouteStatusView.swift */,
+				F1TRNROW01000000000000A1 /* TrainRow.swift */,
+				F1STDETAIL00000000000000A1 /* StationDetailsView.swift */,
 				A11A0DBE2F4B840B00C96DA1 /* TripHistoryView.swift */,
 				A18E54392DEB88E500AB2B74 /* LiveActivityService.swift */,
 				A126E5552E25BBC700958ABA /* DeepLink.swift */,
@@ -726,6 +732,8 @@
 				A11A0DBF2F4B840B00C96DA1 /* TripHistoryView.swift in Sources */,
 				A1STNPK0012F6000000000002 /* StationPickerSheet.swift in Sources */,
 				A1ROUTE0012F5000000000002 /* RouteStatusView.swift in Sources */,
+				F1TRNROW01000000000000A2 /* TrainRow.swift in Sources */,
+				F1STDETAIL00000000000000A2 /* StationDetailsView.swift in Sources */,
 				A11A0DC12F4B840B00C96DA1 /* AddRouteAlertView.swift in Sources */,
 				A10E98042DE39F23002F3214 /* TrainListView.swift in Sources */,
 				A183B7E12E6352E80024FADC /* LegacySheetAwareScrollView.swift in Sources */,

--- a/ios/TrackRat/App/ContentView.swift
+++ b/ios/TrackRat/App/ContentView.swift
@@ -20,6 +20,7 @@ enum NavigationDestination: Hashable {
     case congestionMap
     case favoriteStations
     case tripHistory
+    case stationDetails(stationCode: String)
 }
 
 #Preview {

--- a/ios/TrackRat/Views/Components/TrainRow.swift
+++ b/ios/TrackRat/Views/Components/TrainRow.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// Compact, line-color-bar departure row used by overview screens
+/// (route status, station details). For interactive trip-planning cards
+/// see `TrainCard` in `TrainListView.swift`.
+struct TrainRow: View {
+    let train: TrainV2
+    let dataSource: String
+
+    /// Whether this transit system uses synthetic train IDs (e.g., subway, PATCO)
+    private var useSyntheticId: Bool {
+        TrainSystem.syntheticTrainIdSources.contains(dataSource)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: train.line.color))
+                .frame(width: 4, height: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                if useSyntheticId {
+                    Text(train.line.name)
+                        .font(.subheadline.bold())
+                } else {
+                    Text("Train \(train.trainId)")
+                        .font(.subheadline.bold())
+                }
+                HStack(spacing: 8) {
+                    if let track = train.track, !track.isEmpty {
+                        Text("Track \(track)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    if train.isCancelled {
+                        Text("Cancelled")
+                            .font(.caption.bold())
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(departureTimeString)
+                    .font(.subheadline.bold())
+                delayBadge
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private var departureTimeString: String {
+        guard let time = train.departure.updatedTime ?? train.departure.scheduledTime else {
+            return "--"
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        formatter.timeZone = TimeZone(identifier: "America/New_York")
+        return formatter.string(from: time)
+    }
+
+    @ViewBuilder
+    private var delayBadge: some View {
+        if train.isCancelled {
+            EmptyView()
+        } else if train.departure.delayMinutes > 0 {
+            Text("+\(train.departure.delayMinutes)m")
+                .font(.caption.bold())
+                .foregroundColor(.red)
+        } else {
+            Text("On Time")
+                .font(.caption)
+                .foregroundColor(.green)
+        }
+    }
+}

--- a/ios/TrackRat/Views/Screens/DeparturePickerView.swift
+++ b/ios/TrackRat/Views/Screens/DeparturePickerView.swift
@@ -383,12 +383,14 @@ struct DeparturePickerView: View {
     @ViewBuilder
     private var stationResultsView: some View {
         ForEach(searchResults.stations, id: \.self) { station in
+            let code = Stations.getStationCode(station)
             stationRow(station)
                 .onTapGesture {
-                    if let code = Stations.getStationCode(station) {
+                    if let code {
                         selectDeparture(name: station, code: code)
                     }
                 }
+                .stationDetailsContextMenu(code: code, path: $appState.navigationPath)
         }
     }
 
@@ -672,6 +674,7 @@ struct DepartureButton: View {
         .padding(.vertical, 16)
         .background(TrackRatTheme.Colors.surfaceCard)
         .cornerRadius(TrackRatTheme.CornerRadius.md)
+        .stationDetailsContextMenu(code: code, path: $appState.navigationPath)
     }
 }
 

--- a/ios/TrackRat/Views/Screens/DestinationPickerView.swift
+++ b/ios/TrackRat/Views/Screens/DestinationPickerView.swift
@@ -327,6 +327,7 @@ struct DestinationPickerView: View {
                         .stroke(TrackRatTheme.Colors.border, lineWidth: 1)
                 )
         )
+        .stationDetailsContextMenu(code: code, path: $appState.navigationPath)
     }
 
     /// Demoted search row for stations on systems the user hasn't activated.
@@ -380,6 +381,7 @@ struct DestinationPickerView: View {
                         .stroke(TrackRatTheme.Colors.border.opacity(0.6), lineWidth: 1)
                 )
         )
+        .stationDetailsContextMenu(code: code, path: $appState.navigationPath)
     }
 
     private func selectDestination(_ destination: String) {

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -747,6 +747,8 @@ struct MapContainerView: View {
                 )
             case .tripHistory:
                 TripHistoryView()
+            case .stationDetails(let stationCode):
+                StationDetailsView(stationCode: stationCode)
             }
         }
         .transparentNavigationBackground()

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -852,7 +852,7 @@ enum ServiceAlertFilter: CaseIterable {
 
 // MARK: - Service Alert Card
 
-private struct ServiceAlertCard: View {
+struct ServiceAlertCard: View {
     let alert: V2ServiceAlert
     @State private var isExpanded = false
 
@@ -951,85 +951,6 @@ private struct NowDivider: View {
         }
         .padding(.vertical, 2)
         .onReceive(timer) { now = $0 }
-    }
-}
-
-// MARK: - Train Row
-
-private struct TrainRow: View {
-    let train: TrainV2
-    let dataSource: String
-
-    /// Whether this transit system uses synthetic train IDs (e.g., subway, PATCO)
-    private var useSyntheticId: Bool {
-        TrainSystem.syntheticTrainIdSources.contains(dataSource)
-    }
-
-    var body: some View {
-        HStack(spacing: 12) {
-            // Line color indicator
-            RoundedRectangle(cornerRadius: 2)
-                .fill(Color(hex: train.line.color))
-                .frame(width: 4, height: 40)
-
-            VStack(alignment: .leading, spacing: 2) {
-                if useSyntheticId {
-                    Text(train.line.name)
-                        .font(.subheadline.bold())
-                } else {
-                    Text("Train \(train.trainId)")
-                        .font(.subheadline.bold())
-                }
-                HStack(spacing: 8) {
-                    if let track = train.track, !track.isEmpty {
-                        Text("Track \(track)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    if train.isCancelled {
-                        Text("Cancelled")
-                            .font(.caption.bold())
-                            .foregroundColor(.red)
-                    }
-                }
-            }
-
-            Spacer()
-
-            VStack(alignment: .trailing, spacing: 2) {
-                Text(departureTimeString)
-                    .font(.subheadline.bold())
-                delayBadge
-            }
-        }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
-    }
-
-    private var departureTimeString: String {
-        guard let time = train.departure.updatedTime ?? train.departure.scheduledTime else {
-            return "--"
-        }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "h:mm a"
-        formatter.timeZone = TimeZone(identifier: "America/New_York")
-        return formatter.string(from: time)
-    }
-
-    @ViewBuilder
-    private var delayBadge: some View {
-        if train.isCancelled {
-            EmptyView()
-        } else if train.departure.delayMinutes > 0 {
-            Text("+\(train.departure.delayMinutes)m")
-                .font(.caption.bold())
-                .foregroundColor(.red)
-        } else {
-            Text("On Time")
-                .font(.caption)
-                .foregroundColor(.green)
-        }
     }
 }
 

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -105,6 +105,11 @@ struct SettingsView: View {
                     }
                 }
             }
+            .navigationDestination(for: NavigationDestination.self) { destination in
+                if case .stationDetails(let stationCode) = destination {
+                    StationDetailsView(stationCode: stationCode)
+                }
+            }
             .navigationBarHidden(true)
             .edgeSwipeBack(path: $navigationPath)
         }
@@ -419,6 +424,7 @@ struct SettingsSection: View {
                         }
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     }
+                    .stationDetailsContextMenu(code: ratSense.getHomeStation(), path: $navigationPath)
 
                     // Work Station
                     FavoriteStationRow(
@@ -440,6 +446,7 @@ struct SettingsSection: View {
                         }
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     }
+                    .stationDetailsContextMenu(code: ratSense.getWorkStation(), path: $navigationPath)
 
                     // Other favorites
                     let homeCode = ratSense.getHomeStation()
@@ -453,7 +460,7 @@ struct SettingsSection: View {
                             stationCode: fav.id,
                             isLast: fav.id == otherFavorites.last?.id && appState.favoriteStations.count >= 10
                         ) {
-                            // Tap does nothing for "other" favorites — they're just listed
+                            navigationPath.append(NavigationDestination.stationDetails(stationCode: fav.id))
                         } onClear: {
                             appState.removeFavoriteStation(code: fav.id)
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
@@ -848,7 +855,11 @@ private struct FavoriteStationRow: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 12) {
-                if showControls && label != nil {
+                // Wrap in a Button whenever there's a meaningful tap target:
+                // labelled rows (Home/Work) always tap to repick; unlabelled
+                // ("other") rows only tap when a station is set, since they
+                // navigate to that station's details.
+                if showControls && (label != nil || stationCode != nil) {
                     Button(action: onTap) {
                         rowContent
                             .contentShape(Rectangle())

--- a/ios/TrackRat/Views/Screens/StationDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/StationDetailsView.swift
@@ -1,0 +1,482 @@
+import SwiftUI
+import MapKit
+
+/// Per-station overview: upcoming/recent departures, service alerts, routes
+/// served, and quick actions (favorite, set as home/work). Reachable from
+/// any station row via the `stationDetailsContextMenu` modifier or via a
+/// direct tap from places where users browse stations (Settings favorites,
+/// Onboarding favorites list).
+struct StationDetailsView: View {
+    let stationCode: String
+
+    @StateObject private var viewModel: StationDetailsViewModel
+    @EnvironmentObject private var appState: AppState
+    @ObservedObject private var ratSense = RatSenseService.shared
+
+    init(stationCode: String) {
+        self.stationCode = stationCode
+        self._viewModel = StateObject(wrappedValue: StationDetailsViewModel(stationCode: stationCode))
+    }
+
+    private var displayName: String { Stations.displayName(for: stationCode) }
+    private var fullName: String { StationData.stationName(forCode: stationCode) ?? displayName }
+    private var stationSystems: Set<TrainSystem> { Stations.systemsForStation(stationCode) }
+    private var hasAlertSupport: Bool { stationSystems.contains { Self.alertSupportedSystems.contains($0) } }
+    private var coordinate: CLLocationCoordinate2D? { Stations.getCoordinates(for: stationCode) }
+
+    private var routesServingStation: [RouteLine] {
+        RouteTopology.allRoutes
+            .filter { $0.stationCodes.contains(stationCode) }
+            .filter { TrainSystem(rawValue: $0.dataSource).map(stationSystems.contains) ?? false }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                headerSection
+                mapSnippetSection
+                actionsSection
+                upcomingDeparturesSection
+                serviceAlertsSection
+                recentDeparturesSection
+                routesServingSection
+            }
+            .padding()
+            .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingDepartures)
+            .animation(.easeInOut(duration: 0.3), value: viewModel.isLoadingAlerts)
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle(displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await viewModel.load(alertSupportedSystems: Self.alertSupportedSystems)
+        }
+        .refreshable {
+            await viewModel.load(alertSupportedSystems: Self.alertSupportedSystems)
+        }
+        .sheet(item: $viewModel.selectedTrain) { train in
+            NavigationStack {
+                TrainDetailsView(
+                    trainNumber: train.trainId,
+                    fromStation: stationCode,
+                    journeyDate: train.journeyDate,
+                    dataSource: train.dataSource,
+                    isSheet: true
+                )
+            }
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        }
+        .sheet(item: $viewModel.routeStatusContext) { context in
+            RouteStatusView(context: context)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(fullName)
+                .font(.title2.bold())
+                .lineLimit(2)
+                .minimumScaleFactor(0.7)
+
+            HStack(spacing: 8) {
+                ForEach(Array(stationSystems).sorted(by: { $0.rawValue < $1.rawValue })) { system in
+                    Text(system.chipLabel)
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(Color(hex: system.color).opacity(0.2)))
+                        .foregroundColor(Color(hex: system.color))
+                }
+                let lines = SubwayLines.lines(forStationCode: stationCode)
+                if !lines.isEmpty {
+                    SubwayLineChips(lines: lines, size: 18)
+                }
+                Spacer()
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+    }
+
+    // MARK: - Map snippet
+
+    @ViewBuilder
+    private var mapSnippetSection: some View {
+        if let coord = coordinate {
+            Map(initialPosition: .region(MKCoordinateRegion(
+                center: coord,
+                span: MKCoordinateSpan(latitudeDelta: 0.012, longitudeDelta: 0.012)
+            ))) {
+                Marker(displayName, coordinate: coord)
+                    .tint(.orange)
+            }
+            .mapStyle(.standard(pointsOfInterest: .excludingAll))
+            .frame(height: 140)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .allowsHitTesting(false)
+        }
+    }
+
+    // MARK: - Actions (favorite / home / work)
+
+    @ViewBuilder
+    private var actionsSection: some View {
+        let isFavorited = appState.isStationFavorited(code: stationCode)
+        let isHome = ratSense.getHomeStation() == stationCode
+        let isWork = ratSense.getWorkStation() == stationCode
+
+        HStack(spacing: 8) {
+            actionButton(
+                title: isFavorited ? "Favorited" : "Favorite",
+                systemImage: isFavorited ? "heart.fill" : "heart",
+                isActive: isFavorited
+            ) {
+                appState.toggleFavoriteStation(code: stationCode, name: fullName)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }
+            actionButton(
+                title: isHome ? "Home" : "Set Home",
+                systemImage: "house.fill",
+                isActive: isHome
+            ) {
+                ratSense.setHomeStation(isHome ? nil : stationCode)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }
+            actionButton(
+                title: isWork ? "Work" : "Set Work",
+                systemImage: "briefcase.fill",
+                isActive: isWork
+            ) {
+                ratSense.setWorkStation(isWork ? nil : stationCode)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionButton(title: String, systemImage: String, isActive: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 16, weight: .semibold))
+                Text(title)
+                    .font(.caption.bold())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(RoundedRectangle(cornerRadius: 10)
+                .fill(isActive ? Color.orange.opacity(0.25) : Color(.secondarySystemGroupedBackground)))
+            .foregroundColor(isActive ? .orange : .primary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Upcoming departures
+
+    @ViewBuilder
+    private var upcomingDeparturesSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Upcoming Departures")
+                .font(.headline)
+
+            if viewModel.isLoadingDepartures {
+                ForEach(0..<3, id: \.self) { _ in skeletonRow }
+            } else if viewModel.upcoming.isEmpty {
+                emptyRow("No upcoming departures")
+            } else {
+                ForEach(viewModel.upcoming.prefix(10)) { train in
+                    Button {
+                        viewModel.selectedTrain = train
+                    } label: {
+                        TrainRow(train: train, dataSource: train.dataSource)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+    }
+
+    // MARK: - Recent departures
+
+    @ViewBuilder
+    private var recentDeparturesSection: some View {
+        if viewModel.isLoadingDepartures || !viewModel.recent.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Recently Departed")
+                    .font(.headline)
+
+                if viewModel.isLoadingDepartures {
+                    ForEach(0..<2, id: \.self) { _ in skeletonRow.opacity(0.55) }
+                } else {
+                    ForEach(viewModel.recent.prefix(5)) { train in
+                        Button {
+                            viewModel.selectedTrain = train
+                        } label: {
+                            TrainRow(train: train, dataSource: train.dataSource)
+                        }
+                        .buttonStyle(.plain)
+                        .opacity(0.55)
+                    }
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        }
+    }
+
+    // MARK: - Service alerts
+
+    @ViewBuilder
+    private var serviceAlertsSection: some View {
+        if hasAlertSupport && !viewModel.isLoadingAlerts && !viewModel.alerts.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Service Alerts")
+                    .font(.headline)
+
+                ForEach(viewModel.alerts) { alert in
+                    ServiceAlertCard(alert: alert)
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        }
+    }
+
+    // MARK: - Routes serving
+
+    @ViewBuilder
+    private var routesServingSection: some View {
+        if !routesServingStation.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Routes Serving This Station")
+                    .font(.headline)
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 140), spacing: 8)], spacing: 8) {
+                    ForEach(routesServingStation) { route in
+                        Button {
+                            viewModel.routeStatusContext = RouteStatusContext(
+                                dataSource: route.dataSource,
+                                lineId: route.id
+                            )
+                        } label: {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(route.name)
+                                    .font(.subheadline.bold())
+                                    .lineLimit(1)
+                                if let subtitle = route.terminalSubtitle {
+                                    Text(subtitle)
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var skeletonRow: some View {
+        HStack(spacing: 12) {
+            ShimmerRect(width: 4, height: 40, cornerRadius: 2)
+            VStack(alignment: .leading, spacing: 4) {
+                ShimmerRect(width: 90, height: 16)
+                ShimmerRect(width: 60, height: 12)
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 4) {
+                ShimmerRect(width: 60, height: 16)
+                ShimmerRect(width: 50, height: 12)
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private func emptyRow(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 8)
+    }
+
+    /// Data sources that publish service alerts. Mirrors the constant in
+    /// `RouteStatusViewModel`; kept local to avoid coupling the two views.
+    private static let alertSupportedSystems: Set<TrainSystem> = [.subway, .lirr, .mnr, .njt]
+}
+
+// MARK: - View Model
+
+@MainActor
+final class StationDetailsViewModel: ObservableObject {
+    let stationCode: String
+
+    @Published private(set) var upcoming: [TrainV2] = []
+    @Published private(set) var recent: [TrainV2] = []
+    @Published private(set) var alerts: [V2ServiceAlert] = []
+    @Published private(set) var isLoadingDepartures = true
+    @Published private(set) var isLoadingAlerts = true
+    @Published var selectedTrain: TrainV2?
+    @Published var routeStatusContext: RouteStatusContext?
+
+    private static let recentWindowMinutes = 60
+
+    init(stationCode: String) {
+        self.stationCode = stationCode
+    }
+
+    func load(alertSupportedSystems: Set<TrainSystem>) async {
+        let systems = Stations.systemsForStation(stationCode)
+        async let departuresAndRecent: () = loadDepartures(systems: systems)
+        async let alertsResult: () = loadAlerts(systems: systems, alertSupportedSystems: alertSupportedSystems)
+        _ = await (departuresAndRecent, alertsResult)
+    }
+
+    // MARK: Departures
+
+    private func loadDepartures(systems: Set<TrainSystem>) async {
+        isLoadingDepartures = true
+        defer { isLoadingDepartures = false }
+
+        async let upcomingTask = fetchUpcoming(systems: systems)
+        async let recentTask = fetchRecent(systems: systems)
+        let (u, r) = await (upcomingTask, recentTask)
+        upcoming = u
+        recent = r
+    }
+
+    private func fetchUpcoming(systems: Set<TrainSystem>) async -> [TrainV2] {
+        do {
+            return try await APIService.shared.searchTrains(
+                fromStationCode: stationCode,
+                toStationCode: nil,
+                date: nil,
+                dataSources: systems.isEmpty ? nil : systems
+            )
+        } catch {
+            return []
+        }
+    }
+
+    private func fetchRecent(systems: Set<TrainSystem>) async -> [TrainV2] {
+        do {
+            return try await APIService.shared.searchRecentTrains(
+                fromStationCode: stationCode,
+                toStationCode: nil,
+                windowMinutes: Self.recentWindowMinutes,
+                dataSources: systems.isEmpty ? nil : systems
+            )
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: Alerts
+
+    private func loadAlerts(systems: Set<TrainSystem>, alertSupportedSystems: Set<TrainSystem>) async {
+        isLoadingAlerts = true
+        defer { isLoadingAlerts = false }
+
+        let systemsToFetch = systems.intersection(alertSupportedSystems)
+        guard !systemsToFetch.isEmpty else {
+            alerts = []
+            return
+        }
+
+        // Per-system relevant route IDs; filtering is scoped to each system
+        // so an unmapped NJT lineId can't accidentally suppress all NJT alerts.
+        let relevantRouteIdsBySystem = relevantGtfsRouteIdsBySystem()
+
+        var collected: [V2ServiceAlert] = []
+        await withTaskGroup(of: [V2ServiceAlert].self) { group in
+            for system in systemsToFetch {
+                let relevant = relevantRouteIdsBySystem[system] ?? []
+                group.addTask {
+                    do {
+                        let alerts = try await APIService.shared.fetchServiceAlerts(dataSource: system.dataSource)
+                        // No mapping for this system → show all of its alerts (better
+                        // to over-show than to silently drop).
+                        if relevant.isEmpty { return alerts }
+                        return alerts.filter {
+                            !Set($0.affectedRouteIds).isDisjoint(with: relevant)
+                        }
+                    } catch {
+                        return []
+                    }
+                }
+            }
+            for await result in group {
+                collected.append(contentsOf: result)
+            }
+        }
+
+        // Active first, then upcoming; chronological within each group.
+        alerts = collected.sorted {
+            if $0.isActiveNow != $1.isActiveNow { return $0.isActiveNow }
+            return $0.earliestStartEpoch < $1.earliestStartEpoch
+        }
+    }
+
+    /// Per-system GTFS route IDs for routes touching this station, used to scope
+    /// alerts to lines actually serving the station (e.g., a Penn user shouldn't
+    /// see Brooklyn-only G-train alerts).
+    private func relevantGtfsRouteIdsBySystem() -> [TrainSystem: Set<String>] {
+        var map: [TrainSystem: Set<String>] = [:]
+        let routes = RouteTopology.allRoutes.filter { $0.stationCodes.contains(stationCode) }
+        for route in routes {
+            guard let system = TrainSystem(rawValue: route.dataSource) else { continue }
+            let context = RouteStatusContext(dataSource: route.dataSource, lineId: route.id)
+            map[system, default: []].formUnion(context.gtfsRouteIds)
+        }
+        return map
+    }
+}
+
+// MARK: - Context Menu Helper
+
+extension View {
+    /// Adds a context menu entry that pushes `StationDetailsView` for the given
+    /// station code onto the supplied navigation path. Used on station rows in
+    /// the pickers, where the primary tap action selects the station for trip
+    /// planning and the secondary action exposes details. A nil code is a
+    /// no-op so callers don't need to wrap the modifier in a conditional.
+    @ViewBuilder
+    func stationDetailsContextMenu(
+        code: String?,
+        path: Binding<NavigationPath>
+    ) -> some View {
+        if let code {
+            contextMenu {
+                Button {
+                    path.wrappedValue.append(NavigationDestination.stationDetails(stationCode: code))
+                } label: {
+                    Label("View Station Details", systemImage: "info.circle")
+                }
+            }
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
Adds a per-station overview screen reachable from any station row. v1
sections: header (name, system chips, subway bullets), small map
snippet, quick actions (favorite / set home / set work), upcoming
departures, service alerts, recent departures, and routes serving the
station (tap to open RouteStatusView).

Navigation
- New `NavigationDestination.stationDetails(stationCode:)` case routed
  through `MapContainerView`'s navigation switch and registered on
  `SettingsView`'s stack so taps from Settings push onto the same view.

Entry points
- Picker rows (`DeparturePickerView`, `DestinationPickerView`,
  `DepartureButton`) get a `.stationDetailsContextMenu` long-press
  affordance — primary tap behavior (select for trip planning) is
  unchanged.
- Settings favorites: "other" favorites tap to details; Home/Work
  retain their tap-to-repick behavior with a context menu for
  "View Station Details".

Data
- Reuses existing endpoints: `searchTrains` (upcoming, no `to`),
  `searchRecentTrains` (last 60 min, no `to`), `fetchServiceAlerts`
  per supported system. Alerts are filtered per-system using the
  GTFS route IDs from `RouteStatusContext` so a station's view doesn't
  accidentally suppress alerts from systems whose IDs aren't in the
  union.

Refactor
- Extracts `TrainRow` from `RouteStatusView.swift` into
  `Views/Components/TrainRow.swift` so both views can share it
  (pure relocation; no behavior change).
- Un-privates `ServiceAlertCard` for reuse from `StationDetailsView`.

https://claude.ai/code/session_01Wu24hCeDwifXDwwkfV8StF