### PR TITLE
docs: weekly audit - add recent-departures to backend endpoint table

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -224,7 +224,7 @@ All endpoints are prefixed with `/api/v2/`:
 ```python
 # Train Operations
 GET /trains/departures?from=NY&to=TR&limit=50         # Find departures between stations
-GET /trains/recent-departures?data_source=NJT&limit=50  # Recent departures (no route filter)
+GET /trains/recent-departures?from=NY&data_sources=NJT&limit=50  # Recent departures (no route filter)
 GET /trains/{train_id}?date=2024-01-01&refresh=true   # Get specific train journey
 GET /trains/{train_id}/history?date=2024-01-01        # Historical train performance
 GET /trains/stations/{station_code}/tracks/occupied   # Real-time track occupancy

--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -224,6 +224,7 @@ All endpoints are prefixed with `/api/v2/`:
 ```python
 # Train Operations
 GET /trains/departures?from=NY&to=TR&limit=50         # Find departures between stations
+GET /trains/recent-departures?data_source=NJT&limit=50  # Recent departures (no route filter)
 GET /trains/{train_id}?date=2024-01-01&refresh=true   # Get specific train journey
 GET /trains/{train_id}/history?date=2024-01-01        # Historical train performance
 GET /trains/stations/{station_code}/tracks/occupied   # Real-time track occupancy


### PR DESCRIPTION
## Summary

Weekly documentation audit. Reviewed all CLAUDE.md and README.md files (root, backend_v2, ios, android, webpage_v2, infra_v2) against the current codebase and the past 7 days of commits.

The vast majority of docs are accurate — the previous audit (PR #1239) covered most drift, and the only code changes since then were two NJT/trip-search bug fixes that don't surface in any docs.

One real gap found and fixed:

- `/api/v2/trains/recent-departures` is registered in `backend_v2/src/trackrat/api/trains.py:222` and listed in both the root `CLAUDE.md` and root `README.md`, but was missing from the endpoint reference table in `backend_v2/CLAUDE.md`. Added a one-line entry to match the existing style.

## Test plan

- [x] Verified endpoint is registered in `backend_v2/src/trackrat/api/trains.py`
- [x] Confirmed it was already documented in `CLAUDE.md` and `README.md` at the repo root
- [x] Docs-only change — no code or tests affected

https://claude.ai/code/session_01VmQttJnrDGcxYFTHj28Jij

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmQttJnrDGcxYFTHj28Jij)_