### PR TITLE
fix(trip-search): only fall back to equivalence expansion for alias-only codes

### DIFF
--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -128,6 +128,25 @@ def _filter_cross_system_direct_trips(
     return [t for t in trips if t.legs[0].data_source in valid_systems]
 
 
+def _systems_for_station(code: str) -> set[str]:
+    """Return the transit systems natively serving a station code.
+
+    Falls back to equivalence-group expansion only for alias-only codes (codes
+    that aren't in any route topology, e.g. TS for Secaucus Lower Level).  For
+    codes that are in a route topology, returns just the native systems —
+    expanding cross-modal equivalence groups (e.g. {NY, S128, SA28}) would
+    defeat the cross-system direct-trip filter by adding commuter-rail systems
+    to a subway code's system set.
+    """
+    direct = get_systems_serving_station(code)
+    if direct:
+        return direct
+    expanded: set[str] = set()
+    for equivalent in expand_station_codes(code):
+        expanded |= get_systems_serving_station(equivalent)
+    return expanded
+
+
 def _get_station_lines_expanded(station_code: str, system: str) -> frozenset[str]:
     """Get line codes for a station and its physical-equivalent codes."""
     lines: set[str] = set()
@@ -289,14 +308,10 @@ async def search_trips(
     )
 
     # Systems natively serving each endpoint (used for direct-trip filtering
-    # and transfer search below).  Expand equivalence aliases first so that
-    # alias-only codes (e.g. TS → SE) resolve to the canonical station's systems.
-    from_systems: set[str] = set()
-    for code in expand_station_codes(from_station):
-        from_systems |= get_systems_serving_station(code)
-    to_systems: set[str] = set()
-    for code in expand_station_codes(to_station):
-        to_systems |= get_systems_serving_station(code)
+    # and transfer search below).  Equivalence-group expansion is applied only
+    # for alias-only codes; see _systems_for_station.
+    from_systems = _systems_for_station(from_station)
+    to_systems = _systems_for_station(to_station)
 
     # --- Step 1: Try direct service ---
     direct_response = await departure_service.get_departures(

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -44,6 +44,7 @@ from trackrat.services.trip_search import (
     _make_direct_trip,
     _orient_transfer,
     _rank_transfer_points,
+    _systems_for_station,
 )
 
 ET = ZoneInfo("America/New_York")
@@ -1141,6 +1142,52 @@ class TestTransferPointSymmetryIntegration:
             f"Forward:  {[(tp.station_a, tp.system_a, tp.station_b, tp.system_b) for tp in fwd_ranked]}\n"
             f"Reverse:  {[(tp.station_a, tp.system_a, tp.station_b, tp.system_b) for tp in rev_ranked]}"
         )
+
+
+class TestSystemsForStation:
+    """Verify _systems_for_station's hybrid lookup behavior.
+
+    Native codes (codes that appear in a route topology) must return only
+    their native systems — expanding cross-modal equivalence groups would
+    defeat the cross-system direct-trip filter (#1121).  Alias-only codes
+    (codes that are not in any route topology) fall back to expansion so
+    they still resolve to the canonical station's systems.
+    """
+
+    def test_native_code_returns_native_systems_only(self):
+        """S128 (subway) is in subway routes, so expansion must NOT add NJT/AMTRAK/LIRR.
+
+        S128 is in equivalence group {NY, S128, SA28}. Without the alias-only
+        guard, expansion would union systems from NY, polluting the subway
+        code's set with commuter-rail systems and breaking the
+        cross-system direct filter for TR↔S128 etc.
+        """
+        assert _systems_for_station("S128") == {"SUBWAY"}
+
+    def test_native_code_with_cross_modal_equivalence_unaffected(self):
+        """NY (Penn) is shared by NJT/AMTRAK/LIRR; expansion would add SUBWAY.
+
+        We want exactly the systems whose routes call at NY, not the systems
+        of the equivalent subway codes (S128, SA28).
+        """
+        assert _systems_for_station("NY") == {"NJT", "AMTRAK", "LIRR"}
+
+    def test_native_path_code_unaffected_by_njt_amtrak_equivalence(self):
+        """PNK is in {NP, PNK} with NP served by NJT/AMTRAK; expansion would
+        add those to PNK's set and break the PATH↔commuter-rail direct filter.
+        """
+        assert _systems_for_station("PNK") == {"PATH"}
+
+    def test_alias_only_code_falls_back_to_expansion(self):
+        """TS (Secaucus Lower Level) is alias-only and must resolve to NJT via SE."""
+        # Precondition: TS is genuinely alias-only.
+        assert get_systems_serving_station("TS") == set()
+        # Fallback expansion picks up SE → NJT.
+        assert "NJT" in _systems_for_station("TS")
+
+    def test_unknown_code_returns_empty(self):
+        """A completely unknown code returns empty (no native, no expansion)."""
+        assert _systems_for_station("ZZZZ_NOT_A_STATION") == set()
 
 
 class TestFilterCrossSystemDirectTrips:


### PR DESCRIPTION
## Summary

Fixes a regression introduced by 99e6956 ("Fix alias-only station codes producing empty system sets in trip search") that broke the cross-system direct-trip filter from #1121.

The previous fix expanded both endpoints via `STATION_EQUIVALENCE_GROUPS` before unioning systems, so alias-only codes like `TS` (Secaucus Lower Level) would resolve to `NJT` via `SE`. The unintended consequence: any equivalence group that mixes systems started polluting the to-side or from-side with foreign systems, defeating the cross-system filter.

Concretely, expanding `S128` → `{S128, NY, SA28}` added NJT/AMTRAK/LIRR to `to_systems`, so for `TR → S128`:

| Logic | from_systems (TR) | to_systems (S128) | intersection | result |
|---|---|---|---|---|
| Pre-99e6956 (post-#1121) | `{NJT, AMTRAK}` | `{SUBWAY}` | `∅` | direct trips dropped → transfer search ✅ |
| Post-99e6956 (regression) | `{NJT, AMTRAK}` | `{SUBWAY, NJT, LIRR, AMTRAK}` | `{NJT, AMTRAK}` | Amtrak/NJT direct trips returned to subway station ❌ |

Same break for any cross-modal equivalence group:

- `{"NY", "S128", "SA28"}` — Penn / 34 St-Penn (commuter rail ↔ subway)
- `{"GCT", "S631", "S723", "S901"}` — Grand Central (MNR/LIRR ↔ subway)
- `{"PWC", "S138", "S228", "SA36", "SE01", "SR25"}` — WTC / Oculus (PATH ↔ subway)
- `{"NP", "PNK"}` — Newark Penn (NJT/Amtrak ↔ PATH)

Caught by staging E2E:
```
NJT→SUBWAY Trenton↔34StPenn
  FAIL TR → S128: expected transfer but got direct
  FAIL S128 → TR: expected transfer but got direct
```

## Fix

Replace the unconditional expand+union with a small `_systems_for_station` helper that returns native systems when the code is in a route topology and only falls back to equivalence-group expansion for alias-only codes (codes that don't appear in any route).

```python
def _systems_for_station(code: str) -> set[str]:
    direct = get_systems_serving_station(code)
    if direct:
        return direct
    expanded: set[str] = set()
    for equivalent in expand_station_codes(code):
        expanded |= get_systems_serving_station(equivalent)
    return expanded
```

This preserves the `TS → SE` fix while leaving cross-modal equivalence groups untouched.

## Verification

Direct simulation against the live config:

| Search | Pre-fix intersection | Post-fix intersection | Behavior |
|---|---|---|---|
| `TR → S128` | `{NJT, AMTRAK}` | `∅` | falls through to transfer ✅ |
| `S128 → TR` | `{NJT, AMTRAK}` | `∅` | falls through to transfer ✅ |
| `GCT → S631` | `{MNR, LIRR}` | `∅` | falls through to transfer ✅ |
| `PWC → S138` | `{PATH}` | `∅` | falls through to transfer ✅ |
| `PNK → P33` (PATH↔PATH) | `{PATH}` | `{PATH}` | direct kept ✅ |
| `TS → TR` (alias-only) | `{NJT}` | `{NJT}` | direct kept (TS→SE preserved) ✅ |
| `NY → TR` (real direct) | `{NJT, AMTRAK}` | `{NJT, AMTRAK}` | direct kept ✅ |

## Test plan

- [x] Add `TestSystemsForStation` unit tests covering native, cross-modal-equivalent, alias-only, and unknown codes
- [x] All 82 trip-search tests pass (`PYTHONPATH=src poetry run pytest tests/unit/services/test_trip_search.py`)
- [x] `black` and `ruff` clean
- [ ] After deploy: re-run `bash scripts/validate-staging.sh` and confirm `TR↔S128` resolves to `transfer` (and that the matching `S128→TR` test passes too)

https://claude.ai/code/session_0168tXhy6iLHzt7JNKt74feY

---
_Generated by [Claude Code](https://claude.ai/code/session_0168tXhy6iLHzt7JNKt74feY)_