### PR TITLE
Issue #1120: Fix greenlet_spawn errors from noload() on delete-orphan relationships

### DIFF
--- a/backend_v2/src/trackrat/collectors/mta_common.py
+++ b/backend_v2/src/trackrat/collectors/mta_common.py
@@ -13,27 +13,20 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any
 
-from sqlalchemy.orm import noload, selectinload
+from sqlalchemy.orm import selectinload
 
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.utils.time import normalize_to_et
 
 logger = logging.getLogger(__name__)
 
-# Loader options for GTFS-RT collector update queries (subway, LIRR, MNR,
-# BART, MBTA, Metra). TrainJourney has 5 delete-orphan child collections
-# (snapshots, segment_times, dwell_times, progress, progress_snapshots)
-# that SQLAlchemy would lazy-load during flush orphan checks, triggering
-# greenlet_spawn errors in async context. These collectors never modify
-# any of them — they only read/merge journey.stops — so noload() skips
-# the check without the per-journey round-trips that selectinload costs.
 JOURNEY_UPDATE_LOAD_OPTIONS = (
     selectinload(TrainJourney.stops),
-    noload(TrainJourney.snapshots),
-    noload(TrainJourney.segment_times),
-    noload(TrainJourney.dwell_times),
-    noload(TrainJourney.progress),
-    noload(TrainJourney.progress_snapshots),
+    selectinload(TrainJourney.snapshots),
+    selectinload(TrainJourney.segment_times),
+    selectinload(TrainJourney.dwell_times),
+    selectinload(TrainJourney.progress),
+    selectinload(TrainJourney.progress_snapshots),
 )
 
 # Terminal stations where outbound trains originate (direction_id=0).

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -10,7 +10,7 @@ from typing import Any
 from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import noload, selectinload
+from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from trackrat.collectors.njt.client import NJTransitClient, TrainNotFoundError
@@ -44,19 +44,13 @@ from trackrat.utils.train import (
 
 logger = get_logger(__name__)
 
-# Loader options for the NJT JIT refresh path. Must load `stops` (merged by
-# NJT journey collector) and `snapshots` (cleared and rewritten by
-# JourneyCollector.create_journey_snapshot). The other 3 delete-orphan child
-# collections aren't touched in this path, so noload() skips the orphan-check
-# lazy-loads that would otherwise trigger greenlet_spawn errors in async
-# context — at much lower per-journey cost than a defensive selectinload.
 _NJT_REFRESH_LOAD_OPTIONS = (
     selectinload(TrainJourney.stops),
     selectinload(TrainJourney.snapshots),
-    noload(TrainJourney.segment_times),
-    noload(TrainJourney.dwell_times),
-    noload(TrainJourney.progress),
-    noload(TrainJourney.progress_snapshots),
+    selectinload(TrainJourney.segment_times),
+    selectinload(TrainJourney.dwell_times),
+    selectinload(TrainJourney.progress),
+    selectinload(TrainJourney.progress_snapshots),
 )
 
 # Tracks station codes currently being refreshed in background tasks.

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2923,7 +2923,7 @@ class SchedulerService:
                     self._running_tasks[task_id] = task
 
                 from sqlalchemy import and_, select
-                from sqlalchemy.orm import noload, selectinload, sessionmaker
+                from sqlalchemy.orm import selectinload, sessionmaker
 
                 # Use synchronous database access to avoid greenlet issues in scheduler context
                 SyncSession = sessionmaker(self._get_sync_engine())
@@ -2989,18 +2989,12 @@ class SchedulerService:
                             select(TrainJourney)
                             .where(and_(*journey_filters))
                             .options(
-                                # Live Activity status calc reads journey.stops
-                                # and journey.snapshots[-1].train_status; the
-                                # other 4 delete-orphan collections aren't
-                                # touched, so noload() skips orphan-check
-                                # lazy-loads without the per-journey round-
-                                # trips a defensive selectinload would cost.
                                 selectinload(TrainJourney.stops),
                                 selectinload(TrainJourney.snapshots),
-                                noload(TrainJourney.segment_times),
-                                noload(TrainJourney.dwell_times),
-                                noload(TrainJourney.progress),
-                                noload(TrainJourney.progress_snapshots),
+                                selectinload(TrainJourney.segment_times),
+                                selectinload(TrainJourney.dwell_times),
+                                selectinload(TrainJourney.progress),
+                                selectinload(TrainJourney.progress_snapshots),
                             )
                         )
 


### PR DESCRIPTION
## Summary

- Replaced `noload()` with `selectinload()` for all TrainJourney delete-orphan cascade relationships (`segment_times`, `dwell_times`, `progress`, `progress_snapshots`) in three locations
- Eliminates intermittent `greenlet_spawn has not been called` errors (13 occurrences over 5 days in production) that caused NJT station refresh data to silently go stale
- Also fixed the same latent risk in `mta_common.py` (GTFS-RT collectors) and `scheduler.py` (Live Activity queries) as a preventive measure

## Why

`noload()` on delete-orphan cascade relationships doesn't reliably prevent lazy loads during SQLAlchemy's unit-of-work flush after a deadlock-triggered `session.rollback()` + retry. After rollback, all ORM attributes are expired. On retry, `noload()` resets collections to empty, but during flush, SQLAlchemy's cascade/orphan-check processing can still attempt implicit lazy loads — which fail in async context because the greenlet bridge isn't present at flush time.

## Files modified

| File | Change |
|------|--------|
| `backend_v2/src/trackrat/services/departure.py` | `_NJT_REFRESH_LOAD_OPTIONS`: `noload()` → `selectinload()` for 4 relationships; removed unused `noload` import |
| `backend_v2/src/trackrat/collectors/mta_common.py` | `JOURNEY_UPDATE_LOAD_OPTIONS`: same fix; removed unused `noload` import |
| `backend_v2/src/trackrat/services/scheduler.py` | Live Activity query inline options: same fix; removed unused `noload` import |

## Design decisions

- **`selectinload` over `raiseload`**: `raiseload` would make the failure immediate but doesn't fix it — SQLAlchemy issue #5398 confirms `raiseload` conflicts with cascade operations. `selectinload` ensures all relationship data is in memory so no lazy IO occurs during flush.
- **All three locations fixed**: Even though only `departure.py` had confirmed production errors, `mta_common.py` and `scheduler.py` had the identical `noload()` pattern and the same latent risk under concurrent access / deadlock retry.
- **Consistent with existing patterns**: `jit.py` and `njt/journey.py` already use `selectinload` for all 6 relationships — this makes the codebase consistent.
- **Performance cost is minimal**: The extra queries load typically-small collections (segment_times, dwell_times per journey are ~10-15 rows each; progress is 1 row). Negligible compared to intermittent production crashes.

## Test coverage

- 2458 unit tests pass, 0 failures (217 errors are pre-existing PostgreSQL connection issues in CI-only test suites)
- No tests directly reference `_NJT_REFRESH_LOAD_OPTIONS` or `JOURNEY_UPDATE_LOAD_OPTIONS` — these are runtime-only load option tuples
- The fix is a behavioral change in how SQLAlchemy loads data, not in application logic — existing integration tests exercise the code paths that use these options

Closes #1120

https://claude.ai/code/session_01G9HUgyiNVQbDcRQhLa7mf5

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9HUgyiNVQbDcRQhLa7mf5)_