### PR TITLE
Prevent false expiry of running trains with stale API departure times

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -943,6 +943,22 @@ class JourneyCollector(BaseJourneyCollector):
             journey.last_updated_at = now_et()
             journey.update_count = (journey.update_count or 0) + 1
 
+            # If any stop on this journey is already marked departed, the
+            # train physically ran — the mismatch is necessarily stale
+            # upstream data (NJT often holds a delayed DEP_TIME estimate
+            # for hours after a train left on time), not evidence the row
+            # is a phantom slot. Skip the strike so we don't false-expire
+            # real, running trains and remove them from /departures.
+            if await self._journey_has_departed_stop(session, journey):
+                logger.info(
+                    "skipping_mismatch_strike_for_departed_journey",
+                    train_id=journey.train_id,
+                    journey_id=journey.id,
+                    api_error_count=journey.api_error_count or 0,
+                )
+                await session.flush()
+                return
+
             # Increment api_error_count so a *sustained* mismatch eventually
             # expires the row. Without this, a stale slot that the API keeps
             # serving with wrong-time data would never trigger expiry — the
@@ -1904,6 +1920,31 @@ class JourneyCollector(BaseJourneyCollector):
                 journey_id=journey.id,
                 total_stops=len(sequences),
             )
+
+    async def _journey_has_departed_stop(
+        self,
+        session: AsyncSession,
+        journey: TrainJourney,
+    ) -> bool:
+        """Return True if any stop on this journey is marked departed.
+
+        Used by the DEPARTURE_TIME_MISMATCH path to distinguish a real
+        running train (whose journey row must not be expired) from a
+        phantom train_id slot. Once any stop has has_departed_station=True,
+        we have evidence the train physically ran, regardless of whether
+        the API's lingering DEP_TIME for the origin still matches.
+        """
+        result = await session.scalar(
+            select(JourneyStop.id)
+            .where(
+                and_(
+                    JourneyStop.journey_id == journey.id,
+                    JourneyStop.has_departed_station.is_(True),
+                )
+            )
+            .limit(1)
+        )
+        return result is not None
 
     async def _attempt_completion_on_expiry(
         self,

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -568,6 +568,99 @@ class TestStaleOriginDetection:
         )
 
     @pytest.mark.asyncio
+    async def test_sustained_mismatch_does_not_expire_running_train(
+        self, db_session: AsyncSession, journey_collector, mock_njt_client
+    ):
+        """Once any stop is marked departed, the train physically ran and the
+        mismatch is necessarily stale upstream data (NJT often serves a
+        delayed DEP_TIME estimate for hours after the train left on time).
+        Strikes must not accumulate against the journey or it would
+        false-expire real running trains and remove them from /departures.
+
+        Production observation (May 2026): trains like NJT 3855 (NY→Trenton,
+        scheduled 15:04, actual departure 15:04, NJT API persistently
+        reporting DEP_TIME=15:30) were getting expired ~30 minutes after
+        leaving on time, removing them from the iOS app's listing.
+        """
+        scheduled_departure = now_et().replace(
+            hour=15, minute=4, second=0, microsecond=0
+        )
+        api_actual_departure = scheduled_departure + timedelta(minutes=26)
+
+        journey = TrainJourney(
+            train_id="3855",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=scheduled_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            is_expired=False,
+            api_error_count=0,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # Origin is marked departed (NJT confirmed DEPARTED=YES at 15:04).
+        # This is the proof-of-life that the running-train guard relies on.
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=scheduled_departure,
+            actual_departure=scheduled_departure,
+            has_departed_station=True,
+            departure_source="api_explicit",
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="3855",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_actual_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        mock_njt_client.get_train_stop_list.return_value = api_response
+
+        # Run well past the 3-strike threshold — must never expire.
+        for _ in range(5):
+            await journey_collector.collect_journey_details(db_session, journey)
+            await db_session.refresh(journey)
+
+        assert journey.is_expired is False, (
+            "Sustained DEPARTURE_TIME_MISMATCH must not expire a journey "
+            "whose origin stop has has_departed_station=True — that's proof "
+            "the train physically ran, so the API's lingering wrong-time data "
+            "is stale upstream noise, not evidence of a phantom slot."
+        )
+        assert journey.api_error_count == 0, (
+            "Strike counter must not advance once the train has physically "
+            "departed (counter starts at 0 and stays at 0)"
+        )
+        assert journey.is_completed is False, (
+            "We must not falsely complete a still-running train via the "
+            "completion-on-expiry backstop"
+        )
+        assert journey.last_updated_at is not None, (
+            "Mismatch must still advance last_updated_at so the scheduler "
+            "does not busy-loop re-collecting this journey every cycle"
+        )
+
+    @pytest.mark.asyncio
     async def test_sustained_time_mismatch_expires_after_three_strikes(
         self, db_session: AsyncSession, journey_collector, mock_njt_client
     ):

--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -65,8 +65,12 @@ struct TrainV2: Identifiable, Codable {
     
     // MARK: - Computed Properties for UI Compatibility
     
+    // Best-known departure time at the origin: actual > updated > scheduled.
+    // Preferring actualTime once set keeps the displayed time honest after
+    // the train has physically departed, even when the upstream API
+    // continues to publish a stale delayed-departure estimate.
     var departureTime: Date {
-        departure.updatedTime ?? departure.scheduledTime ?? Date()
+        departure.actualTime ?? departure.updatedTime ?? departure.scheduledTime ?? Date()
     }
     
     var track: String? {
@@ -182,15 +186,17 @@ struct TrainV2: Identifiable, Codable {
         return false
     }
     
-    // Get departure time from a specific station (best available: updated > scheduled)
+    // Get departure time from a specific station (best available: actual > updated > scheduled).
+    // actualDeparture wins once set so departed trains stop showing their
+    // pre-departure delay estimate, which sometimes lingers in the upstream
+    // API for hours after the train left on time.
     func getDepartureTime(fromStationCode: String) -> Date? {
         if Stations.areEquivalentStations(fromStationCode, originStationCode) {
             return departureTime
         }
 
-        // Find departure from stops if available, prefer real-time updated time
         if let stop = stops?.first(where: { Stations.areEquivalentStations($0.stationCode, fromStationCode) }) {
-            return stop.updatedDeparture ?? stop.scheduledDeparture
+            return stop.actualDeparture ?? stop.updatedDeparture ?? stop.scheduledDeparture
         }
         return nil
     }


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where trains that have physically departed are being incorrectly expired and removed from the app when the upstream NJT API continues to publish stale delayed-departure estimates. The fix distinguishes between real running trains (which have proof-of-life via departed stops) and phantom train slots by skipping mismatch strikes once any stop is marked as departed.

## Key Changes

**Backend (journey.py)**
- Added `_journey_has_departed_stop()` helper method to check if any stop on a journey is marked as physically departed
- Modified the `DEPARTURE_TIME_MISMATCH` handling to skip incrementing the strike counter if the journey has any departed stops
- This prevents real, running trains from being expired due to lingering stale API data while still expiring phantom slots

**iOS (TrainV2.swift)**
- Updated `departureTime` computed property to prefer `actualTime` over `updatedTime`, ensuring the displayed departure time reflects the actual departure once the train has left
- Updated `getDepartureTime(fromStationCode:)` to also prefer `actualDeparture` in the same order
- This keeps the UI honest after departure, preventing the display of pre-departure delay estimates that may linger in the API for hours

**Tests**
- Added comprehensive test `test_sustained_mismatch_does_not_expire_running_train()` that validates:
  - A journey with a departed origin stop is never expired despite sustained time mismatches
  - Strike counter does not advance once the train has physically departed
  - The journey is not falsely completed via the expiry backstop
  - `last_updated_at` still advances to prevent busy-loop re-collection

## Implementation Details
The solution leverages the fact that once NJT confirms a stop has `DEPARTED=YES`, we have definitive proof the train physically ran. Any subsequent mismatch between the API's `DEP_TIME` and actual departure is necessarily stale upstream data, not evidence of a phantom slot. By checking for departed stops before applying strikes, we protect real running trains while still expiring genuinely phantom entries that never depart.

https://claude.ai/code/session_013Yw8DA4m2mSmr2cVbsvYf3