### PR TITLE
Issue #1268: Normalize NJT updated times at train details endpoint

### DIFF
--- a/backend_v2/src/trackrat/api/trains.py
+++ b/backend_v2/src/trackrat/api/trains.py
@@ -46,7 +46,11 @@ from trackrat.services.gtfs import GTFSService
 from trackrat.services.jit import JustInTimeUpdateService
 from trackrat.utils.request_stats import get_request_stats
 from trackrat.utils.time import DATETIME_MIN_ET, now_et, safe_datetime_subtract
-from trackrat.utils.train import get_effective_observation_type, is_amtrak_train
+from trackrat.utils.train import (
+    effective_njt_updated_times,
+    get_effective_observation_type,
+    is_amtrak_train,
+)
 
 logger = get_logger(__name__)
 
@@ -444,6 +448,13 @@ async def get_train_details(
     # Build stop details
     stops = []
     for stop in sorted(journey.stops, key=lambda s: s.stop_sequence or 0):
+        # NJT's raw updated_arrival/updated_departure have inverted semantics at
+        # intermediate stops (DEP_TIME=schedule, TIME=live estimate). Normalize
+        # here so clients reading either field get the live delayed estimate —
+        # mirrors the max() applied in services/departure.py for /departures.
+        updated_arrival, updated_departure = effective_njt_updated_times(
+            stop, journey.data_source
+        )
         stop_detail = StopDetails(
             station=SimpleStationInfo(
                 code=stop.station_code,
@@ -454,8 +465,8 @@ async def get_train_details(
             stop_sequence=stop.stop_sequence or 0,
             scheduled_arrival=stop.scheduled_arrival,
             scheduled_departure=stop.scheduled_departure,
-            updated_arrival=stop.updated_arrival,
-            updated_departure=stop.updated_departure,
+            updated_arrival=updated_arrival,
+            updated_departure=updated_departure,
             actual_arrival=stop.actual_arrival,
             actual_departure=stop.actual_departure,
             track=stop.track,

--- a/backend_v2/src/trackrat/utils/train.py
+++ b/backend_v2/src/trackrat/utils/train.py
@@ -2,13 +2,14 @@
 Train-related utility functions for TrackRat V2.
 """
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm.base import NO_VALUE
 
 if TYPE_CHECKING:
-    from trackrat.models.database import TrainJourney
+    from trackrat.models.database import JourneyStop, TrainJourney
 
 
 def _stops_loaded(journey: "TrainJourney") -> bool:
@@ -106,6 +107,36 @@ def get_train_data_source(train_id: str) -> str:
         Data source: "AMTRAK" or "NJT" (default fallback)
     """
     return "AMTRAK" if is_amtrak_train(train_id) else "NJT"
+
+
+def effective_njt_updated_times(
+    stop: "JourneyStop", data_source: str | None
+) -> tuple[datetime | None, datetime | None]:
+    """Return ``(updated_arrival, updated_departure)`` with NJT inversion correction.
+
+    NJT's ``TIME`` and ``DEP_TIME`` API fields have inverted semantics at
+    intermediate stops: ``DEP_TIME`` is the original schedule (immutable) while
+    ``TIME`` is the live delayed estimate. The collector persists both as raw
+    passthroughs on ``JourneyStop.updated_departure`` and ``.updated_arrival``,
+    so any client that reads ``updated_departure`` directly at an intermediate
+    NJT stop sees the schedule and thinks the train is on time.
+
+    For NJT records where both fields are populated, this helper returns
+    ``max(updated_arrival, updated_departure)`` for both — the canonical
+    pattern already used by ``services/departure.py`` for the departures
+    endpoint. For all other providers (Amtrak, GTFS-RT, PATH, WMATA) both
+    fields are genuine live estimates that may legitimately differ by the
+    stop's dwell time, so we return them unmodified to preserve that
+    distinction.
+    """
+    if data_source != "NJT":
+        return stop.updated_arrival, stop.updated_departure
+
+    if stop.updated_arrival is not None and stop.updated_departure is not None:
+        latest = max(stop.updated_arrival, stop.updated_departure)
+        return latest, latest
+
+    return stop.updated_arrival, stop.updated_departure
 
 
 def is_njt_stop_cancelled(status: str | None) -> bool:

--- a/backend_v2/tests/unit/test_effective_njt_updated_times.py
+++ b/backend_v2/tests/unit/test_effective_njt_updated_times.py
@@ -1,0 +1,171 @@
+"""Tests for ``effective_njt_updated_times`` — the helper that normalizes NJT's
+inverted ``TIME``/``DEP_TIME`` semantics before they leak to API clients.
+
+Background (regression-protects issue #1268):
+  NJT's intermediate-stop API rows have ``DEP_TIME`` = original schedule and
+  ``TIME`` = live delayed estimate. The collector persists these as raw
+  passthroughs on ``JourneyStop.updated_departure`` / ``.updated_arrival``.
+  Any consumer that reads ``updated_departure`` directly at an intermediate
+  NJT stop sees the schedule and silently shows the train as on-time. The
+  ``/api/v2/trains/{train_id}`` endpoint was guilty of this until the
+  helper here started normalizing the pair before serialization.
+
+The helper is also a deliberate no-op for non-NJT providers — their
+``updated_arrival`` / ``updated_departure`` are distinct live estimates of
+arrival vs. departure at a stop, and conflating them via ``max()`` would
+overwrite the arrival display with the (typically later) departure time.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from trackrat.models.database import JourneyStop
+from trackrat.utils.train import effective_njt_updated_times
+
+# Realistic delayed-train sample times (HH:MM in UTC; ET semantics don't matter
+# for arithmetic but production data is always tz-aware).
+_SCHEDULE = datetime(2026, 6, 4, 21, 30, tzinfo=UTC)
+_LIVE_ESTIMATE = datetime(2026, 6, 4, 21, 50, tzinfo=UTC)  # 20-min delay
+
+
+class TestNJTIntermediateStopInversion:
+    """The bug from issue #1268: intermediate NJT stops should expose the live
+    estimate via both fields, not the schedule via ``updated_departure``."""
+
+    def test_intermediate_stop_with_inversion_returns_live_estimate_on_both_fields(
+        self,
+    ) -> None:
+        stop = JourneyStop(
+            station_code="HB",
+            station_name="Hoboken",
+            updated_arrival=_LIVE_ESTIMATE,  # NJT TIME — actually the live estimate
+            updated_departure=_SCHEDULE,  # NJT DEP_TIME — actually the schedule
+        )
+        arr, dep = effective_njt_updated_times(stop, "NJT")
+        assert arr == _LIVE_ESTIMATE
+        assert dep == _LIVE_ESTIMATE
+        # Sanity: caller should no longer see the schedule when they read
+        # updated_departure — that was the bug.
+        assert dep != _SCHEDULE
+
+    def test_intermediate_stop_when_estimate_lives_in_updated_departure(self) -> None:
+        """Defensive case: production has occasionally shown both orderings
+        as collector bugs were fixed. ``max()`` resolves either direction."""
+        stop = JourneyStop(
+            station_code="HB",
+            station_name="Hoboken",
+            updated_arrival=_SCHEDULE,
+            updated_departure=_LIVE_ESTIMATE,
+        )
+        arr, dep = effective_njt_updated_times(stop, "NJT")
+        assert arr == _LIVE_ESTIMATE
+        assert dep == _LIVE_ESTIMATE
+
+
+class TestNJTEdgeCases:
+    """Cases where only one ``updated_*`` field is populated — origin and
+    terminal stops, plus malformed data — should pass through untouched."""
+
+    def test_origin_stop_only_has_updated_departure(self) -> None:
+        """NJT origin: ``updated_departure`` is the actual departure time and
+        ``updated_arrival`` is None. We must not invent an arrival value."""
+        stop = JourneyStop(
+            station_code="DV",
+            station_name="Dover",
+            updated_arrival=None,
+            updated_departure=_LIVE_ESTIMATE,
+        )
+        arr, dep = effective_njt_updated_times(stop, "NJT")
+        assert arr is None
+        assert dep == _LIVE_ESTIMATE
+
+    def test_terminal_stop_only_has_updated_arrival(self) -> None:
+        """NJT terminal: DEP_TIME isn't published, so ``updated_departure`` is
+        None and ``updated_arrival`` carries the live estimate."""
+        stop = JourneyStop(
+            station_code="HB",
+            station_name="Hoboken",
+            updated_arrival=_LIVE_ESTIMATE,
+            updated_departure=None,
+        )
+        arr, dep = effective_njt_updated_times(stop, "NJT")
+        assert arr == _LIVE_ESTIMATE
+        assert dep is None
+
+    def test_both_fields_none(self) -> None:
+        stop = JourneyStop(
+            station_code="HB",
+            station_name="Hoboken",
+            updated_arrival=None,
+            updated_departure=None,
+        )
+        arr, dep = effective_njt_updated_times(stop, "NJT")
+        assert arr is None
+        assert dep is None
+
+
+class TestNonNJTPassthrough:
+    """For Amtrak / PATH / GTFS-RT / WMATA, ``updated_arrival`` and
+    ``updated_departure`` are distinct live estimates of arrival vs. departure.
+    The helper must preserve that distinction — collapsing them via ``max()``
+    would silently shift the arrival display forward by the dwell time."""
+
+    def test_amtrak_intermediate_stop_keeps_distinct_arrival_and_departure(
+        self,
+    ) -> None:
+        arrival = datetime(2026, 6, 4, 21, 30, tzinfo=UTC)
+        departure = datetime(2026, 6, 4, 21, 31, tzinfo=UTC)  # 1-min dwell
+        stop = JourneyStop(
+            station_code="NYP",
+            station_name="New York Penn",
+            updated_arrival=arrival,
+            updated_departure=departure,
+        )
+        arr, dep = effective_njt_updated_times(stop, "AMTRAK")
+        assert arr == arrival
+        assert dep == departure
+        # Critical: arr is NOT pulled forward to the departure time
+        assert arr != departure
+
+    def test_path_passthrough(self) -> None:
+        arrival = datetime(2026, 6, 4, 21, 30, tzinfo=UTC)
+        departure = datetime(2026, 6, 4, 21, 32, tzinfo=UTC)
+        stop = JourneyStop(
+            station_code="WTC",
+            station_name="World Trade Center",
+            updated_arrival=arrival,
+            updated_departure=departure,
+        )
+        arr, dep = effective_njt_updated_times(stop, "PATH")
+        assert arr == arrival
+        assert dep == departure
+
+    def test_lirr_subway_metro_north_passthrough(self) -> None:
+        # One spot-check is enough — same code path as PATH/AMTRAK; any
+        # non-NJT data_source short-circuits to a raw passthrough.
+        arrival = datetime(2026, 6, 4, 21, 30, tzinfo=UTC)
+        departure = datetime(2026, 6, 4, 21, 31, tzinfo=UTC)
+        stop = JourneyStop(
+            station_code="ABC",
+            station_name="Anywhere",
+            updated_arrival=arrival,
+            updated_departure=departure,
+        )
+        for source in ("LIRR", "MNR", "SUBWAY", "BART", "MBTA", "METRA", "WMATA"):
+            arr, dep = effective_njt_updated_times(stop, source)
+            assert arr == arrival, f"{source} arrival was rewritten"
+            assert dep == departure, f"{source} departure was rewritten"
+
+    def test_none_data_source_treated_as_non_njt(self) -> None:
+        """Defensive: a missing data_source should not silently apply the NJT
+        inversion fix to arbitrary records."""
+        stop = JourneyStop(
+            station_code="HB",
+            station_name="Hoboken",
+            updated_arrival=_LIVE_ESTIMATE,
+            updated_departure=_SCHEDULE,
+        )
+        arr, dep = effective_njt_updated_times(stop, None)
+        assert arr == _LIVE_ESTIMATE
+        assert dep == _SCHEDULE  # untouched


### PR DESCRIPTION
## Summary

Closes #1268.

NJT's `TIME` and `DEP_TIME` API fields have **inverted semantics at intermediate stops**: `DEP_TIME` is the immutable schedule and `TIME` is the live delayed estimate. The collector persists both as raw passthroughs on `JourneyStop.updated_departure` / `updated_arrival`.

`services/departure.py` already applies `max(updated_departure, updated_arrival)` before serving `/departures`, but `api/trains.py` was passing the raw fields straight through on `/api/v2/trains/{train_id}`. iOS reads `stop.updatedDeparture` in several places (`StopV2.delayMinutes`, `adaptV2TrainDetailsToTrainV2`, `getEstimatedDepartureTime`), so for a delayed NJT train at an intermediate stop, the user's `train_details` screen showed the schedule and computed a delay of 0 — exactly the report ("It says delayed, but it doesn't say when").

The fix lives server-side so iOS, Android, and web all benefit without per-client patches.

## Changes

- **`backend_v2/src/trackrat/utils/train.py`** — new `effective_njt_updated_times(stop, data_source)` helper. For NJT records where both `updated_arrival` and `updated_departure` are populated, returns `max(...)` on both fields so downstream consumers see the live delayed estimate via either accessor. For non-NJT providers (Amtrak, GTFS-RT, PATH, WMATA), it's a deliberate raw passthrough — those providers' two fields are distinct live estimates of arrival vs. departure and conflating them would shift the displayed arrival time forward by the dwell.
- **`backend_v2/src/trackrat/api/trains.py`** — call the helper when building `StopDetails`, mirroring the canonical pattern already used by `services/departure.py`.
- **`backend_v2/tests/unit/test_effective_njt_updated_times.py`** — 9 unit tests covering: the inversion fix at intermediate stops (both orderings of which field holds the live value), origin / terminal / null edge cases, and pass-through for AMTRAK / PATH / LIRR / MNR / SUBWAY / BART / MBTA / METRA / WMATA plus a `data_source=None` defensive case.

## Test coverage

- All 9 new unit tests pass.
- Existing `tests/unit/api/test_share.py` pure-function tests pass (2 DB-backed share tests fail with `ConnectionRefusedError` on port 5434 — pre-existing infra gap, unrelated to this change).
- `tests/unit/collectors/njt/test_cancellation_detection.py` and `tests/unit/collectors/njt/test_journey_data_quality.py` pass — confirms the `utils.train` module still imports cleanly for collector code paths.
- `ruff check`, `black --check`, and `mypy` all clean on the changed files.

## Design decisions

- **Why server-side, not iOS**: the docstring in `database.py` says "consumers must use `max(...)`", but that contract has been enforced inconsistently — `services/departure.py` and `api/share.py` apply it; `api/trains.py` forgot to; iOS forgot to at four call sites. Fixing on the server closes the leaky abstraction once for all clients.
- **Why NJT-only, not blanket `max()`**: Amtrak / GTFS-RT / WMATA distinguish arrival and departure estimates at intermediate stops (a few seconds to a minute apart). Applying `max()` to those would silently overwrite the arrival display with the departure time.
- **Why both fields rather than introducing a new effective field**: minimizes API surface change. iOS's existing `StopV2` decoder, `StopV2.delayMinutes`, `adaptV2TrainDetailsToTrainV2`, and `TrainDetailsView` all start returning correct values with no client release needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8T9h7s55CVHxQ1hKjEVz4)_