### PR TITLE
Include sibling rail systems in station equivalence expansion

### DIFF
--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
 from trackrat.config.stations import expand_station_codes, get_station_name
+from trackrat.config.stations.common import STATION_EQUIVALENTS
 from trackrat.config.transfer_points import (
     TransferPoint,
     get_intra_system_transfers,
@@ -129,22 +130,35 @@ def _filter_cross_system_direct_trips(
 
 
 def _systems_for_station(code: str) -> set[str]:
-    """Return the transit systems natively serving a station code.
+    """Return the transit systems available to a passenger at this station.
 
-    Falls back to equivalence-group expansion only for alias-only codes (codes
-    that aren't in any route topology, e.g. TS for Secaucus Lower Level).  For
-    codes that are in a route topology, returns just the native systems —
-    expanding cross-modal equivalence groups (e.g. {NY, S128, SA28}) would
-    defeat the cross-system direct-trip filter by adding commuter-rail systems
-    to a subway code's system set.
+    For non-subway station codes, includes sibling systems from the same
+    equivalence group so e.g. NP (Newark Penn Station, NJT/Amtrak) also
+    surfaces PATH via its equivalent PNK — both codes refer to the same
+    physical building.  SUBWAY is excluded from the expansion of non-subway
+    codes because subway-platform codes in a large complex (e.g. S128 inside
+    NY Penn) are physically separate from the rail concourses and would
+    defeat the cross-system direct-trip filter (#1121).
+
+    Subway-only codes stay strict (only SUBWAY) so subway-platform queries
+    like S128→TR don't pick up rail trains arriving at NY.
+
+    Alias-only codes (not in any route topology, e.g. TS for Secaucus Lower
+    Level) fall back to full equivalence expansion so they resolve to the
+    canonical station's systems.
     """
     direct = get_systems_serving_station(code)
-    if direct:
+    group = STATION_EQUIVALENTS.get(code)
+    if not group:
         return direct
     expanded: set[str] = set()
-    for equivalent in expand_station_codes(code):
+    for equivalent in group:
         expanded |= get_systems_serving_station(equivalent)
-    return expanded
+    if not direct:
+        return expanded
+    if direct <= {"SUBWAY"}:
+        return direct
+    return expanded - {"SUBWAY"}
 
 
 def _get_station_lines_expanded(station_code: str, system: str) -> frozenset[str]:

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -1172,11 +1172,18 @@ class TestSystemsForStation:
         """
         assert _systems_for_station("NY") == {"NJT", "AMTRAK", "LIRR"}
 
-    def test_native_path_code_unaffected_by_njt_amtrak_equivalence(self):
-        """PNK is in {NP, PNK} with NP served by NJT/AMTRAK; expansion would
-        add those to PNK's set and break the PATH↔commuter-rail direct filter.
+    def test_non_subway_code_includes_sibling_rail_systems(self):
+        """NP (Newark Penn Station) is served natively by NJT/AMTRAK; its
+        equivalent PNK is served by PATH at the same physical building.
+
+        For non-subway station codes we include sibling systems from the
+        equivalence group so a search NP→PWC surfaces direct PATH trains
+        (issue #1172).  SUBWAY is still excluded from the cross-modal
+        expansion of non-subway codes (preserves the #1121 filter).
         """
-        assert _systems_for_station("PNK") == {"PATH"}
+        assert _systems_for_station("NP") == {"NJT", "AMTRAK", "PATH"}
+        # And symmetrically: PNK should see NJT/AMTRAK from its NP equivalent.
+        assert _systems_for_station("PNK") == {"NJT", "AMTRAK", "PATH"}
 
     def test_alias_only_code_falls_back_to_expansion(self):
         """TS (Secaucus Lower Level) is alias-only and must resolve to NJT via SE."""
@@ -1188,6 +1195,26 @@ class TestSystemsForStation:
     def test_unknown_code_returns_empty(self):
         """A completely unknown code returns empty (no native, no expansion)."""
         assert _systems_for_station("ZZZZ_NOT_A_STATION") == set()
+
+    def test_amtrak_mnr_shared_station_includes_both(self):
+        """Stations shared between Amtrak and Metro-North (e.g. New Rochelle)
+        should surface both systems regardless of which code the user picks.
+        """
+        assert _systems_for_station("NRO") == {"AMTRAK", "MNR"}
+        assert _systems_for_station("MNRC") == {"AMTRAK", "MNR"}
+
+    def test_np_pwc_direct_filter_keeps_path_trips(self):
+        """End-to-end check for issue #1172: a PATH train NP→PWC must survive
+        _filter_cross_system_direct_trips so the user sees direct PATH service
+        from Newark Penn Station to World Trade Center / Grove Street.
+        """
+        from_sys = _systems_for_station("NP")
+        to_sys = _systems_for_station("PWC")
+        valid = from_sys & to_sys
+        assert "PATH" in valid, (
+            f"PATH should be a valid direct system for NP→PWC. "
+            f"from_systems={from_sys}, to_systems={to_sys}"
+        )
 
 
 class TestFilterCrossSystemDirectTrips:


### PR DESCRIPTION
## Summary
Fixes issue #1172 by expanding `_systems_for_station()` to include sibling systems from the same equivalence group for non-subway station codes, while preserving the cross-system direct-trip filter for subway-platform codes.

## Changes
- **Updated `_systems_for_station()` logic**: Now returns all systems available to a passenger at a physical station location, not just natively-serving systems
  - Non-subway codes (e.g., NP for Newark Penn Station) now include sibling systems from their equivalence group (e.g., PATH via equivalent PNK)
  - SUBWAY is explicitly excluded from non-subway code expansion to preserve the #1121 filter that prevents subway-platform codes from picking up rail trains
  - Subway-only codes remain strict (only SUBWAY) so subway-platform queries don't incorrectly match rail service
  - Alias-only codes continue to fall back to full equivalence expansion

- **Refactored to use `STATION_EQUIVALENTS` directly**: Changed from `expand_station_codes()` to directly accessing the equivalence group, providing clearer control over expansion behavior

- **Enhanced test coverage**: 
  - Updated existing test to verify symmetric behavior (NP and PNK both surface all three systems: NJT, AMTRAK, PATH)
  - Added test for Amtrak/Metro-North shared stations (NRO/MNRC)
  - Added end-to-end test verifying PATH trains from NP→PWC survive the cross-system direct filter

## Implementation Details
The new logic follows this precedence:
1. If code has no equivalence group, return only native systems
2. If code has no native systems (alias-only), return all systems from the equivalence group
3. If code is subway-only, return only SUBWAY (strict)
4. Otherwise (non-subway with native systems), return native systems plus sibling systems from equivalence group, excluding SUBWAY

https://claude.ai/code/session_017qsKASHmQFDywJHxpubmeA