### PR TITLE
Issue #1105: Add orange highlight to active Route Alerts and Get Updates buttons

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -5,6 +5,8 @@ struct TrainDetailsView: View {
     @EnvironmentObject private var appState: AppState
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: TrainDetailsViewModel
+    @ObservedObject private var liveActivityService = LiveActivityService.shared
+    @ObservedObject private var alertService = AlertSubscriptionService.shared
     // PERFORMANCE: Track visibility to prevent polling when view is not visible
     @State private var isViewVisible = false
 
@@ -116,15 +118,17 @@ struct TrainDetailsView: View {
                        !destCode.isEmpty,
                        let originCode = appState.departureStationCode,
                        !originCode.isEmpty {
+                        let ds = train.dataSource
+                        let lineId: String? = ds == "SUBWAY" ? nil : RouteTopology.routeContaining(from: originCode, to: destCode, dataSource: ds)?.id
+                        let routeContext = RouteStatusContext(
+                            dataSource: ds,
+                            lineId: lineId,
+                            fromStationCode: originCode,
+                            toStationCode: destCode
+                        )
+                        let hasActiveAlert = !alertService.subscriptions(for: routeContext).isEmpty
                         Button {
-                            let ds = train.dataSource
-                            let lineId: String? = ds == "SUBWAY" ? nil : RouteTopology.routeContaining(from: originCode, to: destCode, dataSource: ds)?.id
-                            appState.pendingRouteStatus = RouteStatusContext(
-                                dataSource: ds,
-                                lineId: lineId,
-                                fromStationCode: originCode,
-                                toStationCode: destCode
-                            )
+                            appState.pendingRouteStatus = routeContext
                         } label: {
                             HStack(spacing: 6) {
                                 Image(systemName: "bell.badge")
@@ -135,7 +139,8 @@ struct TrainDetailsView: View {
                             .foregroundColor(.white.opacity(0.8))
                             .padding(.horizontal, 14)
                             .padding(.vertical, 8)
-                            .background(Capsule().fill(Color.white.opacity(0.12)))
+                            .background(Capsule().fill(hasActiveAlert ? Color.orange.opacity(0.15) : Color.white.opacity(0.12)))
+                            .overlay(Capsule().stroke(hasActiveAlert ? Color.orange.opacity(0.6) : Color.clear, lineWidth: 1.5))
                         }
                         .buttonStyle(.plain)
                     }
@@ -143,6 +148,7 @@ struct TrainDetailsView: View {
                     // Get Updates button (Live Activity)
                     if let originCode = appState.departureStationCode,
                        !originCode.isEmpty {
+                        let isTracking = liveActivityService.currentActivity?.attributes.trainNumber == train.trainId
                         TrackTrainInlineButton(
                             train: train,
                             originCode: originCode,
@@ -155,7 +161,8 @@ struct TrainDetailsView: View {
                         )
                         .padding(.horizontal, 14)
                         .padding(.vertical, 8)
-                        .background(Capsule().fill(Color.white.opacity(0.12)))
+                        .background(Capsule().fill(isTracking ? Color.orange.opacity(0.15) : Color.white.opacity(0.12)))
+                        .overlay(Capsule().stroke(isTracking ? Color.orange.opacity(0.6) : Color.clear, lineWidth: 1.5))
                     }
 
                 }

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TrainListView: View {
     @EnvironmentObject private var appState: AppState
     @StateObject private var viewModel: TrainListViewModel
+    @ObservedObject private var alertService = AlertSubscriptionService.shared
     // Configuration constants
     private static let DELAY_THRESHOLD_MINUTES = 6
 
@@ -99,17 +100,17 @@ struct TrainListView: View {
                 HStack(spacing: 12) {
                     // Route alerts button
                     if let destinationCode = Stations.getStationCode(destination) {
+                        let ds = viewModel.trains.first?.dataSource ?? appState.selectedSystems.first?.rawValue ?? "NJT"
+                        let lineId: String? = ds == "SUBWAY" ? nil : RouteTopology.routeContaining(from: departureStationCode, to: destinationCode, dataSource: ds)?.id
+                        let routeContext = RouteStatusContext(
+                            dataSource: ds,
+                            lineId: lineId,
+                            fromStationCode: departureStationCode,
+                            toStationCode: destinationCode
+                        )
+                        let hasActiveAlert = !alertService.subscriptions(for: routeContext).isEmpty
                         Button {
-                            let ds = viewModel.trains.first?.dataSource ?? appState.selectedSystems.first?.rawValue ?? "NJT"
-                            // For subway, don't set lineId — station pairs are served by multiple lines
-                            // and gtfsRouteIds will infer all relevant lines from the station pair.
-                            let lineId: String? = ds == "SUBWAY" ? nil : RouteTopology.routeContaining(from: departureStationCode, to: destinationCode, dataSource: ds)?.id
-                            appState.pendingRouteStatus = RouteStatusContext(
-                                dataSource: ds,
-                                lineId: lineId,
-                                fromStationCode: departureStationCode,
-                                toStationCode: destinationCode
-                            )
+                            appState.pendingRouteStatus = routeContext
                         } label: {
                             HStack(spacing: 6) {
                                 Image(systemName: "bell.badge")
@@ -120,7 +121,8 @@ struct TrainListView: View {
                             .foregroundColor(.white.opacity(0.8))
                             .padding(.horizontal, 14)
                             .padding(.vertical, 8)
-                            .background(Capsule().fill(Color.white.opacity(0.12)))
+                            .background(Capsule().fill(hasActiveAlert ? Color.orange.opacity(0.15) : Color.white.opacity(0.12)))
+                            .overlay(Capsule().stroke(hasActiveAlert ? Color.orange.opacity(0.6) : Color.clear, lineWidth: 1.5))
                         }
                         .buttonStyle(.plain)
                     }

--- a/ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift
+++ b/ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift
@@ -387,4 +387,96 @@ class AlertSubscriptionServiceTests: XCTestCase {
         XCTAssertEqual(evening.activeEndMinutes, 1140, "Evening commute ends at 7pm")
         XCTAssertEqual(evening.delayThresholdMinutes, 10, "Evening: less sensitive to delays")
     }
+
+    // MARK: - subscriptions(for:) — Route Context Matching (drives orange highlight in UI)
+
+    func testSubscriptionsFor_matchesLineSubscription() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "NEC", lineName: "Northeast Corridor",
+            direction: "NY", activeDays: 127
+        )
+        service.addSubscriptions([sub])
+
+        let context = RouteStatusContext(dataSource: "NJT", lineId: "NEC", fromStationCode: "TR", toStationCode: "NY")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertEqual(matches.count, 1, "Should match when lineId matches context lineId")
+        XCTAssertEqual(matches.first?.lineId, "NEC", "Matched subscription should be for NEC line")
+    }
+
+    func testSubscriptionsFor_doesNotMatchDifferentLine() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "NEC", lineName: "Northeast Corridor",
+            direction: "NY", activeDays: 127
+        )
+        service.addSubscriptions([sub])
+
+        let context = RouteStatusContext(dataSource: "NJT", lineId: "NJCL", fromStationCode: "NY", toStationCode: "LB")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertTrue(matches.isEmpty, "Should not match when lineId differs")
+    }
+
+    func testSubscriptionsFor_doesNotMatchDifferentDataSource() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "NEC", lineName: "Northeast Corridor",
+            direction: "NY", activeDays: 127
+        )
+        service.addSubscriptions([sub])
+
+        let context = RouteStatusContext(dataSource: "AMTRAK", lineId: "NEC", fromStationCode: "NY", toStationCode: "WS")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertTrue(matches.isEmpty, "Should not match when dataSource differs even if lineId is same")
+    }
+
+    func testSubscriptionsFor_matchesStationPairSubscription() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR",
+            activeDays: 127
+        )
+        service.addSubscriptions([sub])
+
+        let context = RouteStatusContext(dataSource: "NJT", lineId: "NEC", fromStationCode: "NY", toStationCode: "TR")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertEqual(matches.count, 1, "Should match station pair subscription by from/to codes")
+    }
+
+    func testSubscriptionsFor_doesNotMatchReverseStationPair() {
+        let sub = RouteAlertSubscription(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR",
+            activeDays: 127
+        )
+        service.addSubscriptions([sub])
+
+        let context = RouteStatusContext(dataSource: "NJT", lineId: "NEC", fromStationCode: "TR", toStationCode: "NY")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertTrue(matches.isEmpty, "Should not match reverse direction station pair (direction-sensitive)")
+    }
+
+    func testSubscriptionsFor_returnsEmptyWhenNoSubscriptions() {
+        let context = RouteStatusContext(dataSource: "NJT", lineId: "NEC", fromStationCode: "NY", toStationCode: "TR")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertTrue(matches.isEmpty, "Should return empty array when no subscriptions exist")
+    }
+
+    func testSubscriptionsFor_returnsMultipleMatches() {
+        let lineSub = RouteAlertSubscription(
+            dataSource: "NJT", lineId: "NEC", lineName: "Northeast Corridor",
+            direction: "TR", activeDays: 127
+        )
+        let pairSub = RouteAlertSubscription(
+            dataSource: "NJT", fromStationCode: "NY", toStationCode: "TR",
+            activeDays: 31
+        )
+        service.addSubscriptions([lineSub, pairSub])
+
+        let context = RouteStatusContext(dataSource: "NJT", lineId: "NEC", fromStationCode: "NY", toStationCode: "TR")
+        let matches = service.subscriptions(for: context)
+
+        XCTAssertEqual(matches.count, 2, "Should return both line and station-pair matches for same route")
+    }
 }


### PR DESCRIPTION
## Summary\n\n- Adds orange border + tinted background to the **Route Alerts** button when the user has an active subscription for the current route\n- Adds the same orange highlight to the **Stop Updates / Get Updates** button when a Live Activity is tracking the current train\n- Applied consistently across both `TrainDetailsView` and `TrainListView`\n- Adds 7 unit tests for `AlertSubscriptionService.subscriptions(for:)` which drives the highlight logic\n\n## Files modified\n\n| File | Change |\n|------|--------|\n| `ios/TrackRat/Views/Screens/TrainDetailsView.swift` | Added `@ObservedObject` for `LiveActivityService` and `AlertSubscriptionService`; conditional orange capsule styling for both buttons |\n| `ios/TrackRat/Views/Screens/TrainListView.swift` | Added `@ObservedObject` for `AlertSubscriptionService`; conditional orange capsule styling for Route Alerts button |\n| `ios/TrackRatTests/Services/AlertSubscriptionServiceTests.swift` | Added 7 tests covering `subscriptions(for:)` matching by line, station pair, data source, reverse direction, empty state, and multiple matches |\n\n## Design decisions\n\n- Used `Capsule().fill(Color.orange.opacity(0.15))` + `Capsule().stroke(Color.orange.opacity(0.6), lineWidth: 1.5)` — consistent with existing orange highlight patterns in the app (DeparturePickerView, OnboardingView, track prediction cards)\n- Extracted `RouteStatusContext` construction outside the button action closure so it can be reused for both the tap handler and the subscription check\n- Used `Color.clear` stroke when inactive rather than conditional overlay to keep the view type stable\n\nCloses #1105

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lm11Cx8TBKQyvcjQ2rtdRr)_