### PR TITLE
[codex] Fix NJT live activity completion timing

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -2099,7 +2099,18 @@ class JourneyCollector(BaseJourneyCollector):
         if not last_stop_db:
             return
 
-        last_stop_api = stops_data[-1]
+        # The caller passes raw NJT API order here, while update_journey_stops
+        # sorts only a local copy before sequencing. Match the authoritative
+        # DB terminal by station code so a misordered non-terminal row cannot
+        # supply the terminal ETA or terminal cancellation status.
+        last_stop_api = next(
+            (
+                stop
+                for stop in stops_data
+                if stop.STATION_2CHAR == last_stop_db.station_code
+            ),
+            None,
+        )
 
         # Terminal stop departed directly (rare for NJT terminals, but possible).
         # Still require the terminal arrival time to be due so time-inferred
@@ -2188,8 +2199,8 @@ class JourneyCollector(BaseJourneyCollector):
         cancelled_stops = sum(
             1 for stop in stops_data if is_njt_stop_cancelled(stop.STOP_STATUS)
         )
-        terminal_cancelled = bool(stops_data) and is_njt_stop_cancelled(
-            stops_data[-1].STOP_STATUS
+        terminal_cancelled = bool(last_stop_api) and is_njt_stop_cancelled(
+            last_stop_api.STOP_STATUS
         )
 
         if cancelled_stops and (

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -30,6 +30,7 @@ from trackrat.utils.time import (
     DATETIME_MAX_ET,
     DATETIME_MIN_ET,
     ET,
+    ensure_timezone_aware,
     now_et,
     parse_njt_time,
 )
@@ -1946,6 +1947,46 @@ class JourneyCollector(BaseJourneyCollector):
         )
         return result is not None
 
+    @staticmethod
+    def _terminal_arrival_reference(
+        terminal_stop: JourneyStop,
+        terminal_api_stop: NJTransitStopData | None = None,
+    ) -> tuple[datetime | None, str | None]:
+        """Best terminal arrival timestamp for deciding completion.
+
+        Prefer the current NJT terminal TIME field when available because it is
+        the live terminal-arrival estimate. On expiry, use the last stored
+        terminal estimate before falling back to the static schedule.
+        """
+        if terminal_stop.actual_arrival:
+            return terminal_stop.actual_arrival, terminal_stop.arrival_source
+
+        if terminal_api_stop and terminal_api_stop.TIME:
+            return parse_njt_time(terminal_api_stop.TIME), "api_observed"
+
+        if terminal_stop.updated_arrival:
+            return terminal_stop.updated_arrival, "api_observed"
+
+        if terminal_stop.scheduled_arrival:
+            return terminal_stop.scheduled_arrival, "scheduled_fallback"
+
+        return None, None
+
+    @classmethod
+    def _terminal_arrival_due(
+        cls,
+        terminal_stop: JourneyStop,
+        terminal_api_stop: NJTransitStopData | None = None,
+    ) -> bool:
+        """Return True only once the terminal arrival time is no longer future."""
+        terminal_arrival, _ = cls._terminal_arrival_reference(
+            terminal_stop, terminal_api_stop
+        )
+        if terminal_arrival is None:
+            return False
+
+        return ensure_timezone_aware(terminal_arrival) <= now_et()
+
     async def _attempt_completion_on_expiry(
         self,
         session: AsyncSession,
@@ -1953,10 +1994,10 @@ class JourneyCollector(BaseJourneyCollector):
     ) -> None:
         """Last-chance completion when a train disappears from the NJT API.
 
-        If the penultimate stop has departed, the train reached its terminal.
-        We can't set terminal actual_arrival (no API data available), but we
-        mark the journey completed and use scheduled_arrival as a fallback
-        so route history stats aren't N/A.
+        If the penultimate stop has explicitly departed and the terminal
+        arrival time is due, mark the journey completed. Without current API
+        data, use the stored terminal estimate or schedule as a conservative
+        fallback.
         """
         # Get last two stops by sequence
         last_two_stmt = (
@@ -1974,17 +2015,24 @@ class JourneyCollector(BaseJourneyCollector):
         terminal_stop = last_two[0]
         penultimate_stop = last_two[1]
 
-        if not penultimate_stop.has_departed_station:
+        if not (
+            penultimate_stop.has_departed_station
+            and penultimate_stop.departure_source == "api_explicit"
+            and self._terminal_arrival_due(terminal_stop)
+        ):
             return
 
-        # Penultimate stop departed — train reached its terminal
+        # Penultimate stop departed and terminal arrival is due.
         journey.is_completed = True
 
-        # Use scheduled_arrival as fallback for the terminal stop if we have it
-        if terminal_stop.actual_arrival is None and terminal_stop.scheduled_arrival:
-            terminal_stop.actual_arrival = terminal_stop.scheduled_arrival
-            terminal_stop.arrival_source = "scheduled_fallback"
-            journey.actual_arrival = terminal_stop.scheduled_arrival
+        terminal_arrival, arrival_source = self._terminal_arrival_reference(
+            terminal_stop
+        )
+        if terminal_arrival:
+            journey.actual_arrival = terminal_arrival
+            if terminal_stop.actual_arrival is None:
+                terminal_stop.actual_arrival = terminal_arrival
+                terminal_stop.arrival_source = arrival_source
 
         logger.info(
             "journey_completed_on_expiry",
@@ -2019,10 +2067,10 @@ class JourneyCollector(BaseJourneyCollector):
         # 2. sequential_inference: earlier stops have departed
         # 3. time_inference: >5 minutes past scheduled time
         #
-        # Terminal stops (e.g., NY Penn) never get DEPARTED="YES" from the
-        # NJT API, and sequential_inference can't fire (nothing after them).
-        # So we also check if the penultimate stop has departed — if it has
-        # *via api_explicit*, the train has necessarily reached the terminal.
+        # Terminal stops (e.g., NY Penn) almost never get DEPARTED="YES" from
+        # the NJT API, and sequential_inference can't fire (nothing after them).
+        # So we also check if the penultimate stop has departed *via
+        # api_explicit* and the terminal arrival time is due.
         #
         # The penultimate check MUST require `api_explicit` and reject
         # `time_inference` / `sequential_inference`. Time_inference fires
@@ -2051,8 +2099,15 @@ class JourneyCollector(BaseJourneyCollector):
         if not last_stop_db:
             return
 
-        # Terminal stop departed directly (rare for NJT terminals, but possible)
-        terminal_reached = last_stop_db.has_departed_station
+        last_stop_api = stops_data[-1]
+
+        # Terminal stop departed directly (rare for NJT terminals, but possible).
+        # Still require the terminal arrival time to be due so time-inferred
+        # terminal departures cannot complete a delayed or still-en-route trip.
+        terminal_reached = (
+            last_stop_db.has_departed_station
+            and self._terminal_arrival_due(last_stop_db, last_stop_api)
+        )
 
         # If not, check if the penultimate stop has departed.
         # Use ORDER BY desc with offset to handle non-contiguous sequences
@@ -2079,16 +2134,19 @@ class JourneyCollector(BaseJourneyCollector):
                 penultimate_stop
                 and penultimate_stop.has_departed_station
                 and penultimate_stop.departure_source == "api_explicit"
+                and self._terminal_arrival_due(last_stop_db, last_stop_api)
             ):
                 terminal_reached = True
 
         if terminal_reached:
             journey.is_completed = True
 
-            # Set actual arrival from the last stop's data
-            last_stop_api = stops_data[-1]
-            if last_stop_api.TIME:
-                arrival_time = parse_njt_time(last_stop_api.TIME)
+            # Set actual arrival from the current terminal estimate when
+            # available, otherwise from the conservative stored fallback.
+            arrival_time, arrival_source = self._terminal_arrival_reference(
+                last_stop_db, last_stop_api
+            )
+            if arrival_time:
                 journey.actual_arrival = arrival_time
 
                 # Also set actual_arrival on the terminal stop itself.
@@ -2099,7 +2157,7 @@ class JourneyCollector(BaseJourneyCollector):
                 # on-time percentage at terminal destinations.
                 if last_stop_db.actual_arrival is None:
                     last_stop_db.actual_arrival = arrival_time
-                    last_stop_db.arrival_source = "api_observed"
+                    last_stop_db.arrival_source = arrival_source
 
             logger.info(
                 "journey_completed",

--- a/backend_v2/tests/unit/collectors/njt/test_journey_data_quality.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_data_quality.py
@@ -1359,7 +1359,7 @@ class TestTerminalStopActualArrival:
     ):
         """When a journey completes, the terminal stop must have actual_arrival
         set so route history stats can compute on-time percentage."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         arrival_time = base_time + timedelta(minutes=60)
 
         journey = TrainJourney(
@@ -1469,7 +1469,7 @@ class TestTerminalStopActualArrival:
     ):
         """If the terminal stop already has actual_arrival, completion should
         not overwrite it (preserves the frozen value from an earlier cycle)."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         original_arrival = base_time + timedelta(minutes=58)
         later_arrival = base_time + timedelta(minutes=60)
 
@@ -1564,9 +1564,11 @@ class TestPenultimateTimeInferenceDoesNotCompleteJourney:
         a scheduled departure 10 minutes in the past (so time_inference would
         legitimately fire for it), and NY (terminal) has no departure source.
 
-        The caller picks the source of SE's departure flag.
+        The caller picks the source of SE's departure flag. NY is scheduled to
+        arrive five minutes before now so tests can isolate the departure
+        source check from the terminal-arrival due check.
         """
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=90)
 
         journey = TrainJourney(
             train_id="3918",
@@ -1689,8 +1691,8 @@ class TestPenultimateTimeInferenceDoesNotCompleteJourney:
         self, sqlite_session: AsyncSession, journey_collector
     ):
         """Positive case: when NJT explicitly reports the penultimate as
-        DEPARTED=YES (`api_explicit`), the train has physically passed it and
-        the journey is correctly marked complete."""
+        DEPARTED=YES (`api_explicit`) and terminal arrival is due, the journey
+        is correctly marked complete."""
         journey, base_time = self._build_journey_with_stops(
             sqlite_session, penultimate_source="api_explicit"
         )
@@ -1777,7 +1779,7 @@ class TestPenultimateTimeInferenceDoesNotCompleteJourney:
         assert journey.is_completed is True, (
             "Journey MUST be marked complete when the penultimate stop has "
             "an api_explicit DEPARTED=YES from NJT — the train has physically "
-            "passed it and is at/past the terminal."
+            "passed it and terminal arrival is due."
         )
 
 

--- a/backend_v2/tests/unit/collectors/njt/test_terminal_stop_completion.py
+++ b/backend_v2/tests/unit/collectors/njt/test_terminal_stop_completion.py
@@ -3,8 +3,8 @@ Tests for NJT terminal stop journey completion fix.
 
 Verifies that journeys are correctly completed when the terminal stop
 (e.g., NY Penn) is the destination. Terminal stops never get DEPARTED="YES"
-from the NJT API, so the completion logic must check the penultimate stop
-instead.
+from the NJT API, so completion requires the penultimate stop to be explicitly
+departed and the terminal arrival time to be due.
 
 Also tests the last-chance completion-on-expiry path for trains that
 disappear from the API before normal completion runs.
@@ -138,7 +138,8 @@ async def _create_tr_to_ny_journey(
 
     Args:
         session: DB session
-        base_time: Base time for scheduled departures
+        base_time: Base time for scheduled departures. Terminal arrival is
+            base_time + 60 minutes.
         penultimate_departed: Whether NP (penultimate) has_departed_station
         terminal_departed: Whether NY (terminal) has_departed_station
     """
@@ -215,16 +216,16 @@ async def _create_tr_to_ny_journey(
 
 
 class TestTerminalStopCompletion:
-    """Test that journey completion triggers via the penultimate stop."""
+    """Test journey completion through terminal-arrival checks."""
 
     @pytest.mark.asyncio
     async def test_penultimate_departed_triggers_completion(
         self, sqlite_session, journey_collector
     ):
         """When the penultimate stop (NP) has departed, the journey should
-        be marked completed even though the terminal stop (NY) has not
-        departed (which is the normal case for NJT terminals)."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        be marked completed once the terminal arrival time is due, even though
+        the terminal stop (NY) has not departed (the normal NJT case)."""
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         journey = await _create_tr_to_ny_journey(
             sqlite_session, base_time, penultimate_departed=True
         )
@@ -287,12 +288,69 @@ class TestTerminalStopCompletion:
         print(f"  Journey is_completed: {journey.is_completed}")
 
     @pytest.mark.asyncio
+    async def test_penultimate_departed_does_not_complete_before_terminal_arrival(
+        self, sqlite_session, journey_collector
+    ):
+        """An on-time train that just left the penultimate stop should remain
+        active until the terminal arrival time is due."""
+        now = now_et().replace(second=0, microsecond=0)
+        base_time = now - timedelta(minutes=50)
+        journey = await _create_tr_to_ny_journey(
+            sqlite_session, base_time, penultimate_departed=True
+        )
+
+        builder = StopBuilder()
+        ny_arrival_time = now + timedelta(minutes=8)
+        stops_data = [
+            _make_stop(
+                builder,
+                "TR",
+                "Trenton",
+                base_time.strftime(NJT_TIME_FORMAT),
+                departed=True,
+            ),
+            _make_stop(
+                builder,
+                "NP",
+                "Newark Penn",
+                (base_time + timedelta(minutes=42)).strftime(NJT_TIME_FORMAT),
+                arr_time=(base_time + timedelta(minutes=40)).strftime(NJT_TIME_FORMAT),
+                departed=True,
+            ),
+            _make_stop(
+                builder,
+                "NY",
+                "New York Penn",
+                None,
+                arr_time=ny_arrival_time.strftime(NJT_TIME_FORMAT),
+                departed=False,
+            ),
+        ]
+        stops_data[2].DEP_TIME = None
+
+        await journey_collector.check_journey_completion(
+            sqlite_session, journey, stops_data
+        )
+
+        assert journey.is_completed is not True, (
+            "Journey should not complete merely because the train left the "
+            "penultimate stop while terminal arrival is still in the future"
+        )
+        ny_stop = await sqlite_session.scalar(
+            select(JourneyStop).where(
+                JourneyStop.journey_id == journey.id,
+                JourneyStop.station_code == "NY",
+            )
+        )
+        assert ny_stop.actual_arrival is None
+
+    @pytest.mark.asyncio
     async def test_no_completion_when_penultimate_not_departed(
         self, sqlite_session, journey_collector
     ):
         """Journey should NOT be completed when neither terminal nor
         penultimate stop has departed."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         journey = await _create_tr_to_ny_journey(
             sqlite_session, base_time, penultimate_departed=False
         )
@@ -332,7 +390,7 @@ class TestTerminalStopCompletion:
     ):
         """The original logic (terminal stop departed) should still work
         for edge cases where it does fire."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         journey = await _create_tr_to_ny_journey(
             sqlite_session,
             base_time,
@@ -391,7 +449,7 @@ class TestStopSequenceRobustness:
         """If a phantom stop was deleted leaving a gap in sequences
         (e.g., 0, 1, 3 instead of 0, 1, 2), completion should still find
         the correct terminal stop via ORDER BY desc, not len(stops_data)-1."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
 
         journey = TrainJourney(
             train_id="3830",
@@ -509,9 +567,9 @@ class TestCompletionOnExpiry:
     async def test_expiry_completes_when_penultimate_departed(
         self, sqlite_session, journey_collector
     ):
-        """When a train disappears from the API and the penultimate stop
-        has departed, the journey should be marked completed (not expired)."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        """When a train disappears from the API after terminal arrival time,
+        the journey should be marked completed (not expired)."""
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         journey = await _create_tr_to_ny_journey(
             sqlite_session, base_time, penultimate_departed=True
         )
@@ -538,6 +596,51 @@ class TestCompletionOnExpiry:
         print(f"  Expiry completion: arrival_source={ny_stop.arrival_source}")
 
     @pytest.mark.asyncio
+    async def test_expiry_does_not_complete_before_terminal_arrival(
+        self, sqlite_session, journey_collector
+    ):
+        """Expiry fallback should not complete a train that left the
+        penultimate stop but is still scheduled to arrive at the terminal."""
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=50)
+        journey = await _create_tr_to_ny_journey(
+            sqlite_session, base_time, penultimate_departed=True
+        )
+
+        await journey_collector._attempt_completion_on_expiry(sqlite_session, journey)
+
+        assert journey.is_completed is not True, (
+            "Expiry completion should wait until the terminal arrival time is due"
+        )
+
+    @pytest.mark.asyncio
+    async def test_expiry_uses_latest_terminal_estimate_before_schedule_fallback(
+        self, sqlite_session, journey_collector
+    ):
+        """A stale static schedule should not complete a delayed train when the
+        latest terminal estimate is still in the future."""
+        now = now_et().replace(second=0, microsecond=0)
+        base_time = now - timedelta(minutes=70)
+        journey = await _create_tr_to_ny_journey(
+            sqlite_session, base_time, penultimate_departed=True
+        )
+        ny_stop = await sqlite_session.scalar(
+            select(JourneyStop).where(
+                JourneyStop.journey_id == journey.id,
+                JourneyStop.station_code == "NY",
+            )
+        )
+        ny_stop.updated_arrival = now + timedelta(minutes=8)
+        await sqlite_session.flush()
+
+        await journey_collector._attempt_completion_on_expiry(sqlite_session, journey)
+
+        assert journey.is_completed is not True, (
+            "Expiry completion should honor the latest terminal estimate before "
+            "falling back to schedule"
+        )
+        assert ny_stop.actual_arrival is None
+
+    @pytest.mark.asyncio
     async def test_expiry_does_not_complete_when_penultimate_not_departed(
         self, sqlite_session, journey_collector
     ):
@@ -562,7 +665,7 @@ class TestCompletionOnExpiry:
     ):
         """If journey is already completed, expiry handler should not
         run (guarded by the caller)."""
-        base_time = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        base_time = now_et().replace(second=0, microsecond=0) - timedelta(minutes=70)
         journey = await _create_tr_to_ny_journey(
             sqlite_session, base_time, penultimate_departed=True
         )

--- a/backend_v2/tests/unit/collectors/njt/test_terminal_stop_completion.py
+++ b/backend_v2/tests/unit/collectors/njt/test_terminal_stop_completion.py
@@ -345,6 +345,65 @@ class TestTerminalStopCompletion:
         assert ny_stop.actual_arrival is None
 
     @pytest.mark.asyncio
+    async def test_misordered_api_stops_use_terminal_row_for_arrival_due(
+        self, sqlite_session, journey_collector
+    ):
+        """Completion should match the terminal API row by station code, not
+        raw list position."""
+        now = now_et().replace(second=0, microsecond=0)
+        base_time = now - timedelta(minutes=70)
+        journey = await _create_tr_to_ny_journey(
+            sqlite_session, base_time, penultimate_departed=True
+        )
+
+        builder = StopBuilder()
+        terminal_arrival_time = now - timedelta(minutes=1)
+        future_intermediate_time = now + timedelta(minutes=8)
+        stops_data = [
+            _make_stop(
+                builder,
+                "TR",
+                "Trenton",
+                base_time.strftime(NJT_TIME_FORMAT),
+                departed=True,
+            ),
+            _make_stop(
+                builder,
+                "NY",
+                "New York Penn",
+                None,
+                arr_time=terminal_arrival_time.strftime(NJT_TIME_FORMAT),
+                departed=False,
+            ),
+            _make_stop(
+                builder,
+                "NP",
+                "Newark Penn",
+                future_intermediate_time.strftime(NJT_TIME_FORMAT),
+                arr_time=future_intermediate_time.strftime(NJT_TIME_FORMAT),
+                departed=True,
+            ),
+        ]
+        stops_data[1].DEP_TIME = None
+
+        await journey_collector.check_journey_completion(
+            sqlite_session, journey, stops_data
+        )
+
+        assert journey.is_completed is True, (
+            "Journey should complete using the NY terminal row even when NJT "
+            "returns a non-terminal stop last"
+        )
+        ny_stop = await sqlite_session.scalar(
+            select(JourneyStop).where(
+                JourneyStop.journey_id == journey.id,
+                JourneyStop.station_code == "NY",
+            )
+        )
+        assert ny_stop.actual_arrival == terminal_arrival_time
+        assert ny_stop.arrival_source == "api_observed"
+
+    @pytest.mark.asyncio
     async def test_no_completion_when_penultimate_not_departed(
         self, sqlite_session, journey_collector
     ):


### PR DESCRIPTION
## Summary

- Require NJT terminal arrival time to be due before marking a journey complete from penultimate-stop departure.
- Share terminal arrival reference logic between normal completion and expiry completion.
- Prefer the latest stored terminal estimate before schedule fallback when a train disappears from the NJT API.
- Add regression coverage for on-time trains between the penultimate and terminal stops, plus expiry cases.

## Root Cause

The backend could mark a journey completed as soon as the penultimate stop had explicitly departed. For on-time trains, that can still be several minutes before arrival at the user's final terminal station, which then causes the scheduler to send a Live Activity `end` event early.

## Validation

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/trackrat-pycache python3 -m py_compile src/trackrat/collectors/njt/journey.py tests/unit/collectors/njt/test_terminal_stop_completion.py tests/unit/collectors/njt/test_journey_data_quality.py`

`pytest` was not runnable in this local shell because neither `pytest` nor `poetry` is installed here.