### PR TITLE
Issue #1168: Bound track prediction queries to recent history

### DIFF
--- a/backend_v2/src/trackrat/services/historical_track_predictor.py
+++ b/backend_v2/src/trackrat/services/historical_track_predictor.py
@@ -5,7 +5,7 @@ Uses hierarchical historical data to predict tracks with high accuracy.
 No ML models required - just SQL queries and simple logic.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from sqlalchemy import and_, case, func, select
@@ -15,6 +15,7 @@ from structlog import get_logger
 from trackrat.config.station_configs import get_station_config
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.services.track_occupancy import get_track_occupancy_service
+from trackrat.utils.time import now_et
 
 logger = get_logger(__name__)
 
@@ -28,6 +29,13 @@ MIN_SERVICE_PROVIDER_RECORDS = (
 
 # Time window for time+line code matching (±30 minutes)
 TIME_WINDOW_MINUTES = 30
+
+# Bound distribution queries to recent history so Postgres can use the
+# journey_date index and avoid sorting/hashing the full retention window
+# (which exhausted /dev/shm and surfaced as DiskFullError on staging —
+# issue #1168). Track patterns are stable, so 90 days is far above all
+# MIN_*_RECORDS thresholds at every modeled station.
+HISTORICAL_LOOKBACK_DAYS = 90
 
 
 class HistoricalTrackPredictor:
@@ -245,6 +253,8 @@ class HistoricalTrackPredictor:
     ) -> dict[str, Any] | None:
         """Get track distribution for specific train ID."""
 
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
         # Query historical track assignments for this train
         query = (
             select(JourneyStop.track, func.count(JourneyStop.id).label("count"))
@@ -253,6 +263,7 @@ class HistoricalTrackPredictor:
                 and_(
                     JourneyStop.station_code == station_code,
                     TrainJourney.train_id == train_id,
+                    TrainJourney.journey_date >= cutoff_date,
                     JourneyStop.track.is_not(None),
                 )
             )
@@ -305,6 +316,8 @@ class HistoricalTrackPredictor:
             else_=1440 - raw_diff,
         )
 
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
         query = (
             select(JourneyStop.track, func.count(JourneyStop.id).label("count"))
             .join(TrainJourney, JourneyStop.journey_id == TrainJourney.id)
@@ -312,6 +325,7 @@ class HistoricalTrackPredictor:
                 and_(
                     JourneyStop.station_code == station_code,
                     TrainJourney.line_code == line_code,
+                    TrainJourney.journey_date >= cutoff_date,
                     JourneyStop.track.is_not(None),
                     JourneyStop.scheduled_departure.is_not(None),
                     circular_diff <= TIME_WINDOW_MINUTES,
@@ -345,6 +359,8 @@ class HistoricalTrackPredictor:
     ) -> dict[str, Any] | None:
         """Get track distribution for trains on this line."""
 
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
         query = (
             select(JourneyStop.track, func.count(JourneyStop.id).label("count"))
             .join(TrainJourney, JourneyStop.journey_id == TrainJourney.id)
@@ -352,6 +368,7 @@ class HistoricalTrackPredictor:
                 and_(
                     JourneyStop.station_code == station_code,
                     TrainJourney.line_code == line_code,
+                    TrainJourney.journey_date >= cutoff_date,
                     JourneyStop.track.is_not(None),
                 )
             )
@@ -382,6 +399,8 @@ class HistoricalTrackPredictor:
     ) -> dict[str, Any] | None:
         """Get track distribution for service provider."""
 
+        cutoff_date = now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+
         query = (
             select(JourneyStop.track, func.count(JourneyStop.id).label("count"))
             .join(TrainJourney, JourneyStop.journey_id == TrainJourney.id)
@@ -389,6 +408,7 @@ class HistoricalTrackPredictor:
                 and_(
                     JourneyStop.station_code == station_code,
                     TrainJourney.data_source == data_source,
+                    TrainJourney.journey_date >= cutoff_date,
                     JourneyStop.track.is_not(None),
                 )
             )

--- a/backend_v2/tests/unit/services/test_track_predictor_lookback.py
+++ b/backend_v2/tests/unit/services/test_track_predictor_lookback.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for the historical lookback bound on track-distribution queries.
+
+Issue #1168: The four distribution methods used to scan the full retention
+window (120 days), which on staging exhausted Postgres /dev/shm and surfaced
+as DiskFullError on /predictions/track. We now cap each query at the
+HISTORICAL_LOOKBACK_DAYS window via `TrainJourney.journey_date >= cutoff`.
+
+These tests verify the filter is present on the compiled SQL for every
+distribution method, so future regressions (e.g., copying a query without
+the bound) are caught at unit-test time rather than via /dev/shm pressure
+in production.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from trackrat.services.historical_track_predictor import (
+    HISTORICAL_LOOKBACK_DAYS,
+    HistoricalTrackPredictor,
+)
+
+
+def _empty_result() -> AsyncMock:
+    """Mock execute() return value that yields no rows."""
+    result = AsyncMock()
+    result.all = lambda: []
+    return result
+
+
+async def _capture_query(predictor: HistoricalTrackPredictor, coro):
+    """Invoke a distribution method and return the compiled SQL it issued."""
+    captured: dict[str, object] = {}
+
+    async def fake_execute(stmt):
+        captured["stmt"] = stmt
+        return _empty_result()
+
+    db = AsyncMock()
+    db.execute = fake_execute
+    await coro(db)
+
+    stmt = captured["stmt"]
+    return str(
+        stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def test_historical_lookback_days_is_positive():
+    """The lookback constant must be a sensible positive value."""
+    assert HISTORICAL_LOOKBACK_DAYS > 0
+    # Anything beyond the default retention (120 days) would be a no-op cap.
+    assert HISTORICAL_LOOKBACK_DAYS <= 120
+
+
+@pytest.mark.asyncio
+async def test_train_id_distribution_bounds_by_journey_date():
+    """_get_train_id_distribution must filter by TrainJourney.journey_date."""
+    predictor = HistoricalTrackPredictor()
+    sql = await _capture_query(
+        predictor,
+        lambda db: predictor._get_train_id_distribution(db, "NY", "3927"),
+    )
+    assert "train_journeys.journey_date >=" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_time_line_distribution_bounds_by_journey_date():
+    """_get_time_line_distribution must filter by TrainJourney.journey_date."""
+    predictor = HistoricalTrackPredictor()
+    scheduled = datetime(2026, 5, 11, 8, 30, tzinfo=UTC)
+    sql = await _capture_query(
+        predictor,
+        lambda db: predictor._get_time_line_distribution(db, "NY", "NE", scheduled),
+    )
+    assert "train_journeys.journey_date >=" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_line_code_distribution_bounds_by_journey_date():
+    """_get_line_code_distribution must filter by TrainJourney.journey_date."""
+    predictor = HistoricalTrackPredictor()
+    sql = await _capture_query(
+        predictor,
+        lambda db: predictor._get_line_code_distribution(db, "NY", "NE"),
+    )
+    assert "train_journeys.journey_date >=" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_service_distribution_bounds_by_journey_date():
+    """_get_service_distribution must filter by TrainJourney.journey_date."""
+    predictor = HistoricalTrackPredictor()
+    sql = await _capture_query(
+        predictor,
+        lambda db: predictor._get_service_distribution(db, "NY", "NJT"),
+    )
+    assert "train_journeys.journey_date >=" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_cutoff_matches_configured_lookback():
+    """The compiled cutoff value must equal today() - HISTORICAL_LOOKBACK_DAYS.
+
+    We use the train_id query as a representative; all four methods compute
+    the cutoff identically via now_et().date() - timedelta(days=...).
+    """
+    from trackrat.utils.time import now_et
+
+    predictor = HistoricalTrackPredictor()
+    sql = await _capture_query(
+        predictor,
+        lambda db: predictor._get_train_id_distribution(db, "NY", "3927"),
+    )
+
+    expected_cutoff = (
+        now_et().date() - timedelta(days=HISTORICAL_LOOKBACK_DAYS)
+    ).isoformat()
+    assert expected_cutoff in sql, sql


### PR DESCRIPTION
## Summary

The four distribution queries in `HistoricalTrackPredictor` scanned the full `journey_stops` retention window (120 days) with no time bound. Under load, Postgres spilled `GROUP BY` / `ORDER BY` work to `/dev/shm` and surfaced `DiskFullError ... could not resize shared memory segment` on `/predictions/track` in staging (issue #1168). When this happens during a user-visible request, the prediction call returns 500 → iOS swallows the decode error → predictions silently disappear.

Fix: add a `HISTORICAL_LOOKBACK_DAYS = 90` cap and filter every distribution query by `TrainJourney.journey_date >= cutoff`.

## Why 90 days

The MIN_*_RECORDS thresholds in `historical_track_predictor.py` are 10 / 10 / 25 / 250. NJT NY Penn alone sees ~150 trains/day, so the 250-record service-provider bar is hit in ~2 days. 90 days is far above every threshold at every modeled station, and bounded enough that Postgres can use `idx_journey_date` / `idx_train_id` instead of scanning the full retention window. Anything beyond 120 days would be a no-op cap (default retention is `TRACKRAT_RETENTION_DAYS=120`).

## Files modified

- `backend_v2/src/trackrat/services/historical_track_predictor.py` — add the constant, compute `cutoff_date` from `now_et().date()`, and add `TrainJourney.journey_date >= cutoff_date` to all four distribution `WHERE` clauses (`_get_train_id_distribution`, `_get_time_line_distribution`, `_get_line_code_distribution`, `_get_service_distribution`).
- `backend_v2/tests/unit/services/test_track_predictor_lookback.py` — new test file. Captures the SQLAlchemy statement issued by each distribution method, compiles it to a literal-bound Postgres SQL string, and asserts the `train_journeys.journey_date >=` filter is present with the correctly computed cutoff. Catches regressions (e.g., copy-paste of a new distribution method without the bound) at unit-test time rather than via `/dev/shm` pressure in production.

## Test coverage added

```
test_historical_lookback_days_is_positive               PASSED
test_train_id_distribution_bounds_by_journey_date       PASSED
test_time_line_distribution_bounds_by_journey_date      PASSED
test_line_code_distribution_bounds_by_journey_date      PASSED
test_service_distribution_bounds_by_journey_date        PASSED
test_cutoff_matches_configured_lookback                 PASSED
```

23 tests pass across the track predictor test files. `ruff`, `black`, and `mypy` all clean for the touched files.

## Design decisions

- **One constant, one place**: `HISTORICAL_LOOKBACK_DAYS = 90` lives next to the existing `MIN_*_RECORDS` thresholds it interacts with, keeping the tunables co-located.
- **Per-method cutoff computation**: each method recomputes `cutoff_date` from `now_et().date()` rather than caching on the predictor. The predictor is a stateless singleton served across requests that can span days; caching the cutoff would let an early-morning instance keep using yesterday's cutoff for hours.
- **SQL-string assertion, not integration test**: the test database isn't part of this PR's environment, and a literal-bound SQL inspection is sufficient to detect the regression we care about (missing date filter). It also avoids coupling the test to a seeded dataset that would drift as retention defaults change.

## Scope note

Issue #1168 also flags two separate problems — `greenlet_spawn has not been called` in `services/departure.py` and the same `DiskFullError` class hitting `/routes/summary` and `/predictions/delay`. The maintainer triage comment recommends splitting those out; this PR addresses only `/predictions/track`, which is the most user-visible of the three (every iOS train detail view requests it). The remaining items can be addressed in follow-up PRs against the same issue or new issues.

Closes #1168 (partial — track predictions only; see scope note above).

https://claude.ai/code/session_01KkkmDJHATdotY1ryws1AzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkkmDJHATdotY1ryws1AzT)_