### PR TITLE
feat(ios): share Active/Upcoming alerts tabs between station and route views

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		A11A0DBF2F4B840B00C96DA1 /* TripHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0DBE2F4B840B00C96DA1 /* TripHistoryView.swift */; };
 		A11A0DC12F4B840B00C96DA1 /* AddRouteAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A0DBC2F4B840B00C96DA1 /* AddRouteAlertView.swift */; };
 		F1TRNROW01000000000000A2 /* TrainRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1TRNROW01000000000000A1 /* TrainRow.swift */; };
+		F1SVCALR01000000000000A2 /* ServiceAlertsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SVCALR01000000000000A1 /* ServiceAlertsSection.swift */; };
 		F1STDETAIL00000000000000A2 /* StationDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1STDETAIL00000000000000A1 /* StationDetailsView.swift */; };
 		A11A2C332E27C1A400B74BB5 /* StaticTrackDistributionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11A2C322E27C1A400B74BB5 /* StaticTrackDistributionService.swift */; };
 		A126E5582E25BBC700958ABA /* TrainV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = A126E5562E25BBC700958ABA /* TrainV2.swift */; };
@@ -220,6 +221,7 @@
 		A11A0DB72F4B83CF00C96DA1 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = APIService.swift; path = TrackRat/Services/APIService.swift; sourceTree = "<group>"; };
 		A11A0DBC2F4B840B00C96DA1 /* AddRouteAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AddRouteAlertView.swift; path = Views/Screens/AddRouteAlertView.swift; sourceTree = "<group>"; };
 		F1TRNROW01000000000000A1 /* TrainRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TrainRow.swift; path = Views/Components/TrainRow.swift; sourceTree = "<group>"; };
+		F1SVCALR01000000000000A1 /* ServiceAlertsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ServiceAlertsSection.swift; path = Views/Components/ServiceAlertsSection.swift; sourceTree = "<group>"; };
 		F1STDETAIL00000000000000A1 /* StationDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StationDetailsView.swift; path = Views/Screens/StationDetailsView.swift; sourceTree = "<group>"; };
 		A11A0DBE2F4B840B00C96DA1 /* TripHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TripHistoryView.swift; path = Views/Screens/TripHistoryView.swift; sourceTree = "<group>"; };
 		A11A2C322E27C1A400B74BB5 /* StaticTrackDistributionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StaticTrackDistributionService.swift; path = Services/StaticTrackDistributionService.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				A1STNPK0012F6000000000001 /* StationPickerSheet.swift */,
 				A1ROUTE0012F5000000000001 /* RouteStatusView.swift */,
 				F1TRNROW01000000000000A1 /* TrainRow.swift */,
+				F1SVCALR01000000000000A1 /* ServiceAlertsSection.swift */,
 				F1STDETAIL00000000000000A1 /* StationDetailsView.swift */,
 				A11A0DBE2F4B840B00C96DA1 /* TripHistoryView.swift */,
 				A18E54392DEB88E500AB2B74 /* LiveActivityService.swift */,
@@ -748,6 +751,7 @@
 				A1STNPK0012F6000000000002 /* StationPickerSheet.swift in Sources */,
 				A1ROUTE0012F5000000000002 /* RouteStatusView.swift in Sources */,
 				F1TRNROW01000000000000A2 /* TrainRow.swift in Sources */,
+				F1SVCALR01000000000000A2 /* ServiceAlertsSection.swift in Sources */,
 				F1STDETAIL00000000000000A2 /* StationDetailsView.swift in Sources */,
 				A11A0DC12F4B840B00C96DA1 /* AddRouteAlertView.swift in Sources */,
 				A10E98042DE39F23002F3214 /* TrainListView.swift in Sources */,

--- a/ios/TrackRat/Views/Components/ServiceAlertsSection.swift
+++ b/ios/TrackRat/Views/Components/ServiceAlertsSection.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+// MARK: - Service Alerts Section
+
+/// Two-tab service alerts section (Active / Upcoming) with badge counts.
+/// Defaults to currently-active alerts. Shared by `RouteStatusView` and
+/// `StationDetailsView`; callers decide whether to render it (e.g. only when
+/// the system supports alerts and loading has finished).
+struct ServiceAlertsSection: View {
+    let alerts: [V2ServiceAlert]
+    @State private var selectedFilter: ServiceAlertFilter = .active
+
+    var body: some View {
+        let active = alerts
+            .filter { $0.isActiveNow }
+            .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
+        let upcoming = alerts
+            .filter { !$0.isActiveNow }
+            .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
+        let visible = selectedFilter == .active ? active : upcoming
+
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Service Alerts")
+                    .font(.headline)
+                Spacer()
+                Picker("", selection: $selectedFilter) {
+                    ForEach(ServiceAlertFilter.allCases, id: \.self) { filter in
+                        Text(filter.label(activeCount: active.count, upcomingCount: upcoming.count)).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+            }
+
+            if visible.isEmpty {
+                Text(selectedFilter == .active ? "No active alerts" : "No upcoming alerts")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(visible) { alert in
+                    ServiceAlertCard(alert: alert)
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+    }
+}
+
+// MARK: - Service Alert Filter
+
+enum ServiceAlertFilter: CaseIterable {
+    case active, upcoming
+
+    func label(activeCount: Int, upcomingCount: Int) -> String {
+        switch self {
+        case .active: return "Active (\(activeCount))"
+        case .upcoming: return "Upcoming (\(upcomingCount))"
+        }
+    }
+}
+
+// MARK: - Service Alert Card
+
+struct ServiceAlertCard: View {
+    let alert: V2ServiceAlert
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(alert.alertTypeLabel.uppercased())
+                    .font(.caption2.bold())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(alertTypeColor.opacity(0.2)))
+                    .foregroundColor(alertTypeColor)
+
+                if alert.isActiveNow && !alert.activePeriods.isEmpty {
+                    Text("ACTIVE NOW")
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.green.opacity(0.2)))
+                        .foregroundColor(.green)
+                }
+
+                Spacer()
+            }
+
+            if let periodText = alert.activePeriodText {
+                HStack(spacing: 4) {
+                    Image(systemName: "calendar")
+                        .font(.caption2)
+                    Text(periodText)
+                        .font(.caption)
+                    if alert.additionalPeriodCount > 0 {
+                        Text("(+\(alert.additionalPeriodCount) more)")
+                            .font(.caption)
+                    }
+                }
+                .foregroundColor(.secondary)
+            }
+
+            Text(alert.headerText)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+
+            if let description = alert.descriptionText, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(isExpanded ? nil : 3)
+
+                if description.count > 120 {
+                    Button(isExpanded ? "Show Less" : "Show More") {
+                        withAnimation { isExpanded.toggle() }
+                    }
+                    .font(.caption.bold())
+                    .foregroundColor(.orange)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private var alertTypeColor: Color {
+        switch alert.alertType {
+        case "planned_work": return .yellow
+        case "alert": return .red
+        case "elevator": return .blue
+        default: return .orange
+        }
+    }
+}

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -20,9 +20,6 @@ struct RouteStatusView: View {
     /// Selected history time period for the segmented picker.
     @State private var selectedHistoryPeriod: HistoryPeriod = .hour
 
-    /// Selected service alert filter (active vs upcoming).
-    @State private var selectedAlertFilter: ServiceAlertFilter = .active
-
     /// Preferred highlight mode derived from this route's data source
     private var preferredMode: SegmentHighlightMode {
         TrainSystem(rawValue: context.dataSource)?.preferredHighlightMode ?? .delays
@@ -469,42 +466,7 @@ struct RouteStatusView: View {
         if viewModel.isLoadingServiceAlerts && viewModel.hasServiceAlertSystems {
             // No skeleton for service alerts — they appear when ready
         } else if viewModel.hasServiceAlertSystems {
-            let activeAlerts = viewModel.serviceAlerts
-                .filter { $0.isActiveNow }
-                .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
-            let upcomingAlerts = viewModel.serviceAlerts
-                .filter { !$0.isActiveNow }
-                .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
-            let filteredAlerts = selectedAlertFilter == .active ? activeAlerts : upcomingAlerts
-
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    Text("Service Alerts")
-                        .font(.headline)
-                    Spacer()
-                    Picker("", selection: $selectedAlertFilter) {
-                        ForEach(ServiceAlertFilter.allCases, id: \.self) { filter in
-                            Text(filter.label(activeCount: activeAlerts.count, upcomingCount: upcomingAlerts.count)).tag(filter)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 220)
-                }
-
-                if filteredAlerts.isEmpty {
-                    Text(selectedAlertFilter == .active ? "No active alerts" : "No upcoming alerts")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 8)
-                } else {
-                    ForEach(filteredAlerts) { alert in
-                        ServiceAlertCard(alert: alert)
-                    }
-                }
-            }
-            .padding()
-            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+            ServiceAlertsSection(alerts: viewModel.serviceAlerts)
         }
     }
 
@@ -849,94 +811,6 @@ enum HistoryPeriod: CaseIterable {
         case .hour: return "Hour"
         case .day: return "Day"
         case .week: return "Week"
-        }
-    }
-}
-
-// MARK: - Service Alert Filter
-
-enum ServiceAlertFilter: CaseIterable {
-    case active, upcoming
-
-    func label(activeCount: Int, upcomingCount: Int) -> String {
-        switch self {
-        case .active: return "Active (\(activeCount))"
-        case .upcoming: return "Upcoming (\(upcomingCount))"
-        }
-    }
-}
-
-// MARK: - Service Alert Card
-
-struct ServiceAlertCard: View {
-    let alert: V2ServiceAlert
-    @State private var isExpanded = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Text(alert.alertTypeLabel.uppercased())
-                    .font(.caption2.bold())
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(alertTypeColor.opacity(0.2)))
-                    .foregroundColor(alertTypeColor)
-
-                if alert.isActiveNow && !alert.activePeriods.isEmpty {
-                    Text("ACTIVE NOW")
-                        .font(.caption2.bold())
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Capsule().fill(Color.green.opacity(0.2)))
-                        .foregroundColor(.green)
-                }
-
-                Spacer()
-            }
-
-            if let periodText = alert.activePeriodText {
-                HStack(spacing: 4) {
-                    Image(systemName: "calendar")
-                        .font(.caption2)
-                    Text(periodText)
-                        .font(.caption)
-                    if alert.additionalPeriodCount > 0 {
-                        Text("(+\(alert.additionalPeriodCount) more)")
-                            .font(.caption)
-                    }
-                }
-                .foregroundColor(.secondary)
-            }
-
-            Text(alert.headerText)
-                .font(.subheadline)
-                .foregroundColor(.primary)
-
-            if let description = alert.descriptionText, !description.isEmpty {
-                Text(description)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(isExpanded ? nil : 3)
-
-                if description.count > 120 {
-                    Button(isExpanded ? "Show Less" : "Show More") {
-                        withAnimation { isExpanded.toggle() }
-                    }
-                    .font(.caption.bold())
-                    .foregroundColor(.orange)
-                }
-            }
-        }
-        .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
-    }
-
-    private var alertTypeColor: Color {
-        switch alert.alertType {
-        case "planned_work": return .yellow
-        case "alert": return .red
-        case "elevator": return .blue
-        default: return .orange
         }
     }
 }

--- a/ios/TrackRat/Views/Screens/StationDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/StationDetailsView.swift
@@ -221,17 +221,8 @@ struct StationDetailsView: View {
 
     @ViewBuilder
     private var serviceAlertsSection: some View {
-        if hasAlertSupport && !viewModel.isLoadingAlerts && !viewModel.alerts.isEmpty {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Service Alerts")
-                    .font(.headline)
-
-                ForEach(viewModel.alerts) { alert in
-                    ServiceAlertCard(alert: alert)
-                }
-            }
-            .padding()
-            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        if hasAlertSupport && !viewModel.isLoadingAlerts {
+            ServiceAlertsSection(alerts: viewModel.alerts)
         }
     }
 
@@ -426,11 +417,9 @@ final class StationDetailsViewModel: ObservableObject {
             }
         }
 
-        // Active first, then upcoming; chronological within each group.
-        alerts = collected.sorted {
-            if $0.isActiveNow != $1.isActiveNow { return $0.isActiveNow }
-            return $0.earliestStartEpoch < $1.earliestStartEpoch
-        }
+        // ServiceAlertsSection partitions and sorts internally; just hand it
+        // the raw collected alerts.
+        alerts = collected
     }
 
     /// Per-system GTFS route IDs for routes touching this station, used to scope


### PR DESCRIPTION
Extract the segmented Active/Upcoming service alerts section from
RouteStatusView into a standalone ServiceAlertsSection component (also
moves ServiceAlertFilter and ServiceAlertCard) and adopt it in
StationDetailsView so the station details screen now defaults to
currently-active alerts with an Upcoming tab, matching route details.

https://claude.ai/code/session_01NNcquA31rg4tcTFxCYL8XK