### PR TITLE
Issue #1122: Downgrade benign journey collection logs from ERROR to DEBUG

### DIFF
--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -1244,16 +1244,26 @@ class SchedulerService:
                 self._collect_single_njt_journey_safe(train_id, j_date)
             )
 
-            if result:
-                # Debug level for successful collection
+            if result and result.get("success"):
                 logger.debug(
                     "journey.collection.completed",
                     train_id=train_id,
                     is_completed=result.get("is_completed", False),
                     stops_count=result.get("stops_count", 0),
                 )
+            elif result and result.get("skipped"):
+                logger.debug(
+                    "journey.collection.skipped",
+                    train_id=train_id,
+                    reason=result.get("reason"),
+                )
+            elif result:
+                logger.info(
+                    "journey.collection.unsuccessful",
+                    train_id=train_id,
+                    error=result.get("error"),
+                )
             else:
-                # Error for actual failures
                 logger.error(
                     "journey.collection.failed",
                     train_id=train_id,
@@ -1833,7 +1843,9 @@ class SchedulerService:
             journey_date: The journey date to filter by (defaults to today if not provided)
 
         Returns:
-            Dict with journey info if successful, None if failed
+            Dict with journey info. Keys: success (bool), and optionally
+            skipped (bool) + reason (str) for benign no-ops, or
+            error (str) for handled failures. None only for genuine errors.
         """
         try:
             from sqlalchemy import and_, select
@@ -1867,7 +1879,12 @@ class SchedulerService:
 
             if not row:
                 logger.warning("journey_not_found_sync", train_id=train_id)
-                return None
+                return {
+                    "train_id": train_id,
+                    "success": False,
+                    "skipped": True,
+                    "reason": "journey_not_found",
+                }
 
             journey_id = row.id
             journey_is_expired = row.is_expired
@@ -1875,7 +1892,12 @@ class SchedulerService:
 
             if journey_is_expired:
                 logger.debug("skipping_expired_train_sync", train_id=train_id)
-                return None
+                return {
+                    "train_id": train_id,
+                    "success": False,
+                    "skipped": True,
+                    "reason": "already_expired",
+                }
 
             # ── Phase 2: Call NJT API (no DB connection held) ──
             # Semaphore caps concurrent API calls to prevent overwhelming
@@ -1956,7 +1978,12 @@ class SchedulerService:
                         train_id=train_id,
                         journey_id=journey_id,
                     )
-                    return None
+                    return {
+                        "train_id": train_id,
+                        "success": False,
+                        "skipped": True,
+                        "reason": "journey_disappeared",
+                    }
 
                 collector = JourneyCollector(self.njt_client)
                 await collector.collect_journey_details(

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2104,6 +2104,12 @@ class SchedulerService:
                                     train_id=train_id,
                                     stops_count=retry_result.get("stops_count", 0),
                                 )
+                            elif retry_result and retry_result.get("skipped"):
+                                logger.debug(
+                                    "njt_journey_batch_skipped",
+                                    train_id=train_id,
+                                    reason=retry_result.get("reason"),
+                                )
                             else:
                                 error_count += 1
                                 logger.warning(
@@ -2116,6 +2122,12 @@ class SchedulerService:
                                 "njt_journey_collected",
                                 train_id=train_id,
                                 stops_count=result.get("stops_count", 0),
+                            )
+                        elif result.get("skipped"):
+                            logger.debug(
+                                "njt_journey_batch_skipped",
+                                train_id=train_id,
+                                reason=result.get("reason"),
                             )
                         else:
                             error_count += 1

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -818,3 +818,181 @@ class TestSchedulerHorizontalScaling:
         # 60-minute task should have 54-minute safe interval
         interval = calculate_safe_interval(60)
         assert interval == 3240  # (60 - 6) * 60
+
+
+class TestCollectJourneyLogging:
+    """Test that collect_journey logs at appropriate levels based on
+    _collect_single_njt_journey_safe return values.
+
+    Addresses issue #1122: benign expired/missing journeys were logged
+    as journey.collection.failed (ERROR) instead of being skipped quietly.
+    """
+
+    @pytest.fixture
+    def test_settings(self):
+        return Settings(
+            njt_api_token="test_token",
+            discovery_interval_minutes=30,
+            journey_update_interval_minutes=15,
+            data_staleness_seconds=60,
+            environment="testing",
+        )
+
+    @pytest.fixture
+    def mock_apns_service(self):
+        service = AsyncMock()
+        service.send_update = AsyncMock()
+        return service
+
+    @pytest.fixture
+    def scheduler_service(self, test_settings, mock_apns_service):
+        with patch("trackrat.services.scheduler.NJTransitClient"):
+            svc = SchedulerService(
+                settings=test_settings, apns_service=mock_apns_service
+            )
+            svc.njt_client = AsyncMock()
+            return svc
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_logs_debug_on_success(
+        self, scheduler_service
+    ):
+        """Successful collection should log at DEBUG level."""
+        result = {
+            "train_id": "1234",
+            "success": True,
+            "is_completed": False,
+            "stops_count": 5,
+        }
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            return_value=result,
+        ):
+            with patch("trackrat.services.scheduler.logger") as mock_logger:
+                await scheduler_service.collect_journey("1234", datetime(2026, 5, 7))
+                mock_logger.debug.assert_any_call(
+                    "journey.collection.completed",
+                    train_id="1234",
+                    is_completed=False,
+                    stops_count=5,
+                )
+                mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_logs_debug_on_skipped_expired(
+        self, scheduler_service
+    ):
+        """Skipped (already expired) should log at DEBUG, not ERROR."""
+        result = {
+            "train_id": "47",
+            "success": False,
+            "skipped": True,
+            "reason": "already_expired",
+        }
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            return_value=result,
+        ):
+            with patch("trackrat.services.scheduler.logger") as mock_logger:
+                await scheduler_service.collect_journey("47", datetime(2026, 5, 7))
+                mock_logger.debug.assert_any_call(
+                    "journey.collection.skipped",
+                    train_id="47",
+                    reason="already_expired",
+                )
+                mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_logs_debug_on_skipped_not_found(
+        self, scheduler_service
+    ):
+        """Skipped (journey not found) should log at DEBUG, not ERROR."""
+        result = {
+            "train_id": "49",
+            "success": False,
+            "skipped": True,
+            "reason": "journey_not_found",
+        }
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            return_value=result,
+        ):
+            with patch("trackrat.services.scheduler.logger") as mock_logger:
+                await scheduler_service.collect_journey("49", datetime(2026, 5, 7))
+                mock_logger.debug.assert_any_call(
+                    "journey.collection.skipped",
+                    train_id="49",
+                    reason="journey_not_found",
+                )
+                mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_logs_debug_on_skipped_disappeared(
+        self, scheduler_service
+    ):
+        """Skipped (journey disappeared between phases) should log at DEBUG."""
+        result = {
+            "train_id": "535",
+            "success": False,
+            "skipped": True,
+            "reason": "journey_disappeared",
+        }
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            return_value=result,
+        ):
+            with patch("trackrat.services.scheduler.logger") as mock_logger:
+                await scheduler_service.collect_journey("535", datetime(2026, 5, 7))
+                mock_logger.debug.assert_any_call(
+                    "journey.collection.skipped",
+                    train_id="535",
+                    reason="journey_disappeared",
+                )
+                mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_logs_info_on_unsuccessful(
+        self, scheduler_service
+    ):
+        """Non-skipped unsuccessful result (e.g. TrainNotFoundError) logs INFO."""
+        result = {
+            "train_id": "5530",
+            "success": False,
+            "error": "Train not found",
+            "expired": True,
+        }
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            return_value=result,
+        ):
+            with patch("trackrat.services.scheduler.logger") as mock_logger:
+                await scheduler_service.collect_journey("5530", datetime(2026, 5, 7))
+                mock_logger.info.assert_any_call(
+                    "journey.collection.unsuccessful",
+                    train_id="5530",
+                    error="Train not found",
+                )
+                mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_logs_error_on_none(
+        self, scheduler_service
+    ):
+        """Genuine failure (None) should still log ERROR."""
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            return_value=None,
+        ):
+            with patch("trackrat.services.scheduler.logger") as mock_logger:
+                await scheduler_service.collect_journey("9999", datetime(2026, 5, 7))
+                mock_logger.error.assert_any_call(
+                    "journey.collection.failed",
+                    train_id="9999",
+                    error="No result returned from collection",
+                )

--- a/backend_v2/tests/unit/test_scheduler_njt_batch.py
+++ b/backend_v2/tests/unit/test_scheduler_njt_batch.py
@@ -338,6 +338,76 @@ class TestCollectNJTJourneysBatch:
             await scheduler_service.collect_njt_journeys_batch(["3737"])
 
 
+    @pytest.mark.asyncio
+    async def test_skipped_results_not_counted_as_errors(self, scheduler_service):
+        """Skipped results (expired/not-found/disappeared) should not
+        increment error_count in batch collection.
+
+        Addresses chatgpt-codex-connector review on PR #1130: the new
+        {"success": False, "skipped": True} return value must be handled
+        by collect_njt_journeys_batch, not classified as an error.
+        """
+        train_ids = ["47", "49", "3737"]
+
+        results = [
+            {
+                "train_id": "47",
+                "success": False,
+                "skipped": True,
+                "reason": "already_expired",
+            },
+            {
+                "train_id": "49",
+                "success": False,
+                "skipped": True,
+                "reason": "journey_not_found",
+            },
+            {
+                "train_id": "3737",
+                "success": True,
+                "stops_count": 10,
+            },
+        ]
+
+        call_idx = 0
+
+        async def mock_collect(train_id, journey_date=None):
+            nonlocal call_idx
+            result = results[call_idx]
+            call_idx += 1
+            return result
+
+        with patch.object(
+            scheduler_service,
+            "_collect_single_njt_journey_safe",
+            side_effect=mock_collect,
+        ):
+            with patch.object(scheduler_service, "_running_tasks", {}):
+                with patch(
+                    "trackrat.services.scheduler.logger"
+                ) as mock_logger:
+                    await scheduler_service.collect_njt_journeys_batch(train_ids)
+
+        # Verify batch completion log shows 1 success, 0 errors
+        batch_complete_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c[0][0] == "njt_batch_collection_completed"
+        ]
+        assert len(batch_complete_calls) == 1
+        kwargs = batch_complete_calls[0][1]
+        assert kwargs["success_count"] == 1
+        assert kwargs["error_count"] == 0
+
+        # Verify skipped results were logged at debug level
+        skip_calls = [
+            c
+            for c in mock_logger.debug.call_args_list
+            if c[0][0] == "njt_journey_batch_skipped"
+        ]
+        assert len(skip_calls) == 2
+
+
 class TestNJTBatchCollectionIntegration:
     """Integration tests for the full NJT batch collection flow."""
 


### PR DESCRIPTION
## Summary

Closes #1122

- **Changed three benign `return None` paths** in `_collect_single_njt_journey_safe` to return dicts with `skipped: True` and a `reason` key, so the caller can distinguish them from genuine errors.
- **Updated `collect_journey`** to use a four-way branch on the result: `success` → DEBUG, `skipped` → DEBUG, unsuccessful (truthy but not success/skipped) → INFO, `None` → ERROR.
- This eliminates ~60 spurious ERROR logs per 5 days in production from expired/missing journeys that were being logged as `journey.collection.failed`.

## Files modified

| File | Change |
|------|--------|
| `backend_v2/src/trackrat/services/scheduler.py` | Changed `_collect_single_njt_journey_safe` to return `{skipped: True, reason: ...}` dicts for journey_not_found, already_expired, and journey_disappeared cases instead of `None`. Updated `collect_journey` result handling to log at appropriate levels. Updated docstring. |
| `backend_v2/tests/unit/services/test_scheduler.py` | Added `TestCollectJourneyLogging` class with 6 tests covering all four result branches: success (DEBUG), skipped/expired (DEBUG), skipped/not_found (DEBUG), skipped/disappeared (DEBUG), unsuccessful (INFO), and genuine failure/None (ERROR). |

## Design decisions

- **No new classes or enums**: Reused the existing dict-based return pattern already used by `_collect_single_njt_journey_safe` for `TrainNotFoundError` and transient DB error cases. Added `skipped` and `reason` keys to the same dict shape.
- **Kept `None` for genuine errors only**: `njt_client not initialized` (line 1905) and unhandled exceptions (line 2007) still return `None` and log ERROR, since these represent actual failures requiring attention.
- **`no_train_data_received_sync` stays as `None`**: Empty API response after a successful HTTP call is ambiguous and worth logging as an error.
- **No scheduler job cleanup needed**: The periodic update query already filters `is_expired IS NOT TRUE` (line 1169). The race window (train expires between scheduling and execution) is inherent and harmless — this fix just stops it from generating noise.

## Test coverage

All 23 scheduler tests pass (17 existing + 6 new), no regressions.

https://claude.ai/code/session_0148EqqxZ4BbZ43shfq4nKWN

---
_Generated by [Claude Code](https://claude.ai/code/session_0148EqqxZ4BbZ43shfq4nKWN)_