### PR TITLE
Unify departures display and add station tap navigation

### DIFF
--- a/ios/TrackRat/Views/Screens/CongestionMapView.swift
+++ b/ios/TrackRat/Views/Screens/CongestionMapView.swift
@@ -1072,6 +1072,31 @@ struct SystemCongestionMapView: UIViewRepresentable {
     let highlightMode: SegmentHighlightMode
     let onSegmentTap: (CongestionSegment) -> Void
     let onIndividualSegmentTap: ((IndividualJourneySegment) -> Void)?
+    let onStationTap: ((String) -> Void)?
+
+    init(
+        region: Binding<MKCoordinateRegion>,
+        segments: [CongestionSegment],
+        individualSegments: [IndividualJourneySegment],
+        stations: [MapStation],
+        showRoutes: Bool,
+        selectedSystems: Set<TrainSystem>,
+        highlightMode: SegmentHighlightMode,
+        onSegmentTap: @escaping (CongestionSegment) -> Void,
+        onIndividualSegmentTap: ((IndividualJourneySegment) -> Void)? = nil,
+        onStationTap: ((String) -> Void)? = nil
+    ) {
+        self._region = region
+        self.segments = segments
+        self.individualSegments = individualSegments
+        self.stations = stations
+        self.showRoutes = showRoutes
+        self.selectedSystems = selectedSystems
+        self.highlightMode = highlightMode
+        self.onSegmentTap = onSegmentTap
+        self.onIndividualSegmentTap = onIndividualSegmentTap
+        self.onStationTap = onStationTap
+    }
 
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
@@ -1294,6 +1319,7 @@ struct SystemCongestionMapView: UIViewRepresentable {
         context.coordinator.individualSegments = individualSegments
         context.coordinator.onSegmentTap = onSegmentTap
         context.coordinator.onIndividualSegmentTap = onIndividualSegmentTap ?? { _ in }
+        context.coordinator.onStationTap = onStationTap
     }
     
     
@@ -1311,6 +1337,7 @@ struct SystemCongestionMapView: UIViewRepresentable {
         var individualSegments: [IndividualJourneySegment] = []
         var onSegmentTap: (CongestionSegment) -> Void = { _ in }
         var onIndividualSegmentTap: (IndividualJourneySegment) -> Void = { _ in }
+        var onStationTap: ((String) -> Void)?
         var highlightMode: SegmentHighlightMode = .delays
 
         var currentAggregatedOverlayState: Set<OverlayIdentity> = []
@@ -1492,6 +1519,17 @@ struct SystemCongestionMapView: UIViewRepresentable {
         }
 
         // MARK: - Tap Handling
+
+        /// Tapping a station pin pushes that station's details. We deselect immediately so
+        /// the same pin can be tapped again after returning, and avoid the default callout.
+        func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+            guard let stationAnnotation = view.annotation as? SystemStationAnnotation,
+                  let code = stationAnnotation.station?.code,
+                  let onStationTap else { return }
+            mapView.deselectAnnotation(view.annotation, animated: false)
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onStationTap(code)
+        }
 
         @objc func handleMapTap(_ gesture: UITapGestureRecognizer) {
             guard let mapView = gesture.view as? MKMapView else { return }

--- a/ios/TrackRat/Views/Screens/MapContainerView.swift
+++ b/ios/TrackRat/Views/Screens/MapContainerView.swift
@@ -158,6 +158,9 @@ struct MapContainerView: View {
                     guard appState.enableSegmentTap else { return }
                     selectedIndividualSegment = individualSegment
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                },
+                onStationTap: { code in
+                    appState.navigationPath.append(NavigationDestination.stationDetails(stationCode: code))
                 }
             )
             .ignoresSafeArea()

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -944,8 +944,9 @@ struct ServiceAlertCard: View {
 // MARK: - Now Divider
 
 /// Thin orange hairline with a centered "NOW · h:mm a" pill, used to separate past and
-/// future rows in the unified Departures section. Updates each minute.
-private struct NowDivider: View {
+/// future rows in the unified Departures section. Updates each minute. Shared with
+/// `StationDetailsView`.
+struct NowDivider: View {
     @State private var now: Date = Date()
     private let timer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -507,22 +507,26 @@ struct SettingsSection: View {
                             $0.id != homeCode && $0.id != workCode
                         }
 
-                        if homeCode != nil {
+                        if let homeCode {
                             FavoriteStationRow(
                                 label: "Home",
                                 stationCode: homeCode,
                                 isLast: workCode == nil && otherFavorites.isEmpty,
                                 showControls: false
-                            )
+                            ) {
+                                navigationPath.append(NavigationDestination.stationDetails(stationCode: homeCode))
+                            }
                         }
 
-                        if workCode != nil {
+                        if let workCode {
                             FavoriteStationRow(
                                 label: "Work",
                                 stationCode: workCode,
                                 isLast: otherFavorites.isEmpty,
                                 showControls: false
-                            )
+                            ) {
+                                navigationPath.append(NavigationDestination.stationDetails(stationCode: workCode))
+                            }
                         }
 
                         ForEach(otherFavorites) { fav in
@@ -531,7 +535,9 @@ struct SettingsSection: View {
                                 stationCode: fav.id,
                                 isLast: fav.id == otherFavorites.last?.id,
                                 showControls: false
-                            )
+                            ) {
+                                navigationPath.append(NavigationDestination.stationDetails(stationCode: fav.id))
+                            }
                         }
 
                         if appState.favoriteStations.isEmpty {
@@ -861,11 +867,15 @@ private struct FavoriteStationRow: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 12) {
-                // Wrap in a Button whenever there's a meaningful tap target:
-                // labelled rows (Home/Work) always tap to repick; unlabelled
-                // ("other") rows only tap when a station is set, since they
-                // navigate to that station's details.
-                if showControls && (label != nil || stationCode != nil) {
+                // Wrap in a Button whenever the row has a meaningful tap target.
+                // In edit mode (showControls=true), labelled Home/Work rows tap to
+                // repick (even with no station set) and unlabelled rows tap to
+                // navigate to details. In display mode (showControls=false), only
+                // rows with a station are tappable — they navigate to details.
+                let isTappable = showControls
+                    ? (label != nil || stationCode != nil)
+                    : (stationCode != nil)
+                if isTappable {
                     Button(action: onTap) {
                         rowContent
                             .contentShape(Rectangle())

--- a/ios/TrackRat/Views/Screens/StationDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/StationDetailsView.swift
@@ -330,7 +330,9 @@ final class StationDetailsViewModel: ObservableObject {
     @Published var selectedTrain: TrainV2?
     @Published var routeStatusContext: RouteStatusContext?
 
-    private static let recentWindowMinutes = 60
+    /// Match `RouteStatusViewModel.recentTrainsWindowMinutes` so the unified
+    /// Departures section reads from the same window in both views.
+    private static let recentWindowMinutes = 120
 
     init(stationCode: String) {
         self.stationCode = stationCode

--- a/ios/TrackRat/Views/Screens/StationDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/StationDetailsView.swift
@@ -229,6 +229,19 @@ struct StationDetailsView: View {
             }
             .padding()
             .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Departures")
+                    .font(.headline)
+
+                Text("No departures available")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 4)
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
         }
     }
 

--- a/ios/TrackRat/Views/Screens/StationDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/StationDetailsView.swift
@@ -36,9 +36,8 @@ struct StationDetailsView: View {
                 headerSection
                 mapSnippetSection
                 actionsSection
-                upcomingDeparturesSection
+                departuresSection
                 serviceAlertsSection
-                recentDeparturesSection
                 routesServingSection
             }
             .padding()
@@ -180,54 +179,52 @@ struct StationDetailsView: View {
         .buttonStyle(.plain)
     }
 
-    // MARK: - Upcoming departures
+    // MARK: - Departures (unified recent/upcoming around a NOW divider)
 
+    /// Mirrors `RouteStatusView.departuresSection`: recent trains (oldest at top,
+    /// dimmed), a NOW pill, then upcoming trains. Skeleton matches that view's
+    /// 2-past / 2-future layout.
     @ViewBuilder
-    private var upcomingDeparturesSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Upcoming Departures")
-                .font(.headline)
+    private var departuresSection: some View {
+        if viewModel.isLoadingDepartures {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Departures")
+                    .font(.headline)
 
-            if viewModel.isLoadingDepartures {
-                ForEach(0..<3, id: \.self) { _ in skeletonRow }
-            } else if viewModel.upcoming.isEmpty {
-                emptyRow("No upcoming departures")
-            } else {
-                ForEach(viewModel.upcoming.prefix(10)) { train in
-                    Button {
-                        viewModel.selectedTrain = train
-                    } label: {
+                ForEach(0..<2, id: \.self) { _ in skeletonRow.opacity(0.55) }
+                NowDivider()
+                ForEach(0..<2, id: \.self) { _ in skeletonRow }
+            }
+            .padding()
+            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        } else if !viewModel.upcoming.isEmpty || !viewModel.recent.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Departures")
+                    .font(.headline)
+
+                ForEach(Array(viewModel.recent.prefix(3).reversed())) { train in
+                    Button { viewModel.selectedTrain = train } label: {
+                        TrainRow(train: train, dataSource: train.dataSource)
+                    }
+                    .buttonStyle(.plain)
+                    .opacity(0.55)
+                }
+
+                NowDivider()
+
+                ForEach(viewModel.upcoming.prefix(3)) { train in
+                    Button { viewModel.selectedTrain = train } label: {
                         TrainRow(train: train, dataSource: train.dataSource)
                     }
                     .buttonStyle(.plain)
                 }
-            }
-        }
-        .padding()
-        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
-    }
 
-    // MARK: - Recent departures
-
-    @ViewBuilder
-    private var recentDeparturesSection: some View {
-        if viewModel.isLoadingDepartures || !viewModel.recent.isEmpty {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Recently Departed")
-                    .font(.headline)
-
-                if viewModel.isLoadingDepartures {
-                    ForEach(0..<2, id: \.self) { _ in skeletonRow.opacity(0.55) }
-                } else {
-                    ForEach(viewModel.recent.prefix(5)) { train in
-                        Button {
-                            viewModel.selectedTrain = train
-                        } label: {
-                            TrainRow(train: train, dataSource: train.dataSource)
-                        }
-                        .buttonStyle(.plain)
-                        .opacity(0.55)
-                    }
+                if viewModel.upcoming.isEmpty {
+                    Text("No more trains scheduled")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 4)
                 }
             }
             .padding()
@@ -312,14 +309,6 @@ struct StationDetailsView: View {
         .padding(.vertical, 4)
         .padding(.horizontal, 10)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
-    }
-
-    private func emptyRow(_ text: String) -> some View {
-        Text(text)
-            .font(.subheadline)
-            .foregroundColor(.secondary)
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.vertical, 8)
     }
 
     /// Data sources that publish service alerts. Mirrors the constant in

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -534,6 +534,13 @@ struct CombinedDetailsCard: View {
                             departureStationCode: appState.departureStationCode,
                             shouldShowJourneyPredictions: shouldShowJourneyPredictions
                         )
+                        // Long-press a stop to open that station's details. Only wire when
+                        // pushed (not presented as a sheet), since sheet contexts use their
+                        // own NavigationStack that doesn't register `.stationDetails`.
+                        .stationDetailsContextMenu(
+                            code: isSheet ? nil : stop.stationCode,
+                            path: $appState.navigationPath
+                        )
                     }
                     
                     if hasMoreDisplayStops {


### PR DESCRIPTION
## Summary
This PR consolidates the station details view's separate "Upcoming" and "Recently Departed" sections into a single unified "Departures" section with a NOW divider, matching the pattern already established in RouteStatusView. Additionally, it enables navigation to station details by tapping station pins on the congestion map and favorite stations in settings.

## Key Changes

- **Unified Departures Section**: Combined `upcomingDeparturesSection` and `recentDeparturesSection` into a single `departuresSection` that displays recent trains (dimmed, oldest at top), a NOW divider, and upcoming trains. Updated skeleton loading to show 2 past + 2 future layout.

- **Recent Window Alignment**: Increased `recentWindowMinutes` from 60 to 120 in `StationDetailsViewModel` to match `RouteStatusViewModel`, ensuring consistent data windows across both views.

- **Shared NowDivider**: Made `NowDivider` public so it can be reused in `StationDetailsView`, eliminating duplication.

- **Station Pin Tap Navigation**: Added `onStationTap` callback to `SystemCongestionMapView` with proper initialization and coordinator support. Tapping a station pin now navigates to that station's details view with haptic feedback.

- **Favorite Station Navigation**: Updated `FavoriteStationRow` in SettingsView to navigate to station details when tapped in display mode (showControls=false), with improved tap target logic.

- **Train Details Context Menu**: Added `.stationDetailsContextMenu` to stops in `CombinedDetailsCard` to enable long-press navigation to station details (only when pushed, not presented as sheet).

- **Code Cleanup**: Removed unused `emptyRow` helper function; consolidated empty state messaging into the unified departures section.

## Implementation Details

- The unified departures section mirrors RouteStatusView's layout: recent trains are displayed with 0.55 opacity, followed by a NowDivider pill, then upcoming trains.
- Station tap handling includes immediate deselection to allow re-tapping the same pin after navigation returns.
- Favorite station tappability logic now clearly distinguishes between edit mode (showControls=true) and display mode (showControls=false).

https://claude.ai/code/session_01DtocwXwSVPmfMuj6kv6FMm