### PR TITLE
Issue #1238: finalize stale prior-day NJT journeys instead of re-polling

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -733,7 +733,11 @@ class JourneyCollector(BaseJourneyCollector):
                     if stored_origin_found_in_stops:
                         # Don't return False - let the journey continue to be processed
                         pass
-                    elif time_diff > STALE_PRIOR_RUN_THRESHOLD_SECONDS:
+                    elif (
+                        time_diff > STALE_PRIOR_RUN_THRESHOLD_SECONDS
+                        and stored_journey.journey_date is not None
+                        and stored_journey.journey_date < now_et().date()
+                    ):
                         # A mismatch this large is not a delay: NJT reuses the
                         # same numeric train_id every service day, so
                         # getTrainStopList is now serving a later day's run,
@@ -744,6 +748,16 @@ class JourneyCollector(BaseJourneyCollector):
                         # Classify it distinctly (and log at info, since reused
                         # train_id is expected, not anomalous) so the caller can
                         # finalize it instead of looping. See issue #1238.
+                        #
+                        # Gate on journey_date < today: the finalize path in
+                        # collect_journey_details bypasses the departed-stop
+                        # guard and 3-strike behavior used for a generic
+                        # DEPARTURE_TIME_MISMATCH, so we only take it for a
+                        # genuine prior-service-day row. A same-day train with a
+                        # large skew (a severe >6h delay or an API date anomaly)
+                        # is NOT a reused-train_id case and must keep the
+                        # conservative mismatch path so it isn't prematurely
+                        # removed from active tracking / /departures.
                         logger.info(
                             "journey_stale_prior_run_detected",
                             journey_id=stored_journey.id,

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -50,6 +50,17 @@ class JourneyMatchResult(Enum):
     MATCH = "match"
     DESTINATION_MISMATCH = "destination_mismatch"
     DEPARTURE_TIME_MISMATCH = "departure_time_mismatch"
+    STALE_PRIOR_RUN = "stale_prior_run"
+
+
+# A first-stop departure-time mismatch larger than this cannot be a real-world
+# delay; it means the NJT API is serving a different service day's run. NJT
+# reuses the same numeric train_id every day, so getTrainStopList(<id>) on a
+# later day returns that day's run, ~24h displaced from a stored prior-day
+# journey. 6h sits far above any plausible NJT delay yet well below the ~24h
+# daily displacement, so it cleanly separates "delayed today" from "yesterday's
+# reused train_id". See JourneyMatchResult.STALE_PRIOR_RUN and issue #1238.
+STALE_PRIOR_RUN_THRESHOLD_SECONDS = 6 * 3600
 
 
 def _journey_eager_options() -> list[Any]:
@@ -722,6 +733,32 @@ class JourneyCollector(BaseJourneyCollector):
                     if stored_origin_found_in_stops:
                         # Don't return False - let the journey continue to be processed
                         pass
+                    elif time_diff > STALE_PRIOR_RUN_THRESHOLD_SECONDS:
+                        # A mismatch this large is not a delay: NJT reuses the
+                        # same numeric train_id every service day, so
+                        # getTrainStopList is now serving a later day's run,
+                        # ~24h displaced from this stored prior-day journey.
+                        # The stored row physically ran but was never finalized,
+                        # so it stays an update candidate and the scheduler
+                        # re-polls it every cycle for the rest of the day.
+                        # Classify it distinctly (and log at info, since reused
+                        # train_id is expected, not anomalous) so the caller can
+                        # finalize it instead of looping. See issue #1238.
+                        logger.info(
+                            "journey_stale_prior_run_detected",
+                            journey_id=stored_journey.id,
+                            train_id=stored_journey.train_id,
+                            stored_departure=stored_departure.isoformat(),
+                            api_departure=api_departure.isoformat(),
+                            difference_minutes=int(time_diff / 60),
+                            api_first_station=first_stop.STATION_2CHAR,
+                            journey_date=(
+                                stored_journey.journey_date.isoformat()
+                                if stored_journey.journey_date
+                                else None
+                            ),
+                        )
+                        return JourneyMatchResult.STALE_PRIOR_RUN
                     else:
                         # This is actually a different journey
                         logger.warning(
@@ -926,6 +963,39 @@ class JourneyCollector(BaseJourneyCollector):
                 has_complete_journey=journey.has_complete_journey,
                 update_count=journey.update_count,
                 api_error_count=journey.api_error_count,
+            )
+
+            await session.flush()
+            return
+
+        if match_result is JourneyMatchResult.STALE_PRIOR_RUN:
+            # NJT reused this train_id for a later service day; the API is now
+            # serving that day's run (~24h displaced). Our row is a prior-day
+            # journey that physically ran but never got is_completed/is_expired
+            # set, so schedule_periodic_updates keeps re-polling it — and each
+            # poll re-fetches the wrong day and re-triggers this path — until
+            # its journey_date ages out of the candidate window (~next
+            # midnight). Finalize it now so it drops out of the candidate set.
+            # We never applied the displaced data, so there is no user-facing
+            # change; we only flip the lifecycle flags. Prefer real completion
+            # (using stored data only) and fall back to expiry.
+            if not journey.is_completed:
+                await self._attempt_completion_on_expiry(session, journey)
+
+            if not journey.is_completed:
+                journey.is_expired = True
+
+            journey.last_updated_at = now_et()
+
+            logger.info(
+                "stale_prior_run_finalized",
+                train_id=journey.train_id,
+                journey_id=journey.id,
+                journey_date=(
+                    journey.journey_date.isoformat() if journey.journey_date else None
+                ),
+                is_completed=journey.is_completed,
+                is_expired=journey.is_expired,
             )
 
             await session.flush()

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -22,7 +22,11 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from trackrat.collectors.njt.client import NJTransitClient
-from trackrat.collectors.njt.journey import JourneyCollector, JourneyMatchResult
+from trackrat.collectors.njt.journey import (
+    STALE_PRIOR_RUN_THRESHOLD_SECONDS,
+    JourneyCollector,
+    JourneyMatchResult,
+)
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.utils.time import ET, now_et
 
@@ -742,3 +746,354 @@ class TestStaleOriginDetection:
             "Three sustained DEPARTURE_TIME_MISMATCH responses must expire "
             "the journey when the completion backstop cannot fire"
         )
+
+
+class TestStalePriorRunDetection:
+    """Test handling of prior-day journeys re-served under a reused train_id.
+
+    NJT reuses the same numeric train_id every service day. A prior-day
+    journey row that physically ran but was never finalized stays an update
+    candidate; getTrainStopList(<id>) on a later day returns *that* day's run,
+    ~24h displaced from the stored departure. Before the fix, this displaced
+    response logged a journey_mismatch_departure_time WARNING and was skipped
+    (because the row has a departed stop), so the row was never finalized and
+    the scheduler re-polled it every cycle for the rest of the day. The fix
+    classifies a whole-service-day displacement as STALE_PRIOR_RUN and
+    finalizes the row so it drops out of the candidate set. See issue #1238.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_day_displacement_classified_as_stale_prior_run(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """A ~24h first-stop displacement (the reused-train_id smoking gun)
+        must be classified as STALE_PRIOR_RUN, NOT DEPARTURE_TIME_MISMATCH.
+
+        Returning STALE_PRIOR_RUN (rather than DEPARTURE_TIME_MISMATCH) is also
+        what guarantees the noisy journey_mismatch_departure_time WARNING is not
+        emitted — that warning is logged only on the DEPARTURE_TIME_MISMATCH
+        branch, immediately before it returns.
+        """
+        # Stored journey ran yesterday; API now serves today's run (+24h).
+        stored_departure = (now_et() - timedelta(days=1)).replace(
+            hour=16, minute=0, second=0, microsecond=0
+        )
+        api_departure = stored_departure + timedelta(days=1)
+
+        journey = TrainJourney(
+            train_id="4250",
+            journey_date=date.today() - timedelta(days=1),  # yesterday
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stored_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=stored_departure,
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="4250",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+
+        result = await journey_collector._is_same_journey(
+            db_session, journey, api_response
+        )
+
+        assert result is JourneyMatchResult.STALE_PRIOR_RUN, (
+            "A ~24h first-stop displacement is daily train_id reuse, not a "
+            "delay — it must be classified as STALE_PRIOR_RUN so the caller "
+            "finalizes the row instead of skipping and re-polling it forever"
+        )
+
+    @pytest.mark.asyncio
+    async def test_threshold_boundary_separates_delay_from_prior_run(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """The classifier must split on STALE_PRIOR_RUN_THRESHOLD_SECONDS: a
+        large-but-sub-threshold skew is still treated as a (possible) delay
+        (DEPARTURE_TIME_MISMATCH), while an over-threshold skew is a reused
+        train_id (STALE_PRIOR_RUN). This pins the boundary so the threshold
+        can't silently drift.
+        """
+        stored_departure = now_et().replace(hour=10, minute=0, second=0, microsecond=0)
+
+        journey = TrainJourney(
+            train_id="4244",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stored_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=stored_departure,
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+
+        # 1h BELOW the threshold → still a delay-shaped mismatch.
+        below_departure = stored_departure + timedelta(
+            seconds=STALE_PRIOR_RUN_THRESHOLD_SECONDS - 3600
+        )
+        below_response = create_stop_list_response(
+            train_id="4244",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    below_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        below_result = await journey_collector._is_same_journey(
+            db_session, journey, below_response
+        )
+        assert below_result is JourneyMatchResult.DEPARTURE_TIME_MISMATCH, (
+            "A skew below STALE_PRIOR_RUN_THRESHOLD_SECONDS must remain a "
+            "DEPARTURE_TIME_MISMATCH (handled as a possible delay), not be "
+            "misclassified as a prior-day run"
+        )
+
+        # 1h ABOVE the threshold → reused-train_id displacement.
+        above_departure = stored_departure + timedelta(
+            seconds=STALE_PRIOR_RUN_THRESHOLD_SECONDS + 3600
+        )
+        above_response = create_stop_list_response(
+            train_id="4244",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    above_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        above_result = await journey_collector._is_same_journey(
+            db_session, journey, above_response
+        )
+        assert above_result is JourneyMatchResult.STALE_PRIOR_RUN, (
+            "A skew above STALE_PRIOR_RUN_THRESHOLD_SECONDS must be classified "
+            "as STALE_PRIOR_RUN"
+        )
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_details_expires_stale_prior_run(
+        self, db_session: AsyncSession, journey_collector, mock_njt_client
+    ):
+        """A stale prior-day run that ran (has a departed stop) but cannot be
+        completed (no penultimate-departed backstop) must be finalized via
+        is_expired=True so schedule_periodic_updates stops selecting it. The
+        strike counter must NOT be advanced — this is not an API error, it is
+        expected reuse, so api_error_count stays put.
+        """
+        stored_departure = (now_et() - timedelta(days=1)).replace(
+            hour=14, minute=23, second=0, microsecond=0
+        )
+        api_departure = stored_departure + timedelta(days=1)
+
+        journey = TrainJourney(
+            train_id="5517",
+            journey_date=date.today() - timedelta(days=1),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stored_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            is_expired=False,
+            api_error_count=0,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # Single departed origin stop: proof the train ran, but with only one
+        # stop the completion backstop cannot fire, so expiry is the outcome.
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=stored_departure,
+            actual_departure=stored_departure,
+            has_departed_station=True,
+            departure_source="api_explicit",
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="5517",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        mock_njt_client.get_train_stop_list.return_value = api_response
+
+        await journey_collector.collect_journey_details(db_session, journey)
+        await db_session.refresh(journey)
+
+        assert journey.is_expired is True, (
+            "A stale prior-day run with no completion backstop must be expired "
+            "so it leaves the periodic-update candidate set"
+        )
+        assert journey.is_completed is False, (
+            "Without a penultimate-departed api_explicit stop, the row must "
+            "expire rather than be falsely completed"
+        )
+        assert journey.api_error_count == 0, (
+            "Reused-train_id displacement is expected, not an API error — the "
+            "strike counter must not advance for STALE_PRIOR_RUN"
+        )
+        assert (
+            journey.last_updated_at is not None
+        ), "Finalizing must advance last_updated_at"
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_details_completes_stale_prior_run_when_backstop_fires(
+        self, db_session: AsyncSession, journey_collector, mock_njt_client
+    ):
+        """When the completion backstop can fire (penultimate stop departed
+        via api_explicit and terminal arrival is due), a stale prior-day run
+        must be marked COMPLETED rather than merely expired — preserving the
+        real terminal arrival for history rather than discarding the journey.
+        """
+        stored_departure = (now_et() - timedelta(days=1)).replace(
+            hour=15, minute=0, second=0, microsecond=0
+        )
+        api_departure = stored_departure + timedelta(days=1)
+
+        journey = TrainJourney(
+            train_id="1720",
+            journey_date=date.today() - timedelta(days=1),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stored_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            is_expired=False,
+            api_error_count=0,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # Origin (used by _is_same_journey for the stored-departure lookup).
+        origin_stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=stored_departure,
+        )
+        # Penultimate stop departed explicitly — satisfies the completion
+        # backstop's precondition.
+        penultimate_stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NP",
+            station_name="Newark Penn Station",
+            stop_sequence=5,
+            scheduled_departure=stored_departure + timedelta(minutes=50),
+            actual_departure=stored_departure + timedelta(minutes=50),
+            has_departed_station=True,
+            departure_source="api_explicit",
+        )
+        # Terminal arrival in the past (yesterday) → "due".
+        terminal_stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="TR",
+            station_name="Trenton Station",
+            stop_sequence=10,
+            scheduled_arrival=stored_departure + timedelta(minutes=90),
+        )
+        db_session.add_all([origin_stop, penultimate_stop, terminal_stop])
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="1720",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        mock_njt_client.get_train_stop_list.return_value = api_response
+
+        await journey_collector.collect_journey_details(db_session, journey)
+        await db_session.refresh(journey)
+
+        assert journey.is_completed is True, (
+            "A stale prior-day run whose penultimate stop departed and whose "
+            "terminal arrival is due must be completed via the backstop"
+        )
+        assert journey.is_expired is False, (
+            "Completion is preferred over expiry — the row must not be flagged "
+            "expired when it can be legitimately completed"
+        )
+        assert (
+            journey.actual_arrival is not None
+        ), "Completion-on-expiry must record the terminal arrival time"

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -840,12 +840,15 @@ class TestStalePriorRunDetection:
         (DEPARTURE_TIME_MISMATCH), while an over-threshold skew is a reused
         train_id (STALE_PRIOR_RUN). This pins the boundary so the threshold
         can't silently drift.
+
+        The journey is prior-day so the prior-day gate is satisfied and the
+        time-delta threshold is the only variable under test.
         """
         stored_departure = now_et().replace(hour=10, minute=0, second=0, microsecond=0)
 
         journey = TrainJourney(
             train_id="4244",
-            journey_date=date.today(),
+            journey_date=date.today() - timedelta(days=1),
             line_code="NE",
             line_name="Northeast Corridor",
             destination="Trenton",
@@ -1097,3 +1100,150 @@ class TestStalePriorRunDetection:
         assert (
             journey.actual_arrival is not None
         ), "Completion-on-expiry must record the terminal arrival time"
+
+    @pytest.mark.asyncio
+    async def test_same_day_large_skew_classified_as_departure_time_mismatch(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """A same-day journey with an over-threshold skew must NOT be treated as
+        a reused-train_id stale prior run. The STALE_PRIOR_RUN finalize path
+        bypasses the departed-stop guard / 3-strike protection, so it is gated
+        on journey_date < today. A same-day train whose first-stop time is
+        wildly off (a severe >6h delay or an API date anomaly) must instead stay
+        on the conservative DEPARTURE_TIME_MISMATCH path so it is not prematurely
+        removed from active tracking / /departures.
+        """
+        stored_departure = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        # >6h skew, but the journey is *today*, so this is not train_id reuse.
+        api_departure = stored_departure + timedelta(
+            seconds=STALE_PRIOR_RUN_THRESHOLD_SECONDS + 3600
+        )
+
+        journey = TrainJourney(
+            train_id="4692",
+            journey_date=date.today(),  # same service day — gate must block STALE_PRIOR_RUN
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stored_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=stored_departure,
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="4692",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+
+        result = await journey_collector._is_same_journey(
+            db_session, journey, api_response
+        )
+
+        assert result is JourneyMatchResult.DEPARTURE_TIME_MISMATCH, (
+            "A >6h skew on a same-day journey is not daily train_id reuse — the "
+            "prior-day gate must keep it on the DEPARTURE_TIME_MISMATCH path so "
+            "the departed-stop guard / 3-strike protection still applies"
+        )
+
+    @pytest.mark.asyncio
+    async def test_collect_journey_details_keeps_same_day_running_train(
+        self, db_session: AsyncSession, journey_collector, mock_njt_client
+    ):
+        """End-to-end guard for the codex P1 concern: a *running* same-day train
+        (a departed stop present) whose API first-stop time is >6h off must NOT
+        be finalized. The prior-day gate routes it to DEPARTURE_TIME_MISMATCH,
+        and the departed-stop guard there leaves it active (not expired, not
+        completed, strike counter untouched) so it stays in /departures.
+        """
+        stored_departure = now_et().replace(hour=8, minute=0, second=0, microsecond=0)
+        api_departure = stored_departure + timedelta(
+            seconds=STALE_PRIOR_RUN_THRESHOLD_SECONDS + 3600
+        )
+
+        journey = TrainJourney(
+            train_id="717",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="Trenton",
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=stored_departure,
+            has_complete_journey=True,
+            is_completed=False,
+            is_expired=False,
+            api_error_count=0,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        # The train physically ran (departed origin) — proof it must stay active.
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=stored_departure,
+            actual_departure=stored_departure,
+            has_departed_station=True,
+            departure_source="api_explicit",
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="717",
+            line_code="NE",
+            destination="Trenton",
+            stops=[
+                builder.build_stop(
+                    "NY",
+                    "New York Penn Station",
+                    api_departure.strftime(NJT_TIME_FORMAT),
+                ),
+            ],
+        )
+        mock_njt_client.get_train_stop_list.return_value = api_response
+
+        await journey_collector.collect_journey_details(db_session, journey)
+        await db_session.refresh(journey)
+
+        assert journey.is_expired is False, (
+            "A same-day running train with a large skew must not be expired — "
+            "the prior-day gate keeps it off the STALE_PRIOR_RUN finalize path"
+        )
+        assert (
+            journey.is_completed is False
+        ), "A still-running same-day train must not be force-completed"
+        assert journey.api_error_count == 0, (
+            "The departed-stop guard on DEPARTURE_TIME_MISMATCH must skip the "
+            "strike for a running train, so the counter stays at 0"
+        )


### PR DESCRIPTION
## Summary

Fixes the recurring `journey_mismatch_departure_time` warning storm and wasted `getTrainStopList` calls described in #1238.

NJT reuses the same numeric `train_id` every service day. A prior-day journey row that physically ran but was never finalized (`is_completed`/`is_expired` both unset) stays an update candidate in `schedule_periodic_updates` (`journey_date >= today - 1`). When `getTrainStopList(<id>)` is called on a later day it returns *that* day's run — ~24h displaced from the stored departure. The existing `DEPARTURE_TIME_MISMATCH` handler's departed-stop guard correctly refuses to apply the displaced data, but it returns **without finalizing the row**, so the scheduler re-polls each stale journey every ~15 min for the rest of the day (≈96 redundant API calls/journey/day) and floods the logs with warnings.

The fix distinguishes a **whole-service-day displacement** (the reused-`train_id` signature) from a genuine delay using the time delta, and finalizes the row so it leaves the candidate set.

## Changes

**`backend_v2/src/trackrat/collectors/njt/journey.py`**
- Added `JourneyMatchResult.STALE_PRIOR_RUN` and a module constant `STALE_PRIOR_RUN_THRESHOLD_SECONDS = 6 * 3600`. 6h sits far above any plausible NJT delay yet well below the observed ~24h displacement, cleanly separating "delayed today" from "yesterday's reused train_id".
- In `_is_same_journey`, when the first-stop `time_diff` exceeds the threshold (and the stored origin wasn't matched as an intermediate stop), return `STALE_PRIOR_RUN` and log `journey_stale_prior_run_detected` at **info** (reused `train_id` is expected, not anomalous) instead of the `journey_mismatch_departure_time` **warning**.
- In `collect_journey_details`, handle `STALE_PRIOR_RUN` by finalizing the row: attempt real completion via the existing `_attempt_completion_on_expiry` (stored-data-only, no new API calls), and fall back to `is_expired = True`. Logs `stale_prior_run_finalized` at info. This drops the row out of the periodic-update candidate set.

**`backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py`**
- New `TestStalePriorRunDetection` class with 4 tests.

## Why this is safe

- **Threshold isolates the bug shape.** A genuinely delayed train reports an API first-stop time *close* to the stored departure (same physical run), so it keeps the existing small-diff `DEPARTURE_TIME_MISMATCH` path untouched. Only a >6h displacement — which can only arise from a different service day — is reclassified.
- **No user-facing data change.** These rows already ran and the handler never applied the displaced data; only the lifecycle flags flip.
- **Cross-midnight trains unaffected.** A train departing 23:55 still running after midnight has `journey_date = yesterday` but its API run matches (small diff) → still `MATCH`.
- **Completion preferred over expiry.** Reusing `_attempt_completion_on_expiry` preserves the real terminal arrival for history when the backstop can fire.

## Test coverage added

- `test_full_day_displacement_classified_as_stale_prior_run` — ~24h displacement → `STALE_PRIOR_RUN` (and therefore no `journey_mismatch_departure_time` warning, which is only logged on the other branch).
- `test_threshold_boundary_separates_delay_from_prior_run` — pins the boundary: 1h below threshold → `DEPARTURE_TIME_MISMATCH`, 1h above → `STALE_PRIOR_RUN`.
- `test_collect_journey_details_expires_stale_prior_run` — stale run with a departed stop but no completion backstop → `is_expired=True`, `is_completed=False`, `api_error_count` unchanged (not treated as an API error), `last_updated_at` advanced.
- `test_collect_journey_details_completes_stale_prior_run_when_backstop_fires` — penultimate stop departed (`api_explicit`) + terminal arrival due → `is_completed=True`, `is_expired=False`, terminal `actual_arrival` recorded.

All 13 tests in the file pass, and the full NJT collector suite (178 tests) passes. `black` and `ruff` are clean on `journey.py`; `mypy src/trackrat/collectors/njt/journey.py` reports no issues.

## Design decisions

- **6h threshold** chosen as the midpoint of "impossible as a delay" and "well under the daily displacement"; defined as a named constant so it can't silently drift and is referenced by the boundary test.
- **Info-level logging** for both detection and finalization, since daily `train_id` reuse is expected behavior — the goal is to stop the warning noise, not relabel it.
- **Reuse of `_attempt_completion_on_expiry`** rather than a new finalizer keeps the change minimal and introduces no new query patterns.
- Out of scope (per #1238): the NJT 27-hour schedule-generation `SCHED_DEP_DATE` concern and the unrelated greenlet / DiskFullError / trip-search issues.

Closes #1238

https://claude.ai/code/session_01RQuVvDVBdi3zZys38aTAhj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQuVvDVBdi3zZys38aTAhj)_