### PR TITLE
Issue #1246: Reflect cancellations in congestion map level

### DIFF
--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -16,6 +16,7 @@ from structlog import get_logger
 
 from trackrat.models.database import TrainJourney
 from trackrat.services.congestion_types import (
+    CANCELLATION_CONGESTION_WEIGHT,
     CONGESTION_THRESHOLD_HEAVY,
     CONGESTION_THRESHOLD_MODERATE,
     CONGESTION_THRESHOLD_NORMAL,
@@ -23,6 +24,7 @@ from trackrat.services.congestion_types import (
     FREQ_THRESHOLD_MODERATE,
     FREQ_THRESHOLD_REDUCED,
     SegmentCongestion,
+    effective_congestion_factor,
     get_congestion_level,
     get_frequency_level,
 )
@@ -79,10 +81,12 @@ __all__ = [
     "SegmentCongestion",
     "get_congestion_level",
     "get_frequency_level",
+    "effective_congestion_factor",
     "CongestionAnalyzer",
     "CONGESTION_THRESHOLD_NORMAL",
     "CONGESTION_THRESHOLD_MODERATE",
     "CONGESTION_THRESHOLD_HEAVY",
+    "CANCELLATION_CONGESTION_WEIGHT",
     "FREQ_THRESHOLD_HEALTHY",
     "FREQ_THRESHOLD_MODERATE",
     "FREQ_THRESHOLD_REDUCED",
@@ -473,14 +477,26 @@ class CongestionAnalyzer:
             WHERE
                 -- LEAD returns NULL for last stop in journey (no next stop)
                 sp.to_station IS NOT NULL
-                -- Within time window
-                AND COALESCE(sp.from_actual_departure, sp.from_updated_departure, sp.from_actual_arrival, sp.from_updated_arrival) >= :cutoff_time
-                -- Valid times: need some real-time departure and arrival time
-                AND COALESCE(sp.from_actual_departure, sp.from_updated_departure, sp.from_actual_arrival, sp.from_updated_arrival) IS NOT NULL
-                AND COALESCE(sp.to_actual_arrival, sp.to_updated_arrival) IS NOT NULL
-                -- Ensure arrival is after departure (positive transit time)
-                AND COALESCE(sp.to_actual_arrival, sp.to_updated_arrival) >
-                    COALESCE(sp.from_actual_departure, sp.from_updated_departure, sp.from_actual_arrival, sp.from_updated_arrival)
+                AND (
+                    -- Running trains: need positive real-time transit time
+                    -- within the lookback window. (>= :cutoff_time implies the
+                    -- coalesced departure is non-NULL.)
+                    (
+                        COALESCE(sp.from_actual_departure, sp.from_updated_departure, sp.from_actual_arrival, sp.from_updated_arrival) >= :cutoff_time
+                        AND COALESCE(sp.to_actual_arrival, sp.to_updated_arrival) IS NOT NULL
+                        AND COALESCE(sp.to_actual_arrival, sp.to_updated_arrival) >
+                            COALESCE(sp.from_actual_departure, sp.from_updated_departure, sp.from_actual_arrival, sp.from_updated_arrival)
+                    )
+                    -- Cancelled trains have no real-time times, so window them
+                    -- on their scheduled departure instead. They contribute
+                    -- only to cancelled_count (every active metric below filters
+                    -- NOT is_cancelled), letting heavy cancellations register on
+                    -- the congestion map even when running trains are on time.
+                    OR (
+                        tj.is_cancelled
+                        AND sp.from_scheduled_departure >= :cutoff_time
+                    )
+                )
         ),
         segment_with_recency AS (
             -- Add recency window for efficient filtering
@@ -638,7 +654,13 @@ class CongestionAnalyzer:
             current_avg = float(row.current_avg_minutes or row.avg_actual or baseline)
             congestion_factor = current_avg / baseline if baseline > 0 else 1.0
 
-            level = get_congestion_level(congestion_factor)
+            # Fold cancellations into the level so heavy cancellations register
+            # on the map even when the running trains are on time. (Segments are
+            # re-aggregated in normalize_aggregated_segments, which applies the
+            # same weighting; this keeps each raw segment self-consistent.)
+            level = get_congestion_level(
+                effective_congestion_factor(congestion_factor, cancellation_rate)
+            )
 
             # Calculate average delay
             average_delay = current_avg - baseline

--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -99,11 +99,17 @@ def _stop_pairs_cte(ds_filter: str) -> str:
 
     Filters on tj_pre.last_updated_at >= :cutoff_time so PostgreSQL prunes
     journeys before the expensive LEAD() window function runs. Cancelled
-    journeys are admitted via scheduled_departure instead, because the NJT
-    journey collector stops touching them once is_cancelled is set
-    (collectors/njt/journey.py filters is_cancelled.is_not(True)), so a
-    train cancelled hours before its scheduled run would otherwise be
-    pruned and never reach segment_data's cancellation window.
+    journeys are admitted unconditionally (still bounded by the 1-day
+    journey_date filter), because the NJT journey collector stops touching
+    them once is_cancelled is set (collectors/njt/journey.py filters
+    is_cancelled.is_not(True)), so a train cancelled hours before its
+    scheduled run would otherwise be pruned and never reach segment_data's
+    cancellation window. The filter is journey-level (not per-stop) because
+    a per-stop scheduled_departure check drops the TO row of each pair
+    (it has scheduled_arrival, not scheduled_departure), breaking LEAD()
+    so to_station resolves to NULL. segment_data's
+    `sp.from_scheduled_departure >= :cutoff_time` predicate narrows the
+    admitted cancellations to the relevant window.
     Requires :cutoff_time in the query's params dict.
     """
     return f"""stop_pairs AS (
@@ -126,7 +132,7 @@ def _stop_pairs_cte(ds_filter: str) -> str:
           AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
           AND (
               tj_pre.last_updated_at >= :cutoff_time
-              OR (tj_pre.is_cancelled AND js.scheduled_departure >= :cutoff_time)
+              OR tj_pre.is_cancelled
           )
           {ds_filter}
         WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)

--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -98,7 +98,12 @@ def _stop_pairs_cte(ds_filter: str) -> str:
     """Generate the stop_pairs CTE with cutoff_time pushdown.
 
     Filters on tj_pre.last_updated_at >= :cutoff_time so PostgreSQL prunes
-    journeys before the expensive LEAD() window function runs.
+    journeys before the expensive LEAD() window function runs. Cancelled
+    journeys are admitted via scheduled_departure instead, because the NJT
+    journey collector stops touching them once is_cancelled is set
+    (collectors/njt/journey.py filters is_cancelled.is_not(True)), so a
+    train cancelled hours before its scheduled run would otherwise be
+    pruned and never reach segment_data's cancellation window.
     Requires :cutoff_time in the query's params dict.
     """
     return f"""stop_pairs AS (
@@ -119,7 +124,10 @@ def _stop_pairs_cte(ds_filter: str) -> str:
         JOIN train_journeys tj_pre ON tj_pre.id = js.journey_id
         WHERE js.station_code IS NOT NULL
           AND tj_pre.journey_date >= CURRENT_DATE - INTERVAL '1 day'
-          AND tj_pre.last_updated_at >= :cutoff_time
+          AND (
+              tj_pre.last_updated_at >= :cutoff_time
+              OR (tj_pre.is_cancelled AND js.scheduled_departure >= :cutoff_time)
+          )
           {ds_filter}
         WINDOW w AS (PARTITION BY js.journey_id ORDER BY js.stop_sequence)
     )"""

--- a/backend_v2/src/trackrat/services/congestion_types.py
+++ b/backend_v2/src/trackrat/services/congestion_types.py
@@ -10,6 +10,14 @@ CONGESTION_THRESHOLD_MODERATE = 1.25  # <= 25% slower than baseline
 CONGESTION_THRESHOLD_HEAVY = 1.5  # <= 50% slower than baseline
 # Above 1.5 = severe
 
+# Weight applied to a segment's cancellation rate (a percentage, 0-100) when
+# folding cancellations into the congestion factor. Mirrors the iOS client's
+# CongestionColors.cancellationCongestionWeight (ios/.../Utilities/Extensions.swift)
+# so the web map (which colors by congestion_level) and iOS (which colors by
+# congestion_factor + cancellation_rate) stay consistent: ~1 congestion tier per
+# 10% of scheduled trains cancelled.
+CANCELLATION_CONGESTION_WEIGHT = 0.015
+
 # Frequency/health level thresholds (factor = train_count / baseline)
 # Higher is better - measures service reliability
 FREQ_THRESHOLD_HEALTHY = 0.9  # >= 90% of baseline trains
@@ -32,6 +40,20 @@ def get_congestion_level(congestion_factor: float) -> str:
         return "heavy"
     else:
         return "severe"
+
+
+def effective_congestion_factor(
+    congestion_factor: float, cancellation_rate: float = 0.0
+) -> float:
+    """Fold a segment's cancellation rate into its congestion factor.
+
+    ``cancellation_rate`` is a percentage (0-100). Heavy cancellations raise the
+    effective factor so a segment with many cancelled trains is not reported as
+    "normal" just because the few trains still running happen to be on time.
+    """
+    return (
+        congestion_factor + max(0.0, cancellation_rate) * CANCELLATION_CONGESTION_WEIGHT
+    )
 
 
 def get_frequency_level(frequency_factor: float) -> str:

--- a/backend_v2/src/trackrat/services/segment_normalizer.py
+++ b/backend_v2/src/trackrat/services/segment_normalizer.py
@@ -18,6 +18,7 @@ from trackrat.config.route_topology import (
 )
 from trackrat.services.congestion_types import (
     SegmentCongestion,
+    effective_congestion_factor,
     get_congestion_level,
     get_frequency_level,
 )
@@ -177,7 +178,6 @@ def normalize_aggregated_segments(
 
         # Calculate congestion factor
         congestion_factor = avg_transit / avg_baseline if avg_baseline > 0 else 1.0
-        congestion_level = get_congestion_level(congestion_factor)
 
         # Average delay
         average_delay = avg_transit - avg_baseline
@@ -186,6 +186,14 @@ def normalize_aggregated_segments(
         total_journeys = total_samples + total_cancellations
         cancellation_rate = (
             (total_cancellations / total_journeys * 100) if total_journeys > 0 else 0.0
+        )
+
+        # Fold cancellations into the displayed level so a segment with many
+        # cancelled trains is not shown as "normal" just because the trains
+        # still running are on time. Mirrors the iOS client, which colors by
+        # congestion_factor + cancellation_rate.
+        congestion_level = get_congestion_level(
+            effective_congestion_factor(congestion_factor, cancellation_rate)
         )
 
         # Aggregate frequency metrics (sum train_count and baseline_train_count)

--- a/backend_v2/tests/unit/services/test_congestion.py
+++ b/backend_v2/tests/unit/services/test_congestion.py
@@ -694,18 +694,27 @@ class TestCongestionAnalyzer:
         assert "journey_date >= CURRENT_DATE" in sql
         assert "LEAD(js.station_code) OVER w" in sql
 
-    def test_stop_pairs_cte_admits_stale_cancellations_by_scheduled_departure(self):
-        """Cancelled journeys must also be admitted via scheduled_departure,
-        because NJT's journey collector stops touching them after cancellation
-        (collectors/njt/journey.py filters is_cancelled.is_not(True)) so
-        last_updated_at freezes — and a train cancelled hours before its
-        scheduled run would otherwise be pruned before reaching segment_data
-        and never count toward cancellation_rate. Guards the fix from the
-        chatgpt-codex review on PR #1248.
+    def test_stop_pairs_cte_admits_stale_cancellations(self):
+        """Cancelled journeys must be admitted (journey-level, not per-stop)
+        regardless of last_updated_at, because NJT's journey collector stops
+        touching them after cancellation (collectors/njt/journey.py filters
+        is_cancelled.is_not(True)) so last_updated_at freezes — and a train
+        cancelled hours before its scheduled run would otherwise be pruned
+        before reaching segment_data and never count toward cancellation_rate.
+
+        The filter must be journey-level (not per-stop). A per-stop
+        scheduled_departure check would drop the TO row of each pair (its
+        scheduled_departure is NULL — it carries scheduled_arrival instead),
+        causing LEAD() to produce a NULL to_station and segment_data to
+        discard the row via its `sp.to_station IS NOT NULL` filter.
+
+        Guards the fix from the chatgpt-codex review on PR #1248.
         """
         sql = _stop_pairs_cte("")
         assert "tj_pre.is_cancelled" in sql
-        assert "js.scheduled_departure >= :cutoff_time" in sql
+        # Must be journey-level: no per-stop scheduled_departure predicate
+        # gating the is_cancelled branch (it would drop the TO row).
+        assert "js.scheduled_departure >= :cutoff_time" not in sql
 
     def test_stop_pairs_cte_includes_data_source_filter(self):
         """When a data_source filter is provided, it must appear in the CTE."""

--- a/backend_v2/tests/unit/services/test_congestion.py
+++ b/backend_v2/tests/unit/services/test_congestion.py
@@ -694,6 +694,19 @@ class TestCongestionAnalyzer:
         assert "journey_date >= CURRENT_DATE" in sql
         assert "LEAD(js.station_code) OVER w" in sql
 
+    def test_stop_pairs_cte_admits_stale_cancellations_by_scheduled_departure(self):
+        """Cancelled journeys must also be admitted via scheduled_departure,
+        because NJT's journey collector stops touching them after cancellation
+        (collectors/njt/journey.py filters is_cancelled.is_not(True)) so
+        last_updated_at freezes — and a train cancelled hours before its
+        scheduled run would otherwise be pruned before reaching segment_data
+        and never count toward cancellation_rate. Guards the fix from the
+        chatgpt-codex review on PR #1248.
+        """
+        sql = _stop_pairs_cte("")
+        assert "tj_pre.is_cancelled" in sql
+        assert "js.scheduled_departure >= :cutoff_time" in sql
+
     def test_stop_pairs_cte_includes_data_source_filter(self):
         """When a data_source filter is provided, it must appear in the CTE."""
         sql_with_ds = _stop_pairs_cte("AND tj_pre.data_source = :data_source")

--- a/backend_v2/tests/unit/services/test_congestion.py
+++ b/backend_v2/tests/unit/services/test_congestion.py
@@ -795,3 +795,91 @@ class TestCongestionAnalyzer:
             "get_individual_segments_optimized must SET LOCAL statement_timeout "
             "before executing the query"
         )
+
+    def test_effective_congestion_factor(self):
+        """effective_congestion_factor folds cancellation rate into the factor
+        using the same weight as the iOS client (0.015 per percent)."""
+        from trackrat.services.congestion import effective_congestion_factor
+
+        # No cancellations -> factor unchanged
+        assert effective_congestion_factor(1.0, 0.0) == pytest.approx(1.0)
+        # 10% cancellations ~= one congestion tier (+0.15)
+        assert effective_congestion_factor(1.0, 10.0) == pytest.approx(1.15)
+        # 50% cancellations -> +0.75
+        assert effective_congestion_factor(1.0, 50.0) == pytest.approx(1.75)
+        # Negative rates are clamped to zero (never reduce the factor)
+        assert effective_congestion_factor(1.2, -5.0) == pytest.approx(1.2)
+
+    @pytest.mark.asyncio
+    async def test_aggregated_congestion_sql_counts_cancelled_trains(
+        self, congestion_analyzer, mock_db
+    ):
+        """Reproduces #1246: cancelled trains have no real-time arrival/departure
+        times, so the old segment_data filter dropped them entirely and
+        cancellation_count/cancellation_rate were always ~0. The query must
+        admit cancelled journeys (windowed on their scheduled departure) so
+        heavy cancellations register on the congestion map.
+        """
+        mock_result = Mock()
+        mock_result.fetchall.return_value = []
+        mock_db.execute.return_value = mock_result
+        congestion_analyzer._cache.clear()
+
+        await congestion_analyzer.get_network_congestion_optimized(
+            mock_db, time_window_hours=3, data_source="NJT"
+        )
+
+        main_sql = next(
+            (
+                str(call.args[0])
+                for call in mock_db.execute.call_args_list
+                if "WITH stop_pairs" in str(call.args[0])
+            ),
+            None,
+        )
+        assert main_sql is not None, "main aggregated query was not executed"
+        # Cancelled journeys must be admitted via their scheduled departure.
+        assert "tj.is_cancelled" in main_sql
+        assert "sp.from_scheduled_departure >= :cutoff_time" in main_sql
+        # cancelled_count must still only count cancelled rows.
+        assert "FILTER (WHERE is_cancelled)" in main_sql
+
+    @pytest.mark.asyncio
+    async def test_optimized_high_cancellation_elevates_level(
+        self, congestion_analyzer, mock_db
+    ):
+        """End-to-end (DB row -> normalized segment): a segment whose running
+        trains are on time but which has a high cancellation rate surfaces as a
+        worse-than-normal level. Reproduces #1246.
+        """
+        mock_row = Mock()
+        mock_row.from_station = "NY"
+        mock_row.to_station = "SE"  # adjacent NEC pair -> no expansion
+        mock_row.data_source = "NJT"
+        mock_row.active_count = 5
+        mock_row.cancelled_count = 5  # 50% of scheduled trains cancelled
+        mock_row.avg_actual = 5.0
+        mock_row.baseline_minutes = 5.0  # running trains exactly on time
+        mock_row.recent_avg = 5.0
+        mock_row.current_avg_minutes = 5.0
+        mock_row.median_actual = 5.0
+        mock_row.train_count = 5
+        mock_row.baseline_train_count = 10.0
+        mock_row.frequency_factor = 0.5
+
+        mock_result = Mock()
+        mock_result.fetchall.return_value = [mock_row]
+        mock_db.execute.return_value = mock_result
+        congestion_analyzer._cache.clear()
+
+        with patch("trackrat.services.congestion.now_et") as mock_now:
+            mock_now.return_value = datetime.now(UTC)
+            results = await congestion_analyzer.get_network_congestion_optimized(
+                mock_db, time_window_hours=3
+            )
+
+        seg = next(s for s in results if (s.from_station, s.to_station) == ("NY", "SE"))
+        assert seg.cancellation_rate == pytest.approx(50.0)
+        assert seg.congestion_factor == pytest.approx(1.0)
+        # 1.0 + 50% * 0.015 = 1.75 -> severe
+        assert seg.congestion_level == "severe"

--- a/backend_v2/tests/unit/services/test_congestion_cancellations.py
+++ b/backend_v2/tests/unit/services/test_congestion_cancellations.py
@@ -1,0 +1,171 @@
+"""Real-database tests for cancellation handling in network congestion.
+
+Reproduces #1246: NJT NEC (Trenton -> NY Penn) had many cancellations while the
+congestion map stayed green. Cancelled trains have no real-time arrival/departure
+times, so the optimized congestion query used to filter them out before counting,
+leaving cancellation_rate at ~0 and the displayed level unaffected.
+
+These tests require a PostgreSQL test database because the congestion calculation
+is a raw SQL query inside get_network_congestion_optimized.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from trackrat.models.database import JourneyStop, TrainJourney
+from trackrat.services.congestion import CongestionAnalyzer
+from trackrat.utils.time import now_et
+
+
+async def _add_njt_nec_journey(
+    db: AsyncSession,
+    train_id: str,
+    from_station: str,
+    to_station: str,
+    scheduled_departure: datetime,
+    scheduled_arrival: datetime,
+    *,
+    is_cancelled: bool,
+    actual_departure: datetime | None = None,
+    actual_arrival: datetime | None = None,
+) -> None:
+    """Create an NJT NEC journey with a single from->to stop pair.
+
+    Running trains get actual times; cancelled trains get only scheduled times,
+    mirroring real data — a cancelled train never produces real-time times.
+    """
+    journey = TrainJourney(
+        train_id=train_id,
+        journey_date=scheduled_departure.date(),
+        line_code="NE",
+        line_name="Northeast Corridor",
+        destination="New York Penn Station",
+        origin_station_code=from_station,
+        terminal_station_code=to_station,
+        data_source="NJT",
+        observation_type="SCHEDULED" if is_cancelled else "OBSERVED",
+        scheduled_departure=scheduled_departure,
+        is_cancelled=is_cancelled,
+        has_complete_journey=not is_cancelled,
+        stops_count=2,
+    )
+    db.add(journey)
+    await db.flush()
+
+    db.add(
+        JourneyStop(
+            journey_id=journey.id,
+            station_code=from_station,
+            station_name=from_station,
+            stop_sequence=1,
+            scheduled_departure=scheduled_departure,
+            actual_departure=actual_departure,
+        )
+    )
+    db.add(
+        JourneyStop(
+            journey_id=journey.id,
+            station_code=to_station,
+            station_name=to_station,
+            stop_sequence=2,
+            scheduled_arrival=scheduled_arrival,
+            actual_arrival=actual_arrival,
+        )
+    )
+    await db.flush()
+
+
+@pytest.mark.asyncio
+class TestCongestionCancellationsRealDB:
+    """End-to-end verification that cancelled trains affect congestion."""
+
+    async def test_cancellations_counted_and_elevate_level(
+        self, db_session: AsyncSession
+    ):
+        """5 on-time running + 5 cancelled NEC trains on NY->SE: the segment
+        must report a ~50% cancellation rate and a level worse than 'normal'
+        even though every running train is on time. Reproduces #1246.
+        """
+        dep = now_et() - timedelta(minutes=30)
+        arr = dep + timedelta(minutes=5)
+
+        for i in range(5):
+            await _add_njt_nec_journey(
+                db_session,
+                train_id=f"run_{i}",
+                from_station="NY",
+                to_station="SE",
+                scheduled_departure=dep,
+                scheduled_arrival=arr,
+                is_cancelled=False,
+                actual_departure=dep,  # on time
+                actual_arrival=arr,
+            )
+        for i in range(5):
+            await _add_njt_nec_journey(
+                db_session,
+                train_id=f"cancel_{i}",
+                from_station="NY",
+                to_station="SE",
+                scheduled_departure=dep,
+                scheduled_arrival=arr,
+                is_cancelled=True,
+            )
+        await db_session.commit()
+
+        analyzer = CongestionAnalyzer()
+        segments = await analyzer.get_network_congestion_optimized(
+            db_session, time_window_hours=3, data_source="NJT"
+        )
+
+        ny_se = next(
+            (s for s in segments if (s.from_station, s.to_station) == ("NY", "SE")),
+            None,
+        )
+        assert ny_se is not None, "NY->SE segment should be present in results"
+        # Running trains feed the active sample; cancelled trains are counted
+        # separately (the old query dropped them, leaving this at 0).
+        assert ny_se.sample_count == 5
+        assert ny_se.cancellation_count == 5
+        assert ny_se.cancellation_rate == pytest.approx(50.0)
+        # On-time running trains -> delay factor ~1.0; cancellations alone must
+        # push the level above normal (1.0 + 50% * 0.015 = 1.75 -> severe).
+        assert ny_se.congestion_factor == pytest.approx(1.0, abs=0.05)
+        assert ny_se.congestion_level == "severe"
+
+    async def test_no_cancellations_segment_stays_normal(
+        self, db_session: AsyncSession
+    ):
+        """Control: on-time running trains with no cancellations stay 'normal'."""
+        dep = now_et() - timedelta(minutes=30)
+        arr = dep + timedelta(minutes=5)
+
+        for i in range(5):
+            await _add_njt_nec_journey(
+                db_session,
+                train_id=f"run_{i}",
+                from_station="NY",
+                to_station="SE",
+                scheduled_departure=dep,
+                scheduled_arrival=arr,
+                is_cancelled=False,
+                actual_departure=dep,
+                actual_arrival=arr,
+            )
+        await db_session.commit()
+
+        analyzer = CongestionAnalyzer()
+        segments = await analyzer.get_network_congestion_optimized(
+            db_session, time_window_hours=3, data_source="NJT"
+        )
+
+        ny_se = next(
+            (s for s in segments if (s.from_station, s.to_station) == ("NY", "SE")),
+            None,
+        )
+        assert ny_se is not None
+        assert ny_se.cancellation_count == 0
+        assert ny_se.cancellation_rate == pytest.approx(0.0)
+        assert ny_se.congestion_level == "normal"

--- a/backend_v2/tests/unit/services/test_congestion_cancellations.py
+++ b/backend_v2/tests/unit/services/test_congestion_cancellations.py
@@ -30,6 +30,7 @@ async def _add_njt_nec_journey(
     is_cancelled: bool,
     actual_departure: datetime | None = None,
     actual_arrival: datetime | None = None,
+    last_updated_at: datetime | None = None,
 ) -> None:
     """Create an NJT NEC journey with a single from->to stop pair.
 
@@ -51,6 +52,8 @@ async def _add_njt_nec_journey(
         has_complete_journey=not is_cancelled,
         stops_count=2,
     )
+    if last_updated_at is not None:
+        journey.last_updated_at = last_updated_at
     db.add(journey)
     await db.flush()
 
@@ -133,6 +136,58 @@ class TestCongestionCancellationsRealDB:
         # On-time running trains -> delay factor ~1.0; cancellations alone must
         # push the level above normal (1.0 + 50% * 0.015 = 1.75 -> severe).
         assert ny_se.congestion_factor == pytest.approx(1.0, abs=0.05)
+        assert ny_se.congestion_level == "severe"
+
+    async def test_stale_cancellation_still_counted(self, db_session: AsyncSession):
+        """Cancelled trains stop receiving collector updates (NJT's journey
+        collector filters is_cancelled.is_not(True)), so last_updated_at
+        freezes at cancellation time. A train cancelled hours before its
+        scheduled run must still register on the congestion map as long as
+        its scheduled departure falls in the lookback window.
+        """
+        dep = now_et() - timedelta(minutes=30)
+        arr = dep + timedelta(minutes=5)
+        # Cancelled 6 hours ago: well outside the 3-hour window. Without the
+        # CTE fix, this journey is pruned before reaching segment_data.
+        stale_update = now_et() - timedelta(hours=6)
+
+        for i in range(5):
+            await _add_njt_nec_journey(
+                db_session,
+                train_id=f"run_{i}",
+                from_station="NY",
+                to_station="SE",
+                scheduled_departure=dep,
+                scheduled_arrival=arr,
+                is_cancelled=False,
+                actual_departure=dep,
+                actual_arrival=arr,
+            )
+        for i in range(5):
+            await _add_njt_nec_journey(
+                db_session,
+                train_id=f"stale_cancel_{i}",
+                from_station="NY",
+                to_station="SE",
+                scheduled_departure=dep,
+                scheduled_arrival=arr,
+                is_cancelled=True,
+                last_updated_at=stale_update,
+            )
+        await db_session.commit()
+
+        analyzer = CongestionAnalyzer()
+        segments = await analyzer.get_network_congestion_optimized(
+            db_session, time_window_hours=3, data_source="NJT"
+        )
+
+        ny_se = next(
+            (s for s in segments if (s.from_station, s.to_station) == ("NY", "SE")),
+            None,
+        )
+        assert ny_se is not None
+        assert ny_se.cancellation_count == 5
+        assert ny_se.cancellation_rate == pytest.approx(50.0)
         assert ny_se.congestion_level == "severe"
 
     async def test_no_cancellations_segment_stays_normal(

--- a/backend_v2/tests/unit/test_segment_normalizer.py
+++ b/backend_v2/tests/unit/test_segment_normalizer.py
@@ -4,6 +4,8 @@ Unit tests for the segment normalizer service.
 
 from datetime import date, datetime
 
+import pytest
+
 from trackrat.models.api import IndividualJourneySegment
 from trackrat.services.congestion_types import SegmentCongestion
 from trackrat.services.segment_normalizer import (
@@ -276,6 +278,85 @@ class TestNormalizeAggregatedSegments:
 
         # Cancellation-only segments are filtered out
         assert len(result) == 0
+
+    def test_high_cancellation_rate_elevates_level(self):
+        """Reproduces #1246: a segment whose running trains are on time but
+        which has many cancelled trains must NOT be reported as "normal".
+
+        NJT NEC (Trenton -> NY Penn) had many cancellations while the
+        congestion map stayed green because the level ignored cancellations.
+        """
+        raw = [
+            SegmentCongestion(
+                from_station="NY",
+                to_station="SE",  # adjacent NEC pair -> not expanded
+                data_source="NJT",
+                congestion_factor=1.0,
+                congestion_level="normal",  # input ignored; recomputed
+                avg_transit_minutes=5.0,
+                baseline_minutes=5.0,  # running trains exactly on time
+                sample_count=10,
+                average_delay_minutes=0.0,
+                cancellation_count=10,  # 10 cancelled of 20 scheduled = 50%
+                cancellation_rate=50.0,
+            )
+        ]
+        result = normalize_aggregated_segments(raw)
+
+        assert len(result) == 1
+        seg = result[0]
+        assert seg.cancellation_rate == pytest.approx(50.0)
+        # On-time delay factor stays 1.0; cancellations drive the level.
+        assert seg.congestion_factor == pytest.approx(1.0)
+        # 1.0 + 50% * 0.015 = 1.75 -> severe
+        assert seg.congestion_level == "severe"
+
+    def test_modest_cancellations_bump_one_tier(self):
+        """~10% cancellations bump roughly one congestion tier (normal->moderate)."""
+        raw = [
+            SegmentCongestion(
+                from_station="NY",
+                to_station="SE",
+                data_source="NJT",
+                congestion_factor=1.0,
+                congestion_level="normal",
+                avg_transit_minutes=5.0,
+                baseline_minutes=5.0,
+                sample_count=9,
+                average_delay_minutes=0.0,
+                cancellation_count=1,  # 1 of 10 = 10%
+                cancellation_rate=10.0,
+            )
+        ]
+        result = normalize_aggregated_segments(raw)
+
+        assert len(result) == 1
+        seg = result[0]
+        assert seg.cancellation_rate == pytest.approx(10.0)
+        # 1.0 + 10% * 0.015 = 1.15 -> moderate
+        assert seg.congestion_level == "moderate"
+
+    def test_no_cancellations_level_is_plain_delay_level(self):
+        """Without cancellations the level is the plain delay-based level."""
+        raw = [
+            SegmentCongestion(
+                from_station="NY",
+                to_station="SE",
+                data_source="NJT",
+                congestion_factor=1.0,
+                congestion_level="severe",  # input ignored; recomputed
+                avg_transit_minutes=5.0,
+                baseline_minutes=5.0,
+                sample_count=10,
+                average_delay_minutes=0.0,
+                cancellation_count=0,
+                cancellation_rate=0.0,
+            )
+        ]
+        result = normalize_aggregated_segments(raw)
+
+        assert len(result) == 1
+        assert result[0].congestion_level == "normal"
 
 
 class TestNormalizeIndividualSegments:


### PR DESCRIPTION
## Summary

Fixes #1246 (user feedback): "many cancellations on NJ Transit's Northeast Corridor … but the congestion map line is mostly green."

The congestion map level was derived **only** from the transit-time delay of trains that were actually running, and cancelled trains were silently dropped from the dataset before being counted — so heavy cancellations could never turn a line yellow/red.

### Root cause (two parts)

1. **Cancelled trains weren't counted.** The optimized congestion query's `segment_data` CTE required non-NULL, positive *real-time* arrival/departure times. Cancelled trains never run, so they have no real-time times and were filtered out before aggregation — leaving `cancelled_count` / `cancellation_rate` at ~0 even on a heavily-cancelled line.
2. **The level ignored cancellations.** `congestion_level` was `get_congestion_level(congestion_factor)`, a pure function of delay. The iOS client *already* folds `cancellation_rate` into its color (`CongestionColors.color(forCongestionFactor:cancellationRate:)`, weight `0.015`), but the backend fed it ~0, and the web map colors purely by the `congestion_level` string.

The reporter is on iOS 3.3, so part (1) alone restores correct coloring there; part (2) brings the web map (and the level label/metadata) into line.

## Changes

| File | Why |
|------|-----|
| `backend_v2/src/trackrat/services/congestion.py` | `segment_data` CTE now also admits cancelled journeys, windowed on their **scheduled** departure (they have no real-time times). They contribute only to `cancelled_count` — every active metric still filters `NOT is_cancelled`, so baseline/transit stats are unchanged. The per-row level also folds in the cancellation rate. |
| `backend_v2/src/trackrat/services/congestion_types.py` | New `effective_congestion_factor(factor, cancellation_rate)` helper + `CANCELLATION_CONGESTION_WEIGHT = 0.015`, mirroring the iOS client so web and iOS agree (~1 congestion tier per 10% cancelled). |
| `backend_v2/src/trackrat/services/segment_normalizer.py` | The authoritative place the final per-segment level is set (all optimized results pass through here). Now derives `congestion_level` from the effective factor. |

## Design decisions

- **Reused the iOS weighting (`0.015`)** instead of inventing new cancellation thresholds, so the web map (colors by `congestion_level`) and iOS (colors by `congestion_factor + cancellation_rate`) stay consistent.
- **No min-sample guard / no source gating.** iOS already applies this weighting without a sample guard; adding one server-side would make web and iOS disagree. `cancellation_rate` is 0 for sources without cancellations, so the change is a no-op for them.
- **Cancellation-only segments (no running trains) are still filtered out** by the existing `sample_count > 0` filter in `normalize_aggregated_segments` — that behavior is unchanged here; this PR targets the reported case (segments that are running but show green despite cancellations).

## Test coverage

- `tests/unit/services/test_congestion_cancellations.py` (**new, real PostgreSQL**): creates 5 on-time running + 5 cancelled NJT NEC trains on `NY→SE` and asserts the segment reports `cancellation_count=5`, `cancellation_rate≈50%`, `congestion_factor≈1.0`, and `congestion_level="severe"`. A control test confirms no cancellations stays `normal`. This exercises the actual SQL against Postgres.
- `tests/unit/test_segment_normalizer.py`: high (50%) cancellations → `severe`, modest (10%) → `moderate`, none → plain delay level.
- `tests/unit/services/test_congestion.py`: pure-function test for `effective_congestion_factor`, a SQL-string guard that cancelled journeys are admitted, and an end-to-end (row → normalized segment) assertion.

Verified locally against a real PostgreSQL: **147 passed** across the congestion suite and adjacent tests (`test_api_cache`, `test_delay_forecaster`). `black`, `ruff`, and `mypy` are clean on the changed files.

Closes #1246

https://claude.ai/code/session_016bFo8TbJ8cSVHTpcctvgJM

---
_Generated by [Claude Code](https://claude.ai/code/session_016bFo8TbJ8cSVHTpcctvgJM)_