### PR TITLE
fix(amtrak): drop origin-only fallback for SCHEDULED journeys

### DIFF
--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -547,25 +547,6 @@ class AmtrakPatternScheduler:
             sorted_values[mid - 1] + (sorted_values[mid] - sorted_values[mid - 1]) / 2
         )
 
-    def _origin_only_stop(
-        self,
-        journey: TrainJourney,
-        pattern: dict[str, Any],
-        scheduled_departure: datetime,
-    ) -> list[JourneyStop]:
-        """Build the safe fallback stop list when no stable route is known."""
-        return [
-            JourneyStop(
-                journey=journey,
-                station_code=pattern["origin"],
-                station_name=get_station_name(pattern["origin"]),
-                stop_sequence=0,
-                scheduled_departure=scheduled_departure,
-                scheduled_arrival=scheduled_departure,
-                has_departed_station=False,
-            )
-        ]
-
     @staticmethod
     def _normalize_stop_sequences(stops: list[JourneyStop]) -> list[JourneyStop]:
         """Return stops with contiguous sequences before inserting scheduled rows."""
@@ -611,12 +592,18 @@ class AmtrakPatternScheduler:
         )
 
         if not stop_templates:
-            logger.debug(
+            # Skip creating the SCHEDULED record entirely. An origin-only stop
+            # is actively misleading: the train shows up in searches from the
+            # origin but its detail view shows no destination, and downstream
+            # filters that require both endpoints exclude it inconsistently.
+            # Discovery (every 30 min) will create an OBSERVED record once the
+            # train appears in Amtrak's feed.
+            logger.warning(
                 "no_consensus_stops_for_pattern",
                 train_number=pattern["train_number"],
                 sample_count=len(recent_journeys),
             )
-            return self._origin_only_stop(journey, pattern, scheduled_departure)
+            return []
 
         stops = []
         for i, template in enumerate(stop_templates):
@@ -727,6 +714,11 @@ class AmtrakPatternScheduler:
                 stops = await self._build_scheduled_stops(
                     session, journey, pattern, scheduled_departure
                 )
+                if not stops:
+                    # Consensus produced no stops; skip rather than create a
+                    # journey with no route. _build_scheduled_stops already
+                    # logged the reason at WARNING.
+                    continue
                 journey.stops_count = len(stops)
 
                 scheduled_journeys.append(
@@ -783,6 +775,24 @@ class AmtrakPatternScheduler:
                     existing_journey = result.scalar_one_or_none()
 
                     if existing_journey:
+                        # Defense in depth: refuse to replace a multi-stop
+                        # SCHEDULED record with fewer stops. A consensus pass
+                        # that suddenly produces fewer stops (e.g., one bad
+                        # sample run shrinks the intersection) would otherwise
+                        # permanently downgrade the existing route until the
+                        # train goes OBSERVED.
+                        existing_stops_count = existing_journey.stops_count or 0
+                        if len(stops) < existing_stops_count:
+                            logger.warning(
+                                "refusing_stop_downgrade_for_scheduled_journey",
+                                train_id=journey.train_id,
+                                journey_date=journey.journey_date.isoformat(),
+                                existing_stop_count=existing_stops_count,
+                                new_stop_count=len(stops),
+                            )
+                            stats["skipped"] += 1
+                            continue
+
                         # Update times and stops if pattern is more recent
                         existing_journey.scheduled_departure = (
                             journey.scheduled_departure

--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -601,6 +601,8 @@ class AmtrakPatternScheduler:
             logger.warning(
                 "no_consensus_stops_for_pattern",
                 train_number=pattern["train_number"],
+                origin=pattern["origin"],
+                terminal=pattern["terminal"],
                 sample_count=len(recent_journeys),
             )
             return []

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -435,8 +435,13 @@ def test_consensus_stop_templates_canonicalize_amtrak_station_aliases(
 
 
 @pytest.mark.asyncio
-async def test_create_scheduled_journeys_fallback_no_recent(pattern_scheduler):
-    """Test fallback to origin-only stop when no recent OBSERVED journey exists."""
+async def test_create_scheduled_journeys_skips_when_no_consensus(pattern_scheduler):
+    """When consensus can't infer a route, no SCHEDULED record is created.
+
+    An origin-only journey would mislead users: the train shows up under the
+    origin station's departures but its detail view exposes no destination.
+    Discovery will create an OBSERVED record once the train appears live.
+    """
     target_date = date(2024, 1, 25)
 
     patterns = [
@@ -469,15 +474,7 @@ async def test_create_scheduled_journeys_fallback_no_recent(pattern_scheduler):
             patterns, target_date
         )
 
-        assert len(scheduled_journeys) == 1
-        stops = scheduled_journeys[0]["stops"]
-
-        # Falls back to single origin stop
-        assert len(stops) == 1
-        assert stops[0].station_code == "NYP"
-        assert stops[0].scheduled_departure == ET.localize(
-            datetime.combine(target_date, time(10, 0))
-        )
+        assert scheduled_journeys == []
 
 
 @pytest.mark.asyncio
@@ -645,11 +642,13 @@ async def test_save_scheduled_journeys_update_replaces_stops(pattern_scheduler):
     with patch(
         "trackrat.services.amtrak_pattern_scheduler.get_session"
     ) as mock_session:
-        # Mock finding an existing SCHEDULED journey
+        # Mock finding an existing SCHEDULED journey with the same stop count
+        # so the downgrade guard does not skip the update.
         existing_journey = MagicMock()
         existing_journey.id = 42
         existing_journey.observation_type = "SCHEDULED"
         existing_journey.update_count = 1
+        existing_journey.stops_count = 3
 
         mock_select_result = MagicMock()
         mock_select_result.scalar_one_or_none.return_value = existing_journey
@@ -683,6 +682,93 @@ async def test_save_scheduled_journeys_update_replaces_stops(pattern_scheduler):
         # Verify journey metadata was updated
         assert existing_journey.stops_count == 3
         assert existing_journey.update_count == 2
+
+
+@pytest.mark.asyncio
+async def test_save_scheduled_journeys_refuses_to_downgrade_existing(pattern_scheduler):
+    """Existing multi-stop SCHEDULED records must not be replaced with fewer stops.
+
+    A consensus pass that suddenly produces a smaller stop set (e.g., one bad
+    sample run shrinks the intersection) would otherwise wipe a previously-good
+    schedule. The save guard skips the update and leaves the existing record
+    untouched.
+    """
+    journey = TrainJourney(
+        train_id="2150",
+        journey_date=date(2024, 1, 25),
+        data_source="AMTRAK",
+        observation_type="SCHEDULED",
+        origin_station_code="NYP",
+        terminal_station_code="WAS",
+        destination="Washington",
+        line_name="Regional",
+        line_code="AM",
+        scheduled_departure=datetime(2024, 1, 25, 15, 5),
+        has_complete_journey=False,
+        stops_count=1,
+    )
+
+    # Only the origin stop in the new payload — i.e. consensus shrank
+    stops = [
+        JourneyStop(
+            journey=journey,
+            station_code="NYP",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=datetime(2024, 1, 25, 15, 5),
+        ),
+    ]
+
+    scheduled_journeys = [
+        {
+            "journey": journey,
+            "stops": stops,
+            "pattern_info": {
+                "occurrences": 3,
+                "variance_minutes": 2.5,
+                "sample_dates": ["2024-01-18"],
+            },
+        }
+    ]
+
+    with patch(
+        "trackrat.services.amtrak_pattern_scheduler.get_session"
+    ) as mock_session:
+        # Existing SCHEDULED record already has 3 stops
+        existing_journey = MagicMock()
+        existing_journey.id = 42
+        existing_journey.observation_type = "SCHEDULED"
+        existing_journey.update_count = 1
+        existing_journey.stops_count = 3
+
+        mock_select_result = MagicMock()
+        mock_select_result.scalar_one_or_none.return_value = existing_journey
+        mock_execute = AsyncMock(return_value=mock_select_result)
+
+        mock_add = MagicMock()
+        mock_flush = AsyncMock()
+        mock_commit = AsyncMock()
+
+        session_mock = mock_session.return_value.__aenter__.return_value
+        session_mock.execute = mock_execute
+        session_mock.add = mock_add
+        session_mock.flush = mock_flush
+        session_mock.commit = mock_commit
+
+        stats = await pattern_scheduler.save_scheduled_journeys(scheduled_journeys)
+
+        assert stats["created"] == 0
+        assert stats["updated"] == 0
+        assert stats["skipped"] == 1
+        assert stats["errors"] == 0
+
+        # Only the SELECT ran — no DELETE, no re-insert
+        assert mock_execute.call_count == 1
+        assert mock_add.call_count == 0
+
+        # Existing record is untouched
+        assert existing_journey.stops_count == 3
+        assert existing_journey.update_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When AmtrakPatternScheduler can't infer a route from recent OBSERVED
journeys (consensus returns no stops), it used to fall back to a
single origin stop. That created SCHEDULED journey rows whose
journey_stops table held only the origin — e.g. today's A155 had
just NY Penn while the journey row claimed destination=Norfolk.
The detail view then showed a single stop, and downstream filters
that match on origin alone could leak the train into searches whose
destination it doesn't actually serve.

Three changes, all in amtrak_pattern_scheduler.py:

- Skip the pattern entirely when consensus fails. Discovery (every
  30 min) will create an OBSERVED record once the train appears
  live; an origin-only stub is worse than no record.
- Refuse to replace an existing multi-stop SCHEDULED record with
  fewer stops. A consensus pass that temporarily shrinks (e.g. one
  bad sample run collapses the intersection) would otherwise wipe a
  good schedule. The save guard skips the update.
- Promote no_consensus_stops_for_pattern from DEBUG to WARNING so
  this regression is visible in normal log volume.

https://claude.ai/code/session_01BZT1S9oiLo3dgKyUQPXs6k