### PR TITLE
Issue #1224: Surface track predictions on Live Activity lock screen

### DIFF
--- a/ios/TrackRat/Models/TrainV2.swift
+++ b/ios/TrackRat/Models/TrainV2.swift
@@ -517,6 +517,16 @@ extension TrainV2 {
         // Get next stop arrival time
         let nextStopArrivalTime = getNextStopArrivalTime()
 
+        // Only surface the predicted track when there is no actual track yet
+        let (predictedTrackValue, predictedTrackConfidenceValue): (String?, Double?) = {
+            guard track == nil || track?.isEmpty == true,
+                  let prediction = trackPrediction,
+                  !prediction.primaryPrediction.isEmpty else {
+                return (nil, nil)
+            }
+            return (prediction.primaryPrediction, prediction.confidence)
+        }()
+
         return TrainActivityAttributes.ContentState(
             status: contextStatus.rawValue,
             track: track,
@@ -530,6 +540,8 @@ extension TrainV2 {
             nextStopArrivalTime: nextStopArrivalTime?.toISO8601String(),
             nextStopCode: nextStopCode,
             hasTrainDeparted: hasTrainDeparted,
+            predictedTrack: predictedTrackValue,
+            predictedTrackConfidence: predictedTrackConfidenceValue,
             originStationCode: originCode,
             destinationStationCode: destinationStationCode ?? ""
         )

--- a/ios/TrackRat/Services/LiveActivityService.swift
+++ b/ios/TrackRat/Services/LiveActivityService.swift
@@ -106,6 +106,9 @@ class LiveActivityService: ObservableObject {
         let initialNextStop = getNextStopName(train, originCode: originCode, destinationCode: destinationCode, hasTrainDeparted: hasTrainDeparted)
         let initialNextStopCode = getNextStopCode(train, originCode: originCode, destinationCode: destinationCode, hasTrainDeparted: hasTrainDeparted)
 
+        // Pull the predicted track from the train if we have one (only meaningful before track is assigned)
+        let (predictedTrack, predictedTrackConfidence) = Self.extractPredictedTrack(from: train)
+
         // Create simple initial content state
         let initialState = TrainActivityAttributes.ContentState(
             status: contextStatus.rawValue,
@@ -120,6 +123,8 @@ class LiveActivityService: ObservableObject {
             nextStopArrivalTime: nextStopArrivalTime?.toISO8601String(),
             nextStopCode: initialNextStopCode,
             hasTrainDeparted: hasTrainDeparted,
+            predictedTrack: predictedTrack,
+            predictedTrackConfidence: predictedTrackConfidence,
             originStationCode: originCode,
             destinationStationCode: destinationCode
         )
@@ -318,6 +323,9 @@ class LiveActivityService: ObservableObject {
             // Calculate context-aware status
             let contextStatus = train.calculateStatus(for: context)
 
+            // Refresh predicted-track values (clears once an actual track is assigned)
+            let (predictedTrack, predictedTrackConfidence) = Self.extractPredictedTrack(from: train)
+
             // Create updated state
             let updatedState = TrainActivityAttributes.ContentState(
                 status: contextStatus.rawValue,
@@ -332,6 +340,8 @@ class LiveActivityService: ObservableObject {
                 nextStopArrivalTime: nextStopArrivalTime?.toISO8601String(),
                 nextStopCode: nextStopCode,
                 hasTrainDeparted: hasTrainDeparted,
+                predictedTrack: predictedTrack,
+                predictedTrackConfidence: predictedTrackConfidence,
                 originStationCode: activity.attributes.originStationCode,
                 destinationStationCode: activity.attributes.destinationStationCode
             )
@@ -571,6 +581,19 @@ class LiveActivityService: ObservableObject {
     /// Get the next stop code for user's journey segment
     private func getNextStopCode(_ train: TrainV2, originCode: String, destinationCode: String, hasTrainDeparted: Bool) -> String? {
         return getNextStop(train, originCode: originCode, destinationCode: destinationCode, hasTrainDeparted: hasTrainDeparted)?.stationCode
+    }
+
+    /// Pull the predicted track from a train's inline prediction.
+    /// Returns (nil, nil) once an actual track has been assigned so the prediction
+    /// stops competing with real data in the Live Activity. The widget applies its own
+    /// confidence floor; we pass the raw confidence through for that decision.
+    static func extractPredictedTrack(from train: TrainV2) -> (track: String?, confidence: Double?) {
+        guard train.track == nil || train.track?.isEmpty == true,
+              let prediction = train.trackPrediction,
+              !prediction.primaryPrediction.isEmpty else {
+            return (nil, nil)
+        }
+        return (prediction.primaryPrediction, prediction.confidence)
     }
     
     // MARK: - Compatibility Methods for TrackRatApp

--- a/ios/TrackRat/Shared/LiveActivityModels.swift
+++ b/ios/TrackRat/Shared/LiveActivityModels.swift
@@ -20,6 +20,12 @@ struct TrainActivityAttributes: ActivityAttributes {
         let nextStopArrivalTime: String?
         let nextStopCode: String?
         let hasTrainDeparted: Bool
+
+        // Track prediction surfaced from /v2/predictions/track or the inline train-details prediction.
+        // Only meaningful when `track` is nil (actual track wins). Optional so existing activities
+        // that predate these fields still decode.
+        let predictedTrack: String?
+        let predictedTrackConfidence: Double?
         
         // Computed property for data freshness
         var freshnessText: String {
@@ -119,6 +125,33 @@ struct TrainActivityAttributes: ActivityAttributes {
         var trackDisplay: String? {
             guard let track = track, !track.isEmpty else { return nil }
             return "T\(track)"
+        }
+
+        /// Minimum confidence required before a track prediction is surfaced on the Live Activity.
+        /// Matches the threshold used by `TrackRatPredictionInfo.displayText` for "thinks it may be".
+        static let predictedTrackConfidenceFloor: Double = 0.5
+
+        /// Predicted track display with "T" prefix and a "~" prefix to mark it as an estimate.
+        /// Returns nil when an actual track is already assigned, when there is no prediction,
+        /// or when confidence is below `predictedTrackConfidenceFloor`.
+        var predictedTrackDisplay: String? {
+            guard track == nil || track?.isEmpty == true,
+                  let predicted = predictedTrack, !predicted.isEmpty,
+                  (predictedTrackConfidence ?? 0) >= Self.predictedTrackConfidenceFloor else {
+                return nil
+            }
+            return "~T\(predicted)"
+        }
+
+        /// True when no actual track is assigned but a prediction is available for display.
+        var hasPredictedTrack: Bool { predictedTrackDisplay != nil }
+
+        /// Raw predicted track value once the same confidence/availability checks as
+        /// `predictedTrackDisplay` have passed. Used by lock-screen text that already
+        /// wraps the value with its own "Track" prefix.
+        var displayablePredictedTrack: String? {
+            guard hasPredictedTrack, let predicted = predictedTrack else { return nil }
+            return predicted
         }
         
         /// Destination arrival time for expanded view

--- a/ios/TrackRatTests/Services/LiveActivityServiceTests.swift
+++ b/ios/TrackRatTests/Services/LiveActivityServiceTests.swift
@@ -182,4 +182,108 @@ class LiveActivityServiceTests: XCTestCase {
             dataSource: dataSource
         )
     }
+
+    // MARK: - Predicted Track Tests
+
+    /// Build a content state with the new prediction fields populated.
+    /// Keeps the unrelated fields neutral so tests focus on prediction behavior.
+    private func makeContentState(
+        track: String?,
+        predictedTrack: String?,
+        predictedTrackConfidence: Double?
+    ) -> TrainActivityAttributes.ContentState {
+        TrainActivityAttributes.ContentState(
+            status: "BOARDING",
+            track: track,
+            currentStopName: "New York Penn Station",
+            nextStopName: "Newark Penn Station",
+            delayMinutes: 0,
+            journeyProgress: 0.0,
+            dataTimestamp: Date().timeIntervalSince1970,
+            scheduledDepartureTime: nil,
+            scheduledArrivalTime: nil,
+            nextStopArrivalTime: nil,
+            nextStopCode: "NP",
+            hasTrainDeparted: false,
+            predictedTrack: predictedTrack,
+            predictedTrackConfidence: predictedTrackConfidence,
+            originStationCode: "NY",
+            destinationStationCode: "PH"
+        )
+    }
+
+    func testPredictedTrackDisplay_returnsNilWhenActualTrackAssigned() {
+        let state = makeContentState(track: "4", predictedTrack: "7", predictedTrackConfidence: 0.95)
+        XCTAssertNil(state.predictedTrackDisplay,
+                     "Actual track must always win over prediction so we never show a wrong-track guess")
+        XCTAssertFalse(state.hasPredictedTrack)
+    }
+
+    func testPredictedTrackDisplay_returnsNilWhenNoPrediction() {
+        let state = makeContentState(track: nil, predictedTrack: nil, predictedTrackConfidence: nil)
+        XCTAssertNil(state.predictedTrackDisplay)
+        XCTAssertFalse(state.hasPredictedTrack)
+    }
+
+    func testPredictedTrackDisplay_returnsNilWhenPredictionEmpty() {
+        let state = makeContentState(track: nil, predictedTrack: "", predictedTrackConfidence: 0.9)
+        XCTAssertNil(state.predictedTrackDisplay,
+                     "Empty prediction string must be treated as no prediction")
+        XCTAssertFalse(state.hasPredictedTrack)
+    }
+
+    func testPredictedTrackDisplay_returnsNilWhenConfidenceBelowFloor() {
+        let floor = TrainActivityAttributes.ContentState.predictedTrackConfidenceFloor
+        let state = makeContentState(track: nil, predictedTrack: "7", predictedTrackConfidence: floor - 0.01)
+        XCTAssertNil(state.predictedTrackDisplay,
+                     "Confidence below the floor must suppress the prediction to avoid noisy guesses")
+        XCTAssertFalse(state.hasPredictedTrack)
+    }
+
+    func testPredictedTrackDisplay_returnsTildePrefixedTrackAtFloor() {
+        let floor = TrainActivityAttributes.ContentState.predictedTrackConfidenceFloor
+        let state = makeContentState(track: nil, predictedTrack: "7", predictedTrackConfidence: floor)
+        XCTAssertEqual(state.predictedTrackDisplay, "~T7",
+                       "Exactly at the floor confidence the predicted track must be shown")
+        XCTAssertTrue(state.hasPredictedTrack)
+    }
+
+    func testPredictedTrackDisplay_returnsTildePrefixedTrackWhenHighConfidence() {
+        let state = makeContentState(track: nil, predictedTrack: "4", predictedTrackConfidence: 0.92)
+        XCTAssertEqual(state.predictedTrackDisplay, "~T4")
+        XCTAssertTrue(state.hasPredictedTrack)
+    }
+
+    func testPredictedTrackDisplay_returnsNilWhenEmptyTrackAssigned() {
+        // Some backends report an empty-string track instead of nil while a real assignment is pending;
+        // we treat that as "no actual track" and still surface the prediction.
+        let state = makeContentState(track: "", predictedTrack: "9", predictedTrackConfidence: 0.8)
+        XCTAssertEqual(state.predictedTrackDisplay, "~T9",
+                       "Empty actual track must not block the prediction")
+    }
+
+    func testDisplayablePredictedTrack_returnsRawValueWhenPredictionShown() {
+        let state = makeContentState(track: nil, predictedTrack: "12", predictedTrackConfidence: 0.7)
+        XCTAssertEqual(state.displayablePredictedTrack, "12",
+                       "Lock screen uses the raw track value because it adds its own 'Track' prefix")
+        XCTAssertEqual(state.predictedTrackDisplay, "~T12",
+                       "Compact surfaces use the tilde-prefixed display value")
+    }
+
+    func testDisplayablePredictedTrack_returnsNilWhenSuppressed() {
+        let state = makeContentState(track: nil, predictedTrack: "12", predictedTrackConfidence: 0.1)
+        XCTAssertNil(state.displayablePredictedTrack,
+                     "Low-confidence predictions must be suppressed from the lock-screen text")
+    }
+
+    func testExtractPredictedTrack_returnsNothingWhenTrainHasActualTrack() {
+        // MockDataFactory sets track: "11" on the departure stop and the train track field
+        let train = MockDataFactory.createMockTrainV2(trainId: "T1", fromStationCode: "NY")
+        // Sanity check: the mock factory's track is non-nil
+        XCTAssertNotNil(train.track, "Test relies on the mock having an assigned track")
+
+        let (predicted, confidence) = LiveActivityService.extractPredictedTrack(from: train)
+        XCTAssertNil(predicted)
+        XCTAssertNil(confidence)
+    }
 }

--- a/ios/TrainLiveActivityExtension/LiveActivityWidget.swift
+++ b/ios/TrainLiveActivityExtension/LiveActivityWidget.swift
@@ -324,6 +324,17 @@ struct TrainLiveActivityView: View {
                 Spacer()
             }
             .padding(.top, 4)
+
+            if !context.state.hasTrainDeparted,
+               let predicted = context.state.displayablePredictedTrack {
+                HStack {
+                    Spacer()
+                    Text("🐀 TrackRat predicts Track \(predicted)")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.9))
+                    Spacer()
+                }
+            }
         }
         .padding()
         .onReceive(timer) { _ in


### PR DESCRIPTION
## Summary

Adds the inline `/v2/predictions/track` prediction (already returned with
`fetchTrainDetails(include_predictions=true)`) to the iOS Live Activity
ContentState and renders it on the lock-screen view as a
"🐀 TrackRat predicts Track X" hint while the actual track is still pending.
Closes #1224.

The Live Activity already had a `track: String?` field, but it was only
populated when an actual track was assigned; the user-feedback request was
to show the *predicted* track before assignment so users can start walking
to the platform. The platform-prediction data was already being fetched
(via the inline `track_prediction` field on the train-details response in
`LiveActivityService.fetchAndUpdateTrain`) — it just wasn't propagated to
the ContentState or rendered.

## Files modified

- **`ios/TrackRat/Shared/LiveActivityModels.swift`** — Adds optional
  `predictedTrack` and `predictedTrackConfidence` fields to
  `TrainActivityAttributes.ContentState`. Optional so activities started
  by an older app version still decode (Swift's synthesized `Codable`
  defaults missing optional keys to `nil`). Adds three computed helpers
  (`predictedTrackDisplay`, `displayablePredictedTrack`,
  `hasPredictedTrack`) and a `predictedTrackConfidenceFloor` of `0.5` —
  matching the existing in-app threshold used by
  `TrackRatPredictionInfo.displayText` for "thinks it may be".
- **`ios/TrackRat/Services/LiveActivityService.swift`** — Adds
  `extractPredictedTrack(from:)` that returns `(nil, nil)` once an actual
  track has been assigned so the prediction stops competing with real
  data. Both `startTrackingTrain` and `fetchAndUpdateTrain` populate the
  new ContentState fields on every push.
- **`ios/TrackRat/Models/TrainV2.swift`** —
  `toLiveActivityContentState(from:toCode:toName:)` mirrors the same
  logic so the `shouldEndActivity` code path remains consistent with the
  push payload.
- **`ios/TrainLiveActivityExtension/LiveActivityWidget.swift`** — Lock
  screen `TrainLiveActivityView` adds the prediction hint beneath the
  existing departure-timing row when the train has not departed and
  `displayablePredictedTrack` is set. Compact and expanded Dynamic Island
  views are intentionally left unchanged to preserve the time-to-departure
  reading in their limited horizontal space.

## Test coverage

`ios/TrackRatTests/Services/LiveActivityServiceTests.swift`:

- `testPredictedTrackDisplay_returnsNilWhenActualTrackAssigned` — actual
  track always wins (we never show a guess over a real assignment).
- `testPredictedTrackDisplay_returnsNilWhenNoPrediction` — no field, no
  hint.
- `testPredictedTrackDisplay_returnsNilWhenPredictionEmpty` — empty
  prediction string treated as no prediction.
- `testPredictedTrackDisplay_returnsNilWhenConfidenceBelowFloor` — guards
  the noisy-guess case (`< 0.5` confidence).
- `testPredictedTrackDisplay_returnsTildePrefixedTrackAtFloor` — exact-floor
  boundary is inclusive.
- `testPredictedTrackDisplay_returnsTildePrefixedTrackWhenHighConfidence`
  — happy path, returns `~T4`.
- `testPredictedTrackDisplay_returnsNilWhenEmptyTrackAssigned` —
  empty-string `track` (some backends emit this before assignment) does
  not block the prediction.
- `testDisplayablePredictedTrack_returnsRawValueWhenPredictionShown` /
  `_returnsNilWhenSuppressed` — covers the lock-screen text variant.
- `testExtractPredictedTrack_returnsNothingWhenTrainHasActualTrack` —
  service helper bows out as soon as the real track is set.

## Design decisions

- **Confidence floor `0.5`.** Picked deliberately to match
  `TrackRatPredictionInfo.displayText`'s "thinks it may be" threshold so
  the lock-screen surface matches users' in-app expectations of when
  TrackRat is willing to commit to a guess.
- **`~T<n>` for compact surfaces, "Track <n>" for verbose lock-screen
  text.** Two display formats are exposed (`predictedTrackDisplay` and
  `displayablePredictedTrack`) so the same data can be presented
  consistently in both contexts without duplicating the gate logic.
- **Optional fields with no migration.** ActivityKit serializes
  `ContentState` across the app/widget boundary; adding non-optional
  fields would break decode for any in-flight activity created by the
  prior app build. Both new fields are `String?` / `Double?` so existing
  activities still decode and simply get `nil` for the new keys.
- **Dynamic Island left alone.** The compact trailing slot currently
  shows time-to-departure when no track is assigned. Replacing that with
  a predicted track would lose more information than it adds in such a
  tight space, so the hint is lock-screen-only as the user requested.
- **Prediction cleared automatically.** `extractPredictedTrack` returns
  `(nil, nil)` as soon as `train.track` is non-nil, so on the very next
  30-second update after assignment the lock-screen hint disappears and
  the existing "Boarding on Track X" row takes over.

## Test plan

- [ ] Build TrackRat on iPhone 16 simulator with iOS 18.0+
- [ ] Run `xcodebuild test -scheme TrackRat -destination 'platform=iOS Simulator,name=iPhone 16'`
- [ ] Manually verify on a real device:
  - [ ] Start a Live Activity for a train at NY Penn departing in ~15 min before track posting; confirm "🐀 TrackRat predicts Track X" appears on the lock screen
  - [ ] When the actual track is assigned, confirm the hint disappears and "Boarding on Track X" takes over within one update cycle
  - [ ] Confirm Dynamic Island compact/expanded views still show time-to-departure unchanged
  - [ ] Confirm a low-confidence prediction (e.g. NJT off-peak) does not render the hint
- [ ] Confirm an existing Live Activity started under the prior app version continues to decode and render after upgrade

https://claude.ai/code/session_018BxJegLRAEyGY8adtidybF

---
_Generated by [Claude Code](https://claude.ai/code/session_018BxJegLRAEyGY8adtidybF)_