### PR TITLE
Issue #1211: Fix Live Activity push updates lost across midnight (PATH late-night)

### DIFF
--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -3016,9 +3016,27 @@ class SchedulerService:
                         # Get latest journey for this train. Filter by
                         # data_source when the token has one to avoid picking
                         # the wrong journey on cross-system train_id collisions.
+                        #
+                        # Don't anchor to today's date alone: PATH (and any
+                        # late-night service) stamps ``journey_date`` from the
+                        # origin departure, which for trains that begin late
+                        # in the ET evening sits on the *previous* calendar
+                        # day once the user pulls into a midnight-or-later
+                        # stop. An equality filter on today's date would miss
+                        # those rows and silently stop push updates while the
+                        # trip is still in progress (issue #1211). Search a
+                        # 2-day window (yesterday + today) and take the most
+                        # recently updated journey — token ``expires_at`` is
+                        # only 6 h so we can't pick up something genuinely
+                        # stale, and ``ORDER BY journey_date DESC`` keeps
+                        # tomorrow's pre-generated SCHEDULED rows from
+                        # outranking today's OBSERVED one for recurring NJT
+                        # train numbers.
+                        today = now_et().date()
                         journey_filters = [
                             TrainJourney.train_id == train_number,
-                            TrainJourney.journey_date == now_et().date(),
+                            TrainJourney.journey_date >= today - timedelta(days=1),
+                            TrainJourney.journey_date <= today,
                         ]
                         if data_source:
                             journey_filters.append(
@@ -3027,6 +3045,11 @@ class SchedulerService:
                         journey_stmt = (
                             select(TrainJourney)
                             .where(and_(*journey_filters))
+                            .order_by(
+                                TrainJourney.journey_date.desc(),
+                                TrainJourney.last_updated_at.desc(),
+                            )
+                            .limit(1)
                             .options(
                                 selectinload(TrainJourney.stops),
                                 selectinload(TrainJourney.snapshots),

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -608,6 +608,145 @@ class TestSchedulerService:
                 mock_apns_service.send_live_activity_end.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_update_live_activities_finds_journey_from_previous_day(
+        self, scheduler_service, mock_apns_service
+    ):
+        """Issue #1211: PATH late-night journeys stamp ``journey_date`` from
+        the *origin* departure, which sits on the previous ET calendar day
+        for trains that begin in the late evening. The journey lookup used
+        to filter ``journey_date == now_et().date()``, so once midnight ET
+        rolled by the scheduler missed the still-active journey, logged
+        ``journey_not_found_for_live_activity``, and silently stopped push
+        updates. iOS's ``staleDate`` then expired and the Live Activity
+        froze until the user opened the train details page (which forces a
+        JIT refresh and locally re-arms the activity).
+
+        The fix: search a 2-day window (yesterday + today) and take the
+        most recently updated row, ``ORDER BY journey_date DESC,
+        last_updated_at DESC LIMIT 1``. This catches yesterday's PATH
+        journey while ``journey_date <= today`` keeps tomorrow's
+        pre-generated SCHEDULED rows from outranking today's OBSERVED one.
+
+        This test captures the SQLAlchemy statement passed to
+        ``scalar()``, compiles it, and asserts the WHERE clause shape and
+        ORDER BY / LIMIT so a regression to an equality filter would
+        fail loudly.
+        """
+        scheduler_service.apns_service = mock_apns_service
+
+        with patch("trackrat.services.scheduler.get_session") as mock_get_session:
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            with (
+                patch("sqlalchemy.create_engine"),
+                patch("sqlalchemy.orm.sessionmaker") as mock_sessionmaker,
+            ):
+                mock_sync_session = Mock()
+                mock_sessionmaker.return_value = Mock(return_value=mock_sync_session)
+
+                # Token for a PATH trip that started before midnight.
+                mock_token = Mock(
+                    push_token="path-token",
+                    activity_id="path-act",
+                    train_number="PATH_PNK_worldtrad_1778979000",
+                    origin_code="PNK",
+                    destination_code="PWC",
+                    data_source="PATH",
+                    expires_at=datetime.now(UTC) + timedelta(hours=4),
+                    is_active=True,
+                    track_notified_at=None,
+                )
+
+                mock_tokens_result = Mock()
+                mock_tokens_result.scalars.return_value = [mock_token]
+
+                # Mocked journey row with journey_date = yesterday — the
+                # bug condition. Before the fix, the lookup's equality
+                # filter on today's date would miss this entirely and the
+                # scalar() result would be None.
+                mock_journey = Mock(
+                    train_id="PATH_PNK_worldtrad_1778979000",
+                    data_source="PATH",
+                    observation_type="OBSERVED",
+                    is_cancelled=False,
+                    is_completed=False,
+                    is_expired=False,
+                    last_updated_at=datetime.now(UTC),
+                    stops=[],
+                )
+
+                captured_statements: list = []
+
+                def capture_stmt(stmt):
+                    captured_statements.append(stmt)
+                    return mock_journey
+
+                mock_sync_session.execute.return_value = mock_tokens_result
+                mock_sync_session.scalar.side_effect = capture_stmt
+                mock_sync_session.__enter__ = Mock(return_value=mock_sync_session)
+                mock_sync_session.__exit__ = Mock(return_value=None)
+
+                with patch.object(
+                    scheduler_service,
+                    "_calculate_live_activity_content_state",
+                    return_value={"test": "content"},
+                ):
+                    with patch(
+                        "trackrat.services.scheduler.run_with_freshness_check"
+                    ) as mock_freshness_check:
+
+                        async def execute_task_func(
+                            db, task_name, minimum_interval_seconds, task_func
+                        ):
+                            await task_func()
+                            return True
+
+                        mock_freshness_check.side_effect = execute_task_func
+
+                        await scheduler_service.update_live_activities()
+
+                # Exactly one journey lookup happened, and it received an
+                # update push (not an end push, because is_completed is False).
+                assert len(captured_statements) == 1
+                mock_apns_service.send_live_activity_update.assert_called_once()
+                mock_apns_service.send_live_activity_end.assert_not_called()
+
+                # Compile the captured SELECT and assert its shape:
+                # - WHERE clause uses ``>=`` AND ``<=`` on journey_date,
+                #   spanning at least two distinct dates (i.e. a range, not
+                #   an equality)
+                # - ORDER BY includes journey_date DESC and
+                #   last_updated_at DESC
+                # - LIMIT 1
+                compiled = str(
+                    captured_statements[0].compile(
+                        compile_kwargs={"literal_binds": True}
+                    )
+                ).lower()
+
+                assert "journey_date >=" in compiled, (
+                    "Expected a lower-bound on journey_date; the bug was a "
+                    "strict equality filter that missed previous-day rows. "
+                    f"Compiled SQL: {compiled}"
+                )
+                assert "journey_date <=" in compiled, (
+                    "Expected an upper-bound on journey_date to keep "
+                    "tomorrow's pre-generated SCHEDULED rows out. "
+                    f"Compiled SQL: {compiled}"
+                )
+                # No exact-equality on journey_date.
+                assert "journey_date = " not in compiled, (
+                    "Regression: lookup is back to a single-date equality. "
+                    f"Compiled SQL: {compiled}"
+                )
+                # Most-recent-first ordering with LIMIT 1.
+                assert "order by" in compiled
+                assert "journey_date desc" in compiled
+                assert "last_updated_at desc" in compiled
+                assert "limit 1" in compiled
+
+    @pytest.mark.asyncio
     async def test_update_live_activities_ends_on_is_completed(
         self, scheduler_service, mock_apns_service
     ):


### PR DESCRIPTION
## Summary

User report: "Live activities for path trains seem to lose their state. It gets resolved when I view the train details page." (`PATH_PNK_worldtrad_1778979000`, ~01:03 UTC ≈ 21:03 ET, app version 3.3, iPhone18,2.)

Root cause: in `backend_v2/src/trackrat/services/scheduler.py` `update_live_activities`, the journey lookup filters `TrainJourney.journey_date == now_et().date()`. PATH (and any provider that stamps `journey_date` from the origin departure) writes late-evening journeys with `journey_date` set to the previous ET calendar day. Once midnight rolls past, the equality filter misses the still-active journey, the scheduler logs `journey_not_found_for_live_activity`, and no push goes out.

iOS then runs through `LiveActivityService.swift`'s `staleDate = +120s` and the lock-screen widget freezes — until the user opens the train details page, which forces a JIT refresh through `/api/v2/trains/{train_id}` and locally re-arms the activity via `fetchAndUpdateTrain`. That round-trip masks the backend silence and matches the reported symptom exactly.

## Files modified

- **`backend_v2/src/trackrat/services/scheduler.py`** — In the `update_live_activities` journey lookup, replace the strict `journey_date == today` equality with a 2-day range `[today - 1 day, today]`, add `ORDER BY journey_date DESC, last_updated_at DESC LIMIT 1`. The upper bound `journey_date <= today` keeps tomorrow's pre-generated SCHEDULED rows (NJT runs a 12:30 AM ET schedule collection 27 hours ahead) from outranking today's OBSERVED journey for recurring train numbers. Token `expires_at` is 6 h so the 2-day window can't pick up genuinely stale data.
- **`backend_v2/tests/unit/services/test_scheduler.py`** — `test_update_live_activities_finds_journey_from_previous_day`: captures the SQLAlchemy statement passed to `scalar()`, compiles it with literal binds, and asserts the WHERE clause uses `journey_date >=` and `journey_date <=` (and *not* a `journey_date = ` equality — regression guard), plus `ORDER BY journey_date DESC, last_updated_at DESC LIMIT 1`. End-to-end check that the push update fires and no end push is sent on a yesterday-dated journey.

## Test coverage

```
$ poetry run pytest tests/unit/services/test_scheduler.py
... 29 passed in 0.33s
```

```
$ poetry run pytest tests/unit/services/test_scheduler.py -k live_activit
test_update_live_activities_sends_notifications PASSED
test_update_live_activities_groups_by_data_source PASSED
test_update_live_activities_does_not_end_on_is_expired_alone PASSED
test_update_live_activities_finds_journey_from_previous_day PASSED   # new
test_update_live_activities_ends_on_is_completed PASSED
```

Lint (`ruff check`), formatting (`black --check`), and `mypy` all clean on `scheduler.py`.

## Design decisions

- **2-day window vs. dropping the date filter entirely.** Dropping the filter would also work for the reported PATH case (PATH `train_id` is unique per departure: `PATH_PNK_worldtrad_<timestamp>`), but for NJT-style recurring train numbers it would risk picking up an ancient stale row if today's hadn't been collected yet. The 6-hour `expires_at` on tokens bounds the relevant window to "right now ± a few hours," so the 2-day range is both sufficient and safe.
- **`journey_date <= today` upper bound.** Without it, `ORDER BY journey_date DESC` would prefer tomorrow's pre-generated SCHEDULED row over today's OBSERVED row at 12:30 AM ET. With it, we never look forward of the present day.
- **`ORDER BY ... last_updated_at DESC` as tiebreaker.** If two journey rows happen to land in the window for the same train (shouldn't happen due to the `(train_id, journey_date, data_source)` uniqueness, but defense-in-depth), prefer the more recently touched one.
- **Why not store `journey_date` on the token?** That would be the most precise fix, but it requires a schema migration and a client-side change. The query-level fix is sufficient for the reported symptom and doesn't risk picking up wrong data given the 6h token TTL.
- **Surface area kept minimal.** Single-file behavior change with a single new test. No public API changes, no migration, no iOS change required.

Closes #1211.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGRDaZenkrm1A4HyJGysij)_