### PR TITLE
Issue #1123: Handle NJT discovery INSERT race on unique_train_journey

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -644,56 +644,70 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                         # NOTE: We temporarily use the discovery station as origin,
                         # but this might be an intermediate stop. The journey
                         # collector will correct this when it fetches full details.
-                        journey = TrainJourney(
-                            train_id=train_id,
-                            journey_date=journey_date,
-                            line_code=parse_njt_line_code(
-                                train_data.get("LINE", "").strip()
-                            ),
-                            line_name=train_data.get("LINE_NAME", ""),
-                            destination=train_data.get("DESTINATION", "").strip(),
-                            origin_station_code=station_code,
-                            terminal_station_code=station_code,
-                            scheduled_departure=scheduled_departure,
-                            data_source="NJT",
-                            observation_type="OBSERVED",
-                            first_seen_at=now_et(),
-                            last_updated_at=now_et(),
-                            has_complete_journey=False,
-                            update_count=1,
-                        )
+                        try:
+                            async with session.begin_nested():
+                                journey = TrainJourney(
+                                    train_id=train_id,
+                                    journey_date=journey_date,
+                                    line_code=parse_njt_line_code(
+                                        train_data.get("LINE", "").strip()
+                                    ),
+                                    line_name=train_data.get("LINE_NAME", ""),
+                                    destination=train_data.get(
+                                        "DESTINATION", ""
+                                    ).strip(),
+                                    origin_station_code=station_code,
+                                    terminal_station_code=station_code,
+                                    scheduled_departure=scheduled_departure,
+                                    data_source="NJT",
+                                    observation_type="OBSERVED",
+                                    first_seen_at=now_et(),
+                                    last_updated_at=now_et(),
+                                    has_complete_journey=False,
+                                    update_count=1,
+                                )
 
-                        # Extract line color if available
-                        if "BACKCOLOR" in train_data:
-                            journey.line_color = train_data["BACKCOLOR"].strip()
+                                if "BACKCOLOR" in train_data:
+                                    journey.line_color = train_data[
+                                        "BACKCOLOR"
+                                    ].strip()
 
-                        session.add(journey)
-                        await session.flush()  # Ensure journey has ID
-                        new_train_ids.add(train_id)
+                                session.add(journey)
+                                await session.flush()
 
-                        # Update track directly in journey stop
-                        track = train_data.get("TRACK")
-                        if track and station_code:
-                            await self._update_stop_track_if_needed(
-                                session, journey, station_code, track
+                            new_train_ids.add(train_id)
+
+                            track = train_data.get("TRACK")
+                            if track and station_code:
+                                await self._update_stop_track_if_needed(
+                                    session, journey, station_code, track
+                                )
+
+                            stops_data = train_data.get("STOPS") or []
+                            if stops_data:
+                                await self._populate_stop_times_from_discovery(
+                                    session, journey, stops_data
+                                )
+
+                            logger.debug(
+                                "new_journey_discovered",
+                                train_id=train_id,
+                                journey_date=journey_date,
+                                line=journey.line_code,
+                                destination=journey.destination,
+                                departure=scheduled_departure.isoformat(),
+                                track=track,
                             )
-
-                        # Populate real-time stop times from embedded STOPS data
-                        stops_data = train_data.get("STOPS") or []
-                        if stops_data:
-                            await self._populate_stop_times_from_discovery(
-                                session, journey, stops_data
+                        except IntegrityError:
+                            # Race: another process (concurrent discovery
+                            # or schedule collector) already inserted this
+                            # journey. Safe to skip — next cycle will find
+                            # and update the existing journey.
+                            logger.info(
+                                "discovery_insert_race_skipped",
+                                train_id=train_id,
+                                journey_date=journey_date,
                             )
-
-                        logger.debug(
-                            "new_journey_discovered",
-                            train_id=train_id,
-                            journey_date=journey_date,
-                            line=journey.line_code,
-                            destination=journey.destination,
-                            departure=scheduled_departure.isoformat(),
-                            track=track,
-                        )
 
             except Exception as e:
                 logger.error(

--- a/backend_v2/src/trackrat/collectors/njt/schedule.py
+++ b/backend_v2/src/trackrat/collectors/njt/schedule.py
@@ -9,6 +9,7 @@ from datetime import date, datetime
 from typing import Any
 
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -194,6 +195,15 @@ class NJTScheduleCollector:
                     elif result == "skipped":
                         stats["skipped_observed"] += 1
 
+                except IntegrityError:
+                    # Race: discovery or another collector already created
+                    # this journey concurrently. Treat as a skip.
+                    stats["skipped_observed"] += 1
+                    logger.info(
+                        "schedule_insert_race_skipped",
+                        station_code=station_code,
+                        train_id=item.get("TRAIN_ID"),
+                    )
                 except Exception as e:
                     stats["errors"] += 1
                     logger.error(

--- a/backend_v2/tests/unit/collectors/njt/test_discovery.py
+++ b/backend_v2/tests/unit/collectors/njt/test_discovery.py
@@ -868,3 +868,145 @@ class TestPopulateStopTimesFromDiscovery:
         # TR: arrival was set -> preserved; departure was NULL -> filled
         assert stop_tr.updated_arrival == datetime(2025, 1, 1, 9, 50, 0)
         assert stop_tr.updated_departure == parsed_times[3]
+
+
+class TestDiscoveryInsertRaceCondition:
+    """Test that concurrent INSERT races on unique_train_journey are handled
+    gracefully instead of crashing with UniqueViolationError.
+
+    Addresses issue #1123: NJT discovery hits unique_train_journey constraint
+    violation due to insert race; needs ON CONFLICT handling.
+    """
+
+    @pytest.fixture
+    def collector(self, mock_njt_client):
+        return TrainDiscoveryCollector(mock_njt_client)
+
+    def _make_train_data(self, train_id="3737", destination="New York Penn Station"):
+        return {
+            "TRAIN_ID": train_id,
+            "LINE": "NEC",
+            "LINE_NAME": "Northeast Corridor",
+            "DESTINATION": destination,
+            "SCHED_DEP_DATE": "01-Jan-2025 10:00:00 AM",
+            "BACKCOLOR": "#FF6600",
+        }
+
+    @pytest.mark.asyncio
+    async def test_insert_race_does_not_crash_process(self, collector):
+        """When a concurrent process inserts the same journey between our
+        existence check and our INSERT, the IntegrityError should be caught
+        and the train skipped — not crash the entire discovery cycle."""
+        mock_session = _make_session_mock()
+
+        # Scalar calls per train:
+        # 1. SELECT FOR UPDATE SKIP LOCKED -> None (not found)
+        # 2. EXISTS check -> False (doesn't exist yet)
+        # 3. _find_matching_scheduled_train -> None (no fuzzy match)
+        mock_session.scalar = AsyncMock(side_effect=[None, False, None])
+
+        # session.flush() raises IntegrityError (unique constraint violation)
+        mock_session.flush = AsyncMock(
+            side_effect=IntegrityError(
+                "duplicate key", params=None, orig=Exception("unique_train_journey")
+            )
+        )
+
+        train_data = [self._make_train_data()]
+
+        with patch("trackrat.collectors.njt.discovery.parse_njt_time") as mock_parse:
+            mock_parse.return_value = datetime(2025, 1, 1, 10, 0, 0)
+            with patch("trackrat.collectors.njt.discovery.now_et") as mock_now:
+                mock_now.return_value = datetime(2025, 1, 1, 9, 0, 0)
+
+                # Should NOT raise — IntegrityError is caught internally
+                result = await collector.process_discovered_trains(
+                    mock_session, "NY", train_data
+                )
+
+        # The train should NOT be in the result set (it wasn't created)
+        assert "3737" not in result
+        # Process completed without crashing
+        assert isinstance(result, set)
+
+    @pytest.mark.asyncio
+    async def test_insert_race_does_not_affect_other_trains(self, collector):
+        """An IntegrityError on one train should not prevent processing
+        subsequent trains in the same station batch."""
+        mock_session = _make_session_mock()
+
+        # Scalar calls per train (3 each):
+        # Train 1: FOR UPDATE -> None, EXISTS -> False, fuzzy match -> None
+        # Train 2: FOR UPDATE -> None, EXISTS -> False, fuzzy match -> None
+        mock_session.scalar = AsyncMock(
+            side_effect=[None, False, None, None, False, None]
+        )
+
+        call_count = 0
+
+        async def flush_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise IntegrityError(
+                    "duplicate key",
+                    params=None,
+                    orig=Exception("unique_train_journey"),
+                )
+
+        mock_session.flush = AsyncMock(side_effect=flush_side_effect)
+
+        train_data = [
+            self._make_train_data("3737", "New York Penn Station"),
+            self._make_train_data("5126", "Trenton"),
+        ]
+
+        with patch("trackrat.collectors.njt.discovery.parse_njt_time") as mock_parse:
+            mock_parse.side_effect = [
+                datetime(2025, 1, 1, 10, 0, 0),
+                datetime(2025, 1, 1, 10, 30, 0),
+            ]
+            with patch("trackrat.collectors.njt.discovery.now_et") as mock_now:
+                mock_now.return_value = datetime(2025, 1, 1, 9, 0, 0)
+
+                result = await collector.process_discovered_trains(
+                    mock_session, "NY", train_data
+                )
+
+        # Train 3737 failed due to race, but 5126 should succeed
+        assert "3737" not in result
+        assert "5126" in result
+
+    @pytest.mark.asyncio
+    async def test_insert_race_logged_at_info_not_error(self, collector):
+        """IntegrityError from insert race should be logged at INFO level
+        (not ERROR), since it's a benign race condition."""
+        mock_session = _make_session_mock()
+        # 3 scalar calls: FOR UPDATE -> None, EXISTS -> False, fuzzy -> None
+        mock_session.scalar = AsyncMock(side_effect=[None, False, None])
+        mock_session.flush = AsyncMock(
+            side_effect=IntegrityError(
+                "duplicate key", params=None, orig=Exception("unique_train_journey")
+            )
+        )
+
+        train_data = [self._make_train_data()]
+
+        with patch("trackrat.collectors.njt.discovery.parse_njt_time") as mock_parse:
+            mock_parse.return_value = datetime(2025, 1, 1, 10, 0, 0)
+            with patch("trackrat.collectors.njt.discovery.now_et") as mock_now:
+                mock_now.return_value = datetime(2025, 1, 1, 9, 0, 0)
+                with patch("trackrat.collectors.njt.discovery.logger") as mock_logger:
+                    await collector.process_discovered_trains(
+                        mock_session, "NY", train_data
+                    )
+
+                    # Should log at info level with the race event name
+                    mock_logger.info.assert_any_call(
+                        "discovery_insert_race_skipped",
+                        train_id="3737",
+                        journey_date=datetime(2025, 1, 1, 10, 0, 0).date(),
+                    )
+                    # Should NOT log at error level for this train
+                    for call in mock_logger.error.call_args_list:
+                        assert "3737" not in str(call)

--- a/backend_v2/tests/unit/collectors/njt/test_schedule_insert_race.py
+++ b/backend_v2/tests/unit/collectors/njt/test_schedule_insert_race.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for NJT schedule collector insert race condition handling.
+
+Addresses issue #1123: IntegrityError from concurrent discovery/schedule
+INSERT should be caught and treated as a skip, not logged as an error.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+
+from sqlalchemy.exc import IntegrityError
+
+from trackrat.collectors.njt.schedule import NJTScheduleCollector
+
+
+@pytest.fixture
+def mock_njt_client():
+    client = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def schedule_collector(mock_njt_client):
+    return NJTScheduleCollector(mock_njt_client)
+
+
+class TestScheduleInsertRace:
+    """Test that IntegrityError during schedule INSERT is treated as a skip."""
+
+    @pytest.mark.asyncio
+    async def test_integrity_error_counted_as_skip_not_error(
+        self, schedule_collector
+    ):
+        """When the savepoint commit raises IntegrityError (concurrent
+        discovery already created the journey), it should increment
+        skipped_observed, not errors."""
+        mock_session = AsyncMock()
+
+        # Make begin_nested() raise IntegrityError on __aexit__ (savepoint commit)
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=None)
+        mock_cm.__aexit__ = AsyncMock(
+            side_effect=IntegrityError(
+                "duplicate key", params=None, orig=Exception("unique_train_journey")
+            )
+        )
+        mock_session.begin_nested = MagicMock(return_value=mock_cm)
+        mock_session.commit = AsyncMock()
+
+        schedule_data = [
+            {
+                "STATION_2CHAR": "TR",
+                "STATIONNAME": "Trenton",
+                "ITEMS": [
+                    {
+                        "TRAIN_ID": "3737",
+                        "SCHED_DEP_DATE": "01-Jan-2025 10:00:00 AM",
+                        "DESTINATION": "New York Penn Station",
+                        "LINE": "NEC",
+                    },
+                ],
+            }
+        ]
+
+        with patch("trackrat.collectors.njt.schedule.logger") as mock_logger:
+            stats = await schedule_collector._process_schedule_data(
+                mock_session, schedule_data
+            )
+
+        # IntegrityError should be counted as skip, not error
+        assert stats["skipped_observed"] == 1
+        assert stats["errors"] == 0
+
+        # Should log at info level, not error
+        mock_logger.info.assert_any_call(
+            "schedule_insert_race_skipped",
+            station_code="TR",
+            train_id="3737",
+        )
+
+    @pytest.mark.asyncio
+    async def test_integrity_error_does_not_block_other_items(
+        self, schedule_collector
+    ):
+        """An IntegrityError on one schedule item should not prevent
+        processing subsequent items in the same station."""
+        mock_session = AsyncMock()
+
+        call_count = 0
+
+        async def aexit_side_effect(exc_type, exc_val, exc_tb):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise IntegrityError(
+                    "duplicate key",
+                    params=None,
+                    orig=Exception("unique_train_journey"),
+                )
+            return False
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=None)
+        mock_cm.__aexit__ = AsyncMock(side_effect=aexit_side_effect)
+        mock_session.begin_nested = MagicMock(return_value=mock_cm)
+        mock_session.commit = AsyncMock()
+
+        # Mock _process_schedule_item to return "new" for both items
+        with patch.object(
+            schedule_collector,
+            "_process_schedule_item",
+            return_value="new",
+        ):
+            schedule_data = [
+                {
+                    "STATION_2CHAR": "TR",
+                    "STATIONNAME": "Trenton",
+                    "ITEMS": [
+                        {
+                            "TRAIN_ID": "3737",
+                            "SCHED_DEP_DATE": "01-Jan-2025 10:00:00 AM",
+                            "DESTINATION": "New York Penn Station",
+                            "LINE": "NEC",
+                        },
+                        {
+                            "TRAIN_ID": "5126",
+                            "SCHED_DEP_DATE": "01-Jan-2025 10:30:00 AM",
+                            "DESTINATION": "Princeton Junction",
+                            "LINE": "NEC",
+                        },
+                    ],
+                }
+            ]
+
+            stats = await schedule_collector._process_schedule_data(
+                mock_session, schedule_data
+            )
+
+        # First item hit IntegrityError (skip), second succeeded
+        assert stats["skipped_observed"] == 1
+        assert stats["new_schedules"] == 1
+        assert stats["errors"] == 0


### PR DESCRIPTION
## Summary

- Wraps the new journey INSERT in `discovery.py` with a nested savepoint + `IntegrityError` catch, matching the existing fuzzy-match pattern at line 592. When a concurrent process (another discovery station loop or the schedule collector) inserts the same `(train_id, journey_date, data_source)` tuple between the existence check and the INSERT, the race is now caught and logged at INFO instead of crashing with `UniqueViolationError`.
- Adds a specific `IntegrityError` catch to the schedule collector's caller in `schedule.py`, downgrading the log from ERROR to INFO and counting it as a skip instead of an error.

## Files modified

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/collectors/njt/discovery.py` | Wrap new journey INSERT (lines 647-696) in nested savepoint + `except IntegrityError` — same pattern already used for fuzzy-match race at line 632 |
| `backend_v2/src/trackrat/collectors/njt/schedule.py` | Add `except IntegrityError` before generic `except Exception` in the per-item processing loop, treating the race as a skip |
| `backend_v2/tests/unit/collectors/njt/test_discovery.py` | 3 new tests: race doesn't crash, doesn't block other trains, logs at INFO not ERROR |
| `backend_v2/tests/unit/collectors/njt/test_schedule_insert_race.py` | 2 new tests: IntegrityError counted as skip not error, doesn't block other items |

## Test coverage

5 new tests covering:
- `test_insert_race_does_not_crash_process` — IntegrityError is caught, process continues
- `test_insert_race_does_not_affect_other_trains` — subsequent trains in the same batch still succeed
- `test_insert_race_logged_at_info_not_error` — benign race is logged at INFO, not ERROR
- `test_integrity_error_counted_as_skip_not_error` — schedule collector counts race as skip
- `test_integrity_error_does_not_block_other_items` — schedule collector processes remaining items

## Design decisions

- **Catch-and-skip over ON CONFLICT**: The issue suggested `INSERT ... ON CONFLICT DO NOTHING` as an alternative, but the existing codebase uses ORM `session.add()` throughout. The nested savepoint + `IntegrityError` catch follows the identical pattern already used at discovery.py line 632 for the fuzzy-match race. This is the minimal, lowest-risk fix.
- **No re-query on conflict**: On IntegrityError, we skip rather than re-querying the existing journey to apply track/stop updates. The next discovery cycle (30 min) will find the existing journey via the `SELECT ... FOR UPDATE` path and apply updates. This keeps the fix simple and avoids adding a secondary query path.
- **Schedule.py already had outer protection**: The `except Exception` handler at the caller level already prevented crashes, but logged at ERROR level and counted as an error. The new `except IntegrityError` catch fires first, correctly categorizing it as a benign race.

Closes #1123

https://claude.ai/code/session_016Bqoy8Y7EXPkubkQcVCSyC

---
_Generated by [Claude Code](https://claude.ai/code/session_016Bqoy8Y7EXPkubkQcVCSyC)_