### PR TITLE
Issue #1170: Skip Amtrak scheduled save when row is already OBSERVED

### DIFF
--- a/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
+++ b/backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py
@@ -764,17 +764,34 @@ class AmtrakPatternScheduler:
                 stops = self._normalize_stop_sequences(item["stops"])
 
                 try:
-                    # Check for existing SCHEDULED record
+                    # Check for any existing journey row for this (train_id,
+                    # journey_date, AMTRAK). The unique_train_journey constraint
+                    # ignores observation_type, so we cannot filter on it here:
+                    # a SCHEDULED→OBSERVED flip between create_scheduled_journeys
+                    # and this save would hide the row and send us down the
+                    # insert path, which then raises IntegrityError on commit.
                     stmt = select(TrainJourney).where(
                         and_(
                             TrainJourney.train_id == journey.train_id,
                             TrainJourney.journey_date == journey.journey_date,
                             TrainJourney.data_source == "AMTRAK",
-                            TrainJourney.observation_type == "SCHEDULED",
                         )
                     )
                     result = await session.execute(stmt)
                     existing_journey = result.scalar_one_or_none()
+
+                    if existing_journey and existing_journey.observation_type == "OBSERVED":
+                        # Discovery promoted the row to OBSERVED while we were
+                        # preparing this save. We have real data — leave it
+                        # alone rather than overwriting it with a SCHEDULED
+                        # payload.
+                        logger.debug(
+                            "skipping_scheduled_save_train_already_observed",
+                            train_id=journey.train_id,
+                            journey_date=journey.journey_date.isoformat(),
+                        )
+                        stats["skipped"] += 1
+                        continue
 
                     if existing_journey:
                         # Defense in depth: refuse to replace a multi-stop

--- a/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
+++ b/backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py
@@ -772,6 +772,95 @@ async def test_save_scheduled_journeys_refuses_to_downgrade_existing(pattern_sch
 
 
 @pytest.mark.asyncio
+async def test_save_scheduled_journeys_skips_when_already_observed(pattern_scheduler):
+    """Discovery may flip the row to OBSERVED between create_scheduled_journeys
+    and save_scheduled_journeys. The save must not try to re-insert a SCHEDULED
+    row for the same (train_id, journey_date, AMTRAK) — the unique constraint
+    ignores observation_type, so an INSERT would raise IntegrityError and be
+    counted as an error. Instead, treat the existing OBSERVED row as authoritative
+    and skip.
+    """
+    journey = TrainJourney(
+        train_id="2150",
+        journey_date=date(2024, 1, 25),
+        data_source="AMTRAK",
+        observation_type="SCHEDULED",
+        origin_station_code="NYP",
+        terminal_station_code="WAS",
+        destination="Washington",
+        line_name="Regional",
+        line_code="AM",
+        scheduled_departure=datetime(2024, 1, 25, 15, 5),
+        has_complete_journey=False,
+        stops_count=1,
+    )
+
+    stops = [
+        JourneyStop(
+            journey=journey,
+            station_code="NYP",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=datetime(2024, 1, 25, 15, 5),
+        ),
+    ]
+
+    scheduled_journeys = [
+        {
+            "journey": journey,
+            "stops": stops,
+            "pattern_info": {
+                "occurrences": 3,
+                "variance_minutes": 2.5,
+                "sample_dates": ["2024-01-18"],
+            },
+        }
+    ]
+
+    with patch(
+        "trackrat.services.amtrak_pattern_scheduler.get_session"
+    ) as mock_session:
+        # Discovery flipped the row to OBSERVED between create and save.
+        existing_journey = MagicMock()
+        existing_journey.id = 42
+        existing_journey.observation_type = "OBSERVED"
+        existing_journey.update_count = 5
+        existing_journey.stops_count = 12
+
+        mock_select_result = MagicMock()
+        mock_select_result.scalar_one_or_none.return_value = existing_journey
+        mock_execute = AsyncMock(return_value=mock_select_result)
+
+        mock_add = MagicMock()
+        mock_flush = AsyncMock()
+        mock_commit = AsyncMock()
+
+        session_mock = mock_session.return_value.__aenter__.return_value
+        session_mock.execute = mock_execute
+        session_mock.add = mock_add
+        session_mock.flush = mock_flush
+        session_mock.commit = mock_commit
+
+        stats = await pattern_scheduler.save_scheduled_journeys(scheduled_journeys)
+
+        # Skipped — not created, not updated, not counted as an error
+        assert stats["created"] == 0
+        assert stats["updated"] == 0
+        assert stats["skipped"] == 1
+        assert stats["errors"] == 0
+
+        # Only the SELECT ran — no INSERT, no DELETE, no flush per-item
+        assert mock_execute.call_count == 1
+        assert mock_add.call_count == 0
+        assert mock_flush.call_count == 0
+
+        # Existing OBSERVED row is untouched
+        assert existing_journey.observation_type == "OBSERVED"
+        assert existing_journey.stops_count == 12
+        assert existing_journey.update_count == 5
+
+
+@pytest.mark.asyncio
 async def test_cleanup_old_scheduled_records(pattern_scheduler):
     """Test cleanup of old SCHEDULED records that never became OBSERVED."""
     with patch(


### PR DESCRIPTION
## Summary

Closes the SCHEDULED → OBSERVED race in `AmtrakPatternScheduler.save_scheduled_journeys` reported in #1170.

The SELECT used to filter on `observation_type == "SCHEDULED"`, so if the train discovery flow flipped the row to OBSERVED between `create_scheduled_journeys` and `save_scheduled_journeys`, the SELECT returned None and we fell into the `else` branch — which `session.add`'d a new SCHEDULED `TrainJourney`. The `unique_train_journey` constraint is on `(train_id, journey_date, data_source)` and **does not include `observation_type`**, so this raised `IntegrityError` on flush and was swallowed as `stats["errors"] += 1`, with the misleading log `failed_to_save_scheduled_journey`. Real OBSERVED rows weren't being corrupted, but every per-run race counted as an error and lost the work.

## Change

`backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py` — `save_scheduled_journeys`:
- Drop the `observation_type == "SCHEDULED"` filter from the SELECT.
- Short-circuit when the existing row is already OBSERVED: log `skipping_scheduled_save_train_already_observed`, increment `stats["skipped"]`, and `continue`. This mirrors the safety check that `create_scheduled_journeys` already does at the same race window (lines 675–682) but on the save side, where the race actually has a side effect.

The SCHEDULED-update path and the new-insert path are otherwise unchanged.

## Files modified

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/services/amtrak_pattern_scheduler.py` | Drop the `observation_type` filter and add the OBSERVED short-circuit. |
| `backend_v2/tests/unit/services/test_amtrak_pattern_scheduler.py` | Add `test_save_scheduled_journeys_skips_when_already_observed` covering the race scenario. |

## Test coverage

New test `test_save_scheduled_journeys_skips_when_already_observed` asserts:
- The SELECT finds an OBSERVED row (the race outcome).
- `stats == {created: 0, updated: 0, skipped: 1, errors: 0}`.
- No `session.add`, no DELETE, no flush — the existing OBSERVED row is untouched (observation_type, stops_count, update_count unchanged).

All 22 existing tests in `test_amtrak_pattern_scheduler.py` still pass — in particular the three save-path tests (`test_save_scheduled_journeys_new`, `test_save_scheduled_journeys_update_replaces_stops`, `test_save_scheduled_journeys_refuses_to_downgrade_existing`).

## Design notes

- I considered switching to an `INSERT … ON CONFLICT` upsert (mirroring the NJT journey_stop pattern in `collectors/njt/journey.py:1303-1400`), but it would have been a larger change and would not have preserved the existing "refuse to downgrade stop count" safety in this method. Skipping is the minimum-blast-radius fix that matches the semantics `create_scheduled_journeys` already enforces a few lines up.
- Did not add a new migration. The `unique_train_journey` constraint on `(train_id, journey_date, data_source)` already exists and is what makes silent double-inserts impossible today — the only problem was that we were trying to do them.
- Did not touch the LIKE-vs-exact-match discrepancy with `create_scheduled_journeys` (separate concern tracked in #1171).

Closes #1170

https://claude.ai/code/session_01Mf3U98MW2XKYtW8RJpH5ft

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf3U98MW2XKYtW8RJpH5ft)_