### PR TITLE
Refactor TrainSystemDetailView with interactive map and service alerts

### DIFF
--- a/ios/TrackRat.xcodeproj/project.pbxproj
+++ b/ios/TrackRat.xcodeproj/project.pbxproj
@@ -151,6 +151,10 @@
 		B1B1B1B12FA1B1B100000002 /* Prefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B1B1B12FA1B1B100000001 /* Prefetcher.swift */; };
 		B1B1B1B12FA1B1B100000003 /* Prefetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B1B1B12FA1B1B100000001 /* Prefetcher.swift */; };
 		B1B1B1B12FA1B1B100000005 /* PrefetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B1B1B12FA1B1B100000004 /* PrefetcherTests.swift */; };
+		B1ALERTS01000000000000A1 /* ServiceAlertsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1ALERTS01000000000000A1 /* ServiceAlertsSection.swift */; };
+		B1ALERTS02000000000000A1 /* ServiceAlertsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1ALERTS01000000000000A1 /* ServiceAlertsSection.swift */; };
+		B1SYSROW01000000000000A1 /* SystemRouteListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SYSROW01000000000000A1 /* SystemRouteListRow.swift */; };
+		B1SYSROW02000000000000A1 /* SystemRouteListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1SYSROW01000000000000A1 /* SystemRouteListRow.swift */; };
 		B1LINSEL01000000000000A1 /* LineSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1LINSEL01000000000000A1 /* LineSelectionView.swift */; };
 		B1LINSEL02000000000000A1 /* LineSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1LINSEL01000000000000A1 /* LineSelectionView.swift */; };
 		B1LINTST01000000000000A1 /* LineSelectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1LINTST01000000000000A1 /* LineSelectionViewTests.swift */; };
@@ -318,6 +322,8 @@
 		BD899D62327DBD0B9C1DDDB6 /* TrainSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainSystemTests.swift; sourceTree = "<group>"; };
 		C182D065DE7062F61B8F2446 /* TripDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TripDetailsView.swift; path = Views/Screens/TripDetailsView.swift; sourceTree = "<group>"; };
 		C1A1B2C3D4E5F60718293A4C /* RouteTopologyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTopologyTests.swift; sourceTree = "<group>"; };
+		F1ALERTS01000000000000A1 /* ServiceAlertsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ServiceAlertsSection.swift; path = TrackRat/Views/Components/ServiceAlertsSection.swift; sourceTree = "<group>"; };
+		F1SYSROW01000000000000A1 /* SystemRouteListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SystemRouteListRow.swift; path = TrackRat/Views/Components/SystemRouteListRow.swift; sourceTree = "<group>"; };
 		F1LINSEL01000000000000A1 /* LineSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LineSelectionView.swift; path = TrackRat/Views/Components/LineSelectionView.swift; sourceTree = "<group>"; };
 		F1LINTST01000000000000A1 /* LineSelectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LineSelectionViewTests.swift; path = TrackRatTests/Views/LineSelectionViewTests.swift; sourceTree = "<group>"; };
 		F1SHIMR001000000000000A1 /* ShimmerRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShimmerRect.swift; path = TrackRat/Views/Components/ShimmerRect.swift; sourceTree = "<group>"; };
@@ -394,6 +400,8 @@
 				A1JF00022F00000000000002 /* JourneyFeedbackPromptView.swift */,
 				A18D98D62F1D2F3700F5D22F /* DateSelectorSheet.swift */,
 				60E6F30618D8429081157633 /* AlertConfigurationSection.swift */,
+				F1ALERTS01000000000000A1 /* ServiceAlertsSection.swift */,
+				F1SYSROW01000000000000A1 /* SystemRouteListRow.swift */,
 				F1LINSEL01000000000000A1 /* LineSelectionView.swift */,
 				F1LINTST01000000000000A1 /* LineSelectionViewTests.swift */,
 				F1SHIMR001000000000000A1 /* ShimmerRect.swift */,
@@ -774,6 +782,8 @@
 				B1SYSCHP01000000000000A1 /* SystemChips.swift in Sources */,
 				A18D98D72F1D2F3700F5D22F /* DateSelectorSheet.swift in Sources */,
 				728970FFA08F441C994FCA1C /* AlertConfigurationSection.swift in Sources */,
+				B1ALERTS01000000000000A1 /* ServiceAlertsSection.swift in Sources */,
+				B1SYSROW01000000000000A1 /* SystemRouteListRow.swift in Sources */,
 				B1LINSEL01000000000000A1 /* LineSelectionView.swift in Sources */,
 				B1SHIMR001000000000000A1 /* ShimmerRect.swift in Sources */,
 				A126E5582E25BBC700958ABA /* TrainV2.swift in Sources */,
@@ -824,6 +834,8 @@
 				A1BA60EF2DFC73650002FB39 /* APIServiceTests.swift in Sources */,
 				A18D98D82F1D2F3700F5D22F /* DateSelectorSheet.swift in Sources */,
 				8DA494D9EB3E4FFD97C93AB7 /* AlertConfigurationSection.swift in Sources */,
+				B1ALERTS02000000000000A1 /* ServiceAlertsSection.swift in Sources */,
+				B1SYSROW02000000000000A1 /* SystemRouteListRow.swift in Sources */,
 				B1LINSEL02000000000000A1 /* LineSelectionView.swift in Sources */,
 				B1SHIMR002000000000000A1 /* ShimmerRect.swift in Sources */,
 				B1SUBLNS02000000000000A1 /* SubwayLines.swift in Sources */,

--- a/ios/TrackRat/Views/Components/OperationsSummaryView.swift
+++ b/ios/TrackRat/Views/Components/OperationsSummaryView.swift
@@ -9,6 +9,10 @@ struct OperationsSummaryView: View {
     let fromStation: String?
     let toStation: String?
     let trainId: String?
+    /// Optional data source filter (e.g. "NJT", "PATH"). When set, the
+    /// network/route summary is scoped to that system instead of the
+    /// whole network.
+    let dataSource: String?
     let isExpandable: Bool
     let onTrainTap: ((String) -> Void)?
 
@@ -27,6 +31,7 @@ struct OperationsSummaryView: View {
         fromStation: String? = nil,
         toStation: String? = nil,
         trainId: String? = nil,
+        dataSource: String? = nil,
         isExpandable: Bool = false,
         onTrainTap: ((String) -> Void)? = nil,
         ratSenseRoute: (from: String, to: String)? = nil
@@ -35,6 +40,7 @@ struct OperationsSummaryView: View {
         self.fromStation = fromStation
         self.toStation = toStation
         self.trainId = trainId
+        self.dataSource = dataSource
         self.isExpandable = isExpandable
         self.onTrainTap = onTrainTap
         self.ratSenseRoute = ratSenseRoute
@@ -115,7 +121,8 @@ struct OperationsSummaryView: View {
                 scope: scope,
                 fromStation: fromStation,
                 toStation: toStation,
-                trainId: trainId
+                trainId: trainId,
+                dataSource: dataSource
             )
             summary = result
 
@@ -126,7 +133,8 @@ struct OperationsSummaryView: View {
                         scope: .route,
                         fromStation: route.from,
                         toStation: route.to,
-                        trainId: nil
+                        trainId: nil,
+                        dataSource: dataSource
                     )
                     routeSummary = routeResult
                     print("📊 OperationsSummary: Route summary body='\(routeResult.body.prefix(60))...'")

--- a/ios/TrackRat/Views/Components/ServiceAlertsSection.swift
+++ b/ios/TrackRat/Views/Components/ServiceAlertsSection.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+// MARK: - Service Alert Filter
+
+enum ServiceAlertFilter: CaseIterable {
+    case active, upcoming
+
+    func label(activeCount: Int, upcomingCount: Int) -> String {
+        switch self {
+        case .active: return "Active (\(activeCount))"
+        case .upcoming: return "Upcoming (\(upcomingCount))"
+        }
+    }
+}
+
+// MARK: - Service Alerts Section
+
+/// Reusable section that splits service alerts into Active vs Upcoming buckets,
+/// renders a segmented picker with counts, and lists `ServiceAlertCard`s for the
+/// selected bucket. Used by `RouteStatusView` and `TrainSystemDetailView`.
+///
+/// The caller is responsible for deciding whether to render this view at all
+/// (e.g. only for systems whose data sources publish alert feeds).
+struct ServiceAlertsSection: View {
+    let alerts: [V2ServiceAlert]
+    @State private var selectedFilter: ServiceAlertFilter = .active
+
+    private var activeAlerts: [V2ServiceAlert] {
+        alerts
+            .filter { $0.isActiveNow }
+            .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
+    }
+
+    private var upcomingAlerts: [V2ServiceAlert] {
+        alerts
+            .filter { !$0.isActiveNow }
+            .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
+    }
+
+    private var filteredAlerts: [V2ServiceAlert] {
+        selectedFilter == .active ? activeAlerts : upcomingAlerts
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Service Alerts")
+                    .font(.headline)
+                Spacer()
+                Picker("", selection: $selectedFilter) {
+                    ForEach(ServiceAlertFilter.allCases, id: \.self) { filter in
+                        Text(filter.label(activeCount: activeAlerts.count, upcomingCount: upcomingAlerts.count)).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 220)
+            }
+
+            if filteredAlerts.isEmpty {
+                Text(selectedFilter == .active ? "No active alerts" : "No upcoming alerts")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(filteredAlerts) { alert in
+                    ServiceAlertCard(alert: alert)
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+    }
+}
+
+// MARK: - Service Alert Card
+
+struct ServiceAlertCard: View {
+    let alert: V2ServiceAlert
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(alert.alertTypeLabel.uppercased())
+                    .font(.caption2.bold())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(alertTypeColor.opacity(0.2)))
+                    .foregroundColor(alertTypeColor)
+
+                if alert.isActiveNow && !alert.activePeriods.isEmpty {
+                    Text("ACTIVE NOW")
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.green.opacity(0.2)))
+                        .foregroundColor(.green)
+                }
+
+                Spacer()
+            }
+
+            if let periodText = alert.activePeriodText {
+                HStack(spacing: 4) {
+                    Image(systemName: "calendar")
+                        .font(.caption2)
+                    Text(periodText)
+                        .font(.caption)
+                    if alert.additionalPeriodCount > 0 {
+                        Text("(+\(alert.additionalPeriodCount) more)")
+                            .font(.caption)
+                    }
+                }
+                .foregroundColor(.secondary)
+            }
+
+            Text(alert.headerText)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+
+            if let description = alert.descriptionText, !description.isEmpty {
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(isExpanded ? nil : 3)
+
+                if description.count > 120 {
+                    Button(isExpanded ? "Show Less" : "Show More") {
+                        withAnimation { isExpanded.toggle() }
+                    }
+                    .font(.caption.bold())
+                    .foregroundColor(.orange)
+                }
+            }
+        }
+        .padding(10)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
+    }
+
+    private var alertTypeColor: Color {
+        switch alert.alertType {
+        case "planned_work": return .yellow
+        case "alert": return .red
+        case "elevator": return .blue
+        default: return .orange
+        }
+    }
+}

--- a/ios/TrackRat/Views/Components/SystemRouteListRow.swift
+++ b/ios/TrackRat/Views/Components/SystemRouteListRow.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// A row in the "Routes" list on `TrainSystemDetailView`. Shows a colored
+/// swatch (system brand color), the route name, terminal subtitle, an optional
+/// average-delay pill, and a chevron. Tapping is handled by the parent view.
+struct SystemRouteListRow: View {
+    let route: RouteLine
+    let system: TrainSystem
+    /// Average delay in minutes across this route's segments, or `nil` when
+    /// no congestion data is available yet (e.g. still loading or no samples).
+    let averageDelayMinutes: Double?
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: system.color))
+                .frame(width: 4, height: 32)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(route.name)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.primary)
+                if let subtitle = route.terminalSubtitle {
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            if let delay = averageDelayMinutes {
+                delayPill(delay)
+            }
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func delayPill(_ delay: Double) -> some View {
+        let (label, color) = pillStyle(for: delay)
+        Text(label)
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(color.opacity(0.2)))
+            .foregroundColor(color)
+    }
+
+    private func pillStyle(for delay: Double) -> (String, Color) {
+        if delay < 0.5 { return ("On time", .green) }
+        let label = String(format: "+%.0f min", delay.rounded())
+        if delay < 5 { return (label, .yellow) }
+        return (label, .red)
+    }
+}

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -20,9 +20,6 @@ struct RouteStatusView: View {
     /// Selected history time period for the segmented picker.
     @State private var selectedHistoryPeriod: HistoryPeriod = .hour
 
-    /// Selected service alert filter (active vs upcoming).
-    @State private var selectedAlertFilter: ServiceAlertFilter = .active
-
     /// Preferred highlight mode derived from this route's data source
     private var preferredMode: SegmentHighlightMode {
         TrainSystem(rawValue: context.dataSource)?.preferredHighlightMode ?? .delays
@@ -466,45 +463,8 @@ struct RouteStatusView: View {
 
     @ViewBuilder
     private var serviceAlertsSection: some View {
-        if viewModel.isLoadingServiceAlerts && viewModel.hasServiceAlertSystems {
-            // No skeleton for service alerts — they appear when ready
-        } else if viewModel.hasServiceAlertSystems {
-            let activeAlerts = viewModel.serviceAlerts
-                .filter { $0.isActiveNow }
-                .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
-            let upcomingAlerts = viewModel.serviceAlerts
-                .filter { !$0.isActiveNow }
-                .sorted { $0.earliestStartEpoch < $1.earliestStartEpoch }
-            let filteredAlerts = selectedAlertFilter == .active ? activeAlerts : upcomingAlerts
-
-            VStack(alignment: .leading, spacing: 12) {
-                HStack {
-                    Text("Service Alerts")
-                        .font(.headline)
-                    Spacer()
-                    Picker("", selection: $selectedAlertFilter) {
-                        ForEach(ServiceAlertFilter.allCases, id: \.self) { filter in
-                            Text(filter.label(activeCount: activeAlerts.count, upcomingCount: upcomingAlerts.count)).tag(filter)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 220)
-                }
-
-                if filteredAlerts.isEmpty {
-                    Text(selectedAlertFilter == .active ? "No active alerts" : "No upcoming alerts")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 8)
-                } else {
-                    ForEach(filteredAlerts) { alert in
-                        ServiceAlertCard(alert: alert)
-                    }
-                }
-            }
-            .padding()
-            .background(RoundedRectangle(cornerRadius: 12).fill(.ultraThinMaterial))
+        if !viewModel.isLoadingServiceAlerts && viewModel.hasServiceAlertSystems {
+            ServiceAlertsSection(alerts: viewModel.serviceAlerts)
         }
     }
 
@@ -849,94 +809,6 @@ enum HistoryPeriod: CaseIterable {
         case .hour: return "Hour"
         case .day: return "Day"
         case .week: return "Week"
-        }
-    }
-}
-
-// MARK: - Service Alert Filter
-
-enum ServiceAlertFilter: CaseIterable {
-    case active, upcoming
-
-    func label(activeCount: Int, upcomingCount: Int) -> String {
-        switch self {
-        case .active: return "Active (\(activeCount))"
-        case .upcoming: return "Upcoming (\(upcomingCount))"
-        }
-    }
-}
-
-// MARK: - Service Alert Card
-
-struct ServiceAlertCard: View {
-    let alert: V2ServiceAlert
-    @State private var isExpanded = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Text(alert.alertTypeLabel.uppercased())
-                    .font(.caption2.bold())
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Capsule().fill(alertTypeColor.opacity(0.2)))
-                    .foregroundColor(alertTypeColor)
-
-                if alert.isActiveNow && !alert.activePeriods.isEmpty {
-                    Text("ACTIVE NOW")
-                        .font(.caption2.bold())
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Capsule().fill(Color.green.opacity(0.2)))
-                        .foregroundColor(.green)
-                }
-
-                Spacer()
-            }
-
-            if let periodText = alert.activePeriodText {
-                HStack(spacing: 4) {
-                    Image(systemName: "calendar")
-                        .font(.caption2)
-                    Text(periodText)
-                        .font(.caption)
-                    if alert.additionalPeriodCount > 0 {
-                        Text("(+\(alert.additionalPeriodCount) more)")
-                            .font(.caption)
-                    }
-                }
-                .foregroundColor(.secondary)
-            }
-
-            Text(alert.headerText)
-                .font(.subheadline)
-                .foregroundColor(.primary)
-
-            if let description = alert.descriptionText, !description.isEmpty {
-                Text(description)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(isExpanded ? nil : 3)
-
-                if description.count > 120 {
-                    Button(isExpanded ? "Show Less" : "Show More") {
-                        withAnimation { isExpanded.toggle() }
-                    }
-                    .font(.caption.bold())
-                    .foregroundColor(.orange)
-                }
-            }
-        }
-        .padding(10)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemGroupedBackground)))
-    }
-
-    private var alertTypeColor: Color {
-        switch alert.alertType {
-        case "planned_work": return .yellow
-        case "alert": return .red
-        case "elevator": return .blue
-        default: return .orange
         }
     }
 }

--- a/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
+++ b/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
@@ -118,6 +118,13 @@ struct TrainSystemDetailView: View {
     private var routesSection: some View {
         let routes = RouteTopology.allRoutes.filter { $0.dataSource == system.dataSource }
         if !routes.isEmpty {
+            // Build the segment lookup once per render so each row's
+            // delay computation is O(stops) instead of O(stops × segments).
+            let segmentsByPair = Dictionary(
+                mapViewModel.segments.map { ("\($0.fromStation)→\($0.toStation)", $0) },
+                uniquingKeysWith: { first, _ in first }
+            )
+
             VStack(alignment: .leading, spacing: 0) {
                 HStack {
                     Text("Routes")
@@ -142,7 +149,7 @@ struct TrainSystemDetailView: View {
                         SystemRouteListRow(
                             route: route,
                             system: system,
-                            averageDelayMinutes: averageDelay(for: route)
+                            averageDelayMinutes: averageDelay(for: route, segmentsByPair: segmentsByPair)
                         )
                     }
                     .buttonStyle(.plain)
@@ -163,19 +170,15 @@ struct TrainSystemDetailView: View {
 
     /// Average delay (in minutes) across the segments that make up `route`,
     /// or `nil` if no segments are loaded for the route's consecutive station
-    /// pairs. Uses `mapViewModel.segments` so the value updates with the map.
-    private func averageDelay(for route: RouteLine) -> Double? {
+    /// pairs. Looks up segments via the caller-provided dictionary so the cost
+    /// is O(stops) per route instead of O(stops × segments).
+    private func averageDelay(for route: RouteLine, segmentsByPair: [String: CongestionSegment]) -> Double? {
         let codes = route.stationCodes
         guard codes.count >= 2 else { return nil }
         var totals: [Double] = []
         for i in 0..<(codes.count - 1) {
-            let from = codes[i]
-            let to = codes[i + 1]
-            if let segment = mapViewModel.segments.first(where: {
-                $0.fromStation == from
-                    && $0.toStation == to
-                    && $0.dataSource == route.dataSource
-            }) {
+            let key = "\(codes[i])→\(codes[i + 1])"
+            if let segment = segmentsByPair[key] {
                 totals.append(segment.averageDelayMinutes)
             }
         }

--- a/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
+++ b/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
@@ -38,7 +38,7 @@ struct TrainSystemDetailView: View {
         ScrollView {
             VStack(spacing: 16) {
                 mapSection
-                OperationsSummaryView(scope: .network)
+                OperationsSummaryView(scope: .network, dataSource: system.dataSource)
                 if hasServiceAlertFeed {
                     ServiceAlertsSection(alerts: serviceAlerts)
                 }
@@ -120,10 +120,18 @@ struct TrainSystemDetailView: View {
         if !routes.isEmpty {
             // Build the segment lookup once per render so each row's
             // delay computation is O(stops) instead of O(stops × segments).
-            let segmentsByPair = Dictionary(
-                mapViewModel.segments.map { ("\($0.fromStation)→\($0.toStation)", $0) },
-                uniquingKeysWith: { first, _ in first }
-            )
+            // Key by an alphabetically-ordered pair so A→B and B→A collapse
+            // to the same entry; the backend can return either direction and
+            // we want consecutive route stops to find a match regardless.
+            // When both directions are present, keep the one with more samples.
+            let segmentsByPair: [String: CongestionSegment] = mapViewModel.segments
+                .reduce(into: [:]) { acc, segment in
+                    let key = Self.canonicalPairKey(segment.fromStation, segment.toStation)
+                    if let existing = acc[key], existing.sampleCount >= segment.sampleCount {
+                        return
+                    }
+                    acc[key] = segment
+                }
 
             VStack(alignment: .leading, spacing: 0) {
                 HStack {
@@ -177,13 +185,20 @@ struct TrainSystemDetailView: View {
         guard codes.count >= 2 else { return nil }
         var totals: [Double] = []
         for i in 0..<(codes.count - 1) {
-            let key = "\(codes[i])→\(codes[i + 1])"
+            let key = Self.canonicalPairKey(codes[i], codes[i + 1])
             if let segment = segmentsByPair[key] {
                 totals.append(segment.averageDelayMinutes)
             }
         }
         guard !totals.isEmpty else { return nil }
         return totals.reduce(0, +) / Double(totals.count)
+    }
+
+    /// Alphabetically-ordered key for a station pair so A↔B collapses to a
+    /// single canonical entry. Matches the convention used by
+    /// `buildMergedAggregatedOverlays` in `CongestionMapView`.
+    private static func canonicalPairKey(_ a: String, _ b: String) -> String {
+        a < b ? "\(a)|\(b)" : "\(b)|\(a)"
     }
 
     private var alertsSection: some View {

--- a/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
+++ b/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
 import MapKit
 
-/// System-level details: a route map, recent network stats, and a single
-/// opt-in toggle for system-wide route alerts. Pushed from SettingsView when
-/// a TrainSystemRow is tapped outside of edit mode.
+/// System-level details: an interactive system-wide route map, a network
+/// operations summary, current service alerts, and a single opt-in toggle for
+/// system-wide route alerts. Pushed from SettingsView when a TrainSystemRow is
+/// tapped outside of edit mode.
+///
+/// Tapping a map segment presents `RouteStatusView` as a sheet with the
+/// concrete origin/destination pair, mirroring `CongestionMapView`.
 struct TrainSystemDetailView: View {
     let system: TrainSystem
 
@@ -14,6 +18,16 @@ struct TrainSystemDetailView: View {
     @State private var region: MKCoordinateRegion
     @State private var serviceAlerts: [V2ServiceAlert] = []
     @State private var showingPaywall = false
+    @State private var routeStatusContext: RouteStatusContext?
+
+    /// Data sources whose backend feeds publish service alerts. Other systems
+    /// (PATH, BART, MBTA, etc.) have `supportsAlerts = true` for delay/cancel
+    /// push notifications but no service-alert feed, so the section is hidden.
+    private static let serviceAlertSystems: Set<String> = ["SUBWAY", "LIRR", "MNR", "NJT"]
+
+    private var hasServiceAlertFeed: Bool {
+        Self.serviceAlertSystems.contains(system.dataSource)
+    }
 
     init(system: TrainSystem) {
         self.system = system
@@ -24,8 +38,19 @@ struct TrainSystemDetailView: View {
         ScrollView {
             VStack(spacing: 16) {
                 mapSection
-                statsSection
+                OperationsSummaryView(scope: .network)
+                if hasServiceAlertFeed {
+                    ServiceAlertsSection(alerts: serviceAlerts)
+                }
+                routesSection
                 alertsSection
+                FeedbackButton(
+                    screen: "system_detail",
+                    trainId: nil,
+                    originCode: nil,
+                    destinationCode: nil
+                )
+                .padding(.top, 8)
             }
             .padding()
         }
@@ -42,15 +67,17 @@ struct TrainSystemDetailView: View {
         .sheet(isPresented: $showingPaywall) {
             PaywallView(context: .routeAlerts)
         }
+        .sheet(item: $routeStatusContext) { context in
+            RouteStatusView(context: context)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
     }
 
     // MARK: - Sections
 
     private var mapSection: some View {
         ZStack(alignment: .topTrailing) {
-            // Embedded map preview. Hit-testing is disabled so vertical scroll
-            // gestures aren't stolen by MKMapView; the map serves as visual
-            // context, not as a fully interactive surface.
             SystemCongestionMapView(
                 region: $region,
                 segments: mapViewModel.segments,
@@ -59,12 +86,24 @@ struct TrainSystemDetailView: View {
                 showRoutes: mapViewModel.showRoutes,
                 selectedSystems: [system],
                 highlightMode: mapViewModel.highlightMode,
-                onSegmentTap: { _ in },
+                onSegmentTap: { segment in
+                    let route = RouteTopology.routeContaining(
+                        from: segment.fromStation,
+                        to: segment.toStation,
+                        dataSource: segment.dataSource
+                    )
+                    routeStatusContext = RouteStatusContext(
+                        dataSource: segment.dataSource,
+                        lineId: route?.id,
+                        fromStationCode: segment.fromStation,
+                        toStationCode: segment.toStation
+                    )
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                },
                 onIndividualSegmentTap: nil
             )
             .frame(height: 280)
             .clipShape(RoundedRectangle(cornerRadius: 12))
-            .allowsHitTesting(false)
 
             if mapViewModel.isLoading {
                 ProgressView()
@@ -75,62 +114,73 @@ struct TrainSystemDetailView: View {
         }
     }
 
-    private var statsSection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: 16) {
-                Image(systemName: "chart.bar.fill")
-                    .font(.title2)
-                    .foregroundColor(.orange)
-                    .frame(width: 24, height: 24)
+    @ViewBuilder
+    private var routesSection: some View {
+        let routes = RouteTopology.allRoutes.filter { $0.dataSource == system.dataSource }
+        if !routes.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text("Routes")
+                        .font(.headline)
+                    Spacer()
+                    Text("\(routes.count)")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal)
+                .padding(.top)
+                .padding(.bottom, 8)
 
-                Text("Recent Activity")
-                    .font(.headline)
+                ForEach(Array(routes.enumerated()), id: \.element.id) { index, route in
+                    Button {
+                        routeStatusContext = RouteStatusContext(
+                            dataSource: system.dataSource,
+                            lineId: route.id
+                        )
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    } label: {
+                        SystemRouteListRow(
+                            route: route,
+                            system: system,
+                            averageDelayMinutes: averageDelay(for: route)
+                        )
+                    }
+                    .buttonStyle(.plain)
 
-                Spacer()
+                    if index < routes.count - 1 {
+                        Divider().padding(.leading)
+                    }
+                }
             }
-            .padding()
-
-            Divider()
-
-            statRow(icon: "clock.fill", label: "Average delay", value: averageDelayDisplay)
-            Divider()
-            statRow(icon: "map.fill", label: "Routes", value: "\(systemRouteCount)")
-            Divider()
-            statRow(
-                icon: "exclamationmark.triangle.fill",
-                label: "Active alerts",
-                value: activeAlertCount > 0 ? "\(activeAlertCount)" : "None"
-            )
-            Divider()
-            statRow(
-                icon: "wrench.and.screwdriver.fill",
-                label: "Planned work",
-                value: plannedWorkCount > 0 ? "\(plannedWorkCount)" : "None"
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.ultraThinMaterial)
             )
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(.ultraThinMaterial)
-        )
     }
 
-    private func statRow(icon: String, label: String, value: String) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: icon)
-                .font(.body)
-                .foregroundColor(.orange.opacity(0.8))
-                .frame(width: 24)
-            Text(label)
-                .font(.subheadline)
-            Spacer()
-            Text(value)
-                .font(.subheadline)
-                .fontWeight(.medium)
-                .foregroundColor(.secondary)
+    /// Average delay (in minutes) across the segments that make up `route`,
+    /// or `nil` if no segments are loaded for the route's consecutive station
+    /// pairs. Uses `mapViewModel.segments` so the value updates with the map.
+    private func averageDelay(for route: RouteLine) -> Double? {
+        let codes = route.stationCodes
+        guard codes.count >= 2 else { return nil }
+        var totals: [Double] = []
+        for i in 0..<(codes.count - 1) {
+            let from = codes[i]
+            let to = codes[i + 1]
+            if let segment = mapViewModel.segments.first(where: {
+                $0.fromStation == from
+                    && $0.toStation == to
+                    && $0.dataSource == route.dataSource
+            }) {
+                totals.append(segment.averageDelayMinutes)
+            }
         }
-        .padding(.horizontal)
-        .padding(.vertical, 12)
+        guard !totals.isEmpty else { return nil }
+        return totals.reduce(0, +) / Double(totals.count)
     }
 
     private var alertsSection: some View {
@@ -207,28 +257,6 @@ struct TrainSystemDetailView: View {
         )
     }
 
-    private var systemRouteCount: Int {
-        RouteTopology.allRoutes.filter { $0.dataSource == system.dataSource }.count
-    }
-
-    private var averageDelayDisplay: String {
-        let segments = mapViewModel.segments
-        guard !segments.isEmpty else {
-            return mapViewModel.isLoading ? "—" : "No data"
-        }
-        let avg = segments.map(\.averageDelayMinutes).reduce(0, +) / Double(segments.count)
-        if avg < 0.5 { return "On time" }
-        return String(format: "%.1f min", avg)
-    }
-
-    private var activeAlertCount: Int {
-        serviceAlerts.filter { $0.alertType == "alert" && $0.isActiveNow }.count
-    }
-
-    private var plannedWorkCount: Int {
-        serviceAlerts.filter { $0.alertType == "planned_work" && $0.isActiveNow }.count
-    }
-
     private var alertSubtitleText: String {
         if !system.supportsAlerts {
             return "Real-time alerts not available for \(system.displayName)."
@@ -257,7 +285,7 @@ struct TrainSystemDetailView: View {
     }
 
     private func loadServiceAlerts() async {
-        guard system.supportsAlerts else { return }
+        guard hasServiceAlertFeed else { return }
         do {
             serviceAlerts = try await APIService.shared.fetchServiceAlerts(dataSource: system.dataSource)
         } catch {


### PR DESCRIPTION
## Summary
Significantly enhances `TrainSystemDetailView` with interactive map segment tapping, a dedicated routes list, and extracted service alert components for reusability across views.

## Key Changes

- **Interactive Map Segments**: Map segments now respond to taps by presenting `RouteStatusView` as a sheet, mirroring the behavior in `CongestionMapView`. Tapping triggers haptic feedback and resolves the route topology to populate the context.

- **Routes Section**: Replaced the "Recent Activity" stats section with a new interactive routes list that displays all routes for the system. Each route row shows:
  - Colored swatch matching system branding
  - Route name and terminal subtitle
  - Average delay pill (color-coded: green for on-time, yellow for <5min, red for ≥5min)
  - Tapping a route opens `RouteStatusView` for that specific line

- **Service Alerts Extraction**: Extracted `ServiceAlertCard` and alert filtering logic into a new reusable `ServiceAlertsSection` component. This component:
  - Splits alerts into Active vs Upcoming buckets with segmented picker
  - Displays counts in picker labels
  - Renders empty state messages
  - Is now used by both `RouteStatusView` and `TrainSystemDetailView`

- **Service Alert Feed Gating**: Added `serviceAlertSystems` constant to identify which data sources (SUBWAY, LIRR, MNR, NJT) publish service alert feeds. The service alerts section only renders for these systems, preventing empty sections for systems like PATH and BART that support push notifications but lack alert feeds.

- **New Components**:
  - `SystemRouteListRow.swift`: Reusable row component for displaying routes with delay indicators
  - `ServiceAlertsSection.swift`: Extracted and enhanced service alerts UI with filtering

- **Operations Summary**: Replaced custom stats display with `OperationsSummaryView(scope: .network)` for consistency.

- **Feedback Button**: Added feedback button to the system detail view for user reporting.

- **Performance**: Routes section builds a segment lookup dictionary once per render to ensure delay computation is O(stops) instead of O(stops × segments).

## Implementation Details

- Map hit-testing is now enabled (removed `.allowsHitTesting(false)`) to support segment interaction
- Route status context is managed via `@State private var routeStatusContext: RouteStatusContext?`
- Service alert loading now checks `hasServiceAlertFeed` instead of `system.supportsAlerts` to distinguish between alert feed availability and push notification support
- Haptic feedback (light impact) provided on both map segment and route list taps

https://claude.ai/code/session_011VGwAVg2HYDveZWtZwLXrj