### PR TITLE
Issue #1125: Treat PATH RidePATH HTTP 200 empty body as no-data cycle

### DIFF
--- a/backend_v2/src/trackrat/collectors/path/ridepath_client.py
+++ b/backend_v2/src/trackrat/collectors/path/ridepath_client.py
@@ -105,6 +105,14 @@ class RidePathClient:
             response = await self.session.get(self.base_url)
             response.raise_for_status()
 
+            # The RidePATH API occasionally returns HTTP 200 with an empty
+            # body. Treat that as a transient no-data cycle rather than a
+            # JSON parse failure: the caller already handles an empty
+            # arrival list as a normal no-op pass.
+            if not response.content or not response.content.strip():
+                logger.warning("ridepath_empty_body", url=self.base_url)
+                return []
+
             data = response.json()
             arrivals = self._parse_response(data)
 

--- a/backend_v2/tests/unit/collectors/path/test_ridepath_client.py
+++ b/backend_v2/tests/unit/collectors/path/test_ridepath_client.py
@@ -165,6 +165,54 @@ class TestRidePathClient:
             await client.get_all_arrivals()
 
     @pytest.mark.asyncio
+    async def test_get_all_arrivals_empty_body_returns_empty_list(self, client):
+        """HTTP 200 with an empty body is treated as a no-data cycle.
+
+        Regression for issue #1125: the RidePATH API occasionally returns
+        HTTP 200 with an empty body. The previous behavior was to call
+        ``response.json()``, which raises ``JSONDecodeError`` and was logged
+        at ERROR level, treating a transient upstream quirk as a collector
+        failure. The fix returns ``[]`` (which the collector handles as a
+        no-op cycle) and logs at WARNING.
+        """
+        mock_response = MagicMock()
+        mock_response.content = b""
+        # If json() is reached, that's a regression — fail loudly.
+        mock_response.json.side_effect = AssertionError(
+            "json() must not be called on an empty body"
+        )
+
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_response)
+        client._session = mock_session
+
+        arrivals = await client.get_all_arrivals()
+
+        assert arrivals == []
+        # Cache must NOT be populated by an empty cycle, otherwise we'd
+        # serve [] for the cache TTL even after the API recovers.
+        assert client._cache is None
+        assert client._cache_time is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_arrivals_whitespace_body_returns_empty_list(self, client):
+        """HTTP 200 with a whitespace-only body is also treated as no-data."""
+        mock_response = MagicMock()
+        mock_response.content = b"   \n  "
+        mock_response.json.side_effect = AssertionError(
+            "json() must not be called on a whitespace-only body"
+        )
+
+        mock_session = AsyncMock()
+        mock_session.get = AsyncMock(return_value=mock_response)
+        client._session = mock_session
+
+        arrivals = await client.get_all_arrivals()
+
+        assert arrivals == []
+        assert client._cache is None
+
+    @pytest.mark.asyncio
     async def test_get_all_arrivals_unknown_station(self, client):
         """Test that unknown station codes are skipped gracefully."""
         response_data = {


### PR DESCRIPTION
## Summary

Closes #1125

The RidePATH API occasionally returns HTTP 200 with an empty body (4 occurrences over a 5-day window in production logs). The previous code called `response.json()` unconditionally, which raised `JSONDecodeError`, was caught by the bare `except Exception`, and logged at `ERROR` — treating a transient upstream quirk as a collector failure.

After this change, an empty/whitespace-only body is detected explicitly:

- Log a single `WARNING` (`ridepath_empty_body`) with the URL.
- Return `[]`. The caller in `collectors/path/collector.py:collect()` already handles an empty arrival list as a normal no-op cycle, so the user-facing behavior is identical to a "no trains right now" response.
- The cache is intentionally **not** populated on the empty path — caching `[]` for the 30-second TTL would extend the user-visible blackout past the upstream recovery.

Real HTTP errors (4xx/5xx) and parse failures on a non-empty body still surface as `ERROR` and re-raise, so genuine API failures remain loud.

## Files modified

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/collectors/path/ridepath_client.py` | Add the empty-body branch in `get_all_arrivals` between `raise_for_status()` and `response.json()` |
| `backend_v2/tests/unit/collectors/path/test_ridepath_client.py` | 2 new tests covering empty-body and whitespace-only body, both asserting `[]` is returned, the cache is not populated, and `response.json()` is never called |

## Design decisions

- **Return `[]` rather than the previous cache.** The triage comment on the issue explicitly preferred this over graceful degradation: cycle skipping matches the existing semantics of `collector.collect()` and avoids serving stale predictions during a transient upstream gap. A 30-second blackout (single cycle) is preferable to up-to-30-second-stale arrivals confidently rendered as fresh.
- **Don't populate the cache on empty.** If we did, every request during the 30-second TTL would also see `[]`, prolonging the blackout. Leaving the cache untouched lets the next collection cycle re-fetch.
- **Whitespace-only bodies handled too.** Cheap to check (`content.strip()`), avoids a follow-up bug if the upstream ever returns `"\n"` instead of `""`.
- **Scope kept tight.** The issue raised the question of applying the same defensiveness to NJT/Amtrak/WMATA. Those collectors have different error-handling conventions and weren't observed misbehaving in production logs — out of scope for this PR.

## Test coverage

22 RidePATH client tests pass (20 existing + 2 new):

- `test_get_all_arrivals_empty_body_returns_empty_list` — `b""` body returns `[]`, cache is not populated, `response.json()` is never called (the mock asserts on this)
- `test_get_all_arrivals_whitespace_body_returns_empty_list` — `b"   \n  "` body returns `[]`

Existing HTTP error / 4xx / 5xx tests still pass — those error paths are unchanged.

https://claude.ai/code/session_01KsFpH96MGABBEpENEKTW4B

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsFpH96MGABBEpENEKTW4B)_