### PR TITLE
Issue #1124: Stop escalating Metra empty-feed cycles to ERROR

### DIFF
--- a/backend_v2/src/trackrat/collectors/metra/collector.py
+++ b/backend_v2/src/trackrat/collectors/metra/collector.py
@@ -41,9 +41,12 @@ logger = logging.getLogger(__name__)
 DATA_SOURCE = "METRA"
 
 # Module-level counter that persists across collector instantiations (same process).
-# Reset on any successful non-empty fetch.
+# Reset on any successful non-empty fetch. Exposed as a structured log field on
+# every empty cycle so operators can detect sustained outages via log search /
+# derived metrics (e.g., "Metra empty for >N consecutive cycles"). The counter
+# is diagnostic only — empty 200s from the upstream feed are a known recurring
+# behavior (daily maintenance gap) and are NOT escalated to ERROR.
 _consecutive_empty_cycles = 0
-_CONSECUTIVE_EMPTY_THRESHOLD = 3
 
 
 def _generate_train_id(trip_id: str) -> str:
@@ -146,18 +149,18 @@ class MetraCollector:
             stats["total_arrivals"] = len(arrivals)
 
             if not arrivals:
+                # Empty 200s from the Metra feed are a known recurring upstream
+                # behavior (daily maintenance gap, ~07:30-09:25 UTC). Treat as a
+                # benign skipped cycle: log WARNING with the running counter and
+                # return. Sustained outages are detected via monitoring on the
+                # `consecutive_empty_cycles` field, not via log-level escalation.
+                # Genuine HTTP / auth failures still raise via MetraFetchError.
                 _consecutive_empty_cycles += 1
-                if _consecutive_empty_cycles >= _CONSECUTIVE_EMPTY_THRESHOLD:
-                    raise RuntimeError(
-                        f"Metra collection: {_consecutive_empty_cycles} consecutive "
-                        f"cycles returned 0 arrivals — possible auth or API failure "
-                        f"(auth_method={self.client._auth_method})"
-                    )
                 logger.warning(
                     "metra_empty_feed",
                     extra={
                         "consecutive_empty_cycles": _consecutive_empty_cycles,
-                        "threshold": _CONSECUTIVE_EMPTY_THRESHOLD,
+                        "auth_method": self.client._auth_method,
                     },
                 )
                 return stats

--- a/backend_v2/tests/unit/collectors/metra/test_collector.py
+++ b/backend_v2/tests/unit/collectors/metra/test_collector.py
@@ -525,9 +525,13 @@ class TestCollectorErrorPropagation:
 class TestConsecutiveEmptyCycles:
     """Tests for consecutive-zero arrival detection.
 
-    When the feed returns 0 arrivals for N consecutive cycles, the collector
-    should raise so the scheduler marks the run as failed, making the problem
-    visible in error logs and health checks.
+    Empty 200s from the upstream Metra feed are a known recurring behavior
+    (daily maintenance gap ~07:30-09:25 UTC). The collector logs WARNING with
+    a running counter so monitoring can alert on sustained outages, but does
+    NOT escalate to ERROR — that would generate spurious daily error noise.
+    Genuine HTTP / auth failures still surface via MetraFetchError.
+
+    See: https://github.com/trackrat-dev/trackrat/issues/1124
     """
 
     @pytest.fixture(autouse=True)
@@ -570,8 +574,14 @@ class TestConsecutiveEmptyCycles:
         assert collector_module._consecutive_empty_cycles == 2
 
     @pytest.mark.asyncio
-    async def test_three_consecutive_empty_cycles_raises(self):
-        """Three consecutive empty cycles should raise RuntimeError."""
+    async def test_three_consecutive_empty_cycles_does_not_raise(self):
+        """Empty cycles never escalate to RuntimeError, regardless of count.
+
+        Daily Metra upstream maintenance gaps produce ~20-30 consecutive empty
+        cycles — escalating those to ERROR generated 89 spurious errors in
+        5 days on production (#1124). The counter still increments for ops
+        visibility but the cycle returns normally.
+        """
         collector_module._consecutive_empty_cycles = 2
 
         client = MagicMock(spec=MetraClient)
@@ -581,8 +591,53 @@ class TestConsecutiveEmptyCycles:
         collector = MetraCollector(client=client)
         session = AsyncMock()
 
-        with pytest.raises(RuntimeError, match="consecutive.*cycles returned 0"):
+        result = await collector.collect(session)
+
+        assert result["total_arrivals"] == 0
+        assert collector_module._consecutive_empty_cycles == 3
+
+    @pytest.mark.asyncio
+    async def test_many_consecutive_empty_cycles_does_not_raise(self):
+        """Even 30 consecutive empty cycles (a typical maintenance gap) must
+        not raise — that was the production bug."""
+        collector_module._consecutive_empty_cycles = 29
+
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(return_value=[])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        result = await collector.collect(session)
+
+        assert result["total_arrivals"] == 0
+        assert collector_module._consecutive_empty_cycles == 30
+
+    @pytest.mark.asyncio
+    async def test_empty_cycle_logs_counter_for_monitoring(self, caplog):
+        """Empty cycles must emit a WARNING-level log with the running counter
+        so monitoring can alert on sustained outages."""
+        import logging
+
+        collector_module._consecutive_empty_cycles = 4
+
+        client = MagicMock(spec=MetraClient)
+        client.has_credentials = True
+        client._auth_method = "query_param"
+        client.get_all_arrivals = AsyncMock(return_value=[])
+        collector = MetraCollector(client=client)
+        session = AsyncMock()
+
+        with caplog.at_level(logging.WARNING, logger="trackrat.collectors.metra.collector"):
             await collector.collect(session)
+
+        empty_records = [r for r in caplog.records if r.message == "metra_empty_feed"]
+        assert empty_records, "Expected metra_empty_feed warning to be emitted"
+        record = empty_records[-1]
+        assert record.levelno == logging.WARNING
+        assert getattr(record, "consecutive_empty_cycles", None) == 5
+        assert getattr(record, "auth_method", None) == "query_param"
 
     @pytest.mark.asyncio
     async def test_nonempty_cycle_resets_counter(self):
@@ -618,8 +673,3 @@ class TestConsecutiveEmptyCycles:
             pass
 
         assert collector_module._consecutive_empty_cycles == 0
-
-    @pytest.mark.asyncio
-    async def test_threshold_is_configurable(self):
-        """The threshold constant should be accessible and reasonable."""
-        assert collector_module._CONSECUTIVE_EMPTY_THRESHOLD == 3


### PR DESCRIPTION
## Summary

Closes #1124.

The Metra GTFS-RT feed produces a recurring daily empty-200s window (~07:30–09:25 UTC, consistent with an upstream maintenance gap). The collector was raising `RuntimeError` after 3 consecutive empty cycles, which the scheduler logged as `task_execution_failed` at ERROR level — generating **89 spurious errors over 5 days** on production with no actionable signal.

Empty cycles now log a single WARNING with the running counter as a structured field. Sustained outages can be detected via monitoring on `consecutive_empty_cycles` rather than via log-level escalation. Genuine HTTP / auth failures still surface via `MetraFetchError`, which continues to raise.

## Approach considered & chosen

The issue suggested several alternatives:

1. **A configurable quiet window (`TRACKRAT_METRA_QUIET_WINDOW_UTC=07:30-09:30`)** — rejected: hardcoding a vendor schedule is brittle (the maintenance window can shift), and the comment from triage favored monitoring on a derived metric instead.
2. **Stop raising entirely; log WARNING and let monitoring alert on "Metra empty for >2 hours"** — chosen. The counter is preserved as a structured log field so ops can query it directly.
3. **Probe with a follow-up health request to distinguish auth-failure from feed-empty** — rejected as out of scope: if there's a real auth failure, the next non-empty period will still surface it (and this would add wasted API calls).

The maintainer's triage comment explicitly endorsed option 2, so that's what's implemented. Staging token rotation remains a separate ops task as the maintainer noted.

## Files modified

- `backend_v2/src/trackrat/collectors/metra/collector.py` — removed the `RuntimeError` raise on N consecutive empty cycles; removed the now-unused `_CONSECUTIVE_EMPTY_THRESHOLD` constant. The counter still increments and is now exposed as a structured `consecutive_empty_cycles` field on the `metra_empty_feed` warning, alongside `auth_method`.
- `backend_v2/tests/unit/collectors/metra/test_collector.py` — updated `TestConsecutiveEmptyCycles`:
  - `test_three_consecutive_empty_cycles_does_not_raise` (replaces the previous "raises" test) — verifies behavior at the old escalation threshold.
  - `test_many_consecutive_empty_cycles_does_not_raise` — explicitly covers a 30-cycle gap (typical maintenance scenario).
  - `test_empty_cycle_logs_counter_for_monitoring` — verifies the WARNING includes `consecutive_empty_cycles` and `auth_method` so downstream log monitoring is functional.
  - Removed `test_threshold_is_configurable` (constant deleted).

## Test plan

- [x] All 95 Metra unit tests pass locally (`poetry run pytest tests/unit/collectors/metra/`).
- [ ] Verify Backend Tests CI passes on this PR.
- [ ] After merge, monitor production logs to confirm the daily morning window no longer produces `task_execution_failed` errors. Operators retain visibility through the `metra_empty_feed` warnings.

## Notes

- `MetraFetchError` (HTTP errors, network errors, auth failures) is unchanged: it still propagates as `RuntimeError` and shows up at ERROR level. So **real** failures continue to be loud.
- Staging token rotation (`TRACKRAT_METRA_API_TOKEN`) is a manual ops task not addressed here, per maintainer comment on the issue.

https://claude.ai/code/session_01HrmAkWgH6tnXQq34bEjqDe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrmAkWgH6tnXQq34bEjqDe)_