### PR TITLE
Fix stale journey metadata detection in NJT journey matching

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -593,50 +593,50 @@ class JourneyCollector(BaseJourneyCollector):
                 if dep_time is not None:
                     api_departure = parse_njt_time(dep_time)
 
-                    # Get stored departure, but check if journey metadata is stale
-                    # If origin_station_code doesn't match first stop in our stops table,
-                    # the journey was discovered at an intermediate station and metadata
-                    # was never properly corrected. Use stops table as source of truth.
-                    stored_departure = stored_journey.scheduled_departure
-
-                    if (
-                        stored_journey.origin_station_code
-                        and stored_journey.origin_station_code
-                        != first_stop.STATION_2CHAR
-                    ):
-                        # Query stops explicitly to avoid lazy-load greenlet error
-                        stops_stmt = (
-                            select(JourneyStop)
-                            .where(JourneyStop.journey_id == stored_journey.id)
-                            .order_by(JourneyStop.stop_sequence.asc().nulls_last())
+                    # The stops table is the more reliable source of truth for a
+                    # given station's scheduled_departure: it is populated each
+                    # collection cycle and frozen once set, so it tracks the
+                    # schedule that was in effect when the stop row was created.
+                    # The journey-record `scheduled_departure` field, by contrast,
+                    # can drift -- e.g. when schedule.py creates the journey before
+                    # NJT returns STOPS data and discovery later populates stops
+                    # from a revised schedule, or when a journey is discovered at
+                    # an intermediate station and origin metadata is never
+                    # corrected. When the journey-record value disagrees with the
+                    # stops table, comparing the API against the stale journey
+                    # field falsely rejects the same journey, marks it expired,
+                    # and prevents update_journey_metadata from ever correcting
+                    # the drift -- a self-perpetuating cycle.
+                    #
+                    # Prefer the stops-table value for the API's first station;
+                    # fall back to the journey record only if no matching stop
+                    # exists in our database.
+                    stored_departure: datetime | None = None
+                    if first_stop.STATION_2CHAR:
+                        db_stop_stmt = select(JourneyStop).where(
+                            and_(
+                                JourneyStop.journey_id == stored_journey.id,
+                                JourneyStop.station_code == first_stop.STATION_2CHAR,
+                            )
                         )
-                        stops_result = await session.execute(stops_stmt)
-                        db_stops_sorted = list(stops_result.scalars().all())
-
-                        # Check if our stored stops have a different first station
-                        if db_stops_sorted:
-                            first_db_stop = db_stops_sorted[0]
+                        db_stop = await session.scalar(db_stop_stmt)
+                        if db_stop and db_stop.scheduled_departure:
+                            stored_departure = db_stop.scheduled_departure
                             if (
-                                first_db_stop.station_code
-                                != stored_journey.origin_station_code
-                                and first_db_stop.scheduled_departure
+                                stored_journey.scheduled_departure is not None
+                                and stored_journey.scheduled_departure
+                                != db_stop.scheduled_departure
                             ):
-                                # Stops table has correct origin, journey record is stale
-                                # Use the first stop's departure for comparison
-                                stored_departure = first_db_stop.scheduled_departure
                                 logger.info(
                                     "using_stops_table_departure_for_comparison",
                                     journey_id=stored_journey.id,
                                     train_id=stored_journey.train_id,
-                                    stale_origin=stored_journey.origin_station_code,
-                                    correct_origin=first_db_stop.station_code,
-                                    stale_departure=(
-                                        stored_journey.scheduled_departure.isoformat()
-                                        if stored_journey.scheduled_departure
-                                        else None
-                                    ),
-                                    corrected_departure=stored_departure.isoformat(),
+                                    api_first_station=first_stop.STATION_2CHAR,
+                                    stops_table_departure=db_stop.scheduled_departure.isoformat(),
+                                    journey_record_departure=stored_journey.scheduled_departure.isoformat(),
                                 )
+                    if stored_departure is None:
+                        stored_departure = stored_journey.scheduled_departure
 
                     if stored_departure is not None:
                         # Ensure stored departure is timezone-aware for comparison
@@ -1516,12 +1516,14 @@ class JourneyCollector(BaseJourneyCollector):
             deleted = cast(
                 CursorResult[tuple[()]],
                 await session.execute(
-                    delete(JourneyStop).where(
+                    delete(JourneyStop)
+                    .where(
                         and_(
                             JourneyStop.journey_id == journey.id,
                             JourneyStop.station_code.notin_(api_station_codes),
                         )
-                    ).execution_options(synchronize_session="fetch")
+                    )
+                    .execution_options(synchronize_session="fetch")
                 ),
             )
             phantom_count = deleted.rowcount or 0

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -324,3 +324,89 @@ class TestStaleOriginDetection:
         )
 
         assert result is True, "Incomplete journey should skip departure time check"
+
+    @pytest.mark.asyncio
+    async def test_uses_stops_table_when_origin_matches_but_journey_record_is_stale(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """
+        Test that when journey.origin_station_code matches the API's first stop
+        but journey.scheduled_departure is stale relative to the stops table,
+        _is_same_journey() uses the stops table's value rather than the stale
+        journey-record value.
+
+        Real-world scenario (NJT train 3943, 2026-05-06):
+        - Train 3943 was scheduled NY -> Trenton departing 16:17 ET
+        - At midnight schedule.py created the journey with the morning's schedule
+          time but NJT returned null STOPS, so no stops were created
+        - Discovery later (when the train showed up on station boards) created
+          the NY stop with the current 16:17 schedule
+        - journey.scheduled_departure remained at the original (stale) value
+        - stops[NY].scheduled_departure has the correct 16:17 value
+        - Every JIT collection attempt called getTrainStopList, which returned
+          first_stop=NY at 16:17. _is_same_journey saw origin_station_code=NY ==
+          first_stop=NY, so it used journey.scheduled_departure for comparison.
+          The 26-minute gap exceeded the 10-min tolerance and the journey was
+          falsely marked is_expired=True with api_error_count=99. JIT then
+          short-circuited on is_expired and the user saw stale data with no
+          track until the next discovery cycle reactivated the train.
+
+        With the fix, _is_same_journey looks up the stop in our DB matching the
+        API's first station (NY) and uses its scheduled_departure (16:17) for
+        the comparison, correctly identifying this as the same journey. The
+        subsequent update_journey_metadata then corrects journey.scheduled_departure
+        to match the stops table.
+        """
+        base_time = now_et().replace(hour=16, minute=17, second=0, microsecond=0)
+        # Stale value 26 minutes earlier than reality
+        stale_journey_departure = base_time - timedelta(minutes=26)
+
+        journey = TrainJourney(
+            train_id="3943",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton -SEC",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stale_journey_departure,  # STALE
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # Stops table has the CORRECT (current) scheduled departure for NY
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=base_time,  # Correct
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        # API response with the same correct departure that the stops table has
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="3943",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY", "New York Penn Station", base_time.strftime(NJT_TIME_FORMAT)
+                ),
+            ],
+        )
+
+        result = await journey_collector._is_same_journey(
+            db_session, journey, api_response
+        )
+
+        assert result is True, (
+            "Same journey should be recognized when stops table agrees with API "
+            "even though journey.scheduled_departure is stale"
+        )


### PR DESCRIPTION
## Summary
Fixes a critical bug in the NJT journey collector where stale `journey.scheduled_departure` values caused valid journeys to be incorrectly marked as expired, preventing proper journey tracking and metadata updates.

## Problem
When a journey's `scheduled_departure` field drifted from the actual schedule (e.g., when schedule.py created the journey before NJT returned STOPS data, or when a journey was discovered at an intermediate station), the `_is_same_journey()` method would compare the API response against the stale journey-record value instead of the more reliable stops-table value. This caused:
- Valid journeys to be falsely rejected as mismatches
- Journeys to be marked as expired with `api_error_count=99`
- JIT collection to short-circuit on the expired flag
- Users to see stale data with no track information
- A self-perpetuating cycle where `update_journey_metadata` never got a chance to correct the drift

Real-world example: NJT train 3943 on 2026-05-06 had a 26-minute gap between the stale journey record and the actual schedule, exceeding the 10-minute tolerance threshold.

## Solution
Refactored `_is_same_journey()` to prefer the stops-table value as the source of truth for a given station's `scheduled_departure`:
- When comparing the API's first stop against stored journey data, explicitly query the stops table for a matching station record
- Use the stops-table `scheduled_departure` if it exists, falling back to the journey record only if no matching stop exists
- Added logging to track when the stops-table value is used instead of the journey record
- This allows the comparison to succeed even when journey metadata is stale, and subsequent `update_journey_metadata` calls can correct the drift

## Key Changes
- Modified `_is_same_journey()` to query the stops table for the API's first station and use its `scheduled_departure` for comparison
- Simplified the logic from checking if origin_station_code mismatches to directly checking if a matching stop exists in the database
- Added informative logging when using stops-table values for comparison
- Minor formatting cleanup in the `delete(JourneyStop)` statement for consistency

## Testing
Added comprehensive test case `test_uses_stops_table_when_origin_matches_but_journey_record_is_stale` that validates the fix handles the real-world scenario where journey metadata is stale but the stops table has the correct values.

https://claude.ai/code/session_015Rx92HQ7BdShLbEbtnpcSc