### PR TITLE
Issue #1230: Fix Amtrak Empire NY→ALB silent discovery loss

### DIFF
--- a/backend_v2/src/trackrat/collectors/amtrak/discovery.py
+++ b/backend_v2/src/trackrat/collectors/amtrak/discovery.py
@@ -24,6 +24,12 @@ DISCOVERY_HUBS = {
     "WIL",  # Wilmington
     "RVR",  # Richmond Staples Mill Road
     "CLT",  # Charlotte
+    "ALB",  # Albany-Rensselaer - Empire Service, Adirondack, Maple Leaf,
+            # Ethan Allen, Lake Shore Limited. The Amtraker /v3/trains feed
+            # trims stations a train has already passed, so once an Empire
+            # Service train departs NYP its remaining stops list contains
+            # only upstate-NY stations; without ALB in the hub set those
+            # trains are silently dropped from discovery mid-journey.
     # Midwest hubs
     "CHI",  # Chicago Union Station - Empire Builder, Zephyr, Chief, etc.
     "STL",  # St. Louis - Texas Eagle, Missouri River Runner

--- a/backend_v2/tests/unit/collectors/amtrak/test_discovery.py
+++ b/backend_v2/tests/unit/collectors/amtrak/test_discovery.py
@@ -154,6 +154,27 @@ class TestAmtrakDiscoveryCollector:
         result = collector._stops_at_any_hub(train)
         assert result is False
 
+    def test_stops_at_any_hub_empire_train_past_nyp(self, collector):
+        """An Empire Service train mid-journey (NYP already departed and
+        trimmed from train.stations by the Amtraker /v3/trains feed) must
+        still be discovered via its remaining upstate-NY stops. Regression
+        test for #1230."""
+        empire_remaining_stops = [
+            create_amtrak_station_data(
+                name="Albany-Rensselaer", code="ALB", status="Enroute"
+            ),
+            create_amtrak_station_data(
+                name="Schenectady", code="SDY", status="Enroute"
+            ),
+            create_amtrak_station_data(
+                name="Amsterdam", code="AMS", status="Enroute"
+            ),
+        ]
+        train = create_amtrak_train_data(
+            train_num="284", route="Empire Service", stations=empire_remaining_stops
+        )
+        assert collector._stops_at_any_hub(train) is True
+
     async def test_run_method_interface(self, collector, mock_client):
         """Test the run method interface."""
         parsed_response = self._parse_response_to_objects(AMTRAK_FULL_RESPONSE)

--- a/backend_v2/tests/unit/test_ground_truth_validation.py
+++ b/backend_v2/tests/unit/test_ground_truth_validation.py
@@ -397,6 +397,21 @@ class TestCompareRouteCancellation:
         assert len(result.matches) == 1
         assert result.matches[0].tr.is_cancelled is True
 
+    def test_unmatched_cancelled_goes_to_cancelled_list(self):
+        """An unmatched cancelled TR should go to cancelled_in_tr, not phantoms."""
+        gt = [_gt(minutes_offset=10)]
+        tr = [
+            _tr(minutes_offset=10),  # This one matches the GT
+            _tr(
+                minutes_offset=30, is_cancelled=True
+            ),  # This one is unmatched + cancelled
+        ]
+        result = compare_route(gt, tr, "NWK", "WTC", tolerance_minutes=3)
+
+        assert len(result.matches) == 1
+        assert len(result.cancelled_in_tr) == 1
+        assert len(result.phantoms) == 0
+
 
 class TestRunValidationLoopEmptyGroundTruth:
     """Regression coverage for #1230 silent-skip bug.
@@ -480,21 +495,6 @@ class _StubHttpx:
 
         def close(self):
             pass
-
-    def test_unmatched_cancelled_goes_to_cancelled_list(self):
-        """An unmatched cancelled TR should go to cancelled_in_tr, not phantoms."""
-        gt = [_gt(minutes_offset=10)]
-        tr = [
-            _tr(minutes_offset=10),  # This one matches the GT
-            _tr(
-                minutes_offset=30, is_cancelled=True
-            ),  # This one is unmatched + cancelled
-        ]
-        result = compare_route(gt, tr, "NWK", "WTC", tolerance_minutes=3)
-
-        assert len(result.matches) == 1
-        assert len(result.cancelled_in_tr) == 1
-        assert len(result.phantoms) == 0
 
 
 class TestCompareRouteToleranceBoundary:

--- a/backend_v2/tests/unit/test_ground_truth_validation.py
+++ b/backend_v2/tests/unit/test_ground_truth_validation.py
@@ -397,6 +397,90 @@ class TestCompareRouteCancellation:
         assert len(result.matches) == 1
         assert result.matches[0].tr.is_cancelled is True
 
+
+class TestRunValidationLoopEmptyGroundTruth:
+    """Regression coverage for #1230 silent-skip bug.
+
+    When ground truth returns no arrivals for a direction, the validator
+    previously SKIPped unconditionally — masking real-time outages on
+    registered routes (e.g. Amtrak Empire NY->ALB). The fixed behavior is
+    to still fetch TrackRat and emit a WARN when TR has departures the
+    provider real-time feed does not.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_counters(self, monkeypatch):
+        """Counters are module-level globals; reset before each test."""
+        monkeypatch.setattr(gtv, "PASS_COUNT", 0)
+        monkeypatch.setattr(gtv, "FAIL_COUNT", 0)
+        monkeypatch.setattr(gtv, "WARN_COUNT", 0)
+        monkeypatch.setattr(gtv, "SKIP_COUNT", 0)
+
+    def _patch_single_direction(self, monkeypatch, from_st="NY", to_st="ALB"):
+        """Stub the route topology so the loop processes exactly one direction."""
+        class _FakeRoute:
+            stations = (from_st, to_st)
+
+        monkeypatch.setattr(gtv, "get_routes_for_data_source", lambda _ds: [_FakeRoute()])
+        monkeypatch.setattr(gtv, "get_station_name", lambda code: code)
+        monkeypatch.setattr(gtv, "httpx", _StubHttpx())
+
+    def test_empty_gt_with_tr_departures_emits_warn(self, monkeypatch):
+        """GT empty but TR has departures -> WARN (was silent SKIP). #1230."""
+        self._patch_single_direction(monkeypatch)
+        monkeypatch.setattr(
+            gtv,
+            "fetch_trackrat_departures",
+            lambda *_a, **_kw: [_tr(minutes_offset=10, dest="ALB")],
+        )
+
+        tested = gtv.run_validation_loop(
+            gt_arrivals=[],
+            data_source="AMTRAK",
+            base_url="http://test",
+            tolerance=2.0,
+            verbose=False,
+        )
+
+        # _deduplicated_route_directions yields both forward and reverse
+        # directions for each route, so a single Route -> 2 tested directions.
+        assert tested == 2
+        assert gtv.WARN_COUNT == 2, "expected WARN per direction when GT empty but TR has data"
+        assert gtv.SKIP_COUNT == 0, "must not SKIP when TR has departures"
+        assert gtv.FAIL_COUNT == 0
+
+    def test_empty_gt_and_empty_tr_still_skips(self, monkeypatch):
+        """Both feeds empty is a legitimate quiet window -> SKIP, not WARN."""
+        self._patch_single_direction(monkeypatch)
+        monkeypatch.setattr(gtv, "fetch_trackrat_departures", lambda *_a, **_kw: [])
+
+        tested = gtv.run_validation_loop(
+            gt_arrivals=[],
+            data_source="AMTRAK",
+            base_url="http://test",
+            tolerance=2.0,
+            verbose=False,
+        )
+
+        assert tested == 2
+        assert gtv.SKIP_COUNT == 2
+        assert gtv.WARN_COUNT == 0
+        assert gtv.FAIL_COUNT == 0
+
+
+class _StubHttpx:
+    """Minimal httpx replacement so run_validation_loop can construct a Client()."""
+
+    class Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def close(self):
+            pass
+
     def test_unmatched_cancelled_goes_to_cancelled_list(self):
         """An unmatched cancelled TR should go to cancelled_in_tr, not phantoms."""
         gt = [_gt(minutes_offset=10)]

--- a/scripts/ground-truth-validate.py
+++ b/scripts/ground-truth-validate.py
@@ -835,14 +835,25 @@ def run_validation_loop(
                 a for a in gt_arrivals if a.station_code == from_st and a.destination_code == to_st
             ]
 
+            # Always fetch TrackRat departures so we can surface the
+            # "TR has data, GT does not" asymmetry (e.g. registered route
+            # still scheduled by TR but not actually running per provider).
+            # Previously this path SKIP'd silently whenever GT was empty,
+            # which masked entire-route real-time outages (#1230).
+            tr_departures = fetch_trackrat_departures(client, base_url, from_st, to_st, data_source)
+
             if not relevant_gt:
                 print(f"\n{YELLOW}--- {label} ---{NC}")
-                log_skip(f"No ground truth arrivals at {from_st} heading to {to_st}")
+                if tr_departures:
+                    log_warn(
+                        f"No ground truth arrivals at {from_st} heading to {to_st}, "
+                        f"but TrackRat returned {len(tr_departures)} departure(s) — "
+                        f"possible drift between TrackRat and provider real-time feed"
+                    )
+                else:
+                    log_skip(f"No ground truth arrivals at {from_st} heading to {to_st}")
                 route_directions_tested += 1
                 continue
-
-            # Fetch TrackRat departures
-            tr_departures = fetch_trackrat_departures(client, base_url, from_st, to_st, data_source)
 
             print(f"\n{YELLOW}--- {label} ---{NC}")
 


### PR DESCRIPTION
## Summary

Two fixes for the recurring Amtrak Empire NY→ALB "0 OBSERVED trains" failure described in #1230:

1. **Add `ALB` to `DISCOVERY_HUBS`** in `collectors/amtrak/discovery.py`. Amtraker's `/v3/trains` feed trims stations a train has already passed, so once an Empire Service train leaves NYP its remaining `stations` list contains only upstate-NY stops. With ALB missing from the hub set, those trains were silently dropped from discovery mid-journey, so `discovery → OBSERVED` promotion never happened and the API returned only daily SCHEDULED records.
2. **Fix the GT validator silent-skip** in `scripts/ground-truth-validate.py`. The validator previously SKIP'd unconditionally whenever GT returned no arrivals for a direction. Now it still fetches TrackRat departures and emits **WARN** when TR has data but GT does not — this is the diagnostic signal that was missing and that's why the validator kept reporting CLEAN while the production E2E kept failing.

Adopting Step 2B from the issue (`ALB`) rather than Step 2A (dated endpoint) — it's a single-line change that also covers Adirondack, Maple Leaf, Ethan Allen, and Lake Shore Limited (all traverse ALB after departing NYP), and it leaves the dateless `/v3/trains` endpoint alone, which the existing comment in `client.py:96` documents as the only reliable feed.

## Files modified

- `backend_v2/src/trackrat/collectors/amtrak/discovery.py` — add `ALB` to `DISCOVERY_HUBS` with an explanatory comment about the truncation behavior that made this necessary.
- `scripts/ground-truth-validate.py` — move the TR fetch above the empty-GT check; emit `log_warn` when TR has data but GT does not.
- `backend_v2/tests/unit/collectors/amtrak/test_discovery.py` — regression test `test_stops_at_any_hub_empire_train_past_nyp` builds an Empire-Service train whose `stations` is `[ALB, SDY, AMS]` (no NYP) and asserts it is still discovered.
- `backend_v2/tests/unit/test_ground_truth_validation.py` — new `TestRunValidationLoopEmptyGroundTruth` class with two cases: empty GT + TR has data → WARN; empty GT + empty TR → SKIP (legitimate quiet window).

## Test coverage

```
tests/unit/collectors/amtrak/test_discovery.py ......... 18 passed
tests/unit/test_ground_truth_validation.py ............. 49 passed
```

Pre-existing PostgreSQL-requiring errors in `test_journey.py` are unrelated (port 5434 connection refused in this sandbox).

## Design notes

- Chose **WARN** rather than FAIL for the empty-GT-but-TR-has-data case. TR exposes both SCHEDULED and OBSERVED rows; GT only sees real-time arrivals; window-edge timing differences are plausible. WARN flags the asymmetry without breaking the CLEAN/FAIL gate on legitimate timing skew.
- Deliberately did NOT add `BUF`, `ROC`, or `SYR` — Empire Service trains beyond ALB all pass through ALB, so a single hub addition is sufficient. Adding more hubs without a confirmed coverage gap is over-engineering per CLAUDE.md.
- Deliberately did NOT touch the dateless URL hardcode in `client.py:96-97`. The comment there is explicit that the dated endpoint was abandoned for reliability reasons; reversing that decision on suspicion would be a regression risk.

Closes #1230

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8x6TTKRZ7BhHz3D7XZe7X)_