### PR TITLE
docs: weekly documentation audit (2026-05-11)

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -282,6 +282,7 @@ The APScheduler runs in-process and handles:
 - **Daily at 12:45 AM ET**: Amtrak pattern-based schedule generation
 - **Daily at 1:00 AM ET**: Lock manager cleanup
 - **Daily at 3:00 AM ET**: GTFS static schedule refresh
+- **Daily at 3:30 AM ET**: Data retention cleanup (deletes journeys older than `TRACKRAT_RETENTION_DAYS`)
 - **Every 30 min**: NJT and Amtrak train discovery from major stations
 - **Every 4 min**: PATH collection (unified, RidePATH API)
 - **Every 4 min**: LIRR collection (unified, MTA GTFS-RT)

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -91,6 +91,7 @@ poetry run uvicorn trackrat.main:app --reload
 - **Every 5 minutes**: Update checks for active journeys
 - **Every 5 minutes**: Route alert evaluation and push notifications
 - **Hourly at :05**: Validation across key routes
+- **Daily 3:30 AM ET**: Data retention cleanup (deletes journeys older than `TRACKRAT_RETENTION_DAYS`, default 120 days)
 - Monitor scheduler status at `/scheduler/status` endpoint
 
 **Note**: PATH, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, and WMATA each use unified collectors that handle both discovery and journey updates in a single pass. LIRR, Metro-North, Subway, BART, MBTA, and Metra use GTFS-RT feeds with shared logic in `mta_common.py`. WMATA uses its REST API. PATCO uses GTFS static schedules only (no real-time API).

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -27,11 +27,11 @@ SwiftUI app for tracking trains across 11 transit systems: NJ Transit, Amtrak, P
 TrackRat/
 ├── App/              # TrackRatApp.swift, ContentView.swift
 ├── Views/
-│   ├── Screens/      # 16 screen-level views
-│   ├── Components/   # 25 reusable UI components
+│   ├── Screens/      # 18 screen-level views
+│   ├── Components/   # 28 reusable UI components
 │   └── Paywall/      # PaywallView, ProFeatureLockView
 ├── Models/           # Train, TrainV2, V2APIModels, TrainSystem, TripOption, CompletedTrip, DeepLink
-├── Services/         # 14 singleton services
+├── Services/         # 15 singleton services
 ├── Shared/           # Stations, StationData, StationCoordinates, StationDepartures, LiveActivityModels, RouteTopology, RouteShapes, SubwayLines
 ├── Theme/            # TrackRatTheme.swift
 ├── Utilities/        # Extensions.swift, Logger.swift
@@ -52,6 +52,7 @@ TrackRatTests/               # Unit tests
 | SubscriptionService | StoreKit 2 Pro subscription |
 | BackendWakeupService | Health checks with 15-min cache |
 | AlertSubscriptionService | Route alert subscriptions and APNS registration |
+| Prefetcher | Warms trip list + train detail caches for instant navigation |
 | DeepLinkService | Deep link handling |
 | ShareService | Sharing functionality |
 | JourneyFeedbackService | Journey feedback |

--- a/ios/README.md
+++ b/ios/README.md
@@ -118,10 +118,11 @@ TrackRat/
 │   ├── SubscriptionService.swift # Pro subscription management
 │   ├── TripRecordingService.swift # Trip statistics tracking
 │   ├── JourneyFeedbackService.swift # Journey feedback prompts
+│   ├── Prefetcher.swift           # Warm trips list + train detail caches
 │   └── StaticTrackDistributionService.swift # Track analytics
 │
 ├── Views/                       # UI layer
-│   ├── Screens/                # Full-screen views (16 screens)
+│   ├── Screens/                # Full-screen views (18 screens)
 │   │   ├── TripSelectionView.swift      # Home screen with search
 │   │   ├── DeparturePickerView.swift    # Origin station selection
 │   │   ├── DestinationPickerView.swift  # Destination selection
@@ -132,6 +133,8 @@ TrackRat/
 │   │   ├── HistoricalDataView.swift     # Performance analytics
 │   │   ├── PennStationGuideView.swift   # Penn Station boarding guide
 │   │   ├── SettingsView.swift           # User settings (inline favorites & route alerts)
+│   │   ├── StationDetailsView.swift     # Per-station overview (departures, alerts, routes)
+│   │   ├── TrainSystemDetailView.swift  # System-level overview (map, alerts, routes)
 │   │   ├── MapContainerView.swift       # Primary map interface
 │   │   ├── OnboardingView.swift         # User onboarding
 │   │   ├── AdvancedConfigurationView.swift # Developer settings
@@ -139,7 +142,7 @@ TrackRat/
 │   │   ├── AddRouteAlertView.swift      # Add route alert
 │   │   └── TripHistoryView.swift        # Trip history
 │   │
-│   └── Components/              # Reusable UI components (25 files)
+│   └── Components/              # Reusable UI components (28 files)
 │       ├── ActiveTripsSection.swift     # Live Activity cards
 │       ├── AlertConfigurationSection.swift # Route alert configuration
 │       ├── ConfettiView.swift           # Confetti animation effect
@@ -152,18 +155,21 @@ TrackRat/
 │       ├── LineSelectionView.swift      # Transit line selection
 │       ├── LiveActivityControls.swift   # Start/stop buttons
 │       ├── OperationsSummaryView.swift  # Operations summary
+│       ├── ServiceAlertsSection.swift   # Active/Upcoming alerts tabs (shared)
 │       ├── ShimmerRect.swift            # Shimmer loading placeholder
 │       ├── StationButton.swift          # Station selection button
 │       ├── StationPickerSheet.swift     # Station picker modal
 │       ├── StationRow.swift             # Station list row
 │       ├── SubwayLineChips.swift        # Subway line badge chips
 │       ├── SystemChips.swift            # Transit system indicator chips
+│       ├── SystemRouteListRow.swift     # Routes-list row on TrainSystemDetailView
 │       ├── TrackRatLoadingView.swift    # Loading animation
 │       ├── TrackRatMascot.swift         # Animated character
 │       ├── TrackRatNavigationHeader.swift # Navigation header
 │       ├── TrackTrainInlineButton.swift # Inline track button
 │       ├── TrainDistributionChart.swift # Delay distribution
 │       ├── TrainFrequencyChart.swift    # Frequency chart (column layout)
+│       ├── TrainRow.swift               # Compact line-color-bar departure row
 │       └── TrainStatsSummaryView.swift  # Train performance
 │
 ├── Views/Paywall/               # Subscription UI


### PR DESCRIPTION
## Summary

Weekly audit of all CLAUDE.md and README.md files against the current codebase. Fixes documentation drift introduced in the past 7 days of commits.

### iOS docs

- `ios/CLAUDE.md` and `ios/README.md`: screen count 16 → 18 (adds `StationDetailsView`, `TrainSystemDetailView`), component count 25 → 28 (adds `ServiceAlertsSection`, `SystemRouteListRow`, `TrainRow`), service count 14 → 15 (adds `Prefetcher`).
- File listings in `ios/README.md` updated to include the new files with one-line descriptions matching the existing tone.
- Services table in `ios/CLAUDE.md` adds a `Prefetcher` row.

### Backend docs

- `backend_v2/CLAUDE.md` and `backend_v2/README.md`: document the daily `retention_cleanup` scheduler job at 3:30 AM ET (deletes journeys older than `TRACKRAT_RETENTION_DAYS`, default 120 days). This job exists in `services/scheduler.py` but was undocumented.

### Verified accurate (no changes needed)

- Root `CLAUDE.md`: file locations, API endpoints, scripts, env vars, ground-truth validation, GCP log viewing.
- Root `README.md`: transit systems list, env vars, project structure.
- `webpage_v2/CLAUDE.md` and `webpage_v2/README.md`: component list (20 files matches), endpoints, design system.
- `infra_v2/README.md`: secrets list, deployment pipeline.
- `android/CLAUDE.md` and `android/README.md`: project structure, API endpoints.
- All documented API endpoints (`/api/v2/*`, `/admin/*`, `/health*`, `/scheduler/*`, `/metrics`, `/share/*`) match registered routers.
- All documented scheduler jobs except `retention_cleanup` were already present.
- All documented backend services match `services/` directory contents.

## Test plan

- [ ] Verify diff is limited to the four doc files above
- [ ] Confirm screen / component / service counts match `ls ios/TrackRat/Views/Screens/`, `ls ios/TrackRat/Views/Components/`, and `ls ios/TrackRat/Services/`
- [ ] Confirm `retention_cleanup` job exists in `backend_v2/src/trackrat/services/scheduler.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmuJmkPWBvi9uPcD6BNWdE)_