### PR TITLE
[codex] Fix trip-search and train-identity review findings

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -310,8 +310,14 @@ class SummaryService:
         result = await db.execute(stmt)
         rows = result.all()
 
-        return {
-            row.line_key: LineStats(
+        line_stats: dict[str, LineStats] = {}
+        for row in rows:
+            key = (
+                row.line_key
+                if data_source
+                else f"{row.data_source or 'UNKNOWN'}:{row.line_key}"
+            )
+            line_stats[key] = LineStats(
                 line_name=row.line_name or row.line_key,
                 line_code=row.line_code or "",
                 train_count=row.train_count,
@@ -321,8 +327,7 @@ class SummaryService:
                 data_source=row.data_source or "",
                 arrival_data_count=row.arrival_data_count,
             )
-            for row in rows
-        }
+        return line_stats
 
     async def get_route_summary(
         self,

--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -41,6 +41,15 @@ logger = get_logger(__name__)
 # Maximum number of departure queries per transfer search to keep response fast
 MAX_TRANSFER_QUERIES = 12
 
+_DIRECT_SERVICE_EXACT_ONLY_GROUPS = (
+    frozenset({"NY", "S128", "SA28"}),  # Penn Station / 34 St-Penn Station
+    frozenset({"GCT", "S631", "S723", "S901"}),  # Grand Central / subway
+    frozenset({"PWC", "S138", "S228", "SA36", "SE01", "SR25"}),  # WTC / Oculus
+)
+_DIRECT_SERVICE_EXACT_ONLY_CODES = frozenset(
+    code for group in _DIRECT_SERVICE_EXACT_ONLY_GROUPS for code in group
+)
+
 # Minimum number of minutes after arrival to allow for catching the next train
 # (in addition to the transfer point's walk_minutes)
 CONNECTION_BUFFER_MINUTES = 2
@@ -126,6 +135,22 @@ def _filter_cross_system_direct_trips(
     if not valid_systems:
         return []
     return [t for t in trips if t.legs[0].data_source in valid_systems]
+
+
+def _get_direct_service_systems(station_code: str) -> set[str]:
+    """Return systems that directly serve the requested station code.
+
+    Most station equivalence groups represent the same boarding location across
+    system-specific codes. A few groups are adjacent transfer complexes; those
+    should use exact station systems so walking transfers do not look direct.
+    """
+    if station_code in _DIRECT_SERVICE_EXACT_ONLY_CODES:
+        return set(get_systems_serving_station(station_code))
+
+    systems: set[str] = set()
+    for code in expand_station_codes(station_code):
+        systems |= get_systems_serving_station(code)
+    return systems
 
 
 def _get_station_lines_expanded(station_code: str, system: str) -> frozenset[str]:
@@ -288,9 +313,11 @@ async def search_trips(
         data_sources=data_sources,
     )
 
-    # Systems natively serving each endpoint (used for direct-trip filtering
-    # and transfer search below).  Expand equivalence aliases first so that
-    # alias-only codes (e.g. TS → SE) resolve to the canonical station's systems.
+    # Direct-trip filtering should keep true shared-station aliases but avoid
+    # treating adjacent walking-transfer complexes as a single direct station.
+    from_direct_systems = _get_direct_service_systems(from_station)
+    to_direct_systems = _get_direct_service_systems(to_station)
+
     from_systems: set[str] = set()
     for code in expand_station_codes(from_station):
         from_systems |= get_systems_serving_station(code)
@@ -323,7 +350,7 @@ async def search_trips(
     # Filter out cross-system matches that only connected via station equivalence
     # expansion (e.g., Amtrak to NY appearing as "direct" to subway S128).
     direct_trips = _filter_cross_system_direct_trips(
-        direct_trips, from_systems, to_systems
+        direct_trips, from_direct_systems, to_direct_systems
     )
 
     if direct_trips:

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -6,6 +6,7 @@ headline/body generation and metrics calculation.
 """
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -138,6 +139,78 @@ class TestSummaryService:
     def summary_service(self):
         """Create a SummaryService instance for testing."""
         return SummaryService()
+
+    async def test_line_stats_keys_include_data_source_for_network_queries(
+        self, summary_service, mock_db
+    ):
+        """Network summaries must preserve rows whose display keys collide."""
+        rows = [
+            SimpleNamespace(
+                line_key="Unknown",
+                line_name=None,
+                line_code=None,
+                data_source="NJT",
+                train_count=3,
+                on_time_count=2,
+                cancellation_count=1,
+                total_delay_minutes=4.0,
+                arrival_data_count=2,
+            ),
+            SimpleNamespace(
+                line_key="Unknown",
+                line_name=None,
+                line_code=None,
+                data_source="AMTRAK",
+                train_count=5,
+                on_time_count=4,
+                cancellation_count=0,
+                total_delay_minutes=7.0,
+                arrival_data_count=5,
+            ),
+        ]
+        execute_result = Mock()
+        execute_result.all.return_value = rows
+        mock_db.execute.return_value = execute_result
+
+        line_stats = await summary_service._query_line_stats_sql(
+            mock_db,
+            datetime.now(UTC) - timedelta(minutes=SUMMARY_TIME_WINDOW_MINUTES),
+            data_source=None,
+        )
+
+        assert set(line_stats) == {"NJT:Unknown", "AMTRAK:Unknown"}
+        assert sum(stats.train_count for stats in line_stats.values()) == 8
+        assert line_stats["NJT:Unknown"].data_source == "NJT"
+        assert line_stats["AMTRAK:Unknown"].data_source == "AMTRAK"
+
+    async def test_line_stats_keep_display_key_for_source_filtered_queries(
+        self, summary_service, mock_db
+    ):
+        """Existing per-source callers keep the historical display-key shape."""
+        rows = [
+            SimpleNamespace(
+                line_key="Unknown",
+                line_name=None,
+                line_code=None,
+                data_source="NJT",
+                train_count=3,
+                on_time_count=2,
+                cancellation_count=1,
+                total_delay_minutes=4.0,
+                arrival_data_count=2,
+            )
+        ]
+        execute_result = Mock()
+        execute_result.all.return_value = rows
+        mock_db.execute.return_value = execute_result
+
+        line_stats = await summary_service._query_line_stats_sql(
+            mock_db,
+            datetime.now(UTC) - timedelta(minutes=SUMMARY_TIME_WINDOW_MINUTES),
+            data_source="NJT",
+        )
+
+        assert set(line_stats) == {"Unknown"}
 
     @pytest.fixture
     def sample_journeys(self):

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -40,6 +40,7 @@ from trackrat.services.trip_search import (
     _filter_unreasonable_durations,
     _find_relevant_transfer_points,
     _get_best_time,
+    _get_direct_service_systems,
     _get_station_lines_expanded,
     _make_direct_trip,
     _orient_transfer,
@@ -1303,6 +1304,34 @@ class TestFilterCrossSystemDirectTrips:
             f"remaining: {[t.legs[0].data_source for t in result]}"
         )
 
+    def test_direct_service_systems_prefer_exact_station_over_transfer_complex(self):
+        """S128 belongs to the Penn complex, but is directly subway-only."""
+        subway_systems = _get_direct_service_systems("S128")
+        penn_systems = _get_direct_service_systems("NY")
+
+        assert subway_systems == {"SUBWAY"}
+        assert {"NJT", "AMTRAK"}.isdisjoint(subway_systems)
+        assert {"NJT", "AMTRAK"}.issubset(penn_systems)
+
+    def test_direct_service_systems_keep_true_shared_station_aliases(self):
+        """Same-platform aliases still resolve all direct systems."""
+        systems = _get_direct_service_systems("NRO")
+
+        assert {"AMTRAK", "MNR"}.issubset(systems)
+
+    def test_real_direct_lookup_filters_transfer_complex_matches(self):
+        """Regression: expanded station equivalence must not make S128→TR direct."""
+        from_sys = _get_direct_service_systems("S128")
+        to_sys = _get_direct_service_systems("TR")
+
+        trips = [
+            self._make_trip_with_source("NJT"),
+            self._make_trip_with_source("AMTRAK"),
+        ]
+        result = _filter_cross_system_direct_trips(trips, from_sys, to_sys)
+
+        assert result == []
+
     def test_alias_code_resolves_via_equivalence_expansion(self):
         """Alias-only codes (TS, SC) should resolve systems via expansion.
 
@@ -1312,16 +1341,12 @@ class TestFilterCrossSystemDirectTrips:
         Without expansion, from_systems would be empty and all direct trips
         from TS would be incorrectly filtered.
         """
-        from trackrat.config.stations import expand_station_codes
-
         # Direct lookup returns empty for alias codes
         assert get_systems_serving_station("TS") == set()
         assert get_systems_serving_station("SC") == set()
 
-        # But expansion resolves via SE
-        expanded_systems: set[str] = set()
-        for code in expand_station_codes("TS"):
-            expanded_systems |= get_systems_serving_station(code)
+        # But the direct-service helper falls back to expansion for alias-only codes.
+        expanded_systems = _get_direct_service_systems("TS")
         assert (
             "NJT" in expanded_systems
         ), f"TS should resolve to NJT via SE expansion, got {expanded_systems}"

--- a/ios/TrackRat/App/TrackRatApp.swift
+++ b/ios/TrackRat/App/TrackRatApp.swift
@@ -331,17 +331,24 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             print("❌ Invalid Live Activity push notification data")
             return
         }
-        
+        let dataSource = trainData["data_source"] as? String
+            ?? trainData["dataSource"] as? String
+
         // Update Live Activity if it matches current activity
         if let currentActivity = LiveActivityService.shared.currentActivity,
-           currentActivity.attributes.trainId == trainId || currentActivity.attributes.trainNumber == trainId {
+           currentActivity.attributes.matchesTrain(
+               trainId: trainId,
+               dataSource: dataSource
+           ) {
             await LiveActivityService.shared.fetchAndUpdateTrain()
             print("✅ Live Activity updated from push notification")
         } else {
             print("ℹ️ Push notification for different train, ignoring")
             print("ℹ️ Expected trainId: \(LiveActivityService.shared.currentActivity?.attributes.trainId ?? "none")")
             print("ℹ️ Expected trainNumber: \(LiveActivityService.shared.currentActivity?.attributes.trainNumber ?? "none")")
+            print("ℹ️ Expected dataSource: \(LiveActivityService.shared.currentActivity?.attributes.dataSource ?? "none")")
             print("ℹ️ Received trainId: \(trainId)")
+            print("ℹ️ Received dataSource: \(dataSource ?? "none")")
         }
     }
     
@@ -996,4 +1003,3 @@ final class AppState: ObservableObject {
     }
 
 }
-

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -259,7 +259,12 @@ class LiveActivityService: ObservableObject {
             // Cache the fresh train data for instant loading in TrainDetailsView
             // Use trainId (which is actually the train number) with today's date
             await MainActor.run {
-                cacheService.cacheTrain(train, trainNumber: activity.attributes.trainId, date: Date())
+                cacheService.cacheTrain(
+                    train,
+                    trainNumber: activity.attributes.trainId,
+                    date: Date(),
+                    dataSource: activity.attributes.dataSource
+                )
             }
 
             // Check for departure event (fires exactly once when train departs origin)

--- a/ios/TrackRat/Services/Prefetcher.swift
+++ b/ios/TrackRat/Services/Prefetcher.swift
@@ -136,11 +136,15 @@ final class Prefetcher {
         dataSource: String?
     ) {
         guard !trainNumber.isEmpty else { return }
-        if let age = TrainCacheService.shared.getCacheAge(trainNumber: trainNumber, date: date),
+        if let age = TrainCacheService.shared.getCacheAge(
+            trainNumber: trainNumber,
+            date: date,
+            dataSource: dataSource
+        ),
            age < detailsSkipIfFresherThan {
             return
         }
-        let key = trainDetailsKey(trainNumber: trainNumber, date: date)
+        let key = trainDetailsKey(trainNumber: trainNumber, date: date, dataSource: dataSource)
         guard !inFlightDetails.contains(key) else { return }
         inFlightDetails.insert(key)
         Task {
@@ -152,7 +156,12 @@ final class Prefetcher {
                     date: date,
                     dataSource: dataSource
                 )
-                TrainCacheService.shared.cacheTrain(train, trainNumber: trainNumber, date: date)
+                TrainCacheService.shared.cacheTrain(
+                    train,
+                    trainNumber: trainNumber,
+                    date: date,
+                    dataSource: dataSource
+                )
                 Log.debug("Prefetcher: train details warmed for \(trainNumber)")
             } catch {
                 Log.warning("Prefetcher: prefetchTrainDetails failed for \(trainNumber): \(error.localizedDescription)")
@@ -184,10 +193,11 @@ final class Prefetcher {
         return "\(from)|\(to)|\(dateString)|\(systemsCsv)"
     }
 
-    private func trainDetailsKey(trainNumber: String, date: Date) -> String {
+    private func trainDetailsKey(trainNumber: String, date: Date, dataSource: String?) -> String {
         let dateString = Calendar.current.startOfDay(for: date)
             .formatted(.iso8601.year().month().day())
-        return "\(trainNumber)|\(dateString)"
+        let source = dataSource?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return "\(source)|\(trainNumber)|\(dateString)"
     }
 
     // MARK: - Test support

--- a/ios/TrackRat/Services/TrainCacheService.swift
+++ b/ios/TrackRat/Services/TrainCacheService.swift
@@ -100,6 +100,26 @@ class TrainCacheService {
         return primaryKey == legacyKey ? [primaryKey] : [primaryKey, legacyKey]
     }
 
+    /// Source-qualified keys (`dataSource|trainNumber|date`) that match the
+    /// requested trainNumber and date. Used as a fallback when a caller looks
+    /// up without a dataSource so we still surface entries cached by newer
+    /// source-aware paths. The leading `|` in the suffix ensures the legacy
+    /// `trainNumber|date` form never matches.
+    private func sourceQualifiedKeysMatching(
+        trainNumber: String,
+        date: Date
+    ) -> [String] {
+        let suffix = "|\(trainNumber)|\(dateCacheKey(for: date))"
+        var keys: Set<String> = []
+        for key in memoryCache.keys where key.hasSuffix(suffix) {
+            keys.insert(key)
+        }
+        for key in getCacheMetadata().keys.keys where key.hasSuffix(suffix) {
+            keys.insert(key)
+        }
+        return Array(keys)
+    }
+
     // MARK: - Retrieval
 
     /// Retrieves cached train details. Returns nil for miss or expired entry.
@@ -121,6 +141,22 @@ class TrainCacheService {
                     continue
                 }
                 return cached
+            }
+        }
+
+        // When the caller doesn't know the data source, also check entries
+        // cached under newer `dataSource|trainNumber|date` keys. Without this,
+        // legacy/source-less navigation paths would deterministically miss
+        // entries written by source-aware paths (Live Activities, Train List,
+        // Prefetcher) for the same train.
+        if requestedSource == nil {
+            for cacheKey in sourceQualifiedKeysMatching(
+                trainNumber: trainNumber,
+                date: date
+            ) {
+                if let cached = getCachedTrainByKey(cacheKey) {
+                    return cached
+                }
             }
         }
         return nil

--- a/ios/TrackRat/Services/TrainCacheService.swift
+++ b/ios/TrackRat/Services/TrainCacheService.swift
@@ -55,20 +55,75 @@ class TrainCacheService {
 
     // MARK: - Cache Key Generation
 
-    /// Cache key is `trainNumber|YYYY-MM-DD` — trainNumber uniquely identifies a
-    /// train for a given day across all transit systems we support.
-    private func generateSimpleCacheKey(trainNumber: String, date: Date) -> String {
-        let dateString = Calendar.current.startOfDay(for: date)
+    private func dateCacheKey(for date: Date) -> String {
+        Calendar.current.startOfDay(for: date)
             .formatted(.iso8601.year().month().day())
+    }
+
+    private func normalizedDataSource(_ dataSource: String?) -> String? {
+        guard let source = dataSource?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !source.isEmpty else {
+            return nil
+        }
+        return source
+    }
+
+    /// Legacy key used before dataSource became part of train identity.
+    private func generateLegacyCacheKey(trainNumber: String, date: Date) -> String {
+        "\(trainNumber)|\(dateCacheKey(for: date))"
+    }
+
+    /// Cache key is `dataSource|trainNumber|YYYY-MM-DD` when the source is known.
+    private func generateCacheKey(
+        trainNumber: String,
+        date: Date,
+        dataSource: String?
+    ) -> String {
+        let dateString = dateCacheKey(for: date)
+        if let source = normalizedDataSource(dataSource) {
+            return "\(source)|\(trainNumber)|\(dateString)"
+        }
         return "\(trainNumber)|\(dateString)"
+    }
+
+    private func lookupKeys(
+        trainNumber: String,
+        date: Date,
+        dataSource: String?
+    ) -> [String] {
+        let primaryKey = generateCacheKey(
+            trainNumber: trainNumber,
+            date: date,
+            dataSource: dataSource
+        )
+        let legacyKey = generateLegacyCacheKey(trainNumber: trainNumber, date: date)
+        return primaryKey == legacyKey ? [primaryKey] : [primaryKey, legacyKey]
     }
 
     // MARK: - Retrieval
 
     /// Retrieves cached train details. Returns nil for miss or expired entry.
-    func getCachedTrain(trainNumber: String, date: Date = Date()) -> CachedTrain? {
-        let cacheKey = generateSimpleCacheKey(trainNumber: trainNumber, date: date)
-        return getCachedTrainByKey(cacheKey)
+    func getCachedTrain(
+        trainNumber: String,
+        date: Date = Date(),
+        dataSource: String? = nil
+    ) -> CachedTrain? {
+        let requestedSource = normalizedDataSource(dataSource)
+
+        for cacheKey in lookupKeys(
+            trainNumber: trainNumber,
+            date: date,
+            dataSource: dataSource
+        ) {
+            if let cached = getCachedTrainByKey(cacheKey) {
+                if let requestedSource,
+                   normalizedDataSource(cached.train.dataSource) != requestedSource {
+                    continue
+                }
+                return cached
+            }
+        }
+        return nil
     }
 
     /// Internal helper to get cached train by key
@@ -108,8 +163,16 @@ class TrainCacheService {
 
     /// Returns the age of the cache in seconds, or nil if not cached. Used to gate
     /// background refresh and prefetch when the existing entry is already fresh.
-    func getCacheAge(trainNumber: String, date: Date = Date()) -> TimeInterval? {
-        if let cached = getCachedTrain(trainNumber: trainNumber, date: date) {
+    func getCacheAge(
+        trainNumber: String,
+        date: Date = Date(),
+        dataSource: String? = nil
+    ) -> TimeInterval? {
+        if let cached = getCachedTrain(
+            trainNumber: trainNumber,
+            date: date,
+            dataSource: dataSource
+        ) {
             return TimeInterval(cached.ageSeconds)
         }
         return nil
@@ -117,9 +180,19 @@ class TrainCacheService {
 
     // MARK: - Storage
 
-    /// Stores train details using the canonical trainNumber+date key.
-    func cacheTrain(_ train: TrainV2, trainNumber: String, date: Date = Date()) {
-        let cacheKey = generateSimpleCacheKey(trainNumber: trainNumber, date: date)
+    /// Stores train details using the canonical dataSource+trainNumber+date key when
+    /// the caller has a source, otherwise the legacy trainNumber+date key.
+    func cacheTrain(
+        _ train: TrainV2,
+        trainNumber: String,
+        date: Date = Date(),
+        dataSource: String? = nil
+    ) {
+        let cacheKey = generateCacheKey(
+            trainNumber: trainNumber,
+            date: date,
+            dataSource: normalizedDataSource(dataSource)
+        )
 
         let cached = CachedTrain(
             train: train,
@@ -213,6 +286,37 @@ class TrainCacheService {
     private func saveCacheMetadata(_ metadata: CacheMetadata) {
         if let encoded = try? JSONEncoder().encode(metadata) {
             userDefaults.set(encoded, forKey: cacheMetadataKey)
+        }
+    }
+
+    // MARK: - Test support
+
+    /// Test-only: clear cached state from memory and UserDefaults.
+    func resetForTesting() {
+        let metadata = getCacheMetadata()
+        for cacheKey in metadata.keys.keys {
+            userDefaults.removeObject(forKey: cacheKeyPrefix + cacheKey)
+        }
+        userDefaults.removeObject(forKey: cacheMetadataKey)
+        memoryCache.removeAll()
+        memoryCacheAccessOrder.removeAll()
+    }
+
+    /// Test-only: seed the old trainNumber+date cache shape.
+    func injectLegacyTrainForTesting(
+        _ train: TrainV2,
+        trainNumber: String,
+        date: Date = Date()
+    ) {
+        let cacheKey = generateLegacyCacheKey(trainNumber: trainNumber, date: date)
+        let cached = CachedTrain(train: train, cachedAt: Date(), cacheKey: cacheKey)
+
+        addToMemoryCache(key: cacheKey, value: cached)
+        if let encoded = try? JSONEncoder().encode(cached) {
+            userDefaults.set(encoded, forKey: cacheKeyPrefix + cacheKey)
+            var metadata = getCacheMetadata()
+            metadata.keys[cacheKey] = cached.cachedAt
+            saveCacheMetadata(metadata)
         }
     }
 }

--- a/ios/TrackRat/Shared/LiveActivityModels.swift
+++ b/ios/TrackRat/Shared/LiveActivityModels.swift
@@ -184,6 +184,30 @@ struct TrainActivityAttributes: ActivityAttributes {
     let theme: String // Theme name as string (blue, black, white)
     // Optional so Activities started before this field was added can still decode
     let dataSource: String?
+
+    func matchesTrain(trainId: String, dataSource: String?) -> Bool {
+        guard trainNumber == trainId || self.trainId == trainId else {
+            return false
+        }
+
+        // Activities created before dataSource was added can only be matched by
+        // train number. Newer activities must match the full train identity.
+        guard let activitySource = normalizedDataSource(self.dataSource) else {
+            return true
+        }
+        guard let trainSource = normalizedDataSource(dataSource) else {
+            return false
+        }
+        return activitySource == trainSource
+    }
+
+    private func normalizedDataSource(_ dataSource: String?) -> String? {
+        guard let source = dataSource?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !source.isEmpty else {
+            return nil
+        }
+        return source
+    }
 }
 
 // MARK: - Supporting Data Models

--- a/ios/TrackRat/Views/Components/TrackTrainInlineButton.swift
+++ b/ios/TrackRat/Views/Components/TrackTrainInlineButton.swift
@@ -15,7 +15,10 @@ struct TrackTrainInlineButton: View {
     @State private var isStarting = false
 
     private var isTrackingThisTrain: Bool {
-        liveActivityService.currentActivity?.attributes.trainNumber == train.trainId
+        liveActivityService.currentActivity?.attributes.matchesTrain(
+            trainId: train.trainId,
+            dataSource: train.dataSource
+        ) ?? false
     }
 
     var body: some View {

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -148,7 +148,10 @@ struct TrainDetailsView: View {
                     // Get Updates button (Live Activity)
                     if let originCode = appState.departureStationCode,
                        !originCode.isEmpty {
-                        let isTracking = liveActivityService.currentActivity?.attributes.trainNumber == train.trainId
+                        let isTracking = liveActivityService.currentActivity?.attributes.matchesTrain(
+                            trainId: train.trainId,
+                            dataSource: train.dataSource
+                        ) ?? false
                         TrackTrainInlineButton(
                             train: train,
                             originCode: originCode,
@@ -1197,7 +1200,11 @@ class TrainDetailsViewModel: ObservableObject {
         // (written by LiveActivityService.fetchAndUpdateTrain) is the only instant
         // source of departed-stops state.
         if !trainIdentifier.isEmpty,
-           let cached = cacheService.getCachedTrain(trainNumber: trainIdentifier, date: effectiveDate) {
+           let cached = cacheService.getCachedTrain(
+               trainNumber: trainIdentifier,
+               date: effectiveDate,
+               dataSource: dataSource
+           ) {
             print("📦 Loading from cache (\(cached.ageSeconds)s old) - instant display")
             train = cached.train
             updateComputedProperties()
@@ -1219,7 +1226,12 @@ class TrainDetailsViewModel: ObservableObject {
 
             // Only cache if train has stops data (don't overwrite good cache with partial data)
             if !trainIdentifier.isEmpty && hasStops {
-                cacheService.cacheTrain(existingTrain, trainNumber: trainIdentifier, date: effectiveDate)
+                cacheService.cacheTrain(
+                    existingTrain,
+                    trainNumber: trainIdentifier,
+                    date: effectiveDate,
+                    dataSource: dataSource ?? existingTrain.dataSource
+                )
             }
 
             // Background refresh to get full data (including stops if missing)
@@ -1245,7 +1257,12 @@ class TrainDetailsViewModel: ObservableObject {
 
             // Cache the newly fetched train
             if !trainIdentifier.isEmpty {
-                cacheService.cacheTrain(fetchedTrain, trainNumber: trainIdentifier, date: effectiveDate)
+                cacheService.cacheTrain(
+                    fetchedTrain,
+                    trainNumber: trainIdentifier,
+                    date: effectiveDate,
+                    dataSource: dataSource ?? fetchedTrain.dataSource
+                )
             }
 
             // Update all computed properties after setting train
@@ -1291,7 +1308,12 @@ class TrainDetailsViewModel: ObservableObject {
 
             // Cache the fresh data
             if trainIdentifier != "unknown" {
-                cacheService.cacheTrain(newTrain, trainNumber: trainIdentifier, date: effectiveDate)
+                cacheService.cacheTrain(
+                    newTrain,
+                    trainNumber: trainIdentifier,
+                    date: effectiveDate,
+                    dataSource: dataSource ?? newTrain.dataSource
+                )
             }
 
             print("✅ Background refresh successful - updating UI")
@@ -1337,14 +1359,22 @@ class TrainDetailsViewModel: ObservableObject {
 
             // Cache the fresh data
             if trainIdentifier != "unknown" {
-                cacheService.cacheTrain(newTrain, trainNumber: trainIdentifier, date: effectiveDate)
+                cacheService.cacheTrain(
+                    newTrain,
+                    trainNumber: trainIdentifier,
+                    date: effectiveDate,
+                    dataSource: dataSource ?? newTrain.dataSource
+                )
             }
 
             // Check if Live Activity should auto-end (Primary Fix)
             let liveService = LiveActivityService.shared
             if liveService.isActivityActive,
                let currentActivity = liveService.currentActivity,
-               currentActivity.attributes.trainNumber == newTrain.trainId {
+               currentActivity.attributes.matchesTrain(
+                   trainId: newTrain.trainId,
+                   dataSource: newTrain.dataSource
+               ) {
 
                 print("🔍 Checking Live Activity auto-end for train \(newTrain.trainId)")
 

--- a/ios/TrackRatTests/Services/LiveActivityServiceTests.swift
+++ b/ios/TrackRatTests/Services/LiveActivityServiceTests.swift
@@ -153,4 +153,33 @@ class LiveActivityServiceTests: XCTestCase {
         XCTAssertNotNil(contentState.status)
         XCTAssertEqual(contentState.journeyProgress, 0.0, accuracy: 0.01)
     }
+
+    func testActivityAttributesMatchTrainRequiresDataSourceWhenPresent() {
+        let attributes = makeActivityAttributes(trainId: "3254", dataSource: "NJT")
+
+        XCTAssertTrue(attributes.matchesTrain(trainId: "3254", dataSource: "NJT"))
+        XCTAssertFalse(attributes.matchesTrain(trainId: "3254", dataSource: "AMTRAK"))
+    }
+
+    func testActivityAttributesMatchTrainFallsBackForLegacyActivities() {
+        let attributes = makeActivityAttributes(trainId: "3254", dataSource: nil)
+
+        XCTAssertTrue(attributes.matchesTrain(trainId: "3254", dataSource: "AMTRAK"))
+    }
+
+    private func makeActivityAttributes(trainId: String, dataSource: String?) -> TrainActivityAttributes {
+        TrainActivityAttributes(
+            trainNumber: trainId,
+            trainId: trainId,
+            routeDescription: "New York -> Philadelphia",
+            origin: "New York",
+            destination: "Philadelphia",
+            originStationCode: "NY",
+            destinationStationCode: "PH",
+            departureTime: Date(),
+            scheduledArrivalTime: Date().addingTimeInterval(3600),
+            theme: "black",
+            dataSource: dataSource
+        )
+    }
 }

--- a/ios/TrackRatTests/Services/PrefetcherTests.swift
+++ b/ios/TrackRatTests/Services/PrefetcherTests.swift
@@ -276,4 +276,30 @@ final class TrainCacheServiceTests: XCTestCase {
 
         XCTAssertNil(cached)
     }
+
+    func testSourcelessLookupFindsSourceQualifiedCacheEntry() {
+        // Source-aware paths cache under `dataSource|trainNumber|date`. Legacy
+        // call sites that don't pass a dataSource must still surface those
+        // entries; otherwise they'd hit deterministic cache misses and refetch
+        // the same train. Codex review on PR #1136.
+        let date = Date()
+        let train = makeTrain(trainId: "400", dataSource: "NJT")
+
+        cacheService.cacheTrain(
+            train,
+            trainNumber: "400",
+            date: date,
+            dataSource: "NJT"
+        )
+
+        let cached = cacheService.getCachedTrain(
+            trainNumber: "400",
+            date: date,
+            dataSource: nil
+        )
+
+        XCTAssertNotNil(cached, "Source-less lookup should find source-qualified entry")
+        XCTAssertEqual(cached?.train.trainId, "400")
+        XCTAssertEqual(cached?.train.dataSource, "NJT")
+    }
 }

--- a/ios/TrackRatTests/Services/PrefetcherTests.swift
+++ b/ios/TrackRatTests/Services/PrefetcherTests.swift
@@ -161,3 +161,119 @@ final class PrefetcherTests: XCTestCase {
     // larger refactor. Coalescing is enforced by the type system (single Task<_,_> per key)
     // and by code review.
 }
+
+@MainActor
+final class TrainCacheServiceTests: XCTestCase {
+
+    private let cacheService = TrainCacheService.shared
+
+    override func setUp() {
+        super.setUp()
+        cacheService.resetForTesting()
+    }
+
+    override func tearDown() {
+        cacheService.resetForTesting()
+        super.tearDown()
+    }
+
+    private func makeTrain(trainId: String, dataSource: String) -> TrainV2 {
+        let now = Date()
+        let departure = StationTiming(
+            code: "NY",
+            name: "New York Penn Station",
+            scheduledTime: now,
+            updatedTime: nil,
+            actualTime: nil,
+            track: "11"
+        )
+        let arrival = StationTiming(
+            code: "PH",
+            name: "Philadelphia",
+            scheduledTime: now.addingTimeInterval(3600),
+            updatedTime: nil,
+            actualTime: nil,
+            track: nil
+        )
+
+        return TrainV2(
+            trainId: trainId,
+            journeyDate: now,
+            line: LineInfo(code: "NEC", name: "Northeast Corridor", color: "#FF6B00"),
+            destination: "Philadelphia",
+            departure: departure,
+            arrival: arrival,
+            trainPosition: nil,
+            dataFreshness: nil,
+            observationType: nil,
+            isCancelled: false,
+            isCompleted: false,
+            dataSource: dataSource,
+            stops: nil
+        )
+    }
+
+    func testCacheSeparatesCollidingTrainNumbersByDataSource() {
+        let date = Date()
+        let njtTrain = makeTrain(trainId: "100", dataSource: "NJT")
+        let amtrakTrain = makeTrain(trainId: "100", dataSource: "AMTRAK")
+
+        cacheService.cacheTrain(
+            njtTrain,
+            trainNumber: "100",
+            date: date,
+            dataSource: "NJT"
+        )
+        cacheService.cacheTrain(
+            amtrakTrain,
+            trainNumber: "100",
+            date: date,
+            dataSource: "AMTRAK"
+        )
+
+        let cachedNJT = cacheService.getCachedTrain(
+            trainNumber: "100",
+            date: date,
+            dataSource: "NJT"
+        )
+        let cachedAmtrak = cacheService.getCachedTrain(
+            trainNumber: "100",
+            date: date,
+            dataSource: "AMTRAK"
+        )
+
+        XCTAssertEqual(cachedNJT?.train.dataSource, "NJT")
+        XCTAssertEqual(cachedAmtrak?.train.dataSource, "AMTRAK")
+    }
+
+    func testDataSourceLookupFallsBackToLegacyCacheEntry() {
+        let date = Date()
+        let train = makeTrain(trainId: "200", dataSource: "NJT")
+
+        cacheService.injectLegacyTrainForTesting(train, trainNumber: "200", date: date)
+
+        let cached = cacheService.getCachedTrain(
+            trainNumber: "200",
+            date: date,
+            dataSource: "NJT"
+        )
+
+        XCTAssertEqual(cached?.train.trainId, "200")
+        XCTAssertEqual(cached?.train.dataSource, "NJT")
+    }
+
+    func testDataSourceLookupRejectsMismatchedLegacyCacheEntry() {
+        let date = Date()
+        let train = makeTrain(trainId: "300", dataSource: "NJT")
+
+        cacheService.injectLegacyTrainForTesting(train, trainNumber: "300", date: date)
+
+        let cached = cacheService.getCachedTrain(
+            trainNumber: "300",
+            date: date,
+            dataSource: "AMTRAK"
+        )
+
+        XCTAssertNil(cached)
+    }
+}


### PR DESCRIPTION
## Summary

This PR resolves the four review findings from the `main` vs `production` change review:

- Tightens trip-search direct-trip filtering so station equivalence expansion no longer makes walking-transfer complexes look like direct service.
- Preserves network summary rows when different data sources share the same display line key.
- Makes iOS train detail caching source-aware for the `(train_id, data_source, journey_date)` identity model, with guarded legacy fallback.
- Updates Live Activity active-state and update matching to include `dataSource`, while retaining train-number fallback only for legacy Activities whose attributes do not have a source.

## Backend changes

### Trip search direct service

Root cause: `search_trips` used systems from the full expanded station equivalence group for direct-trip filtering. That was appropriate for transfer discovery, but it also allowed adjacent transfer complexes such as Penn Station / 34 St-Penn Station, Grand Central / subway, and WTC / Oculus to share systems for the purpose of direct service.

Changes:

- Added `_get_direct_service_systems` to separate direct-service system lookup from transfer-search system lookup.
- Kept true shared-station aliases and alias-only station codes working through equivalence expansion.
- Marked the known adjacent transfer complexes as exact-only for direct-service filtering.
- Continued using fully expanded systems for transfer search so valid walking-transfer itineraries are still discoverable.

### Network summary aggregation

Root cause: `_query_line_stats_sql` grouped by `data_source` but returned a dictionary keyed only by `line_key`, so rows from different sources could overwrite each other when they shared a display key such as `Unknown`.

Changes:

- Network-wide queries now key rows by `data_source:line_key` internally.
- Source-filtered queries keep the previous display-key shape to avoid changing per-source behavior.
- Aggregated totals now include all rows instead of whichever row was inserted last for a shared key.

## iOS changes

### Train detail cache identity

Root cause: `TrainCacheService` keyed detail responses by `trainNumber|date`, while newer backend and Live Activity flows identify trains by `(train_id, data_source, journey_date)`.

Changes:

- Added source-qualified cache keys: `dataSource|trainNumber|YYYY-MM-DD`.
- Updated cache reads, cache age checks, cache writes, and prefetch in-flight coalescing to include `dataSource` when available.
- Kept a legacy `trainNumber|YYYY-MM-DD` fallback for older cached entries and legacy Live Activities.
- Guarded the legacy fallback so a source-specific lookup will not accept a legacy cached train whose stored `train.dataSource` conflicts with the requested source.
- Updated Train Details, Prefetcher, and Live Activity refresh paths to pass source identity through cache operations.

### Live Activity active-state matching

Root cause: UI state and some update matching paths compared only train number, which could show or stop tracking for the wrong system when train numbers collide.

Changes:

- Added `TrainActivityAttributes.matchesTrain(trainId:dataSource:)` as the single matching helper.
- Requires `dataSource` to match when the existing Activity has a source.
- Falls back to train-number-only matching only for legacy Activities where `attributes.dataSource` is nil.
- Updated the inline tracking button, Train Details active highlight, Train Details auto-end guard, and push-triggered Live Activity update matching to use the helper.

## Regression coverage added

- Backend trip-search tests cover:
  - exact-only transfer-complex behavior for Penn/subway station codes
  - true shared-station alias behavior for same-platform aliases
  - filtering of real direct lookup results for `S128 -> TR`
  - alias-only expansion for station codes like `TS`

- Backend summary tests cover:
  - preserving colliding network rows from different data sources
  - retaining historical display keys for source-filtered line stats

- iOS tests cover:
  - cache separation for colliding train numbers across sources
  - legacy cache fallback for matching sources
  - rejection of mismatched legacy cache fallback
  - Live Activity matching requiring source equality when source is present
  - Live Activity matching fallback for legacy nil-source activities

## Validation

- Final code review pass completed over the staged diff.
- `git diff --check` passed.
- Local tests were not run per request.