### PR TITLE
Issue #1169: Surface 404 from getPlatformPrediction as APIError.notFound

### DIFF
--- a/ios/TrackRat/Services/APIService.swift
+++ b/ios/TrackRat/Services/APIService.swift
@@ -1277,16 +1277,18 @@ final class APIService: ObservableObject {
 
         if let httpResponse = response as? HTTPURLResponse {
             print("📡 [APIService] Response status: \(httpResponse.statusCode)")
+            if httpResponse.statusCode == 404 {
+                throw APIError.notFound
+            }
             if httpResponse.statusCode != 200 {
-                print("⚠️ [APIService] Non-200 status code")
                 if let responseStr = String(data: data, encoding: .utf8) {
                     print("   Response body: \(responseStr)")
                 }
+                throw APIError.serverError
             }
         }
 
         do {
-            // Try to decode the response
             let prediction = try decoder.decode(PlatformPrediction.self, from: data)
             print("✅ [APIService] Successfully decoded platform prediction")
             return prediction

--- a/ios/TrackRat/Services/StaticTrackDistributionService.swift
+++ b/ios/TrackRat/Services/StaticTrackDistributionService.swift
@@ -86,11 +86,13 @@ class StaticTrackDistributionService {
 
             return PredictionData(trackProbabilities: trackProbabilities)
 
+        } catch APIError.notFound {
+            print("ℹ️ [StaticTrackDistribution] No historical data for train \(train.trainId) at \(train.originStationCode) — predictions unavailable")
+            return nil
         } catch {
             print("❌ [StaticTrackDistribution] ML platform prediction failed:")
             print("   Error: \(error)")
             print("   Localized: \(error.localizedDescription)")
-            // If API fails, don't show predictions
             return nil
         }
     }

--- a/ios/TrackRatTests/Services/APIServiceTests.swift
+++ b/ios/TrackRatTests/Services/APIServiceTests.swift
@@ -62,4 +62,48 @@ class APIServiceTests: XCTestCase {
             XCTFail("Should be able to decode Train from JSON. Error: \(error)")
         }
     }
+
+    func testPlatformPredictionDecodesValidResponse() {
+        let jsonString = """
+        {
+            "platform_probabilities": {"1": 0.6, "2": 0.4},
+            "primary_prediction": "1",
+            "confidence": 0.85,
+            "top_3": ["1", "2", "3"],
+            "model_version": "v1",
+            "station_code": "NY",
+            "train_id": "1234"
+        }
+        """
+        do {
+            let prediction = try TestHelpers.decodeJSON(PlatformPrediction.self, from: jsonString)
+            XCTAssertEqual(prediction.primaryPrediction, "1")
+            XCTAssertEqual(prediction.confidence, 0.85, accuracy: 0.0001)
+            XCTAssertEqual(prediction.top3, ["1", "2", "3"])
+        } catch {
+            XCTFail("Should decode a valid PlatformPrediction. Error: \(error)")
+        }
+    }
+
+    func testPlatformPredictionDoesNotDecodeFromErrorBody() {
+        // Backend returns a 404 with this body when there's no historical data
+        // (see backend_v2/src/trackrat/api/predictions.py).
+        // Pre-fix behavior: getPlatformPrediction would attempt to decode this
+        // body as a PlatformPrediction, surfacing a misleading "Decoding error"
+        // in the caller. The fix is to throw APIError.notFound on a 404 status
+        // before decoding. This test guards that the error body is not
+        // accidentally decodable to PlatformPrediction.
+        let errorBody = """
+        {"detail": "Insufficient historical data to predict track for train 1234 at station NY"}
+        """
+        XCTAssertThrowsError(
+            try TestHelpers.decodeJSON(PlatformPrediction.self, from: errorBody),
+            "An error response body must not silently decode as a PlatformPrediction"
+        )
+    }
+
+    func testAPIErrorDescriptions() {
+        XCTAssertEqual(APIError.notFound.errorDescription, "Resource not found")
+        XCTAssertEqual(APIError.serverError.errorDescription, "Server error")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the latent bug in `APIService.getPlatformPrediction` described in #1169. When the backend returns 404 ("Insufficient historical data...") for a train, the function was attempting to decode the JSON error body as a `PlatformPrediction`, which raised a `DecodingError`. The caller in `StaticTrackDistributionService.getAdjustedPredictionData` swallowed that error with the misleading log `"Decoding error: ..."` rather than `"no historical data"`.

## Changes

- **`ios/TrackRat/Services/APIService.swift`** — `getPlatformPrediction` now checks the HTTP status before decoding and throws `APIError.notFound` on 404 / `APIError.serverError` on other non-200, mirroring the existing pattern in `getRoutePreference` (line ~256-258).
- **`ios/TrackRat/Services/StaticTrackDistributionService.swift`** — adds a `catch APIError.notFound` arm before the generic `catch` so the absence-of-historical-data case logs an informational `"No historical data..."` message rather than the generic `"ML platform prediction failed"` error path.
- **`ios/TrackRatTests/Services/APIServiceTests.swift`** — adds three tests:
  - `testPlatformPredictionDecodesValidResponse` — sanity: a well-formed response still decodes.
  - `testPlatformPredictionDoesNotDecodeFromErrorBody` — guards the bug shape: the 404 `{"detail": "..."}` body must not silently decode to `PlatformPrediction`.
  - `testAPIErrorDescriptions` — locks in the `errorDescription` strings used in user-facing logs.

## Design notes

- Reused the existing `APIError.notFound` / `APIError.serverError` cases rather than adding a prediction-specific error — the caller only needs to distinguish "no data" from "everything else", which the existing enum cleanly expresses.
- Did not refactor `APIService` to accept an injected `URLSession`: `CLAUDE.md` prohibits mocking and the rest of the file uses the same `private let session` pattern, so the tests cover the decode-side of the bug rather than the HTTP-status-mapping side.
- Pure error-path change; no behavioral change on the happy path.

Closes #1169

https://claude.ai/code/session_01W3Xa5X9bvUFngc9zaRRBtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3Xa5X9bvUFngc9zaRRBtm)_