### PR TITLE
[codex] Stabilize iOS feedback sheets

### DIFF
--- a/ios/TrackRat/Views/Components/FeedbackButton.swift
+++ b/ios/TrackRat/Views/Components/FeedbackButton.swift
@@ -55,6 +55,48 @@ enum FeedbackMode {
     }
 }
 
+struct FeedbackSheetRequest: Identifiable {
+    let id = UUID()
+    let mode: FeedbackMode
+    let screen: String
+    let trainId: String?
+    let originCode: String?
+    let destinationCode: String?
+
+    init(
+        mode: FeedbackMode = .issue,
+        screen: String,
+        trainId: String?,
+        originCode: String?,
+        destinationCode: String?
+    ) {
+        self.mode = mode
+        self.screen = screen
+        self.trainId = trainId
+        self.originCode = originCode
+        self.destinationCode = destinationCode
+    }
+
+    init(mode: FeedbackMode, context: JourneyFeedbackContext?) {
+        self.mode = mode
+        self.screen = "journey_feedback_prompt"
+        self.trainId = context?.trainId
+        self.originCode = context?.originCode
+        self.destinationCode = context?.destinationCode
+    }
+}
+
+extension View {
+    func feedbackSheet(
+        request: Binding<FeedbackSheetRequest?>,
+        onDismiss: (() -> Void)? = nil
+    ) -> some View {
+        sheet(item: request, onDismiss: onDismiss) { request in
+            FeedbackSheet(request: request)
+        }
+    }
+}
+
 /// A button that allows users to report data issues
 struct FeedbackButton: View {
     let screen: String
@@ -64,13 +106,24 @@ struct FeedbackButton: View {
     var textColor: Color = .white.opacity(0.6)
     var label: String = "Report an issue"
     var font: Font = .footnote
+    var onRequest: ((FeedbackSheetRequest) -> Void)?
 
-    @State private var showingSheet = false
+    @State private var feedbackRequest: FeedbackSheetRequest?
 
     var body: some View {
         Button {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            showingSheet = true
+            let request = FeedbackSheetRequest(
+                screen: screen,
+                trainId: trainId,
+                originCode: originCode,
+                destinationCode: destinationCode
+            )
+            if let onRequest {
+                onRequest(request)
+            } else {
+                feedbackRequest = request
+            }
         } label: {
             VStack(spacing: 2) {
                 HStack(spacing: 6) {
@@ -86,15 +139,7 @@ struct FeedbackButton: View {
             .foregroundColor(textColor)
         }
         .buttonStyle(.plain)
-        .sheet(isPresented: $showingSheet) {
-            FeedbackSheet(
-                mode: .issue,
-                screen: screen,
-                trainId: trainId,
-                originCode: originCode,
-                destinationCode: destinationCode
-            )
-        }
+        .feedbackSheet(request: $feedbackRequest)
     }
 }
 
@@ -114,13 +159,12 @@ struct FeedbackSheet: View {
         self.destinationCode = destinationCode
     }
 
-    /// Convenience initializer for journey feedback context
-    init(mode: FeedbackMode, context: JourneyFeedbackContext?) {
-        self.mode = mode
-        self.screen = "journey_feedback_prompt"
-        self.trainId = context?.trainId
-        self.originCode = context?.originCode
-        self.destinationCode = context?.destinationCode
+    init(request: FeedbackSheetRequest) {
+        self.mode = request.mode
+        self.screen = request.screen
+        self.trainId = request.trainId
+        self.originCode = request.originCode
+        self.destinationCode = request.destinationCode
     }
 
     @Environment(\.dismiss) private var dismiss

--- a/ios/TrackRat/Views/Components/JourneyFeedbackPromptView.swift
+++ b/ios/TrackRat/Views/Components/JourneyFeedbackPromptView.swift
@@ -7,7 +7,7 @@ struct JourneyFeedbackPromptView: View {
     @ObservedObject private var feedbackService = JourneyFeedbackService.shared
     @Environment(\.dismiss) private var dismiss
 
-    @State private var showImprovementForm = false
+    @State private var improvementFeedbackRequest: FeedbackSheetRequest?
 
     var body: some View {
         NavigationStack {
@@ -50,7 +50,10 @@ struct JourneyFeedbackPromptView: View {
                     Button {
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
                         if feedbackService.userRespondedNegatively() {
-                            showImprovementForm = true
+                            improvementFeedbackRequest = FeedbackSheetRequest(
+                                mode: .improvement,
+                                context: feedbackService.currentJourneyContext
+                            )
                         }
                     } label: {
                         Text("Not really")
@@ -83,11 +86,9 @@ struct JourneyFeedbackPromptView: View {
         .presentationDragIndicator(.visible)
         .presentationBackground(.ultraThinMaterial)
         .preferredColorScheme(.dark)
-        .sheet(isPresented: $showImprovementForm, onDismiss: {
+        .feedbackSheet(request: $improvementFeedbackRequest, onDismiss: {
             feedbackService.shouldShowFeedbackPrompt = false
-        }) {
-            FeedbackSheet(mode: .improvement, context: feedbackService.currentJourneyContext)
-        }
+        })
     }
 }
 

--- a/ios/TrackRat/Views/Screens/RouteStatusView.swift
+++ b/ios/TrackRat/Views/Screens/RouteStatusView.swift
@@ -16,6 +16,7 @@ struct RouteStatusView: View {
     @State private var draftSubscription: RouteAlertSubscription?
 
     @State private var showingPaywall = false
+    @State private var feedbackRequest: FeedbackSheetRequest?
 
     /// Selected history time period for the segmented picker.
     @State private var selectedHistoryPeriod: HistoryPeriod = .hour
@@ -59,7 +60,8 @@ struct RouteStatusView: View {
                         screen: "route_status",
                         trainId: nil,
                         originCode: context.fromStationCode,
-                        destinationCode: context.toStationCode
+                        destinationCode: context.toStationCode,
+                        onRequest: { feedbackRequest = $0 }
                     )
                     .padding(.top, 8)
                 }
@@ -145,6 +147,7 @@ struct RouteStatusView: View {
             .sheet(isPresented: $showingPaywall) {
                 PaywallView(context: .routeAlerts)
             }
+            .feedbackSheet(request: $feedbackRequest)
         }
     }
 

--- a/ios/TrackRat/Views/Screens/SettingsView.swift
+++ b/ios/TrackRat/Views/Screens/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     var editTrainSystems: Bool = false
 
     @State private var showingPaywall = false
+    @State private var feedbackRequest: FeedbackSheetRequest?
     @State private var paywallContext: PaywallContext = .generic
     @State private var navigationPath = NavigationPath()
 
@@ -88,6 +89,14 @@ struct SettingsView: View {
                         navigationPath: $navigationPath,
                         showingPaywall: $showingPaywall,
                         paywallContext: $paywallContext,
+                        onReportIssue: {
+                            feedbackRequest = FeedbackSheetRequest(
+                                screen: "settings",
+                                trainId: nil,
+                                originCode: nil,
+                                destinationCode: nil
+                            )
+                        },
                         showDebugSections: showDebugSections,
                         initialEditTrainSystems: editTrainSystems
                     )
@@ -119,6 +128,7 @@ struct SettingsView: View {
         .sheet(isPresented: $showingPaywall) {
             PaywallView(context: paywallContext)
         }
+        .feedbackSheet(request: $feedbackRequest)
         .interactiveDismissDisabled(appState.selectedSystems.isEmpty)
     }
 
@@ -142,6 +152,7 @@ struct SettingsSection: View {
     @Binding var navigationPath: NavigationPath
     @Binding var showingPaywall: Bool
     @Binding var paywallContext: PaywallContext
+    let onReportIssue: () -> Void
     var showDebugSections: Bool
     var initialEditTrainSystems: Bool = false
     @State private var isEditingTrainSystems = false
@@ -154,7 +165,6 @@ struct SettingsSection: View {
     @State private var selectedSubscription: RouteAlertSubscription?
     @ObservedObject private var alertService = AlertSubscriptionService.shared
     @ObservedObject private var ratSense = RatSenseService.shared
-    @State private var showingFeedbackSheet = false
 
     private enum FavoriteStationRole {
         case home, work, other
@@ -563,7 +573,7 @@ struct SettingsSection: View {
             // Report an Issue
             Button {
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                showingFeedbackSheet = true
+                onReportIssue()
             } label: {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 16) {
@@ -588,14 +598,6 @@ struct SettingsSection: View {
                 )
             }
             .buttonStyle(.plain)
-            .sheet(isPresented: $showingFeedbackSheet) {
-                FeedbackSheet(
-                    screen: "settings",
-                    trainId: nil,
-                    originCode: nil,
-                    destinationCode: nil
-                )
-            }
 
             // GitHub
             Button {

--- a/ios/TrackRat/Views/Screens/TrainDetailsView.swift
+++ b/ios/TrackRat/Views/Screens/TrainDetailsView.swift
@@ -9,6 +9,7 @@ struct TrainDetailsView: View {
     @ObservedObject private var alertService = AlertSubscriptionService.shared
     // PERFORMANCE: Track visibility to prevent polling when view is not visible
     @State private var isViewVisible = false
+    @State private var feedbackRequest: FeedbackSheetRequest?
 
     let trainId: Int  // Keep for backwards compatibility
     let isSheet: Bool
@@ -250,13 +251,14 @@ struct TrainDetailsView: View {
                         // Force view recreation when train identity or status changes
                         .id("\(train.id)-\(train.calculateStatus(fromStationCode: appState.departureStationCode ?? "").rawValue)")
 
-                        // FeedbackButton is outside the .id() scope so live data refreshes
-                        // don't recreate it and dismiss an in-progress feedback sheet
+                        // Keep the button outside the .id() scope and present
+                        // from this view so live refreshes don't dismiss the sheet.
                         FeedbackButton(
                             screen: "train_details",
                             trainId: train.trainId,
                             originCode: appState.departureStationCode,
-                            destinationCode: appState.destinationStationCode
+                            destinationCode: appState.destinationStationCode,
+                            onRequest: { feedbackRequest = $0 }
                         )
                         .padding(.horizontal)
                         .padding(.top, 8)
@@ -330,6 +332,7 @@ struct TrainDetailsView: View {
                 }
             }
         }
+        .feedbackSheet(request: $feedbackRequest)
     }
 }
 

--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -30,6 +30,7 @@ struct TrainListView: View {
     // Date selection for future schedules
     @State private var selectedDate: Date = Date()
     @State private var showDatePicker: Bool = false
+    @State private var feedbackRequest: FeedbackSheetRequest?
 
     /// Check if viewing a future date (not today)
     private var isFutureDate: Bool {
@@ -255,7 +256,8 @@ struct TrainListView: View {
                             screen: "train_list",
                             trainId: nil,
                             originCode: departureStationCode,
-                            destinationCode: Stations.getStationCode(destination)
+                            destinationCode: Stations.getStationCode(destination),
+                            onRequest: { feedbackRequest = $0 }
                         )
                         .padding(.top, 8)
                     }
@@ -289,6 +291,7 @@ struct TrainListView: View {
         .sheet(isPresented: $showDatePicker) {
             DateSelectorSheet(selectedDate: $selectedDate)
         }
+        .feedbackSheet(request: $feedbackRequest)
         .onAppear {
             isViewVisible = true
 

--- a/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
+++ b/ios/TrackRat/Views/Screens/TrainSystemDetailView.swift
@@ -22,6 +22,7 @@ struct TrainSystemDetailView: View {
     @State private var serviceAlerts: [V2ServiceAlert] = []
     @State private var showingPaywall = false
     @State private var routeStatusContext: RouteStatusContext?
+    @State private var feedbackRequest: FeedbackSheetRequest?
 
     /// Locally-edited copies of the matching system-wide subscription, keyed by ID.
     /// Persisted to `alertService` on disappear.
@@ -50,7 +51,8 @@ struct TrainSystemDetailView: View {
                     screen: "system_detail",
                     trainId: nil,
                     originCode: nil,
-                    destinationCode: nil
+                    destinationCode: nil,
+                    onRequest: { feedbackRequest = $0 }
                 )
                 .padding(.top, 8)
             }
@@ -89,6 +91,7 @@ struct TrainSystemDetailView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        .feedbackSheet(request: $feedbackRequest)
     }
 
     // MARK: - Sections


### PR DESCRIPTION
## Summary

Stabilizes iOS feedback sheet presentation for issue #1188 by moving feedback presentation away from volatile button-local Boolean state and onto request-backed sheet hosts.

## What changed

- Added a shared `FeedbackSheetRequest` and `.feedbackSheet(request:)` helper.
- Updated `FeedbackButton` to create a request at tap time, so the presented sheet captures the intended feedback context.
- Hoisted production feedback sheet state to the owning screens for train lists, train details, route status, system details, and settings.
- Updated journey improvement feedback to use the same request-backed presentation path.

## Why

The settings report suggested the Report Issue sheet could rapidly close without user dismissal. The likely failure mode was SwiftUI presentation state living too low in the view tree: if the button/subtree was rebuilt or removed during refresh or sheet layout changes, the local Boolean presenter could disappear and dismiss the sheet. The new request-backed path keeps presentation state on stable owners and uses the same helper across all feedback flows.

## Validation

- `git diff --check`
- `rg --files -g '*.swift' ios/TrackRat ios/TrackRatTests | xargs swiftc -parse`

Full `xcodebuild`/simulator verification was not available in this environment because the active developer directory is Command Line Tools rather than a full Xcode install.