### PR TITLE
[codex] Fix merged Hoboken PATH alerts

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import selectinload
 from structlog import get_logger
 
 from trackrat.config.route_topology import ALL_ROUTES, Route
-from trackrat.config.stations import get_station_name
+from trackrat.config.stations import expand_station_codes, get_station_name
 from trackrat.config.stations.lirr import LIRR_ROUTES
 from trackrat.config.stations.mnr import MNR_ROUTES
 from trackrat.models.database import (
@@ -112,6 +112,16 @@ def _is_system_wide(sub: RouteAlertSubscription) -> bool:
     )
 
 
+def _route_contains_station_pair(route: Route, from_station: str, to_station: str) -> bool:
+    """Check a route for a station pair, honoring station equivalence groups."""
+    to_codes = expand_station_codes(to_station)
+    for from_code in expand_station_codes(from_station):
+        for to_code in to_codes:
+            if route.contains_segment(from_code, to_code):
+                return True
+    return False
+
+
 def _get_gtfs_route_ids_for_subscription(
     sub: RouteAlertSubscription,
 ) -> set[str]:
@@ -139,7 +149,9 @@ def _get_gtfs_route_ids_for_subscription(
         for route in ALL_ROUTES:
             if route.data_source != ds:
                 continue
-            if route.contains_segment(sub.from_station_code, sub.to_station_code):
+            if _route_contains_station_pair(
+                route, sub.from_station_code, sub.to_station_code
+            ):
                 gtfs_ids |= _line_codes_to_gtfs_ids(ds, route.line_codes)
         return gtfs_ids
 
@@ -519,11 +531,13 @@ async def _query_journeys_for_subscription(
         # Eagerly load stops so _is_significantly_delayed can check
         # arrival delay at the destination station.
         eager_opts = [selectinload(TrainJourney.stops)]
+        from_codes = expand_station_codes(sub.from_station_code)
+        to_codes = expand_station_codes(sub.to_station_code)
 
         # First try direct origin/destination match
         direct_conditions = base_conditions + [
-            TrainJourney.origin_station_code == sub.from_station_code,
-            TrainJourney.terminal_station_code == sub.to_station_code,
+            TrainJourney.origin_station_code.in_(from_codes),
+            TrainJourney.terminal_station_code.in_(to_codes),
         ]
         result = await db.execute(
             select(TrainJourney).options(*eager_opts).where(and_(*direct_conditions))
@@ -548,8 +562,8 @@ async def _query_journeys_for_subscription(
             )
             .where(
                 and_(
-                    from_stop.c.station_code == sub.from_station_code,
-                    to_stop.c.station_code == sub.to_station_code,
+                    from_stop.c.station_code.in_(from_codes),
+                    to_stop.c.station_code.in_(to_codes),
                     from_stop.c.stop_sequence.isnot(None),
                     to_stop.c.stop_sequence.isnot(None),
                 )
@@ -647,10 +661,12 @@ async def _query_baseline_train_count(
             return None
         base_conditions.append(TrainJourney.line_code.in_(list(route.line_codes)))
     elif sub.from_station_code and sub.to_station_code:
+        from_codes = expand_station_codes(sub.from_station_code)
+        to_codes = expand_station_codes(sub.to_station_code)
         base_conditions.extend(
             [
-                TrainJourney.origin_station_code == sub.from_station_code,
-                TrainJourney.terminal_station_code == sub.to_station_code,
+                TrainJourney.origin_station_code.in_(from_codes),
+                TrainJourney.terminal_station_code.in_(to_codes),
             ]
         )
     # else: system-wide — no additional filtering, all journeys for data_source
@@ -837,9 +853,10 @@ def _is_significantly_delayed(
 
     # For station-pair subs, also check arrival delay at the destination stop
     if to_station_code and hasattr(journey, "stops") and journey.stops:
+        to_station_codes = set(expand_station_codes(to_station_code))
         for stop in journey.stops:
             if (
-                stop.station_code == to_station_code
+                stop.station_code in to_station_codes
                 and stop.actual_arrival
                 and stop.scheduled_arrival
             ):
@@ -1311,7 +1328,9 @@ def _get_route_name_for_subscription(sub: RouteAlertSubscription) -> str:
         for route in ALL_ROUTES:
             if route.data_source != sub.data_source:
                 continue
-            if route.contains_segment(sub.from_station_code, sub.to_station_code):
+            if _route_contains_station_pair(
+                route, sub.from_station_code, sub.to_station_code
+            ):
                 return route.name
     return sub.data_source or "Unknown"
 

--- a/backend_v2/tests/unit/services/test_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_alert_evaluator.py
@@ -409,6 +409,38 @@ class TestAlertEvaluator:
         count = await evaluate_route_alerts(db_session, apns)
         assert count == 1
 
+    async def test_station_pair_matches_equivalent_origin_destination(
+        self, db_session: AsyncSession
+    ):
+        """Station-pair subscriptions should honor station equivalence groups."""
+        apns = _make_apns()
+        _make_device_and_sub(
+            db_session,
+            data_source="PATH",
+            from_station="HB",
+            to_station="P33",
+        )
+        _make_journey(
+            db_session,
+            train_id="PATH_PHO_P33_1001",
+            data_source="PATH",
+            line_code="HOB-33",
+            origin="PHO",
+            terminal="P33",
+            is_cancelled=True,
+            minutes_ago=20,
+        )
+        await db_session.flush()
+
+        count = await evaluate_route_alerts(db_session, apns)
+        assert count == 1
+        apns.send_alert_notification.assert_called_once()
+        call_kwargs = apns.send_alert_notification.call_args.kwargs
+        route_alert = call_kwargs["custom_data"]["route_alert"]
+        assert route_alert["data_source"] == "PATH"
+        assert route_alert["from_station_code"] == "HB"
+        assert route_alert["to_station_code"] == "P33"
+
     async def test_custom_data_includes_route_alert_metadata(
         self, db_session: AsyncSession
     ):

--- a/backend_v2/tests/unit/services/test_service_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_service_alert_evaluator.py
@@ -158,6 +158,17 @@ class TestGetGtfsRouteIdsForSubscription:
         # Should find at least the Babylon branch GTFS ID
         assert len(result) > 0
 
+    def test_station_pair_uses_equivalent_codes(self):
+        """Station-pair route inference should honor station equivalence groups."""
+        sub = RouteAlertSubscription(
+            device_id="dev1",
+            data_source="SUBWAY",
+            from_station_code="NY",
+            to_station_code="S116",
+        )
+        result = _get_gtfs_route_ids_for_subscription(sub)
+        assert "1" in result
+
     def test_station_pair_no_matching_route_returns_empty(self):
         """Station-pair with stations not on any shared route returns empty."""
         sub = RouteAlertSubscription(
@@ -361,6 +372,17 @@ class TestGetRouteNameForSubscription:
         name = _get_route_name_for_subscription(sub)
         assert name  # Should find a route name
         assert name != "LIRR"  # Should not be the fallback
+
+    def test_station_pair_route_name_uses_equivalent_codes(self):
+        """Station-pair route names should resolve through station equivalences."""
+        sub = RouteAlertSubscription(
+            device_id="dev1",
+            data_source="SUBWAY",
+            from_station_code="NY",
+            to_station_code="S116",
+        )
+        name = _get_route_name_for_subscription(sub)
+        assert name == "1 Broadway - 7 Avenue Local"
 
     def test_station_pair_no_match_returns_data_source(self):
         """Station-pair with no matching route falls back to data_source."""

--- a/ios/TrackRat/Shared/StationDepartures.swift
+++ b/ios/TrackRat/Shared/StationDepartures.swift
@@ -7,7 +7,6 @@ extension Stations {
         ("New York Penn Station", "NY"),
         ("Hoboken", "HB"),
         // PATH
-        ("Hoboken PATH", "PHO"),
         ("World Trade Center", "PWC"),
         ("33rd Street", "P33"),
         ("Journal Square", "PJS"),

--- a/ios/TrackRat/Shared/Stations.swift
+++ b/ios/TrackRat/Shared/Stations.swift
@@ -157,6 +157,7 @@ struct Stations {
     /// - Stations not on any RouteTopology route but belonging to a non-Amtrak system
     private static let stationSystemOverrides: [String: Set<String>] = [
         "NP": ["NJT", "AMTRAK", "PATH"],  // Newark Penn Station (PATH adjacent)
+        "HB": ["NJT", "PATH"],            // Hoboken Terminal (PATH adjacent)
         // NJT stations not in RouteTopology
         "TS": ["NJT"],   // Secaucus Lower Lvl
         "GA": ["NJT"],   // Great Notch
@@ -334,4 +335,3 @@ extension MKCoordinateRegion {
         )
     }
 }
-

--- a/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
+++ b/ios/TrackRat/Views/Screens/AddRouteAlertView.swift
@@ -278,12 +278,7 @@ struct AddRouteAlertView: View {
                     }
                     let fromCode = from.code
                     let toCode = to.code
-                    let fromSystems = Stations.systemStringsForStation(fromCode)
-                    let toSystems = Stations.systemStringsForStation(toCode)
-                    let alertCapableStrings = alertCapableSystems.asRawStrings
-                    // Pick a system shared by both stations that supports alerts
-                    let common = fromSystems.intersection(toSystems).intersection(alertCapableStrings)
-                    let dataSource = common.first ?? fromSystems.intersection(toSystems).first ?? "NJT"
+                    let dataSource = preferredAlertDataSource(from: fromCode, to: toCode)
 
                     let existsAB = alertService.subscriptions.contains {
                         $0.fromStationCode == fromCode &&
@@ -361,6 +356,33 @@ struct AddRouteAlertView: View {
                 }
             )
         }
+    }
+
+    private func preferredAlertDataSource(from fromCode: String, to toCode: String) -> String {
+        let fromSystems = Stations.systemStringsForStation(fromCode)
+        let toSystems = Stations.systemStringsForStation(toCode)
+        let sharedAlertSystems = fromSystems
+            .intersection(toSystems)
+            .intersection(alertCapableSystems.asRawStrings)
+
+        let orderedSharedAlertSystems = TrainSystem.allCases
+            .map(\.rawValue)
+            .filter { sharedAlertSystems.contains($0) }
+
+        if let directSystem = orderedSharedAlertSystems.first(where: {
+            RouteTopology.routeContaining(from: fromCode, to: toCode, dataSource: $0) != nil
+        }) {
+            return directSystem
+        }
+
+        if let firstAlertSystem = orderedSharedAlertSystems.first {
+            return firstAlertSystem
+        }
+
+        let sharedSystems = fromSystems.intersection(toSystems)
+        return TrainSystem.allCases
+            .map(\.rawValue)
+            .first(where: { sharedSystems.contains($0) }) ?? "NJT"
     }
 
     private func noEligibleSystemsView(detail: String) -> some View {

--- a/ios/TrackRatTests/Models/RouteTopologyTests.swift
+++ b/ios/TrackRatTests/Models/RouteTopologyTests.swift
@@ -56,6 +56,12 @@ class RouteTopologyTests: XCTestCase {
         XCTAssertEqual(route?.dataSource, "PATH")
     }
 
+    func testRouteContainingFindsHobokenPATHRouteViaEquivalent() {
+        let route = RouteTopology.routeContaining(from: "HB", to: "P33", dataSource: "PATH")
+        XCTAssertNotNil(route, "Should find a PATH route from canonical Hoboken to 33rd Street")
+        XCTAssertEqual(route?.dataSource, "PATH")
+    }
+
     func testRouteContainingReturnsNilForPartialMatch() {
         // When only one station matches, return nil rather than a misleading partial match
         let route = RouteTopology.routeContaining(from: "NY", to: "NONEXISTENT", dataSource: "NJT")

--- a/ios/TrackRatTests/Models/StationsTests.swift
+++ b/ios/TrackRatTests/Models/StationsTests.swift
@@ -13,7 +13,7 @@ class StationsTests: XCTestCase {
     
     func testDepartureStationsExist() {
         XCTAssertFalse(Stations.departureStations.isEmpty, "Departure stations should not be empty")
-        XCTAssertEqual(Stations.departureStations.count, 23, "Should have exactly 23 departure stations")
+        XCTAssertEqual(Stations.departureStations.count, 79, "Should have exactly 79 departure stations")
     }
     
     func testKnownStations() {
@@ -468,6 +468,11 @@ class StationsTests: XCTestCase {
         XCTAssertTrue(npSystems.contains("AMTRAK"), "Newark Penn should serve AMTRAK")
         XCTAssertTrue(npSystems.contains("PATH"), "Newark Penn should serve PATH")
 
+        // Hoboken should serve NJT and PATH as a single visible station
+        let hbSystems = Stations.systemStringsForStation("HB")
+        XCTAssertTrue(hbSystems.contains("NJT"), "Hoboken should serve NJT")
+        XCTAssertTrue(hbSystems.contains("PATH"), "Hoboken should serve PATH")
+
         // NY Penn should serve NJT and AMTRAK (via RouteTopology)
         let nySystems = Stations.systemStringsForStation("NY")
         XCTAssertTrue(nySystems.contains("NJT"), "NY Penn should serve NJT")
@@ -477,6 +482,17 @@ class StationsTests: XCTestCase {
         let gctSystems = Stations.systemStringsForStation("GCT")
         XCTAssertTrue(gctSystems.contains("LIRR"), "Grand Central should serve LIRR")
         XCTAssertTrue(gctSystems.contains("MNR"), "Grand Central should serve MNR")
+    }
+
+    func testHobokenPathIsMergedInDepartureStations() {
+        XCTAssertTrue(
+            Stations.departureStations.contains { $0.name == "Hoboken" && $0.code == "HB" },
+            "Merged Hoboken departure station should use canonical HB"
+        )
+        XCTAssertFalse(
+            Stations.departureStations.contains { $0.name == "Hoboken PATH" || $0.code == "PHO" },
+            "Hoboken PATH should not appear as a separate departure station"
+        )
     }
 
     func testAmtrakOnlyStationsMapped() {

--- a/ios/TrackRatTests/Models/TrainSystemTests.swift
+++ b/ios/TrackRatTests/Models/TrainSystemTests.swift
@@ -184,6 +184,10 @@ class TrainSystemTests: XCTestCase {
         XCTAssertTrue(systems.contains(.njt), "Newark Penn should include NJT")
         XCTAssertTrue(systems.contains(.amtrak), "Newark Penn should include AMTRAK")
         XCTAssertTrue(systems.contains(.path), "Newark Penn should include PATH")
+
+        let hobokenSystems = Stations.systemsForStation("HB")
+        XCTAssertTrue(hobokenSystems.contains(.njt), "Hoboken should include NJT")
+        XCTAssertTrue(hobokenSystems.contains(.path), "Hoboken should include PATH")
     }
 
     func testSystemsForStation_singleSystem() {


### PR DESCRIPTION
## Summary

- Treat canonical Hoboken (`HB`) as both NJT and PATH on iOS so it gets the PATH badge and appears in PATH route alert selection.
- Remove the separate `Hoboken PATH` quick-pick station from iOS departure shortcuts while retaining `PHO` as an internal PATH topology/data code.
- Make route alert data-source selection deterministic and prefer shared systems that actually have a route topology match.
- Make backend route alert station-pair matching equivalence-aware for live journey queries, baselines, destination delay checks, and route-name inference.

## Root Cause

The previous merge for Hoboken added the `HB`/`PHO` equivalence group and hid `Hoboken PATH` from the main searchable catalog, but iOS still did not classify `HB` as PATH-serving. That prevented PATH badges and route selection from Hoboken. Also, backend alert evaluation still matched station-pair subscriptions by exact station codes, so a canonical `HB -> P33` PATH alert would not match PATH journeys stored as `PHO -> P33`.

## Validation

- `git diff --check`
- `/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m py_compile backend_v2/src/trackrat/services/alert_evaluator.py backend_v2/tests/unit/services/test_alert_evaluator.py backend_v2/tests/unit/services/test_service_alert_evaluator.py`
- `swiftc -parse ios/TrackRat/Views/Screens/AddRouteAlertView.swift ios/TrackRat/Shared/Stations.swift ios/TrackRat/Shared/StationDepartures.swift ios/TrackRatTests/Models/StationsTests.swift ios/TrackRatTests/Models/TrainSystemTests.swift ios/TrackRatTests/Models/RouteTopologyTests.swift`

Full suites were not run locally because this environment does not have Poetry, Docker, or an active Xcode developer directory.