### PR TITLE
docs: weekly audit fixes (delay endpoint, Metra auth, webpage deploy, Live Activity track)

### DIFF
--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -105,7 +105,7 @@ All configuration is done via environment variables. See `.env.example` for avai
 - `TRACKRAT_DATABASE_URL`: PostgreSQL connection string
 - Note: Amtrak uses the public Amtraker API (no authentication required)
 - `TRACKRAT_WMATA_API_KEY`: WMATA developer API key (required for DC Metro)
-- `TRACKRAT_METRA_API_TOKEN`: Metra GTFS-RT API token (required for Metra)
+- `TRACKRAT_METRA_API_TOKEN`: Metra GTFS-RT API token (required for Metra; or use HTTP Basic Auth via `TRACKRAT_METRA_API_USERNAME` / `TRACKRAT_METRA_API_PASSWORD`)
 - **APNS Configuration** (required for Live Activities):
   - `APNS_TEAM_ID`: Apple Developer Team ID (10 characters)
   - `APNS_KEY_ID`: APNS Auth Key ID (10 characters)
@@ -218,6 +218,12 @@ Detailed train records for a specific segment
 GET /api/v2/predictions/track?station_code=NY&train_id=1234&journey_date=2025-09-15
 ```
 ML-powered track predictions with confidence scoring
+
+#### Delay / Cancellation Forecast
+```
+GET /api/v2/predictions/delay?train_id=1234&station_code=NY&journey_date=2025-09-15
+```
+Probability distribution across delay categories (on-time, slight, significant, major), cancellation probability, and expected delay minutes from hierarchical historical data
 
 #### Supported Stations
 ```

--- a/infra_v2/README.md
+++ b/infra_v2/README.md
@@ -114,6 +114,18 @@ gcloud builds submit --config=cloudbuild-staging.yaml .
 gcloud builds submit --config=cloudbuild.yaml .
 ```
 
+### Webpage Deployment
+
+The React webpage (`webpage_v2/`) deploys separately from the API via its own Cloud Build triggers (defined in `terraform-webpage/`):
+- **Push to `main`** (with `webpage_v2/` changes) → `trackrat-webpage-staging` trigger → `gs://trackrat-webpage-staging` (`staging.trackrat.net`)
+- **Push to `production`** (with `webpage_v2/` changes) → `trackrat-webpage-production` trigger → `gs://trackrat-webpage-production` (`trackrat.net` / `www.trackrat.net`)
+
+Manual deploy from the repo root:
+```bash
+./scripts/deploy-webpage.sh [staging|production] [--bucket=<name>] [--dry-run]
+```
+`--bucket` overrides the destination bucket (with or without the `gs://` prefix) while keeping the environment's API URL — useful for pre-populating a new bucket during a migration.
+
 ## Key Configuration
 
 ### Variables (terraform/variables.tf)
@@ -300,7 +312,7 @@ infra_v2/
 │   │   └── requirements.txt
 │   └── train_follow_notifier/   # Train follow push notification service
 ├── terraform-webpage/
-│   └── main.tf                  # Standalone webpage infrastructure (GCS, CDN)
+│   └── main.tf                  # Webpage hosting (staging + production): GCS buckets, LB, SSL certs, CDN, Cloud Build triggers
 └── terraform/
     ├── main.tf                  # Provider and backend config
     ├── variables.tf             # Input variables

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -129,6 +129,7 @@ xcodebuild -scheme TrackRat -sdk iphonesimulator build \
 - Auto-end on arrival or 15 minutes of no updates
 - Push notifications for status changes
 - Journey progress with interpolation
+- Track/platform prediction shown on the Lock Screen when available (`predictedTrack` / `predictedTrackConfidence`)
 
 ## Testing
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -6,6 +6,7 @@ A comprehensive iOS app for tracking NJ Transit, Amtrak, PATH, PATCO, LIRR, Metr
 
 ### Live Activities & Real-time Tracking
 - **Lock Screen Integration**: Real-time train tracking on Lock Screen and Dynamic Island
+- **Track Predictions**: Predicted track/platform surfaced on the Live Activity Lock Screen when available
 - **Push Notifications**: Automatic updates for boarding, delays, and arrivals
 - **30-Second Refresh**: Continuous background updates while tracking
 - **Smart Auto-End**: Automatically ends tracking when journey completes


### PR DESCRIPTION
## Summary

Weekly documentation-drift audit. Cross-referenced all CLAUDE.md/README.md files against the codebase and the last 7 days of commits. Docs were largely accurate; this PR fixes the handful of real gaps found. No accurate sections were rewritten.

### Changes
- **backend_v2/README.md**
  - Document `GET /api/v2/predictions/delay` — it's registered (`api/predictions.py`) and listed in `backend_v2/CLAUDE.md`, but was missing from the README's ML Predictions section.
  - Note the Metra HTTP Basic Auth env vars (`TRACKRAT_METRA_API_USERNAME` / `TRACKRAT_METRA_API_PASSWORD`) alongside the existing token; both exist in `settings.py` and were only in CLAUDE.md.
- **infra_v2/README.md**
  - Add a **Webpage Deployment** subsection (Cloud Build triggers, staging/production buckets, and the manual `deploy-webpage.sh` with the new `--bucket=` flag). This reflects the `trackrat-prod` → `trackrat-v2` webpage migration that landed this week.
  - Correct the understated `terraform-webpage/main.tf` description ("Standalone webpage infrastructure (GCS, CDN)" → it now provisions both staging + production stacks: buckets, LB, SSL certs, CDN, Cloud Build triggers).
- **ios/CLAUDE.md** & **ios/README.md**
  - Note that track/platform predictions are now surfaced on the Live Activity Lock Screen (issue #1224, `predictedTrack` / `predictedTrackConfidence`).

### Verified accurate (no change needed)
- All other documented API endpoints, env vars, collectors, scheduler intervals, scripts, and key file locations matched the codebase.
- Old webpage bucket name (`trackrat-links-…`) does not appear anywhere; webpage_v2/CLAUDE.md already reflects `trackrat-webpage-production`.

## Test plan
- [ ] Confirm `/api/v2/predictions/delay` doc matches the registered route signature
- [ ] Confirm Metra Basic Auth env var names match `settings.py`
- [ ] Confirm webpage trigger branches/buckets match `terraform-webpage/main.tf`

https://claude.ai/code/session_01AmCj5u213ABsfA7Zsg2YXe

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmCj5u213ABsfA7Zsg2YXe)_