### PR TITLE
Move FeedbackButton outside .id() scope to prevent sheet dismissal

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -245,19 +245,22 @@ struct TrainDetailsView: View {
                                     set: { alertSubscription = $0 }
                                 ))
                             }
-
-                            // Report an issue button
-                            FeedbackButton(
-                                screen: "train_details",
-                                trainId: train.trainId,
-                                originCode: appState.departureStationCode,
-                                destinationCode: appState.destinationStationCode
-                            )
-                            .padding(.top, 8)
                         }
                         .padding()
                         // Force view recreation when train identity or status changes
                         .id("\(train.id)-\(train.calculateStatus(fromStationCode: appState.departureStationCode ?? "").rawValue)")
+
+                        // FeedbackButton is outside the .id() scope so live data refreshes
+                        // don't recreate it and dismiss an in-progress feedback sheet
+                        FeedbackButton(
+                            screen: "train_details",
+                            trainId: train.trainId,
+                            originCode: appState.departureStationCode,
+                            destinationCode: appState.destinationStationCode
+                        )
+                        .padding(.horizontal)
+                        .padding(.top, 8)
+                        .padding(.bottom, 16)
                     }
                 } // VStack
             }


### PR DESCRIPTION
## Summary
Refactored the FeedbackButton placement in TrainDetailsView to prevent it from being recreated when live data refreshes occur, which was causing in-progress feedback sheets to be dismissed unexpectedly.

## Key Changes
- Moved FeedbackButton outside the `.id()` modifier scope so it's not recreated when train identity or status changes
- Updated padding to use `.padding(.horizontal)`, `.padding(.top, 8)`, and `.padding(.bottom, 16)` for consistent spacing
- Added clarifying comment explaining why FeedbackButton is positioned outside the `.id()` scope

## Implementation Details
The FeedbackButton was previously nested inside a VStack that had an `.id()` modifier tied to train identity and status. This caused the entire view hierarchy to be recreated whenever the train data refreshed, which would dismiss any open feedback sheet. By moving the FeedbackButton outside this scoped view, it maintains its state independently while still being part of the overall layout.

https://claude.ai/code/session_01CzBzUtVDam3H5aLbMqbm3L