### PR TITLE
Issue #1196: Fix recurring greenlet error in NJT station refresh

### DIFF
--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -1375,9 +1375,17 @@ class DepartureService:
                         if fresh:
                             await njt_collector.collect_journey_details(db, fresh)
 
+                    # Per-journey commit/rollback isolates each refresh so a
+                    # single failure does not erase prior successful work.
+                    # NOTE: do NOT wrap this in `async with db.begin_nested()`.
+                    # `retry_on_deadlock` calls `await session.rollback()` on
+                    # retry, which rolls back the entire outer transaction
+                    # (not the savepoint), leaving the SAVEPOINT state
+                    # inconsistent and triggering `greenlet_spawn has not
+                    # been called` on subsequent flushes/commits.
                     try:
-                        async with db.begin_nested():
-                            await retry_on_deadlock(db, refresh_journey)
+                        await retry_on_deadlock(db, refresh_journey)
+                        await db.commit()
                         individual_updated += 1
                         logger.debug(
                             "stale_train_refreshed",
@@ -1386,11 +1394,13 @@ class DepartureService:
                     except TrainNotFoundError:
                         # Train no longer in NJT system - this is expected for
                         # trains that completed their journey
+                        await db.rollback()
                         logger.debug(
                             "stale_train_not_found",
                             train_id=journey.train_id,
                         )
                     except Exception as e:
+                        await db.rollback()
                         logger.warning(
                             "stale_train_refresh_failed",
                             train_id=journey.train_id,
@@ -1398,7 +1408,6 @@ class DepartureService:
                             error_type=type(e).__name__,
                         )
 
-                await db.commit()
                 logger.info(
                     "stale_past_trains_refresh_complete",
                     station_code=station_code,

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -1354,10 +1354,17 @@ class DepartureService:
                 njt_collector = NJTJourneyCollector(njt_client)
                 individual_updated = 0
 
-                for journey in remaining_stale:
-                    if journey.id is None:
-                        continue
-                    journey_id = journey.id
+                # Snapshot (journey_id, train_id) for every stale journey
+                # before the loop starts. `db.commit()` and `db.rollback()`
+                # below expire all session attributes, so reading
+                # `journey.train_id` from a later iteration would trigger a
+                # sync lazy-load that fails with MissingGreenlet in the
+                # async session.
+                stale_ids: list[tuple[int, str | None]] = [
+                    (j.id, j.train_id) for j in remaining_stale if j.id is not None
+                ]
+
+                for journey_id, train_id in stale_ids:
 
                     async def refresh_journey(jid: int = journey_id) -> None:
                         # Re-query to get fresh state after potential rollback.
@@ -1389,7 +1396,7 @@ class DepartureService:
                         individual_updated += 1
                         logger.debug(
                             "stale_train_refreshed",
-                            train_id=journey.train_id,
+                            train_id=train_id,
                         )
                     except TrainNotFoundError:
                         # Train no longer in NJT system - this is expected for
@@ -1397,13 +1404,13 @@ class DepartureService:
                         await db.rollback()
                         logger.debug(
                             "stale_train_not_found",
-                            train_id=journey.train_id,
+                            train_id=train_id,
                         )
                     except Exception as e:
                         await db.rollback()
                         logger.warning(
                             "stale_train_refresh_failed",
-                            train_id=journey.train_id,
+                            train_id=train_id,
                             error=str(e) or repr(e),
                             error_type=type(e).__name__,
                         )

--- a/backend_v2/tests/integration/test_departure_service.py
+++ b/backend_v2/tests/integration/test_departure_service.py
@@ -863,6 +863,11 @@ class TestDepartureServiceIntegration:
         journey.stops = [stop]
         db_session.add(journey)
         await db_session.commit()
+        # Capture the primary key before _ensure_fresh_station_data runs:
+        # its second-pass rollback (on the simulated API failure) expires
+        # session-attached attributes, so re-reading `journey.id` afterwards
+        # would trigger a sync lazy-load that fails inside the async session.
+        journey_id = journey.id
 
         # API returns empty list
         with patch("trackrat.services.departure.NJTransitClient") as mock_njt:
@@ -877,7 +882,7 @@ class TestDepartureServiceIntegration:
             await service._ensure_fresh_station_data(db_session, "NY", now_et().date())
 
         # Verify journey was not updated
-        refreshed = await db_session.get(TrainJourney, journey.id)
+        refreshed = await db_session.get(TrainJourney, journey_id)
         assert refreshed.update_count == 1
 
     async def test_skip_individual_refresh_skips_second_pass(

--- a/backend_v2/tests/unit/services/test_departure_stop_refresh.py
+++ b/backend_v2/tests/unit/services/test_departure_stop_refresh.py
@@ -1,12 +1,15 @@
 """
-Tests for JIT station refresh fixes (issue #962):
+Tests for JIT station refresh fixes:
 
-1. _update_stops_from_embedded_data uses stops_by_code lookup from
+1. (#962) _update_stops_from_embedded_data uses stops_by_code lookup from
    journey.stops instead of session.get() after pg_insert — prevents
    greenlet_spawn errors from orphan-check lazy loads during flush.
 
-2. Second-pass error handler rolls back the session to prevent
-   PendingRollbackError cascading to subsequent iterations.
+2. (#1196) Second-pass per-journey refresh uses per-journey commit
+   instead of `begin_nested()` around `retry_on_deadlock`. The latter
+   combination corrupted SAVEPOINT state on deadlock retry (inner
+   rollback discards the outer transaction) and triggered greenlet
+   errors on subsequent flushes.
 """
 
 import asyncio
@@ -219,15 +222,28 @@ class TestDepartedFlagSequentialInference:
         assert s2.has_departed_station is True
 
 
-class TestSecondPassSavepoint:
-    """Test that the second-pass per-journey refresh uses begin_nested()
-    (savepoint) to isolate failures and prevent PendingRollbackError cascade
-    while preserving prior successful refreshes (fix for #962)."""
+class TestSecondPassPerJourneyCommit:
+    """Verify second-pass per-journey refresh uses per-journey commit instead
+    of `begin_nested()` for isolation (fix for #1196).
 
-    def test_savepoint_wraps_each_journey_refresh(self):
-        """Each stale journey refresh should be wrapped in begin_nested()
-        so a failure only rolls back that savepoint, not the entire
-        transaction."""
+    Background: issue #962 wrapped each stale-journey refresh in
+    `async with db.begin_nested(): await retry_on_deadlock(db, refresh_journey)`
+    to isolate failures. That combination is broken — `retry_on_deadlock`
+    calls `await session.rollback()` on retry, which rolls back the *outer*
+    transaction (not the savepoint), leaving the SAVEPOINT state inconsistent
+    and triggering `greenlet_spawn has not been called; can't call
+    await_only() here` on subsequent flushes. Recurred 3x in 48h of
+    production logs.
+
+    The fix is per-journey commit: each successful refresh commits
+    immediately, preserving prior work; each failure rolls back only the
+    current journey's partial state, leaving the session clean for the
+    next iteration.
+    """
+
+    def test_no_begin_nested_around_retry_on_deadlock(self):
+        """`begin_nested()` must not wrap `retry_on_deadlock` — the two
+        primitives are incompatible (see class docstring)."""
         import inspect
         from trackrat.services.departure import DepartureService
 
@@ -237,26 +253,92 @@ class TestSecondPassSavepoint:
             "stale_train_refresh_failed" in source
         ), "Expected 'stale_train_refresh_failed' log in _ensure_fresh_station_data"
 
-        # The per-journey refresh must use begin_nested() (savepoint)
-        # instead of a bare db.rollback() that would undo prior successes
-        assert "begin_nested()" in source, (
-            "Expected 'begin_nested()' savepoint wrapping each journey refresh "
-            "to isolate failures without rolling back prior successful work"
+        # Strip comments so the comment that documents the fix doesn't
+        # trip the substring check. Keep only code.
+        code_lines = []
+        for line in source.split("\n"):
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            code_lines.append(line)
+
+        # Walk the code and verify no `begin_nested():` (as a statement,
+        # not a string in a comment) is followed within a few lines by a
+        # call to `retry_on_deadlock(`.
+        for i, line in enumerate(code_lines):
+            if "begin_nested():" in line:
+                window = "\n".join(code_lines[i : i + 5])
+                assert "retry_on_deadlock(" not in window, (
+                    f"Found `begin_nested()` wrapping `retry_on_deadlock` "
+                    f"at code line {i}. This combination is broken — the "
+                    f"inner rollback discards the savepoint, triggering "
+                    f"greenlet errors on subsequent flushes.\n\nContext:\n"
+                    f"{window}"
+                )
+
+    def test_per_journey_commit_isolates_failures(self):
+        """Each successful per-journey refresh must commit before the next
+        iteration so a later failure cannot erase prior successes."""
+        import inspect
+        from trackrat.services.departure import DepartureService
+
+        source = inspect.getsource(DepartureService._ensure_fresh_station_data)
+
+        # Find the per-journey loop: retry_on_deadlock(db, refresh_journey)
+        # must be followed by `await db.commit()` and the success log
+        # before the next iteration.
+        lines = source.split("\n")
+        commit_after_retry = False
+        for i, line in enumerate(lines):
+            if (
+                "retry_on_deadlock(db, refresh_journey)" in line
+                and i + 5 < len(lines)
+            ):
+                window = "\n".join(lines[i : i + 5])
+                if "await db.commit()" in window:
+                    commit_after_retry = True
+                    break
+        assert commit_after_retry, (
+            "Expected `await db.commit()` immediately after "
+            "`retry_on_deadlock(db, refresh_journey)` so each successful "
+            "stale-train refresh is durable before the next iteration."
         )
 
-        # There should be NO bare db.rollback() in the per-journey loop
-        # (between stale_train_refresh_failed and await db.commit()).
-        # The begin_nested() savepoint handles rollback automatically.
-        lines = source.split("\n")
-        in_stale_handler = False
-        for line in lines:
-            if "stale_train_refresh_failed" in line:
-                in_stale_handler = True
-            if in_stale_handler and "await db.commit()" in line:
-                break
-            if in_stale_handler and "await db.rollback()" in line:
-                raise AssertionError(
-                    "Found 'await db.rollback()' between stale_train_refresh_failed "
-                    "and db.commit() — this rolls back the entire transaction "
-                    "including prior successful refreshes. Use begin_nested()."
-                )
+    def test_per_journey_rollback_clears_session_on_failure(self):
+        """Both failure branches in the per-journey loop must `db.rollback()`
+        so the next iteration starts with a clean session — otherwise
+        PendingRollbackError cascades through the rest of the batch."""
+        import inspect
+        from trackrat.services.departure import DepartureService
+
+        source = inspect.getsource(DepartureService._ensure_fresh_station_data)
+
+        # Both handlers must rollback before logging.
+        assert source.count("await db.rollback()") >= 2, (
+            "Expected at least two `await db.rollback()` calls in "
+            "_ensure_fresh_station_data — one in each per-journey except "
+            "handler (TrainNotFoundError and generic Exception)."
+        )
+
+        # Verify the TrainNotFoundError handler rolls back.
+        not_found_idx = source.find("except TrainNotFoundError")
+        warn_idx = source.find('"stale_train_not_found"')
+        assert not_found_idx != -1 and warn_idx > not_found_idx
+        not_found_block = source[not_found_idx:warn_idx]
+        assert "await db.rollback()" in not_found_block, (
+            "TrainNotFoundError handler must roll back the session to "
+            "clear any pending state before the next iteration."
+        )
+
+        # Verify the generic Exception handler rolls back.
+        generic_idx = source.find('"stale_train_refresh_failed"')
+        assert generic_idx != -1
+        # Look backwards from the warning log to the `except Exception`.
+        prelude = source[:generic_idx]
+        last_except = prelude.rfind("except Exception")
+        assert last_except != -1
+        generic_block = source[last_except:generic_idx]
+        assert "await db.rollback()" in generic_block, (
+            "Generic Exception handler must roll back the session to clear "
+            "any pending state before the next iteration."
+        )


### PR DESCRIPTION
## Summary

Fixes the recurring `greenlet_spawn has not been called; can't call await_only() here` error in `backend_v2/src/trackrat/services/departure.py` that reproduced 3× in 48h of production logs (one of the actionable items in #1196).

The per-journey stale-refresh loop in `_ensure_fresh_station_data` wrapped `retry_on_deadlock` in `async with db.begin_nested()`. On deadlock retry, `retry_on_deadlock` calls `await session.rollback()` — which rolls back the **outer** transaction (not the SAVEPOINT). The savepoint context manager then tries to `RELEASE` a savepoint that no longer exists, leaving the session in an inconsistent state and triggering the greenlet error on subsequent flushes/commits (notably the trailing `await db.commit()` after the loop, which is what surfaced as `station_refresh_failed` in production).

The combination `begin_nested + retry_on_deadlock` appears nowhere else in the codebase. The inline comment at `collectors/njt/journey.py:1382-1385` already documents this exact failure mode in a sibling code path — it was simply re-introduced in the per-journey loop by the original #962 fix.

## Approach

Replace the savepoint with **per-journey commit/rollback**:

- Each successful refresh commits before the next iteration (preserves prior work — same goal as #962)
- Each failure rolls back only its own pending state (clean session for the next loop iteration, no `PendingRollbackError` cascade)
- Final post-loop `await db.commit()` is removed since each journey now commits independently

This achieves the failure-isolation that #962 was after, without combining two incompatible primitives.

## Files changed

- **`backend_v2/src/trackrat/services/departure.py`** — `_ensure_fresh_station_data` per-journey loop: removed `async with db.begin_nested():`, added `await db.commit()` on success, added `await db.rollback()` in both `TrainNotFoundError` and generic `Exception` handlers, removed the now-redundant post-loop `await db.commit()`. Added a comment explaining why nesting must not be reintroduced.
- **`backend_v2/tests/unit/services/test_departure_stop_refresh.py`** — replaced `TestSecondPassSavepoint` (which asserted the old, broken invariant that `begin_nested()` must be present) with `TestSecondPassPerJourneyCommit` enforcing the new pattern:
  - `test_no_begin_nested_around_retry_on_deadlock` — strips comments and verifies no `begin_nested():` appears within a few lines of a `retry_on_deadlock(` call.
  - `test_per_journey_commit_isolates_failures` — verifies `await db.commit()` follows `retry_on_deadlock(db, refresh_journey)`.
  - `test_per_journey_rollback_clears_session_on_failure` — verifies both except handlers contain `await db.rollback()` before logging.

## Test coverage

- `tests/unit/services/test_departure_stop_refresh.py` — **9 passed** (3 new structural tests + 6 existing functional tests preserved)
- `tests/unit/services/test_departure_*.py`, `tests/unit/test_departure_*.py` — **81 passed, 4 skipped** (no regressions in adjacent suites)
- `tests/unit/test_db_retry.py`, `tests/unit/test_journey_date_validation.py`, `tests/unit/test_empty_stops_freshness.py`, `tests/unit/test_hide_departed_optimization.py`, `tests/unit/services/test_jit_promotion.py` — **44 passed**
- Full `tests/unit/` suite: **2545 passed**, 4 skipped, 227 pre-existing DB-fixture errors (same on `main`; unrelated to this change).

## Design decisions

- **Per-journey commit over a new savepoint mechanism.** The intent of `begin_nested()` was per-journey isolation. Since `AsyncSession.rollback()` cannot target a savepoint, the only ways to genuinely isolate were (a) commit per journey, or (b) rewrite `retry_on_deadlock` to be savepoint-aware. (a) is a smaller diff, doesn't change semantics for the other three call sites of `retry_on_deadlock` (`services/jit.py`, `services/departure.py:1294`, `collectors/path/collector.py`), and matches the comment in `collectors/njt/journey.py:1382-1385` which already advocates avoiding savepoints in this exact scenario.
- **Test rewrites code-structure assertions, not just behavior.** The original `TestSecondPassSavepoint` was a static-source test, and so are the replacements — they keep the same level of assertion (structural invariants on `_ensure_fresh_station_data`) but enforce the fix rather than the regression. Comments are stripped before substring checks so the explanatory comment can't trip a false positive.
- **Scope kept narrow.** #1196 is a multi-issue health report. This PR addresses only the recurring code defect (greenlet error). Other items in #1196 — transit-feed upstream failures (Metra/Amtrak/NJT 5xx), transfer-graph asymmetries (TR↔S128, WS↔JAM, S601↔SL29), the one-off PostgreSQL shared-memory failure, PATH ground-truth identity mismatches — are unrelated and live in different services. Per the triage comment on #1196, those should be split into discrete sub-issues.

Closes #1196 (the greenlet portion). Other items in #1196 should be split into separate sub-issues per the triage comment.

## Test plan

- [x] `poetry run pytest tests/unit/services/test_departure_stop_refresh.py -v` — 9 passed
- [x] Adjacent departure/JIT/retry unit tests — 125 passed total, no regressions
- [ ] Maintainer: verify in staging that `station_refresh_failed | error=greenlet_spawn...` log entries stop appearing after deploy
- [ ] Maintainer: monitor the per-journey loop in production logs — `stale_train_refreshed` count should be unchanged; `stale_train_refresh_failed` (warning, not error) frequency may drop slightly since previously some non-deadlock errors in earlier loop iterations could cascade and show as the outer `station_refresh_failed`

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5WwVZbheQ7BQ2fH4Wn9iC)_