### PR TITLE
Issue #1121: Filter cross-system direct trips in trip search

### DIFF
--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -289,9 +289,14 @@ async def search_trips(
     )
 
     # Systems natively serving each endpoint (used for direct-trip filtering
-    # and transfer search below).
-    from_systems = get_systems_serving_station(from_station)
-    to_systems = get_systems_serving_station(to_station)
+    # and transfer search below).  Expand equivalence aliases first so that
+    # alias-only codes (e.g. TS → SE) resolve to the canonical station's systems.
+    from_systems: set[str] = set()
+    for code in expand_station_codes(from_station):
+        from_systems |= get_systems_serving_station(code)
+    to_systems: set[str] = set()
+    for code in expand_station_codes(to_station):
+        to_systems |= get_systems_serving_station(code)
 
     # --- Step 1: Try direct service ---
     direct_response = await departure_service.get_departures(

--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -107,6 +107,27 @@ def _filter_unreasonable_durations(trips: list[TripOption]) -> list[TripOption]:
     return [t for t in trips if t.total_duration_minutes <= max_reasonable]
 
 
+def _filter_cross_system_direct_trips(
+    trips: list[TripOption],
+    from_systems: set[str],
+    to_systems: set[str],
+) -> list[TripOption]:
+    """Filter direct trips to those whose data_source natively serves both endpoints.
+
+    Station equivalence expansion in the departure service can match trains from
+    systems that don't actually serve the requested station codes (e.g., an Amtrak
+    train to NY matching a query for subway station S128, because NY and S128 are
+    in the same equivalence group).  These cross-system matches require a physical
+    transfer and should fall through to the transfer search.
+    """
+    if not trips:
+        return trips
+    valid_systems = from_systems & to_systems
+    if not valid_systems:
+        return []
+    return [t for t in trips if t.legs[0].data_source in valid_systems]
+
+
 def _get_station_lines_expanded(station_code: str, system: str) -> frozenset[str]:
     """Get line codes for a station and its physical-equivalent codes."""
     lines: set[str] = set()
@@ -267,6 +288,11 @@ async def search_trips(
         data_sources=data_sources,
     )
 
+    # Systems natively serving each endpoint (used for direct-trip filtering
+    # and transfer search below).
+    from_systems = get_systems_serving_station(from_station)
+    to_systems = get_systems_serving_station(to_station)
+
     # --- Step 1: Try direct service ---
     direct_response = await departure_service.get_departures(
         db=db,
@@ -289,6 +315,12 @@ async def search_trips(
         if trip:
             direct_trips.append(trip)
 
+    # Filter out cross-system matches that only connected via station equivalence
+    # expansion (e.g., Amtrak to NY appearing as "direct" to subway S128).
+    direct_trips = _filter_cross_system_direct_trips(
+        direct_trips, from_systems, to_systems
+    )
+
     if direct_trips:
         logger.info("trip_search_direct", count=len(direct_trips))
         return TripSearchResponse(
@@ -309,8 +341,6 @@ async def search_trips(
         )
 
     # --- Step 2: No direct service — find transfers ---
-    from_systems = get_systems_serving_station(from_station)
-    to_systems = get_systems_serving_station(to_station)
 
     # Restrict to user-enabled systems so transfer search doesn't
     # propose routes through systems the user hasn't selected.

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -36,6 +36,7 @@ from trackrat.services.trip_search import (
     MAX_TRANSFER_QUERIES,
     _departure_to_leg,
     _empty_response,
+    _filter_cross_system_direct_trips,
     _filter_unreasonable_durations,
     _find_relevant_transfer_points,
     _get_best_time,
@@ -972,18 +973,24 @@ class TestRankTransferPoints:
 
     def test_same_station_preferred_over_walk(self):
         """same_station transfers should rank before walk transfers."""
-        walk = self._make_tp(station_a="HB", station_b="PHO", walk_minutes=5, same_station=False)
-        same = self._make_tp(station_a="NP", station_b="PNK", walk_minutes=5, same_station=True)
-        ranked = _rank_transfer_points(
-            [walk, same], "TR", "PWC", {"NJT"}, {"PATH"}
+        walk = self._make_tp(
+            station_a="HB", station_b="PHO", walk_minutes=5, same_station=False
         )
+        same = self._make_tp(
+            station_a="NP", station_b="PNK", walk_minutes=5, same_station=True
+        )
+        ranked = _rank_transfer_points([walk, same], "TR", "PWC", {"NJT"}, {"PATH"})
         assert ranked[0].same_station is True
         assert ranked[1].same_station is False
 
     def test_shorter_walk_preferred(self):
         """Shorter walk_minutes should rank before longer."""
-        long_walk = self._make_tp(station_a="AA", station_b="BB", walk_minutes=10, same_station=False)
-        short_walk = self._make_tp(station_a="CC", station_b="DD", walk_minutes=3, same_station=False)
+        long_walk = self._make_tp(
+            station_a="AA", station_b="BB", walk_minutes=10, same_station=False
+        )
+        short_walk = self._make_tp(
+            station_a="CC", station_b="DD", walk_minutes=3, same_station=False
+        )
         ranked = _rank_transfer_points(
             [long_walk, short_walk], "TR", "PWC", {"NJT"}, {"PATH"}
         )
@@ -996,12 +1003,30 @@ class TestRankTransferPoints:
         This is the core property that fixes issue #1062: reversing from/to
         stations and their system sets must not change which TPs survive truncation.
         """
-        tp1 = self._make_tp(station_a="NP", system_a="NJT", station_b="PNK", system_b="PATH",
-                            walk_minutes=5, same_station=True)
-        tp2 = self._make_tp(station_a="HB", system_a="NJT", station_b="PHO", system_b="PATH",
-                            walk_minutes=7, same_station=False)
-        tp3 = self._make_tp(station_a="NY", system_a="NJT", station_b="S128", system_b="SUBWAY",
-                            walk_minutes=5, same_station=False)
+        tp1 = self._make_tp(
+            station_a="NP",
+            system_a="NJT",
+            station_b="PNK",
+            system_b="PATH",
+            walk_minutes=5,
+            same_station=True,
+        )
+        tp2 = self._make_tp(
+            station_a="HB",
+            system_a="NJT",
+            station_b="PHO",
+            system_b="PATH",
+            walk_minutes=7,
+            same_station=False,
+        )
+        tp3 = self._make_tp(
+            station_a="NY",
+            system_a="NJT",
+            station_b="S128",
+            system_b="SUBWAY",
+            walk_minutes=5,
+            same_station=False,
+        )
 
         forward = _rank_transfer_points(
             [tp1, tp2, tp3], "TR", "PWC", {"NJT", "AMTRAK"}, {"PATH", "SUBWAY"}
@@ -1015,13 +1040,23 @@ class TestRankTransferPoints:
 
     def test_stable_tiebreaker_on_station_codes(self):
         """When same_station and walk_minutes are equal, sort by canonical station/system codes."""
-        tp_a = self._make_tp(station_a="BB", system_a="X", station_b="AA", system_b="Y",
-                             walk_minutes=5, same_station=False)
-        tp_b = self._make_tp(station_a="AA", system_a="X", station_b="CC", system_b="Y",
-                             walk_minutes=5, same_station=False)
-        ranked = _rank_transfer_points(
-            [tp_a, tp_b], "Z1", "Z2", {"X"}, {"Y"}
+        tp_a = self._make_tp(
+            station_a="BB",
+            system_a="X",
+            station_b="AA",
+            system_b="Y",
+            walk_minutes=5,
+            same_station=False,
         )
+        tp_b = self._make_tp(
+            station_a="AA",
+            system_a="X",
+            station_b="CC",
+            system_b="Y",
+            walk_minutes=5,
+            same_station=False,
+        )
+        ranked = _rank_transfer_points([tp_a, tp_b], "Z1", "Z2", {"X"}, {"Y"})
         # Canonical order: tp_a has sorted pair (AA,Y),(BB,X); tp_b has (AA,X),(CC,Y)
         # (AA,X) < (AA,Y) so tp_b comes first
         assert ranked[0] is tp_b
@@ -1062,13 +1097,15 @@ class TestTransferPointSymmetryIntegration:
     @pytest.mark.parametrize(
         "station_a,station_b",
         [
-            ("TR", "PWC"),   # NJT → PATH (Trenton to World Trade Center)
-            ("HB", "P33"),   # NJT/PATH hub → PATH (Hoboken area)
-            ("NP", "PHO"),   # NJT Newark → PATH Hoboken
+            ("TR", "PWC"),  # NJT → PATH (Trenton to World Trade Center)
+            ("HB", "P33"),  # NJT/PATH hub → PATH (Hoboken area)
+            ("NP", "PHO"),  # NJT Newark → PATH Hoboken
         ],
         ids=["trenton-to-wtc", "hoboken-to-33rd", "newark-to-hoboken-path"],
     )
-    def test_ranked_transfer_points_are_direction_symmetric(self, station_a: str, station_b: str):
+    def test_ranked_transfer_points_are_direction_symmetric(
+        self, station_a: str, station_b: str
+    ):
         """Forward and reverse searches must produce identically ranked TPs.
 
         This catches the root cause of issue #1062: set iteration order in
@@ -1103,4 +1140,183 @@ class TestTransferPointSymmetryIntegration:
             f"Direction-dependent ordering detected for {station_a}↔{station_b}.\n"
             f"Forward:  {[(tp.station_a, tp.system_a, tp.station_b, tp.system_b) for tp in fwd_ranked]}\n"
             f"Reverse:  {[(tp.station_a, tp.system_a, tp.station_b, tp.system_b) for tp in rev_ranked]}"
+        )
+
+
+class TestFilterCrossSystemDirectTrips:
+    """Test filtering of direct trips that matched only via station equivalence expansion.
+
+    When the departure service expands station codes across equivalence groups,
+    it can return trains from systems that don't natively serve the user's
+    requested station. E.g., searching to=S128 (subway 34 St-Penn Station)
+    returns Amtrak trains to NY (Penn Station) because {NY, S128, SA28} are
+    equivalent. These cross-system matches are not "direct" — they require a
+    physical system transfer — and should be filtered so the transfer search
+    can propose the correct multi-leg trip.
+    """
+
+    def _make_trip_with_source(self, data_source: str) -> TripOption:
+        """Helper to build a TripOption with a specific data_source."""
+        now = datetime.now(ET)
+        dep_time = now + timedelta(minutes=10)
+        arr_time = dep_time + timedelta(minutes=30)
+        leg = TripLeg(
+            train_id="9999",
+            journey_date=now.date(),
+            line=LineInfo(code="NE", name="Test Line", color="#000000"),
+            destination="Test",
+            boarding=_make_station_info(code="A", name="A", scheduled=dep_time),
+            alighting=_make_station_info(code="B", name="B", scheduled=arr_time),
+            data_source=data_source,
+            observation_type="OBSERVED",
+            is_cancelled=False,
+            train_position=TrainPosition(),
+        )
+        return TripOption(
+            legs=[leg],
+            transfers=[],
+            departure_time=dep_time,
+            arrival_time=arr_time,
+            total_duration_minutes=30,
+            is_direct=True,
+        )
+
+    def test_empty_list_returns_empty(self):
+        result = _filter_cross_system_direct_trips([], {"NJT"}, {"NJT"})
+        assert result == []
+
+    def test_same_system_keeps_all(self):
+        """When from and to are both served by NJT, NJT trips pass through."""
+        trips = [self._make_trip_with_source("NJT")]
+        result = _filter_cross_system_direct_trips(trips, {"NJT", "AMTRAK"}, {"NJT"})
+        assert len(result) == 1
+        assert result[0].legs[0].data_source == "NJT"
+
+    def test_cross_system_filtered_out(self):
+        """Amtrak trip should be filtered when to_station is subway-only (S128).
+
+        This is the core bug: from=TR (NJT, AMTRAK) to=S128 (SUBWAY).
+        Amtrak trains to NY matched via equivalence expansion and were returned
+        as 'direct' trips to the subway station.
+        """
+        trips = [
+            self._make_trip_with_source("AMTRAK"),
+            self._make_trip_with_source("NJT"),
+        ]
+        # TR is served by NJT+AMTRAK, S128 is served by SUBWAY only
+        result = _filter_cross_system_direct_trips(
+            trips,
+            from_systems={"NJT", "AMTRAK"},
+            to_systems={"SUBWAY"},
+        )
+        assert len(result) == 0, (
+            f"Cross-system trips should be filtered when from and to have "
+            f"no common system. Got: {[t.legs[0].data_source for t in result]}"
+        )
+
+    def test_disjoint_systems_returns_empty(self):
+        """When no system serves both endpoints, all direct trips are filtered."""
+        trips = [self._make_trip_with_source("AMTRAK")]
+        result = _filter_cross_system_direct_trips(
+            trips, from_systems={"AMTRAK"}, to_systems={"SUBWAY"}
+        )
+        assert len(result) == 0
+
+    def test_shared_system_kept_different_system_filtered(self):
+        """When from=NY (NJT,AMTRAK,LIRR) and to=TR (NJT,AMTRAK),
+        NJT and AMTRAK trips pass but LIRR trips would be filtered.
+        """
+        trips = [
+            self._make_trip_with_source("NJT"),
+            self._make_trip_with_source("AMTRAK"),
+            self._make_trip_with_source("LIRR"),
+        ]
+        result = _filter_cross_system_direct_trips(
+            trips,
+            from_systems={"NJT", "AMTRAK", "LIRR"},
+            to_systems={"NJT", "AMTRAK"},
+        )
+        sources = [t.legs[0].data_source for t in result]
+        assert "NJT" in sources, f"NJT should be kept, got {sources}"
+        assert "AMTRAK" in sources, f"AMTRAK should be kept, got {sources}"
+        assert "LIRR" not in sources, f"LIRR should be filtered, got {sources}"
+
+    def test_subway_to_subway_direct(self):
+        """Intra-subway trips should pass (both endpoints are SUBWAY)."""
+        trips = [self._make_trip_with_source("SUBWAY")]
+        result = _filter_cross_system_direct_trips(
+            trips, from_systems={"SUBWAY"}, to_systems={"SUBWAY"}
+        )
+        assert len(result) == 1
+
+    def test_penn_station_subway_to_trenton_filtered(self):
+        """Reverse direction: from=S128 (SUBWAY) to=TR (NJT,AMTRAK).
+        NJT trains from NY (matched via equivalence) should be filtered.
+        """
+        trips = [self._make_trip_with_source("NJT")]
+        result = _filter_cross_system_direct_trips(
+            trips,
+            from_systems={"SUBWAY"},
+            to_systems={"NJT", "AMTRAK"},
+        )
+        assert len(result) == 0, (
+            f"NJT trip from equivalence-expanded S128→NY should not be "
+            f"'direct'. Got: {[t.legs[0].data_source for t in result]}"
+        )
+
+    def test_grand_central_mnr_to_subway_filtered(self):
+        """from=GCT (MNR) to=S631 (SUBWAY): MNR trips should be filtered."""
+        trips = [self._make_trip_with_source("MNR")]
+        result = _filter_cross_system_direct_trips(
+            trips, from_systems={"MNR"}, to_systems={"SUBWAY"}
+        )
+        assert len(result) == 0
+
+    def test_wtc_path_to_subway_filtered(self):
+        """from=PWC (PATH) to=S138 (SUBWAY): PATH trips should be filtered."""
+        trips = [self._make_trip_with_source("PATH")]
+        result = _filter_cross_system_direct_trips(
+            trips, from_systems={"PATH"}, to_systems={"SUBWAY"}
+        )
+        assert len(result) == 0
+
+    def test_uses_real_station_systems(self):
+        """Integration test with real get_systems_serving_station data.
+
+        Verifies the fix for the exact scenario reported in issue #1121:
+        from=TR to=S128 should have no valid direct systems.
+        """
+        from_sys = get_systems_serving_station("TR")
+        to_sys = get_systems_serving_station("S128")
+        assert (
+            from_sys & to_sys == set()
+        ), f"TR ({from_sys}) and S128 ({to_sys}) should have no common systems"
+
+        trips = [
+            self._make_trip_with_source("AMTRAK"),
+            self._make_trip_with_source("NJT"),
+        ]
+        result = _filter_cross_system_direct_trips(trips, from_sys, to_sys)
+        assert len(result) == 0, (
+            f"All trips from TR to S128 should be filtered as cross-system. "
+            f"from_systems={from_sys}, to_systems={to_sys}, "
+            f"remaining: {[t.legs[0].data_source for t in result]}"
+        )
+
+    def test_ny_to_trenton_keeps_njt_amtrak(self):
+        """Sanity check: NY→TR is a normal direct route, nothing should be filtered."""
+        from_sys = get_systems_serving_station("NY")
+        to_sys = get_systems_serving_station("TR")
+        valid = from_sys & to_sys
+        assert "NJT" in valid, f"NJT should serve both NY and TR, got {valid}"
+        assert "AMTRAK" in valid, f"AMTRAK should serve both NY and TR, got {valid}"
+
+        trips = [
+            self._make_trip_with_source("NJT"),
+            self._make_trip_with_source("AMTRAK"),
+        ]
+        result = _filter_cross_system_direct_trips(trips, from_sys, to_sys)
+        assert len(result) == 2, (
+            f"Both NJT and AMTRAK should be kept for NY→TR, got "
+            f"{[t.legs[0].data_source for t in result]}"
         )

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -1303,6 +1303,38 @@ class TestFilterCrossSystemDirectTrips:
             f"remaining: {[t.legs[0].data_source for t in result]}"
         )
 
+    def test_alias_code_resolves_via_equivalence_expansion(self):
+        """Alias-only codes (TS, SC) should resolve systems via expansion.
+
+        TS (Secaucus Lower Level) is not in any route topology, so
+        get_systems_serving_station("TS") returns empty. But expanding
+        TS → {TS, SC, SE} and unioning their systems yields {"NJT"} via SE.
+        Without expansion, from_systems would be empty and all direct trips
+        from TS would be incorrectly filtered.
+        """
+        from trackrat.config.stations import expand_station_codes
+
+        # Direct lookup returns empty for alias codes
+        assert get_systems_serving_station("TS") == set()
+        assert get_systems_serving_station("SC") == set()
+
+        # But expansion resolves via SE
+        expanded_systems: set[str] = set()
+        for code in expand_station_codes("TS"):
+            expanded_systems |= get_systems_serving_station(code)
+        assert "NJT" in expanded_systems, (
+            f"TS should resolve to NJT via SE expansion, got {expanded_systems}"
+        )
+
+        # NJT trip from TS to TR should be kept when using expanded systems
+        trips = [self._make_trip_with_source("NJT")]
+        to_sys = get_systems_serving_station("TR")
+        result = _filter_cross_system_direct_trips(trips, expanded_systems, to_sys)
+        assert len(result) == 1, (
+            f"NJT trip from TS (expanded) to TR should be kept. "
+            f"from_systems={expanded_systems}, to_systems={to_sys}"
+        )
+
     def test_ny_to_trenton_keeps_njt_amtrak(self):
         """Sanity check: NY→TR is a normal direct route, nothing should be filtered."""
         from_sys = get_systems_serving_station("NY")


### PR DESCRIPTION
## Summary

Closes #1121

- **Added `_filter_cross_system_direct_trips()`** in `trip_search.py` that filters direct trip results to only keep trips whose `data_source` natively serves both the from and to station codes. This prevents station equivalence expansion (e.g., `{NY, S128, SA28}`) from causing cross-system matches to appear as "direct" trips.
- **Moved `from_systems`/`to_systems` computation** earlier in `search_trips()` so it's computed once and reused for both direct-trip filtering and the transfer search.
- When all direct trips are filtered (e.g., `from=TR to=S128` where no system serves both), the function correctly falls through to the transfer search.

## Files modified

| File | Change |
|------|--------|
| `backend_v2/src/trackrat/services/trip_search.py` | Added `_filter_cross_system_direct_trips()` function; integrated it into `search_trips()` between direct trip construction and the early-return check |
| `backend_v2/tests/unit/services/test_trip_search.py` | Added `TestFilterCrossSystemDirectTrips` class with 12 test cases covering: empty input, same-system passthrough, cross-system filtering, disjoint systems, mixed keep/filter, intra-subway, reverse direction, all three cross-system hub groups (Penn/GCT/WTC), and integration tests with real station topology data |

## Design decisions

- **Filter in `search_trips`, not in `expand_station_codes` or `get_departures`**: The equivalence expansion is correct for departure boards — only trip search needs the cross-system filter. This keeps the change minimal and avoids touching shared infrastructure.
- **Uses `get_systems_serving_station()` intersection**: A trip is "direct" only if its `data_source` is in `from_systems ∩ to_systems`. This naturally handles all cross-system hub equivalence groups (Penn Station, Grand Central, WTC/Oculus, Newark Penn/PATH, Chicago Union).
- **`data_sources` user filter is applied separately**: The cross-system filter uses the full system sets (station-level truth), while the user's `data_sources` preference is applied later for the transfer search only. The departure service already respects `data_sources` for its query.

## Test coverage

12 new tests in `TestFilterCrossSystemDirectTrips`:
- `test_empty_list_returns_empty` — edge case
- `test_same_system_keeps_all` — NJT→NJT passthrough
- `test_cross_system_filtered_out` — core bug: TR→S128 with AMTRAK/NJT trips
- `test_disjoint_systems_returns_empty` — AMTRAK→SUBWAY
- `test_shared_system_kept_different_system_filtered` — NY→TR keeps NJT/AMTRAK, filters LIRR
- `test_subway_to_subway_direct` — intra-system passthrough
- `test_penn_station_subway_to_trenton_filtered` — reverse direction S128→TR
- `test_grand_central_mnr_to_subway_filtered` — GCT→S631
- `test_wtc_path_to_subway_filtered` — PWC→S138
- `test_uses_real_station_systems` — integration with real topology data for TR/S128
- `test_ny_to_trenton_keeps_njt_amtrak` — sanity check: normal direct route unaffected

All 76 trip search tests pass. Full unit suite: 2469 passed (217 errors are pre-existing DB-connection failures unrelated to this change).

https://claude.ai/code/session_01HSXxXGew7LAcybbJ8vPj2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSXxXGew7LAcybbJ8vPj2r)_