### PR TITLE
Consolidate Hoboken station codes across transit systems

### DIFF
--- a/backend_v2/src/trackrat/config/stations/common.py
+++ b/backend_v2/src/trackrat/config/stations/common.py
@@ -98,6 +98,7 @@ STATION_EQUIVALENCE_GROUPS: list[set[str]] = [
     {"NHV", "MNHV"},  # New Haven
     {"STS", "MNSS"},  # New Haven-State St
     {"NP", "PNK"},  # Newark Penn Station / Newark PATH
+    {"HB", "PHO"},  # Hoboken (NJT) / Hoboken PATH
     {"SE", "TS", "SC"},  # Secaucus Upper Lvl / Lower Lvl / Concourse
     {"NF", "PHN"},  # North Philadelphia (NJT NF / Amtrak PHN)
     {"JES", "JSP"},  # Jesup, GA (Amtrak aliases)

--- a/backend_v2/tests/unit/config/test_stations.py
+++ b/backend_v2/tests/unit/config/test_stations.py
@@ -579,7 +579,7 @@ class TestStationEquivalences:
 
     def test_expand_station_codes_without_equivalent(self):
         """expand_station_codes returns single-element list for non-shared stations."""
-        non_shared_codes = ["TR", "PHO", "MWPL", "JAM"]
+        non_shared_codes = ["TR", "PCH", "MWPL", "JAM"]
         for code in non_shared_codes:
             result = expand_station_codes(code)
             assert result == [
@@ -611,7 +611,7 @@ class TestStationEquivalences:
 
     def test_canonical_station_code_non_shared(self):
         """canonical_station_code returns the code itself for non-shared stations."""
-        non_shared_codes = ["NY", "NP", "TR", "PHO", "MWPL"]
+        non_shared_codes = ["NY", "NP", "TR", "PCH", "MWPL"]
         for code in non_shared_codes:
             assert (
                 canonical_station_code(code) == code

--- a/backend_v2/tests/unit/config/test_transfer_points.py
+++ b/backend_v2/tests/unit/config/test_transfer_points.py
@@ -219,8 +219,10 @@ class TestProximityTransfers:
             and "PHO" in (tp.station_a, tp.station_b)
         ]
         assert len(hoboken) == 1, f"Expected 1 Hoboken transfer, got {len(hoboken)}"
-        assert not hoboken[0].same_station  # Different codes = proximity-based
-        assert hoboken[0].walk_meters < 200  # Very close
+        # HB and PHO are in an equivalence group, so the transfer is recorded
+        # as same_station (matching the Newark NP/PNK pattern).
+        assert hoboken[0].same_station
+        assert hoboken[0].walk_meters == 0.0
 
     def test_newark_njt_path(self):
         """NJT/Amtrak Newark (NP) should connect to PATH Newark (PNK)."""

--- a/ios/TrackRat/Shared/StationData.swift
+++ b/ios/TrackRat/Shared/StationData.swift
@@ -76,7 +76,7 @@ extension Stations {
         // PATH Stations
         "Harrison PATH", "Journal Square",
         "Grove Street", "Exchange Place", "Newport",
-        "Hoboken PATH", "Christopher Street", "9th Street",
+        "Christopher Street", "9th Street",
         "14th Street", "23rd Street", "33rd Street",
         "World Trade Center",
 
@@ -3127,6 +3127,7 @@ extension Stations {
             ["NHV", "MNHV"],   // New Haven
             ["STS", "MNSS"],   // New Haven-State St
             ["NP", "PNK"],     // Newark Penn Station / Newark PATH
+            ["HB", "PHO"],     // Hoboken / Hoboken PATH
         ]
 
         // Subway station complexes: build groups from (alternate, canonical) pairs

--- a/webpage_v2/src/data/stations.test.ts
+++ b/webpage_v2/src/data/stations.test.ts
@@ -54,7 +54,7 @@ describe('getStationByCode', () => {
   it('returns correct station for each system', () => {
     const cases: [string, string][] = [
       ['NP', 'NJT'],
-      ['PHO', 'PATH'],
+      ['PCH', 'PATH'],
       ['MANS', 'MNR'],
       ['JAM', 'LIRR'],
       ['CUS', 'METRA'],

--- a/webpage_v2/src/data/stations.test.ts
+++ b/webpage_v2/src/data/stations.test.ts
@@ -65,6 +65,13 @@ describe('getStationByCode', () => {
       expect(station!.system).toBe(expectedSystem);
     }
   });
+
+  it('resolves alias codes (PHO->HB, PNK->NP) to canonical station', () => {
+    // PHO (Hoboken PATH) and PNK (Newark PATH) are not in the searchable
+    // catalog but still appear in route topology and shareable URLs.
+    expect(getStationByCode('PHO')?.code).toBe('HB');
+    expect(getStationByCode('PNK')?.code).toBe('NP');
+  });
 });
 
 describe('searchStations', () => {

--- a/webpage_v2/src/data/stations.ts
+++ b/webpage_v2/src/data/stations.ts
@@ -286,7 +286,6 @@ const _STATIONS_RAW: any[] = [
   { code: 'PGR', name: 'Grove Street', coordinates: { lat: 40.7197, lon: -74.0434 }, system: 'PATH' },
   { code: 'PEX', name: 'Exchange Place', coordinates: { lat: 40.7167, lon: -74.0333 }, system: 'PATH' },
   { code: 'PNP', name: 'Newport', coordinates: { lat: 40.7265, lon: -74.0337 }, system: 'PATH' },
-  { code: 'PHO', name: 'Hoboken PATH', coordinates: { lat: 40.7348, lon: -74.0280 }, system: 'PATH' },
   { code: 'PCH', name: 'Christopher Street', coordinates: { lat: 40.7329, lon: -74.0067 }, system: 'PATH' },
   { code: 'P9S', name: '9th Street', coordinates: { lat: 40.7340, lon: -73.9997 }, system: 'PATH' },
   { code: 'P14', name: '14th Street', coordinates: { lat: 40.7376, lon: -73.9967 }, system: 'PATH' },
@@ -1622,7 +1621,7 @@ for (const s of STATIONS) {
 export const PRIMARY_STATIONS: Record<TransitSystem, string[]> = {
   NJT: ['NY', 'NP', 'HB', 'SE', 'MP', 'PJ', 'HL', 'TR', 'LB', 'PF', 'DN', 'RA'],
   AMTRAK: ['NY', 'PH', 'WI', 'BL', 'WS', 'BOS', 'RVR', 'CLT', 'RGH', 'ATL'],
-  PATH: ['NP', 'PHO', 'PWC', 'PJS', 'P33', 'PGR', 'PEX', 'PNP'],
+  PATH: ['NP', 'HB', 'PWC', 'PJS', 'P33', 'PGR', 'PEX', 'PNP'],
   PATCO: ['LND', 'FFL', 'CTH', 'HDF'],
   LIRR: ['JAM', 'GCT', 'LAT', 'BTA', 'LHUN', 'RON', 'PJN', 'LBH', 'PWS', 'LHVL'],
   MNR: ['GCT', 'M125', 'MWPL', 'MCRH', 'MPOK', 'MBRS', 'MSTM', 'MNHV'],

--- a/webpage_v2/src/data/stations.ts
+++ b/webpage_v2/src/data/stations.ts
@@ -1650,9 +1650,17 @@ export const SYSTEM_NAMES: Record<TransitSystem, string> = {
 // System display order
 export const SYSTEM_ORDER: TransitSystem[] = ['NJT', 'PATH', 'LIRR', 'MNR', 'SUBWAY', 'WMATA', 'BART', 'AMTRAK', 'MBTA', 'PATCO', 'METRA'];
 
+// Aliases for codes that share a physical station with another system's code.
+// The duplicate entry is hidden from the picker, but route data and shareable
+// URLs may still reference the alias code — resolve those to the canonical entry.
+const STATION_CODE_ALIASES: Record<string, string> = {
+  PHO: 'HB',   // Hoboken PATH -> Hoboken (NJT)
+  PNK: 'NP',   // Newark PATH -> Newark Penn Station (NJT)
+};
+
 // Helper functions
 export function getStationByCode(code: string): Station | undefined {
-  return _stationsByCode.get(code);
+  return _stationsByCode.get(code) ?? _stationsByCode.get(STATION_CODE_ALIASES[code]);
 }
 
 export function searchStations(query: string, systems?: TransitSystem[], limit = 15): Station[] {


### PR DESCRIPTION
## Summary
This PR consolidates the Hoboken station representation across NJT and PATH systems by establishing a unified station code mapping. Previously, Hoboken PATH had its own dedicated code (PHO), but it is now mapped as an equivalent station to the NJT Hoboken station (HB).

## Key Changes
- **Station code consolidation**: Removed the standalone `PHO` (Hoboken PATH) station entry and established `HB` (NJT Hoboken) as the canonical code with `PHO` as an equivalent
- **Updated station equivalence mappings**: Added `{"HB", "PHO"}` to station equivalence groups in both backend and iOS configurations
- **Updated primary station lists**: Changed PATH system's primary stations from `PHO` to `HB` to reflect the new canonical code
- **Updated test cases**: Modified test data to use `PCH` (Christopher Street) instead of `PHO` for non-shared station tests, and updated station code tests to reference `PCH` instead of `PHO`

## Implementation Details
- The change maintains backward compatibility by keeping `PHO` as an equivalent code that maps to `HB`
- Station equivalence is now consistently defined across:
  - `backend_v2/src/trackrat/config/stations/common.py`
  - `ios/TrackRat/Shared/StationData.swift`
- The `HB` code now serves as the canonical identifier for Hoboken across both NJT and PATH systems
- Removed the duplicate `PHO` station entry from the raw stations data in `webpage_v2`

https://claude.ai/code/session_01VNgTBpVphgPYDJGigfSPDg