### PR TITLE
docs: weekly audit - share endpoints, ShareImageService, May 2026 changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,14 @@ GET  /api/v2/predictions/track              # Platform predictions
 GET  /api/v2/predictions/delay              # Delay/cancellation forecasts
 POST /api/v2/devices/register              # Register device for push notifications
 PUT  /api/v2/alerts/subscriptions          # Sync route alert subscriptions
+GET  /api/v2/alerts/subscriptions/{device_id}  # Get current alert subscriptions
 GET  /api/v2/alerts/service                # MTA service alerts (planned work, delays)
 GET  /api/v2/trips/search                  # Multi-leg trip search with transfers
+GET  /api/v2/routes/preferences            # User route preferences
+PUT  /api/v2/routes/preferences            # Update route preferences
 POST /api/v2/feedback                      # Submit user feedback
+GET  /share/train/{train_id}                # OG meta tag HTML for link previews
+GET  /share/train/{train_id}/image          # PNG share image for link previews
 GET  /admin/stats                           # Server usage statistics (HTML)
 GET  /admin/stats.json                      # Server usage statistics (JSON)
 GET  /health                                # Health check

--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -267,6 +267,10 @@ GET /trips/search             # Multi-leg trip search with transfers
 GET /routes/preferences       # User route preferences
 PUT /routes/preferences       # Update route preferences
 
+# Share / Link Previews (NOT under /api/v2/ prefix)
+GET /share/train/{train_id}        # OG meta tag HTML with route times
+GET /share/train/{train_id}/image  # PNG share card image
+
 # System Health and Metrics
 GET /health                    # Comprehensive health check
 GET /health/live              # Liveness probe
@@ -767,6 +771,15 @@ The backend is organized into service classes for better maintainability:
 - **BackupService** (`services/backup_service.py`): GCS backup management (optional)
 
 ## Recent Improvements & Known Issues
+
+### Recent Improvements (May 2026)
+- ✅ Train share metadata now includes route times for richer link previews (`api/share.py`)
+- ✅ NJT terminal stop completion / Live Activity arrival timing fixes (`collectors/njt/journey.py`)
+- ✅ Amtrak suffixed `train_id` matching in pattern consensus lookup; skip scheduled save when row is already OBSERVED (`services/amtrak_pattern_scheduler.py`)
+- ✅ HistoricalTrackPredictor bounded to recent history to keep query cost predictable (issue #1168)
+- ✅ Trip search surfaces PATH trains from Newark Penn Station (`services/trip_search.py`)
+- ✅ Merge Hoboken / Hoboken PATH into one canonical station; PHO/PNK resolve to canonical (`config/stations/common.py`)
+- ✅ Service alert evaluator: fix merged Hoboken PATH alerts (`services/alert_evaluator.py`)
 
 ### Recent Improvements (April 2026)
 - ✅ Intra-system transfers for PATH, BART, NJT, LIRR, MBTA, Metra trip search

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -332,6 +332,13 @@ GET /api/v2/trips/search?from={from}&to={to}&limit=50&hide_departed=true
 ```
 Multi-leg trip search with transfers across transit systems
 
+### Share / Link Previews
+```
+GET /share/train/{train_id}        # OG meta tag HTML (includes route times)
+GET /share/train/{train_id}/image  # PNG share card image
+```
+Rich link previews for shared train URLs (not under `/api/v2/` prefix)
+
 ### Route Preferences
 ```
 GET /api/v2/routes/preferences
@@ -498,6 +505,10 @@ The scheduler supports multiple replicas:
 
 #### Route Alerts
 - **AlertEvaluatorService**: Evaluates delay/cancellation conditions for push notifications
+
+#### Share / Link Previews
+- **ShareAPI** (`api/share.py`): OG meta tag HTML and image endpoints for rich link previews
+- **ShareImageService** (`services/share_image.py`): PNG rendering for share card images
 
 #### Infrastructure
 - **SimpleAPNSService**: iOS Live Activity notifications and route alert pushes


### PR DESCRIPTION
## Summary

Weekly documentation drift audit. Cross-referenced all `CLAUDE.md` and `README.md` files against the current codebase and the 28 commits from the last 7 days. Most docs were already accurate (the prior audit on 2026-05-11 caught iOS view/service counts and the retention cleanup job). Remaining gaps fixed here:

- **Root `README.md`**: API table was missing `/share/train/*` endpoints, `/api/v2/routes/preferences` (GET/PUT), and the `GET /api/v2/alerts/subscriptions/{device_id}` endpoint.
- **`backend_v2/CLAUDE.md`**: API endpoints section was missing `/share/train/{train_id}` and `/share/train/{train_id}/image`, even though `ShareAPI` is listed under Key Service Classes. Added a "Recent Improvements (May 2026)" section covering this week's work:
  - Share metadata route times (`api/share.py`)
  - NJT terminal stop / Live Activity arrival timing fixes (`collectors/njt/journey.py`)
  - Amtrak suffixed `train_id` matching + skip scheduled save when row already OBSERVED (`services/amtrak_pattern_scheduler.py`)
  - HistoricalTrackPredictor bounded to recent history (#1168)
  - Trip search surfaces PATH trains from Newark Penn Station (`services/trip_search.py`)
  - Hoboken / Hoboken PATH merge; PHO/PNK canonical resolution (`config/stations/common.py`)
  - Service alert evaluator: merged Hoboken PATH alerts fix (`services/alert_evaluator.py`)
- **`backend_v2/README.md`**: Added share endpoints to the API section and `ShareAPI` / `ShareImageService` to the Key Services list.

No drift found in: `ios/CLAUDE.md`, `ios/README.md`, `webpage_v2/CLAUDE.md`, `webpage_v2/README.md`, `android/CLAUDE.md`, `.claude/CLAUDE.md`, `infra_v2/README.md`, root `CLAUDE.md`.

## Test plan

- [ ] No code changes — docs only
- [ ] Verify endpoint paths match `backend_v2/src/trackrat/api/share.py` and `main.py` registration
- [ ] Confirm `ShareImageService` exists at `backend_v2/src/trackrat/services/share_image.py`


---
_Generated by [Claude Code](https://claude.ai/code/session_01GCeamD1oViVr2TEvfZQxr2)_