### PR TITLE
Add disclosure chevrons to clickable settings rows

### DIFF
--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -894,6 +894,10 @@ private struct FavoriteStationRow: View {
                             .foregroundColor(.white.opacity(0.3))
                     }
                     .buttonStyle(.plain)
+                } else if !showControls && stationCode != nil {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(.white.opacity(0.4))
                 }
             }
             .padding(.horizontal)
@@ -948,6 +952,10 @@ private struct RouteAlertRow: View {
                             .foregroundColor(.white.opacity(0.3))
                     }
                     .buttonStyle(.plain)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundColor(.white.opacity(0.4))
                 }
             }
             .padding(.horizontal)


### PR DESCRIPTION
Match the existing TrainSystemRow pattern by showing a right-facing
chevron on FavoriteStationRow and RouteAlertRow when they are in
display (non-edit) mode, signalling that the row is clickable and
navigates to a details page.