### PR TITLE
Fix premature journey completion and transient APNS failures

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -1980,8 +1980,22 @@ class JourneyCollector(BaseJourneyCollector):
         #
         # Terminal stops (e.g., NY Penn) never get DEPARTED="YES" from the
         # NJT API, and sequential_inference can't fire (nothing after them).
-        # So we also check if the penultimate stop has departed — if it has,
-        # the train has necessarily reached the terminal.
+        # So we also check if the penultimate stop has departed — if it has
+        # *via api_explicit*, the train has necessarily reached the terminal.
+        #
+        # The penultimate check MUST require `api_explicit` and reject
+        # `time_inference` / `sequential_inference`. Time_inference fires
+        # 5 minutes after the penultimate's scheduled departure passes,
+        # which on a delayed train still inbound to that stop will
+        # falsely flip the penultimate to "departed" while the train has
+        # 10–20 minutes of trip remaining. (Sequential_inference for the
+        # penultimate would require the terminal itself to have departed,
+        # and the terminal can only get `time_inference` for NJT — same
+        # unreliable signal cascading.) See premature-completion of NJT
+        # train 3918 on 2026-05-08 for the production failure mode this
+        # guards against: penultimate (SE) was time_inferenced while the
+        # train was at NP, and the user's Live Activity ended ~17 min
+        # before the train actually reached NY Penn.
 
         # Get the last stop from the database (by max stop_sequence, not len)
         last_stop_stmt = (
@@ -2020,7 +2034,11 @@ class JourneyCollector(BaseJourneyCollector):
             )
             result = await session.execute(penultimate_stmt)
             penultimate_stop = result.scalar_one_or_none()
-            if penultimate_stop and penultimate_stop.has_departed_station:
+            if (
+                penultimate_stop
+                and penultimate_stop.has_departed_station
+                and penultimate_stop.departure_source == "api_explicit"
+            ):
                 terminal_reached = True
 
         if terminal_reached:

--- a/backend_v2/src/trackrat/services/apns.py
+++ b/backend_v2/src/trackrat/services/apns.py
@@ -21,15 +21,53 @@ logger = get_logger(__name__)
 class ApnsSendResult(Enum):
     """Outcome of an APNS push send.
 
-    Distinguishes a permanent token failure (410 BadDeviceToken) from
-    transient failures (5xx, timeouts, network errors, JWT issues), so
-    callers only deactivate tokens on real invalidation. Treating
-    transient failures as token death prematurely kills Live Activities.
+    Distinguishes a permanent token failure (410 Unregistered, or 400 with
+    a permanent-reason body like BadDeviceToken / DeviceTokenNotForTopic)
+    from transient failures (5xx, 429, timeouts, network errors, JWT
+    issues), so callers only deactivate tokens on real invalidation.
+    Treating transient failures as token death prematurely kills Live
+    Activities; treating permanent token failures as transient leaves
+    broken tokens in rotation forever.
     """
 
     SUCCESS = "success"
     INVALID_TOKEN = "invalid_token"
     TRANSIENT_FAILURE = "transient_failure"
+
+
+# APNS reason strings that mean the token is permanently invalid.
+# 410 always means Unregistered/ExpiredToken (the response body usually
+# echoes one of these), but APNS can also return a 400 with the same
+# semantic for malformed tokens or topic-mismatch. Per Apple's
+# `Handling Notification Responses from APNs` documentation:
+# https://developer.apple.com/documentation/usernotifications/handling-notification-responses-from-apns
+_APNS_PERMANENT_TOKEN_REASONS: frozenset[str] = frozenset(
+    {
+        "BadDeviceToken",  # 400: token malformed for this environment
+        "DeviceTokenNotForTopic",  # 400: token doesn't belong to our app/topic
+        "Unregistered",  # 410: app uninstalled / push disabled
+        "ExpiredToken",  # 410: token expired
+    }
+)
+
+
+def _parse_apns_reason(response: httpx.Response) -> str | None:
+    """Extract APNS `reason` from a non-200 response body.
+
+    APNS error bodies are JSON like `{"reason": "BadDeviceToken"}`. Some
+    responses (5xx HTML error pages, network errors that produce empty
+    bodies) have nothing useful — return None and let the caller fall
+    back to status-code-based classification.
+    """
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    if isinstance(body, dict):
+        reason = body.get("reason")
+        if isinstance(reason, str):
+            return reason
+    return None
 
 
 class SimpleAPNSService:
@@ -214,13 +252,16 @@ class SimpleAPNSService:
                     )
                     return ApnsSendResult.SUCCESS
 
-                # Handle specific errors
-                if response.status_code == 410:
-                    # Token is no longer valid
+                reason = _parse_apns_reason(response)
+                if (
+                    response.status_code == 410
+                    or reason in _APNS_PERMANENT_TOKEN_REASONS
+                ):
                     logger.warning(
                         "apns_token_invalid",
                         push_token=push_token[:10] + "...",
-                        status_code=410,
+                        status_code=response.status_code,
+                        reason=reason,
                     )
                     return ApnsSendResult.INVALID_TOKEN
 
@@ -228,6 +269,7 @@ class SimpleAPNSService:
                     "apns_error",
                     push_token=push_token[:10] + "...",
                     status_code=response.status_code,
+                    reason=reason,
                     response=response.text,
                 )
                 return ApnsSendResult.TRANSIENT_FAILURE
@@ -390,11 +432,16 @@ class SimpleAPNSService:
                     )
                     return ApnsSendResult.SUCCESS
 
-                if response.status_code == 410:
+                reason = _parse_apns_reason(response)
+                if (
+                    response.status_code == 410
+                    or reason in _APNS_PERMANENT_TOKEN_REASONS
+                ):
                     logger.warning(
                         "apns_token_invalid",
                         push_token=push_token[:10] + "...",
-                        status_code=410,
+                        status_code=response.status_code,
+                        reason=reason,
                     )
                     return ApnsSendResult.INVALID_TOKEN
 
@@ -402,6 +449,7 @@ class SimpleAPNSService:
                     "apns_end_error",
                     push_token=push_token[:10] + "...",
                     status_code=response.status_code,
+                    reason=reason,
                     response=response.text,
                 )
                 return ApnsSendResult.TRANSIENT_FAILURE

--- a/backend_v2/src/trackrat/services/apns.py
+++ b/backend_v2/src/trackrat/services/apns.py
@@ -5,6 +5,7 @@ Simplified implementation focused on just Live Activity push notifications.
 """
 
 import time
+from enum import Enum
 from typing import Any
 
 import httpx
@@ -15,6 +16,20 @@ from structlog import get_logger
 from trackrat.settings import get_settings
 
 logger = get_logger(__name__)
+
+
+class ApnsSendResult(Enum):
+    """Outcome of an APNS push send.
+
+    Distinguishes a permanent token failure (410 BadDeviceToken) from
+    transient failures (5xx, timeouts, network errors, JWT issues), so
+    callers only deactivate tokens on real invalidation. Treating
+    transient failures as token death prematurely kills Live Activities.
+    """
+
+    SUCCESS = "success"
+    INVALID_TOKEN = "invalid_token"
+    TRANSIENT_FAILURE = "transient_failure"
 
 
 class SimpleAPNSService:
@@ -120,7 +135,7 @@ class SimpleAPNSService:
 
     async def send_live_activity_update(
         self, push_token: str, content_state: dict[str, Any]
-    ) -> bool:
+    ) -> ApnsSendResult:
         """
         Send a Live Activity update to iOS device.
 
@@ -129,11 +144,11 @@ class SimpleAPNSService:
             content_state: The content-state dictionary with train data
 
         Returns:
-            True if successful, False otherwise
+            ApnsSendResult.SUCCESS, .INVALID_TOKEN (410), or .TRANSIENT_FAILURE.
         """
         if not self.is_configured:
             logger.warning("apns_send_skipped", reason="Not configured")
-            return False
+            return ApnsSendResult.TRANSIENT_FAILURE
 
         # Extract alertMetadata before building payload (not part of ContentState)
         alert_metadata = content_state.pop("alertMetadata", None)
@@ -197,7 +212,7 @@ class SimpleAPNSService:
                         push_token=push_token[:10] + "...",
                         status_code=response.status_code,
                     )
-                    return True
+                    return ApnsSendResult.SUCCESS
 
                 # Handle specific errors
                 if response.status_code == 410:
@@ -207,7 +222,7 @@ class SimpleAPNSService:
                         push_token=push_token[:10] + "...",
                         status_code=410,
                     )
-                    return False
+                    return ApnsSendResult.INVALID_TOKEN
 
                 logger.error(
                     "apns_error",
@@ -215,13 +230,13 @@ class SimpleAPNSService:
                     status_code=response.status_code,
                     response=response.text,
                 )
-                return False
+                return ApnsSendResult.TRANSIENT_FAILURE
 
         except Exception as e:
             logger.exception(
                 "apns_exception", push_token=push_token[:10] + "...", error=str(e)
             )
-            return False
+            return ApnsSendResult.TRANSIENT_FAILURE
 
     async def send_alert_notification(
         self,
@@ -309,7 +324,7 @@ class SimpleAPNSService:
         push_token: str,
         content_state: dict[str, Any],
         dismissal_date: int | None = None,
-    ) -> bool:
+    ) -> ApnsSendResult:
         """
         Send a Live Activity end event to iOS device.
 
@@ -322,11 +337,11 @@ class SimpleAPNSService:
                            If None, uses current time + 4 hours (keeps on Lock Screen briefly).
 
         Returns:
-            True if successful, False otherwise
+            ApnsSendResult.SUCCESS, .INVALID_TOKEN (410), or .TRANSIENT_FAILURE.
         """
         if not self.is_configured:
             logger.warning("apns_end_skipped", reason="Not configured")
-            return False
+            return ApnsSendResult.TRANSIENT_FAILURE
 
         # Default: dismiss from Lock Screen after 4 hours
         if dismissal_date is None:
@@ -373,7 +388,7 @@ class SimpleAPNSService:
                         push_token=push_token[:10] + "...",
                         status_code=response.status_code,
                     )
-                    return True
+                    return ApnsSendResult.SUCCESS
 
                 if response.status_code == 410:
                     logger.warning(
@@ -381,7 +396,7 @@ class SimpleAPNSService:
                         push_token=push_token[:10] + "...",
                         status_code=410,
                     )
-                    return False
+                    return ApnsSendResult.INVALID_TOKEN
 
                 logger.error(
                     "apns_end_error",
@@ -389,10 +404,10 @@ class SimpleAPNSService:
                     status_code=response.status_code,
                     response=response.text,
                 )
-                return False
+                return ApnsSendResult.TRANSIENT_FAILURE
 
         except Exception as e:
             logger.exception(
                 "apns_end_exception", push_token=push_token[:10] + "...", error=str(e)
             )
-            return False
+            return ApnsSendResult.TRANSIENT_FAILURE

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -38,7 +38,7 @@ from trackrat.services.alert_evaluator import (
     evaluate_service_alerts,
 )
 from trackrat.services.amtrak_pattern_scheduler import AmtrakPatternScheduler
-from trackrat.services.apns import SimpleAPNSService
+from trackrat.services.apns import ApnsSendResult, SimpleAPNSService
 from trackrat.services.jit import JustInTimeUpdateService
 from trackrat.settings import Settings, get_settings
 from trackrat.utils.scheduler_utils import (
@@ -3229,18 +3229,26 @@ class SchedulerService:
                                     )
 
                                 # Send token-specific update via APNS
-                                success = (
+                                send_result = (
                                     await self.apns_service.send_live_activity_update(
                                         token.push_token, content_state
                                     )
                                 )
 
-                                if success and track_just_assigned:
+                                if (
+                                    send_result == ApnsSendResult.SUCCESS
+                                    and track_just_assigned
+                                ):
                                     token.track_notified_at = now_et()
                                     session.commit()
 
-                                # Mark token as inactive if it failed with 410
-                                if not success:
+                                # Only deactivate the token when APNS reports it
+                                # is permanently invalid (410 BadDeviceToken).
+                                # Transient failures (5xx, timeouts, network
+                                # errors, JWT issues) must NOT kill the Live
+                                # Activity — they are routinely retried on the
+                                # next scheduler tick.
+                                if send_result == ApnsSendResult.INVALID_TOKEN:
                                     token.is_active = False
                                     session.commit()
 

--- a/backend_v2/tests/unit/collectors/njt/test_journey_data_quality.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_data_quality.py
@@ -1543,6 +1543,244 @@ class TestTerminalStopActualArrival:
         )
 
 
+class TestPenultimateTimeInferenceDoesNotCompleteJourney:
+    """Regression: a delayed train still en route to its penultimate stop must
+    not be marked complete when that stop's `has_departed_station` was inferred
+    purely from the clock. Production train 3918 on 2026-05-08 was prematurely
+    completed at 11:25:13 UTC — ~17 minutes before its actual NY Penn arrival —
+    because the penultimate (Secaucus Upper Lvl) was flagged
+    `has_departed_station=True` via `time_inference` while the train was
+    physically still at Newark Penn. The user's iOS Live Activity ended
+    `reason=completed` mid-trip.
+    """
+
+    @staticmethod
+    def _build_journey_with_stops(
+        sqlite_session: AsyncSession,
+        penultimate_source: str,
+    ) -> tuple[TrainJourney, datetime]:
+        """Helper: 6-stop NJT journey TR→HL→PJ→NP→SE→NY where the train is
+        physically at NP (NP departed via api_explicit), SE (penultimate) has
+        a scheduled departure 10 minutes in the past (so time_inference would
+        legitimately fire for it), and NY (terminal) has no departure source.
+
+        The caller picks the source of SE's departure flag.
+        """
+        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+
+        journey = TrainJourney(
+            train_id="3918",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Penn Station New York",
+            origin_station_code="TR",
+            terminal_station_code="NY",
+            data_source="NJT",
+            observation_type="OBSERVED",
+            scheduled_departure=base_time,
+            is_cancelled=False,
+            is_completed=False,
+        )
+        sqlite_session.add(journey)
+        return journey, base_time
+
+    @pytest.mark.asyncio
+    async def test_penultimate_time_inference_does_not_complete(
+        self, sqlite_session: AsyncSession, journey_collector
+    ):
+        """SE flagged via time_inference while train is still inbound: must NOT
+        complete the journey. This is the train 3918 production failure."""
+        journey, base_time = self._build_journey_with_stops(
+            sqlite_session, penultimate_source="time_inference"
+        )
+        await sqlite_session.flush()
+
+        # Schedule: TR depart at base, NY arrive base+85min. SE scheduled
+        # departure is 10 min in the past relative to "now" so time_inference
+        # would naturally fire on a delayed train.
+        ny_scheduled_arrival = base_time + timedelta(minutes=85)
+        se_scheduled_departure = now_et() - timedelta(minutes=10)
+
+        stop_specs = [
+            ("TR", "Trenton", 0, "api_explicit", True, base_time),
+            (
+                "HL",
+                "Hamilton",
+                1,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=10),
+            ),
+            (
+                "PJ",
+                "Princeton Junction",
+                2,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=20),
+            ),
+            (
+                "NP",
+                "Newark Penn Station",
+                3,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=60),
+            ),
+            (
+                "SE",
+                "Secaucus Upper Lvl",
+                4,
+                "time_inference",
+                True,
+                se_scheduled_departure,
+            ),
+            ("NY", "New York Penn Station", 5, None, False, None),
+        ]
+        for code, name, seq, source, departed, sched_dep in stop_specs:
+            stop = JourneyStop(
+                journey_id=journey.id,
+                station_code=code,
+                station_name=name,
+                stop_sequence=seq,
+                scheduled_departure=sched_dep,
+                scheduled_arrival=(
+                    ny_scheduled_arrival
+                    if code == "NY"
+                    else (sched_dep if seq > 0 else None)
+                ),
+                has_departed_station=departed,
+                departure_source=source,
+            )
+            sqlite_session.add(stop)
+        await sqlite_session.flush()
+
+        # API still returns all 6 stops; no DEPARTED=YES for SE or NY.
+        builder = StopBuilder()
+        stops_data = [
+            _make_stop_with_sched_fields(
+                builder,
+                code,
+                name,
+                dep_time=(sched_dep or ny_scheduled_arrival).strftime(NJT_TIME_FORMAT),
+                arr_time=(
+                    (sched_dep or ny_scheduled_arrival).strftime(NJT_TIME_FORMAT)
+                    if seq > 0
+                    else None
+                ),
+                departed=departed and source == "api_explicit",
+            )
+            for code, name, seq, source, departed, sched_dep in stop_specs
+        ]
+
+        await journey_collector.check_journey_completion(
+            sqlite_session, journey, stops_data
+        )
+
+        assert journey.is_completed is False, (
+            "Journey must NOT be marked complete when the penultimate stop's "
+            "departure was inferred from the clock alone (time_inference). "
+            "The train may still be physically en route to that stop."
+        )
+
+    @pytest.mark.asyncio
+    async def test_penultimate_api_explicit_does_complete(
+        self, sqlite_session: AsyncSession, journey_collector
+    ):
+        """Positive case: when NJT explicitly reports the penultimate as
+        DEPARTED=YES (`api_explicit`), the train has physically passed it and
+        the journey is correctly marked complete."""
+        journey, base_time = self._build_journey_with_stops(
+            sqlite_session, penultimate_source="api_explicit"
+        )
+        await sqlite_session.flush()
+
+        ny_scheduled_arrival = base_time + timedelta(minutes=85)
+
+        stop_specs = [
+            ("TR", "Trenton", 0, "api_explicit", True, base_time),
+            (
+                "HL",
+                "Hamilton",
+                1,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=10),
+            ),
+            (
+                "PJ",
+                "Princeton Junction",
+                2,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=20),
+            ),
+            (
+                "NP",
+                "Newark Penn Station",
+                3,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=60),
+            ),
+            (
+                "SE",
+                "Secaucus Upper Lvl",
+                4,
+                "api_explicit",
+                True,
+                base_time + timedelta(minutes=78),
+            ),
+            ("NY", "New York Penn Station", 5, None, False, None),
+        ]
+        for code, name, seq, source, departed, sched_dep in stop_specs:
+            stop = JourneyStop(
+                journey_id=journey.id,
+                station_code=code,
+                station_name=name,
+                stop_sequence=seq,
+                scheduled_departure=sched_dep,
+                scheduled_arrival=(
+                    ny_scheduled_arrival
+                    if code == "NY"
+                    else (sched_dep if seq > 0 else None)
+                ),
+                has_departed_station=departed,
+                departure_source=source,
+                actual_departure=sched_dep if departed else None,
+            )
+            sqlite_session.add(stop)
+        await sqlite_session.flush()
+
+        builder = StopBuilder()
+        stops_data = [
+            _make_stop_with_sched_fields(
+                builder,
+                code,
+                name,
+                dep_time=(sched_dep or ny_scheduled_arrival).strftime(NJT_TIME_FORMAT),
+                arr_time=(
+                    (sched_dep or ny_scheduled_arrival).strftime(NJT_TIME_FORMAT)
+                    if seq > 0
+                    else None
+                ),
+                departed=departed and code != "NY",
+            )
+            for code, name, seq, source, departed, sched_dep in stop_specs
+        ]
+
+        await journey_collector.check_journey_completion(
+            sqlite_session, journey, stops_data
+        )
+
+        assert journey.is_completed is True, (
+            "Journey MUST be marked complete when the penultimate stop has "
+            "an api_explicit DEPARTED=YES from NJT — the train has physically "
+            "passed it and is at/past the terminal."
+        )
+
+
 # ---------------------------------------------------------------------------
 # 8. Pydantic field validators normalize NJT API values
 # ---------------------------------------------------------------------------

--- a/backend_v2/tests/unit/collectors/njt/test_terminal_stop_completion.py
+++ b/backend_v2/tests/unit/collectors/njt/test_terminal_stop_completion.py
@@ -180,12 +180,24 @@ async def _create_tr_to_ny_journey(
     ]
 
     for code, name, seq, departed, sched_arr, sched_dep in stops:
+        # Terminals never get DEPARTED=YES from NJT, so simulate them with
+        # departure_source=None when not departed; intermediate stops with
+        # has_departed_station=True are realistically `api_explicit` (NJT
+        # reported DEPARTED=YES). Penultimate completion now requires
+        # api_explicit specifically.
+        if not departed:
+            source = None
+        elif code == "NY":
+            source = "time_inference"
+        else:
+            source = "api_explicit"
         stop = JourneyStop(
             journey_id=journey.id,
             station_code=code,
             station_name=name,
             stop_sequence=seq,
             has_departed_station=departed,
+            departure_source=source,
             scheduled_arrival=sched_arr,
             scheduled_departure=(
                 sched_dep if code != "NY" else None
@@ -414,6 +426,7 @@ class TestStopSequenceRobustness:
                 station_name="Newark Penn",
                 stop_sequence=1,
                 has_departed_station=True,
+                departure_source="api_explicit",
                 scheduled_arrival=base_time + timedelta(minutes=40),
             ),
             # stop_sequence=2 was deleted (phantom stop)

--- a/backend_v2/tests/unit/services/test_apns.py
+++ b/backend_v2/tests/unit/services/test_apns.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from trackrat.services.apns import SimpleAPNSService
+from trackrat.services.apns import ApnsSendResult, SimpleAPNSService
 
 
 def _make_configured_apns() -> SimpleAPNSService:
@@ -136,3 +136,166 @@ class TestAPNSAlertPayload:
             "device-token", "Title", "Body", custom_data={"key": "val"}
         )
         assert result is False
+
+
+def _mock_apns_response(*, status_code: int, body: dict | None = None) -> AsyncMock:
+    """Build an httpx.AsyncClient mock that returns a single response.
+
+    The response's `.json()` returns the supplied body (or raises if None).
+    `.text` is the JSON-encoded body or empty string.
+    """
+    import json as _json
+
+    resp = MagicMock()
+    resp.status_code = status_code
+    if body is None:
+        resp.json = MagicMock(side_effect=ValueError("no json"))
+        resp.text = ""
+    else:
+        resp.json = MagicMock(return_value=body)
+        resp.text = _json.dumps(body)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+@pytest.mark.asyncio
+class TestLiveActivityResultClassification:
+    """`send_live_activity_update` and `send_live_activity_end` must classify
+    APNS responses into the right `ApnsSendResult` so the scheduler
+    deactivates tokens only when the failure is permanent.
+
+    Critical invariants:
+    - 200 => SUCCESS
+    - 410 (any/no body) => INVALID_TOKEN (Unregistered/ExpiredToken — token gone)
+    - 400 with reason in {BadDeviceToken, DeviceTokenNotForTopic} => INVALID_TOKEN
+    - 400 with any other reason (e.g., BadCollapseId, IdleTimeout) => TRANSIENT_FAILURE
+    - 5xx, 429, network errors, timeouts, JWT failures => TRANSIENT_FAILURE
+    """
+
+    async def test_200_returns_success(self):
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(status_code=200),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.SUCCESS
+
+    async def test_410_returns_invalid_token_even_without_body(self):
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(status_code=410),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.INVALID_TOKEN
+
+    async def test_410_with_unregistered_reason_returns_invalid_token(self):
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=410, body={"reason": "Unregistered", "timestamp": 12345}
+            ),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.INVALID_TOKEN
+
+    async def test_400_bad_device_token_returns_invalid_token(self):
+        """Regression for Codex P1: APNS returns permanent token failures
+        as 400 BadDeviceToken too, not just 410. Without this, broken
+        tokens stay active forever and get retried every scheduler tick."""
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=400, body={"reason": "BadDeviceToken"}
+            ),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.INVALID_TOKEN
+
+    async def test_400_device_token_not_for_topic_returns_invalid_token(self):
+        """Regression for Codex P1: 400 DeviceTokenNotForTopic also means
+        the token is permanently unusable for our app/topic."""
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=400, body={"reason": "DeviceTokenNotForTopic"}
+            ),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.INVALID_TOKEN
+
+    async def test_400_bad_collapse_id_is_transient(self):
+        """Other 400 reasons are not token-specific (request issue, not
+        token issue) — should be TRANSIENT_FAILURE so the token stays
+        active and the scheduler keeps trying."""
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=400, body={"reason": "BadCollapseId"}
+            ),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.TRANSIENT_FAILURE
+
+    async def test_503_returns_transient_failure(self):
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=503, body={"reason": "ServiceUnavailable"}
+            ),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.TRANSIENT_FAILURE
+
+    async def test_429_returns_transient_failure(self):
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=429, body={"reason": "TooManyRequests"}
+            ),
+        ):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.TRANSIENT_FAILURE
+
+    async def test_network_exception_returns_transient_failure(self):
+        service = _make_configured_apns()
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=ConnectionError("network blip"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await service.send_live_activity_update("token", {"k": "v"})
+        assert result is ApnsSendResult.TRANSIENT_FAILURE
+
+    async def test_end_400_bad_device_token_returns_invalid_token(self):
+        """`send_live_activity_end` must classify identically to
+        `send_live_activity_update`."""
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(
+                status_code=400, body={"reason": "BadDeviceToken"}
+            ),
+        ):
+            result = await service.send_live_activity_end("token", {"k": "v"})
+        assert result is ApnsSendResult.INVALID_TOKEN
+
+    async def test_end_410_returns_invalid_token(self):
+        service = _make_configured_apns()
+        with patch(
+            "httpx.AsyncClient",
+            return_value=_mock_apns_response(status_code=410),
+        ):
+            result = await service.send_live_activity_end("token", {"k": "v"})
+        assert result is ApnsSendResult.INVALID_TOKEN

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -16,6 +16,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from trackrat.services.apns import ApnsSendResult
 from trackrat.services.scheduler import SchedulerService
 from trackrat.settings import Settings
 
@@ -676,6 +677,163 @@ class TestSchedulerService:
 
                 mock_apns_service.send_live_activity_end.assert_called_once()
                 mock_apns_service.send_live_activity_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_transient_apns_failure_does_not_deactivate_token(
+        self, scheduler_service, mock_apns_service
+    ):
+        """Transient APNS failures (5xx, timeouts, network) must NOT deactivate
+        the Live Activity token. Only a 410 BadDeviceToken response should.
+
+        Regression: production was permanently killing Live Activities on every
+        transient APNS hiccup because the scheduler treated any non-success
+        return as 410.
+        """
+        scheduler_service.apns_service = mock_apns_service
+        mock_apns_service.send_live_activity_update = AsyncMock(
+            return_value=ApnsSendResult.TRANSIENT_FAILURE
+        )
+
+        with patch("trackrat.services.scheduler.get_session") as mock_get_session:
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            with (
+                patch("sqlalchemy.create_engine"),
+                patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker,
+            ):
+                mock_sync_session = Mock()
+                mock_sessionmaker.return_value = Mock(return_value=mock_sync_session)
+
+                mock_token = Mock(
+                    push_token="token-transient",
+                    activity_id="activity-transient",
+                    train_number="1234",
+                    origin_code="NY",
+                    destination_code="TR",
+                    data_source="AMTRAK",
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    is_active=True,
+                    track_notified_at=datetime.now(UTC),
+                )
+
+                mock_tokens_result = Mock()
+                mock_tokens_result.scalars.return_value = [mock_token]
+
+                mock_journey = Mock(
+                    train_id="1234",
+                    data_source="AMTRAK",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=False,
+                    is_expired=False,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+
+                mock_sync_session.execute.return_value = mock_tokens_result
+                mock_sync_session.scalar.return_value = mock_journey
+                mock_sync_session.__enter__ = Mock(return_value=mock_sync_session)
+                mock_sync_session.__exit__ = Mock(return_value=None)
+
+                with patch.object(
+                    scheduler_service,
+                    "_calculate_live_activity_content_state",
+                    return_value={"test": "content"},
+                ):
+                    with patch(
+                        "trackrat.services.scheduler.run_with_freshness_check"
+                    ) as mock_freshness_check:
+
+                        async def execute_task_func(
+                            db, task_name, minimum_interval_seconds, task_func
+                        ):
+                            await task_func()
+                            return True
+
+                        mock_freshness_check.side_effect = execute_task_func
+
+                        await scheduler_service.update_live_activities()
+
+                mock_apns_service.send_live_activity_update.assert_called_once_with(
+                    "token-transient", {"test": "content"}
+                )
+                # Token must remain active so the next scheduler tick retries.
+                assert mock_token.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_response_deactivates_token(
+        self, scheduler_service, mock_apns_service
+    ):
+        """A 410 BadDeviceToken response must deactivate the token so the
+        scheduler stops trying to push to it."""
+        scheduler_service.apns_service = mock_apns_service
+        mock_apns_service.send_live_activity_update = AsyncMock(
+            return_value=ApnsSendResult.INVALID_TOKEN
+        )
+
+        with patch("trackrat.services.scheduler.get_session") as mock_get_session:
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            with (
+                patch("sqlalchemy.create_engine"),
+                patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker,
+            ):
+                mock_sync_session = Mock()
+                mock_sessionmaker.return_value = Mock(return_value=mock_sync_session)
+
+                mock_token = Mock(
+                    push_token="token-invalid",
+                    activity_id="activity-invalid",
+                    train_number="1234",
+                    origin_code="NY",
+                    destination_code="TR",
+                    data_source="AMTRAK",
+                    expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    is_active=True,
+                    track_notified_at=datetime.now(UTC),
+                )
+
+                mock_tokens_result = Mock()
+                mock_tokens_result.scalars.return_value = [mock_token]
+
+                mock_journey = Mock(
+                    train_id="1234",
+                    data_source="AMTRAK",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=False,
+                    is_expired=False,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+
+                mock_sync_session.execute.return_value = mock_tokens_result
+                mock_sync_session.scalar.return_value = mock_journey
+                mock_sync_session.__enter__ = Mock(return_value=mock_sync_session)
+                mock_sync_session.__exit__ = Mock(return_value=None)
+
+                with patch.object(
+                    scheduler_service,
+                    "_calculate_live_activity_content_state",
+                    return_value={"test": "content"},
+                ):
+                    with patch(
+                        "trackrat.services.scheduler.run_with_freshness_check"
+                    ) as mock_freshness_check:
+
+                        async def execute_task_func(
+                            db, task_name, minimum_interval_seconds, task_func
+                        ):
+                            await task_func()
+                            return True
+
+                        mock_freshness_check.side_effect = execute_task_func
+
+                        await scheduler_service.update_live_activities()
+
+                assert mock_token.is_active is False
 
     @pytest.mark.asyncio
     async def test_precompute_congestion_cache(self, scheduler_service):

--- a/backend_v2/tests/unit/test_production_health_fixes.py
+++ b/backend_v2/tests/unit/test_production_health_fixes.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from trackrat.collectors.amtrak.journey import AmtrakJourneyCollector
 from trackrat.models.database import TrainJourney
+from trackrat.services.apns import ApnsSendResult
 from trackrat.services.scheduler import SchedulerService
 from trackrat.settings import Settings
 from trackrat.utils.time import ET
@@ -533,7 +534,7 @@ class TestLiveActivitySessionScope:
         context — this was one of the DB ops outside the `with` block."""
         scheduler_service.apns_service = AsyncMock()
         scheduler_service.apns_service.send_live_activity_update = AsyncMock(
-            return_value=True
+            return_value=ApnsSendResult.SUCCESS
         )
 
         with patch("trackrat.services.scheduler.get_session") as mock_get_session:
@@ -614,7 +615,9 @@ class TestLiveActivitySessionScope:
         """When a Live Activity update fails (410), the token is deactivated
         and session.commit() is called. This must happen within the session context."""
         mock_apns = AsyncMock()
-        mock_apns.send_live_activity_update = AsyncMock(return_value=False)  # 410
+        mock_apns.send_live_activity_update = AsyncMock(
+            return_value=ApnsSendResult.INVALID_TOKEN
+        )  # 410
         scheduler_service.apns_service = mock_apns
 
         with patch("trackrat.services.scheduler.get_session") as mock_get_session:
@@ -693,7 +696,9 @@ class TestLiveActivitySessionScope:
         The engine is disposed once in stop(), not after each method invocation.
         """
         mock_apns = AsyncMock()
-        mock_apns.send_live_activity_update = AsyncMock(return_value=True)
+        mock_apns.send_live_activity_update = AsyncMock(
+            return_value=ApnsSendResult.SUCCESS
+        )
         scheduler_service.apns_service = mock_apns
 
         mock_sync_engine = Mock()


### PR DESCRIPTION
## Summary
This PR fixes two production issues: (1) NJT train journeys being prematurely marked complete when the penultimate stop's departure was inferred from the clock rather than explicitly reported by the API, and (2) transient APNS failures incorrectly deactivating Live Activity tokens.

## Key Changes

### Journey Completion Logic (NJT)
- **Modified penultimate stop check** in `journey.py`: The completion logic now requires the penultimate stop's departure to be sourced from `api_explicit` (explicit NJT API report) rather than accepting `time_inference` or `sequential_inference`. This prevents false completion when a delayed train is still physically en route to the penultimate stop but the clock-based inference has fired.
- **Root cause**: Time inference fires 5 minutes after a stop's scheduled departure passes. On delayed trains, this can trigger while the train is still 10-20 minutes away from that stop, causing premature journey completion.
- **Production incident**: NJT train 3918 on 2026-05-08 was marked complete at 11:25:13 UTC (~17 minutes before actual arrival at NY Penn) because Secaucus Upper Level (penultimate) was flagged departed via time_inference while the train was physically at Newark Penn. Users' iOS Live Activities ended mid-trip.

### APNS Failure Handling
- **Introduced `ApnsSendResult` enum** in `apns.py`: Distinguishes between three outcomes:
  - `SUCCESS`: Push sent successfully
  - `INVALID_TOKEN`: 410 BadDeviceToken response (permanent failure)
  - `TRANSIENT_FAILURE`: 5xx errors, timeouts, network errors, JWT issues (temporary)
- **Updated return types** for `send_live_activity_update()` and `send_live_activity_end()` to return `ApnsSendResult` instead of boolean
- **Modified scheduler logic** in `scheduler.py`: Token deactivation now only occurs on `INVALID_TOKEN` (410), not on transient failures. This prevents permanently killing Live Activities on temporary APNS service hiccups.
- **Root cause**: Production was treating any non-success APNS response as a permanent token failure, causing Live Activities to be deactivated on every transient network issue.

### Test Coverage
- Added comprehensive regression test `TestPenultimateTimeInferenceDoesNotCompleteJourney` with two scenarios:
  - Negative case: penultimate with `time_inference` must NOT complete the journey
  - Positive case: penultimate with `api_explicit` MUST complete the journey
- Added tests for transient vs. invalid APNS token handling in scheduler tests
- Updated existing terminal stop completion tests to properly set `departure_source` field

## Implementation Details
- The penultimate stop check now explicitly validates `departure_source == "api_explicit"` before marking journey complete
- APNS service methods now return enum values allowing callers to distinguish permanent vs. temporary failures
- Scheduler retains active tokens on transient failures so subsequent scheduler ticks can retry
- All changes are backward compatible; existing code paths updated to handle new enum return values

https://claude.ai/code/session_01EdPyjNB11WC9QBvEXgM1t4