### PR TITLE
Issue #1232: raise Postgres /dev/shm to 1GB and cap parallel-worker fan-out

### DIFF
--- a/backend_v2/docker-compose.yml
+++ b/backend_v2/docker-compose.yml
@@ -12,6 +12,10 @@ services:
   db:
     image: postgres:17-alpine
     container_name: trackrat-postgres
+    # /dev/shm holds parallel-worker DSM segments. Docker's 64MB default exhausts
+    # quickly under concurrent parallel queries against journey_stops, surfacing as
+    # asyncpg DiskFullError on predict_track / operations_summary (issue #1232).
+    shm_size: '1gb'
     command:
       - postgres
       - -c
@@ -20,6 +24,11 @@ services:
       - min_wal_size=64MB
       - -c
       - wal_keep_size=0
+      # Cap parallel-worker fan-out per query: each worker grabs its own DSM
+      # segment, so reducing the cap directly attacks the /dev/shm pressure that
+      # the larger pool above is also defending against (issue #1232).
+      - -c
+      - max_parallel_workers_per_gather=1
     volumes:
       - ${DATA_DIR}/pgdata:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
## Summary

Two-line fix in `backend_v2/docker-compose.yml`'s `db:` service to stop the recurring `asyncpg.exceptions.DiskFullError: could not resize shared memory segment ... to {2,4}MB: No space left on device` failures on production. Host disk is healthy (36-38% used) — these are **`/dev/shm` (tmpfs) exhaustions**, not real disk pressure (see #1232 for full diagnosis).

### What changed

- `shm_size: '1gb'` on the db container. Docker defaults `/dev/shm` to 64MB, which the Postgres parallel-worker DSM segments fill quickly under concurrent joins on `journey_stops`. 1GB is ~15× the default and matches standard Postgres-in-Docker guidance.
- `-c max_parallel_workers_per_gather=1` in the db `command`. Each parallel worker grabs its own DSM segment, so capping fan-out attacks the failure mode from the demand side as well as the supply side.

Both changes target the failing endpoints (`/api/v2/predictions/track`, `/api/v2/routes/summary` and the alert evaluator) without changing application code, query plans, or buffer-pool sizing.

### What I deliberately did NOT change

- **`work_mem=16MB` / `shared_buffers=2GB`** from the issue's step 2. Those don't address `/dev/shm` directly (shared_buffers lives in anonymous shared memory, not tmpfs) and increasing memory allocations on a 2 vCPU / 8 GB host (`t2d-standard-2`) warrants its own validation. Easy follow-up if DB load is still elevated after this lands.
- **`predict_track` caching** (issue's step 3). The issue itself lists it as a defer-unless-needed follow-up.

### Files modified

- `backend_v2/docker-compose.yml` — 9 lines added to the `db:` service (2 functional, 7 comment).

### Deployment path verified

- `infra_v2/cloudbuild.yaml:66-72` and `infra_v2/cloudbuild-staging.yaml:172-178` upload `backend_v2/docker-compose.yml` → `gs://${DEPLOY_BUCKET}/docker-compose.yml`.
- `infra_v2/terraform/compute.tf:178-191` (GCE startup) pulls that same file down to `/mnt/disks/data/compose/docker-compose.yml` and runs it.

There is one source-of-truth compose file. The deployment-path caveat in #1232 is resolved.

### Test coverage

Config-only change in a YAML file. No application code paths added or modified, so no Python unit tests apply. Validation:

- `python3 -c "import yaml; ..."` confirms the file parses and the `db` service has `shm_size: 1gb` plus `max_parallel_workers_per_gather=1` in its command list.
- Real validation happens after deploy: `bash scripts/validate-staging.sh` should run clean on `predict_track` / `operations_summary`, and the `DiskFullError` cluster should stop appearing in `cos_containers` logs.

### Design decisions

1. **Minimal-risk first.** The maintainer's triage comment endorsed `shm_size + parallel-worker tuning`; I shipped exactly that. Buffer-pool tuning has higher blast radius and isn't required to stop the failures.
2. **Both knobs together.** `shm_size` alone fixes the immediate failure but leaves the demand uncapped. `max_parallel_workers_per_gather=1` alone reduces demand but doesn't fix the small pool. Doing both means a single subsequent traffic spike can't recreate the same failure mode.
3. **Kept the existing comment style.** YAML comments explain *why* each value was chosen and link to #1232 so the next person reading this knows what they're looking at.

Closes #1232

## Test plan

- [ ] Watch `cos_containers` on staging after merge for absence of `DiskFullError` on `predict_track` / `get_operations_summary` / `route_alert_evaluation`.
- [ ] Run `bash scripts/validate-staging.sh` and confirm Phase 1 timeouts on `operations_summary` go away.
- [ ] After staging looks clean, promote to production and check the same logs.

---
_Generated by [Claude Code](https://claude.ai/code/session_013qZ2PcwCeDAF2ow3HNtdzi)_