### PR TITLE
Issue #1140: pass time_from to GTFS merge in DepartureService

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -539,6 +539,14 @@ class DepartureService:
 
                 gtfs_service = GTFSService()
 
+                # Pass time_from so the GTFS SQL pre-filter prunes trips
+                # before the connection window. Without this, the underlying
+                # SQL query (limit=250 inside get_scheduled_departures) returns
+                # the earliest trips of the day at high-volume station
+                # complexes — e.g. Union Sq Subway expansion {SL03, S635,
+                # SR20} fetches ~3000+ trips/day across 4/5/6/L/N/R/W,
+                # truncating to overnight-only departures before any
+                # post-filter runs. Issue #1140.
                 gtfs_response = await gtfs_service.get_scheduled_departures(
                     db=db,
                     from_station=from_station,
@@ -546,6 +554,7 @@ class DepartureService:
                     target_date=target_date,
                     limit=200,  # Fetch more, we'll filter after merge
                     data_sources=allowed_sources,
+                    time_from=time_from,
                 )
 
                 # Filter GTFS departures:

--- a/backend_v2/tests/unit/services/test_departure_filtering.py
+++ b/backend_v2/tests/unit/services/test_departure_filtering.py
@@ -1437,3 +1437,124 @@ class TestStaleScheduledFiltering:
         )
         assert result[0].train_id == "NJT-CXL"
         assert result[0].is_cancelled is True
+
+
+class TestGtfsMergePassesTimeFrom:
+    """Verify the GTFS merge step propagates time_from to get_scheduled_departures.
+
+    Regression test for issue #1140: trip-search leg-2 queries set time_from
+    to a future leg-1 arrival time. Without propagating time_from to the
+    underlying GTFS SQL query, its `.limit(250)` truncates to overnight-only
+    departures at high-volume station complexes (e.g., the Union Sq subway
+    expansion {SL03, S635, SR20} with ~3000+ trips/day across 4/5/6/L/N/R/W).
+    None of those overnight rows survive the post-filter, leaving leg-2
+    empty and the trip search returning 0 trips.
+    """
+
+    @pytest.mark.asyncio
+    async def test_future_time_from_propagates_to_gtfs_query(self):
+        """When get_departures has a future time_from, it must be passed to GTFS."""
+        future_time_from = now_et() + timedelta(hours=1)
+
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_result = Mock()
+        mock_scalars = Mock()
+        mock_scalars.unique.return_value.all.return_value = []
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.scalar = AsyncMock(return_value=None)
+
+        service = DepartureService()
+
+        with patch.object(
+            service, "_maybe_trigger_background_refresh", new_callable=AsyncMock
+        ):
+            with patch.object(
+                service, "_get_path_cutoff_time", new_callable=AsyncMock
+            ) as mock_cutoff:
+                mock_cutoff.return_value = now_et()
+                with patch("trackrat.services.gtfs.GTFSService") as mock_gtfs_class:
+                    mock_gtfs = AsyncMock()
+                    mock_gtfs.get_scheduled_departures = AsyncMock(
+                        return_value=Mock(departures=[])
+                    )
+                    mock_gtfs_class.return_value = mock_gtfs
+
+                    await service.get_departures(
+                        db=mock_session,
+                        from_station="SL03",
+                        to_station="SL29",
+                        time_from=future_time_from,
+                        data_sources=["SUBWAY"],
+                        limit=20,
+                    )
+
+                    # Assert get_scheduled_departures was called with time_from
+                    # equal to the future time we passed in. The exact value is
+                    # carried through ensure_timezone_aware, so compare the
+                    # underlying instant.
+                    assert mock_gtfs.get_scheduled_departures.await_count == 1
+                    kwargs = mock_gtfs.get_scheduled_departures.await_args.kwargs
+                    assert "time_from" in kwargs, (
+                        "GTFS merge must pass time_from so the SQL pre-filter "
+                        "prunes trips before the connection window. Without "
+                        "this, the .limit(250) at high-volume stations "
+                        "truncates to overnight-only rows. See issue #1140."
+                    )
+                    passed = kwargs["time_from"]
+                    assert passed is not None
+                    assert passed == future_time_from, (
+                        f"time_from passed to GTFS ({passed}) must match the "
+                        f"caller's time_from ({future_time_from}); a mismatch "
+                        f"means leg-2 queries will still hit the SQL truncation."
+                    )
+
+    @pytest.mark.asyncio
+    async def test_default_time_from_still_passed_to_gtfs(self):
+        """Even with default (start-of-day) time_from, pass it through.
+
+        Backward compatible: when callers do not specify time_from, the
+        service defaults it to start-of-day in ET. Passing that through
+        to GTFS is a no-op for the SQL filter (it would have returned the
+        same rows anyway), but keeps the contract simple — GTFS always
+        receives the lower bound the caller intends to enforce.
+        """
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_result = Mock()
+        mock_scalars = Mock()
+        mock_scalars.unique.return_value.all.return_value = []
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.scalar = AsyncMock(return_value=None)
+
+        service = DepartureService()
+
+        with patch.object(
+            service, "_maybe_trigger_background_refresh", new_callable=AsyncMock
+        ):
+            with patch.object(
+                service, "_get_path_cutoff_time", new_callable=AsyncMock
+            ) as mock_cutoff:
+                mock_cutoff.return_value = now_et()
+                with patch("trackrat.services.gtfs.GTFSService") as mock_gtfs_class:
+                    mock_gtfs = AsyncMock()
+                    mock_gtfs.get_scheduled_departures = AsyncMock(
+                        return_value=Mock(departures=[])
+                    )
+                    mock_gtfs_class.return_value = mock_gtfs
+
+                    await service.get_departures(
+                        db=mock_session,
+                        from_station="NY",
+                        to_station="TR",
+                        data_sources=["NJT"],
+                    )
+
+                    assert mock_gtfs.get_scheduled_departures.await_count == 1
+                    kwargs = mock_gtfs.get_scheduled_departures.await_args.kwargs
+                    # Default time_from = start of day in ET; must still be passed.
+                    assert kwargs.get("time_from") is not None
+                    assert kwargs["time_from"].tzinfo is not None
+                    # Should be at midnight ET of today
+                    assert kwargs["time_from"].hour == 0
+                    assert kwargs["time_from"].minute == 0


### PR DESCRIPTION
## Summary

Fixes the trip-search 0-trips bug at high-volume subway station complexes (e.g., Pelham Bay → Canarsie via the 6 → L transfer at Union Sq).

The GTFS merge in `DepartureService.get_departures` called `GTFSService.get_scheduled_departures` without forwarding the caller's `time_from`. The underlying SQL caps each per-source query at 250 rows ordered by `departure_time` ascending. At high-volume station expansions like the Union Sq subway complex `{SL03, S635, SR20}` — which carries ~3000+ trips/day across the 4/5/6/L/N/R/W — those 250 rows all fall in the early-morning window (~04:00–05:30). When trip search's leg-2 query sets `time_from` to a future leg-1 arrival, no rows survive the post-filter and the leg returns empty.

`GTFSService.get_scheduled_departures` already accepts and uses `time_from` (`gtfs.py:1401-1402`); the call site just wasn't passing it. This one-parameter fix propagates the existing argument end-to-end.

Closes #1140.

## Why this matters

Issue #1140 is the SUBWAY-specific instance of the long-leg-1 / sparse-leg-2 bug family with #1138 / #1139. PR #1142 fixes the post-filter for #1138 / #1139, where leg-2 station expansions are smaller and the SQL `.limit(250)` doesn't truncate before `time_from`. For #1140 the SQL truncation alone is enough to drop every candidate connection — the post-filter fix is necessary but not sufficient. Passing `time_from` makes the SQL pre-filter prune correctly, which is the load-bearing change for the SUBWAY case.

The two PRs are complementary and there is no semantic conflict between them. If #1142 lands first, this PR's runtime behaviour is unchanged from what is described above. If this PR lands first, #1142 still applies cleanly to the post-filter.

## Files modified

- `backend_v2/src/trackrat/services/departure.py` — pass `time_from=time_from` to `gtfs_service.get_scheduled_departures(...)` in the GTFS merge step. Comment documents the failure mode and the Union Sq expansion that motivates the fix.
- `backend_v2/tests/unit/services/test_departure_filtering.py` — new `TestGtfsMergePassesTimeFrom` class with two tests:
  - `test_future_time_from_propagates_to_gtfs_query` — the regression case for #1140: with `time_from=now+1h` and `data_sources=["SUBWAY"]`, asserts the future `time_from` is passed verbatim to `get_scheduled_departures`. Verified to fail without the fix and pass with it.
  - `test_default_time_from_still_passed_to_gtfs` — backward-compatibility lock-in: when callers do not specify `time_from`, the default (start-of-day in ET) is propagated. This keeps the contract simple — GTFS always receives the lower bound the caller intends to enforce.

## Design decisions

- **Minimal diff.** One added kwarg in the call site plus a comment. No refactor, no new helper, no API surface change.
- **Backward-compatible.** The user-facing departures path (where `time_from` defaults to start of day) sees no change in returned rows: the SQL filter at `>= 04:00` is a no-op for queries that already include all of the day's trips.
- **Aligns with future-date code path.** The `target_date > today` branch of the same function (`departure.py:231-238`) already passes `time_from`. This change makes the today / GTFS-merge branch consistent.
- **Scoped to #1140.** This PR does not include the post-filter fix from #1142 — that is reviewed separately on its own merits.

## Test plan

- [x] New unit tests pass (`poetry run pytest tests/unit/services/test_departure_filtering.py::TestGtfsMergePassesTimeFrom`)
- [x] Wider unit test sweep passes — `tests/unit/services/test_departure_filtering.py` (41), `tests/unit/services/test_trip_search.py`, `tests/unit/services/test_departure_dedup.py`, `tests/unit/services/test_departure_stop_refresh.py` (108 across the three)
- [x] `poetry run black --check` passes (no reformatting)
- [x] `poetry run mypy src/trackrat/services/departure.py` passes
- [x] Verified the new tests fail without the fix (regression coverage works)
- [ ] Maintainer to verify on staging that `S601 → SL29` and `SL29 → S601` each return ≥1 trip during normal-service hours

## Notes

- Worth a quick eyeball: any other call site in the codebase that constructs a leg-style query with a non-default `time_from` should also propagate it. A quick grep for `get_scheduled_departures(` in `backend_v2/src/` shows only two call sites (this one and the future-date path); both now pass `time_from`.
- This fix should fully resolve #1140. If post-deployment validation finds remaining gaps for sparse leg-2 schedules (e.g., PATH PJS → P33 from #1138), the next levers in priority order are: (a) bumping `_query_leg`'s hardcoded `limit=20` for long-leg-1 cases, and (b) per-leg-1 leg-2 windowing as suggested in #1138.

https://claude.ai/code/session_013JdLgW8bZbK2WTSBAwjbFM

---
_Generated by [Claude Code](https://claude.ai/code/session_013JdLgW8bZbK2WTSBAwjbFM)_