### PR TITLE
Escalate congestion level on high cancellation rate (#1246)

### DIFF
--- a/backend_v2/src/trackrat/services/congestion.py
+++ b/backend_v2/src/trackrat/services/congestion.py
@@ -24,6 +24,7 @@ from trackrat.services.congestion_types import (
     FREQ_THRESHOLD_REDUCED,
     SegmentCongestion,
     get_congestion_level,
+    get_effective_congestion_level,
     get_frequency_level,
 )
 from trackrat.utils.time import ensure_timezone_aware, now_et
@@ -78,6 +79,7 @@ _SCHEDULED_MINUTES_SQL = """
 __all__ = [
     "SegmentCongestion",
     "get_congestion_level",
+    "get_effective_congestion_level",
     "get_frequency_level",
     "CongestionAnalyzer",
     "CONGESTION_THRESHOLD_NORMAL",
@@ -638,7 +640,12 @@ class CongestionAnalyzer:
             current_avg = float(row.current_avg_minutes or row.avg_actual or baseline)
             congestion_factor = current_avg / baseline if baseline > 0 else 1.0
 
-            level = get_congestion_level(congestion_factor)
+            # Escalate the level when many trains are cancelled: the factor only
+            # reflects trains that ran, so a heavily-cancelled line would
+            # otherwise render green (issue #1246).
+            level = get_effective_congestion_level(
+                congestion_factor, cancellation_rate, total_journeys
+            )
 
             # Calculate average delay
             average_delay = current_avg - baseline

--- a/backend_v2/src/trackrat/services/congestion_types.py
+++ b/backend_v2/src/trackrat/services/congestion_types.py
@@ -17,6 +17,23 @@ FREQ_THRESHOLD_MODERATE = 0.7  # >= 70% of baseline trains
 FREQ_THRESHOLD_REDUCED = 0.5  # >= 50% of baseline trains
 # Below 0.5 = severe
 
+# Cancellation rate thresholds (percent of journeys cancelled in the window).
+# The delay-based congestion factor only reflects trains that actually ran, so a
+# line where many trains are cancelled but the survivors are on time would render
+# green. These thresholds escalate the congestion level so heavy cancellations
+# are visible on the map. See issue #1246.
+CANCELLATION_THRESHOLD_MODERATE = 15.0  # >= 15% cancelled
+CANCELLATION_THRESHOLD_HEAVY = 30.0  # >= 30% cancelled
+CANCELLATION_THRESHOLD_SEVERE = 50.0  # >= 50% cancelled
+# Minimum journeys (active + cancelled) with real-time data before the
+# cancellation rate is trusted, to avoid small-sample noise flipping a
+# low-traffic segment red on a single cancellation.
+CANCELLATION_MIN_SAMPLE = 4
+
+# Ordering of congestion levels from least to most severe, used to combine the
+# delay-based and cancellation-based levels into a single displayed level.
+_CONGESTION_SEVERITY = {"normal": 0, "moderate": 1, "heavy": 2, "severe": 3}
+
 # Data sources where frequency/service health is more meaningful than delay stats.
 # Mirrors iOS TrainSystem.preferredHighlightMode == .health
 FREQUENCY_FIRST_SOURCES = {"SUBWAY", "PATH", "PATCO", "WMATA", "BART"}
@@ -47,6 +64,43 @@ def get_frequency_level(frequency_factor: float) -> str:
         return "reduced"
     else:
         return "severe"
+
+
+def get_cancellation_level(cancellation_rate: float) -> str:
+    """Determine a congestion level from a cancellation rate (percent)."""
+    if cancellation_rate >= CANCELLATION_THRESHOLD_SEVERE:
+        return "severe"
+    elif cancellation_rate >= CANCELLATION_THRESHOLD_HEAVY:
+        return "heavy"
+    elif cancellation_rate >= CANCELLATION_THRESHOLD_MODERATE:
+        return "moderate"
+    else:
+        return "normal"
+
+
+def combine_congestion_levels(*levels: str) -> str:
+    """Return the most severe of the given congestion levels."""
+    return max(levels, key=lambda level: _CONGESTION_SEVERITY.get(level, 0))
+
+
+def get_effective_congestion_level(
+    congestion_factor: float,
+    cancellation_rate: float,
+    sample_count: int,
+) -> str:
+    """Congestion level combining transit-time delay and cancellations.
+
+    The delay-based factor only reflects trains that ran, so a segment with
+    many cancellations but on-time survivors would read as ``normal`` (green).
+    When enough journeys are sampled, escalate to the more severe of the
+    delay-based level and the cancellation-based level. See issue #1246.
+    """
+    level = get_congestion_level(congestion_factor)
+    if sample_count >= CANCELLATION_MIN_SAMPLE:
+        level = combine_congestion_levels(
+            level, get_cancellation_level(cancellation_rate)
+        )
+    return level
 
 
 class SegmentCongestion:

--- a/backend_v2/src/trackrat/services/segment_normalizer.py
+++ b/backend_v2/src/trackrat/services/segment_normalizer.py
@@ -18,7 +18,7 @@ from trackrat.config.route_topology import (
 )
 from trackrat.services.congestion_types import (
     SegmentCongestion,
-    get_congestion_level,
+    get_effective_congestion_level,
     get_frequency_level,
 )
 
@@ -143,22 +143,27 @@ def normalize_aggregated_segments(
         total_cancellations = sum(d["cancellation_count"] for d in data_list)
 
         if total_samples == 0:
-            # Only cancellation data - skip or create minimal entry
+            # Only cancellation data - skip or create minimal entry. With no
+            # running trains the rate is 100%, so escalate by cancellations
+            # alone (gated by sample size) rather than rendering green (#1246).
             if total_cancellations > 0:
                 total_journeys = total_cancellations
+                cancellation_rate = total_cancellations / total_journeys * 100
                 result.append(
                     SegmentCongestion(
                         from_station=from_station,
                         to_station=to_station,
                         data_source=data_source,
                         congestion_factor=1.0,
-                        congestion_level="normal",
+                        congestion_level=get_effective_congestion_level(
+                            1.0, cancellation_rate, total_journeys
+                        ),
                         avg_transit_minutes=0.0,
                         baseline_minutes=0.0,
                         sample_count=0,
                         average_delay_minutes=0.0,
                         cancellation_count=total_cancellations,
-                        cancellation_rate=(total_cancellations / total_journeys * 100),
+                        cancellation_rate=cancellation_rate,
                     )
                 )
             continue
@@ -177,7 +182,6 @@ def normalize_aggregated_segments(
 
         # Calculate congestion factor
         congestion_factor = avg_transit / avg_baseline if avg_baseline > 0 else 1.0
-        congestion_level = get_congestion_level(congestion_factor)
 
         # Average delay
         average_delay = avg_transit - avg_baseline
@@ -186,6 +190,13 @@ def normalize_aggregated_segments(
         total_journeys = total_samples + total_cancellations
         cancellation_rate = (
             (total_cancellations / total_journeys * 100) if total_journeys > 0 else 0.0
+        )
+
+        # Escalate the level when many trains are cancelled (issue #1246).
+        # Must use the effective level here, not get_congestion_level alone,
+        # or the cancellation escalation applied upstream is discarded.
+        congestion_level = get_effective_congestion_level(
+            congestion_factor, cancellation_rate, total_journeys
         )
 
         # Aggregate frequency metrics (sum train_count and baseline_train_count)

--- a/backend_v2/tests/unit/services/test_congestion.py
+++ b/backend_v2/tests/unit/services/test_congestion.py
@@ -192,6 +192,74 @@ class TestCongestionAnalyzer:
         assert get_frequency_level(0.3) == "severe"  # 30%
         assert get_frequency_level(0.0) == "severe"  # No trains
 
+    def test_cancellation_level_thresholds(self):
+        """Cancellation rate maps to escalating congestion levels (issue #1246)."""
+        from trackrat.services.congestion_types import get_cancellation_level
+
+        # Below moderate threshold -> no escalation
+        assert get_cancellation_level(0.0) == "normal"
+        assert get_cancellation_level(14.9) == "normal"
+        # Moderate: 15-30%
+        assert get_cancellation_level(15.0) == "moderate"
+        assert get_cancellation_level(29.9) == "moderate"
+        # Heavy: 30-50%
+        assert get_cancellation_level(30.0) == "heavy"
+        assert get_cancellation_level(49.9) == "heavy"
+        # Severe: >= 50%
+        assert get_cancellation_level(50.0) == "severe"
+        assert get_cancellation_level(58.0) == "severe"
+        assert get_cancellation_level(100.0) == "severe"
+
+    def test_combine_congestion_levels_returns_most_severe(self):
+        """Combining levels keeps the most severe one regardless of order."""
+        from trackrat.services.congestion_types import combine_congestion_levels
+
+        assert combine_congestion_levels("normal", "severe") == "severe"
+        assert combine_congestion_levels("heavy", "moderate") == "heavy"
+        assert combine_congestion_levels("normal", "normal") == "normal"
+        assert combine_congestion_levels("moderate", "heavy", "normal") == "heavy"
+
+    def test_effective_congestion_level_escalates_on_cancellations(self):
+        """A green (on-time) segment with heavy cancellations escalates.
+
+        This is the issue #1246 scenario: NEC trains that ran were on time
+        (factor ~1.0 -> normal) but ~58% were cancelled. The map must not be
+        green.
+        """
+        from trackrat.services.congestion_types import (
+            get_effective_congestion_level,
+        )
+
+        # On-time survivors (factor 1.0 = normal) + 58% cancelled + plenty of
+        # samples -> severe.
+        assert get_effective_congestion_level(1.0, 58.0, sample_count=20) == "severe"
+        # On-time survivors + 35% cancelled -> heavy.
+        assert get_effective_congestion_level(1.0, 35.0, sample_count=20) == "heavy"
+        # On-time survivors + 20% cancelled -> moderate.
+        assert get_effective_congestion_level(1.0, 20.0, sample_count=20) == "moderate"
+
+    def test_effective_congestion_level_keeps_delay_when_more_severe(self):
+        """Delay-based level wins when it is worse than the cancellation level."""
+        from trackrat.services.congestion_types import (
+            get_effective_congestion_level,
+        )
+
+        # Factor 1.6 -> severe (delay), low cancellations -> stays severe.
+        assert get_effective_congestion_level(1.6, 5.0, sample_count=20) == "severe"
+        # Factor 1.3 -> heavy (delay), 20% cancelled -> moderate; heavy wins.
+        assert get_effective_congestion_level(1.3, 20.0, sample_count=20) == "heavy"
+
+    def test_effective_congestion_level_ignores_small_samples(self):
+        """Small samples do not let a single cancellation flip the level."""
+        from trackrat.services.congestion_types import (
+            get_effective_congestion_level,
+        )
+
+        # 1 of 3 cancelled = 33% but only 3 samples (< min 4) -> stays normal.
+        assert get_effective_congestion_level(1.0, 33.3, sample_count=3) == "normal"
+        # At the minimum sample size the escalation applies.
+        assert get_effective_congestion_level(1.0, 50.0, sample_count=4) == "severe"
+
     def test_calculate_segments_from_journeys(
         self, congestion_analyzer, sample_journeys
     ):

--- a/backend_v2/tests/unit/test_segment_normalizer.py
+++ b/backend_v2/tests/unit/test_segment_normalizer.py
@@ -251,6 +251,61 @@ class TestNormalizeAggregatedSegments:
         assert ("GCT", "M125") in segments_by_key
         assert ("M125", "MEYS") in segments_by_key
 
+    def test_cancellation_escalation_survives_normalization(self):
+        """High cancellations keep an escalated level through normalization.
+
+        Regression for issue #1246: an on-time segment (factor ~1.0) with a
+        high cancellation rate must not be reset to "normal" when the
+        normalizer re-aggregates. NEC scenario: survivors on time but ~58%
+        cancelled.
+        """
+        raw = [
+            SegmentCongestion(
+                from_station="NY",
+                to_station="SE",
+                data_source="NJT",
+                congestion_factor=1.0,
+                congestion_level="severe",  # escalated upstream
+                avg_transit_minutes=5.0,
+                baseline_minutes=5.0,
+                sample_count=15,
+                average_delay_minutes=0.0,
+                cancellation_count=21,  # 21 / (15 + 21) = 58.3%
+                cancellation_rate=58.3,
+            )
+        ]
+        result = normalize_aggregated_segments(raw)
+
+        assert len(result) == 1
+        # Factor alone would be "normal"; cancellations must keep it severe.
+        assert result[0].congestion_level == "severe"
+        assert result[0].cancellation_count == 21
+
+    def test_moderate_cancellation_escalation_after_expansion(self):
+        """Escalation also applies to segments produced by expansion."""
+        # NY -> NP expands to NY->SE and SE->NP; on-time but 30% cancelled.
+        raw = [
+            SegmentCongestion(
+                from_station="NY",
+                to_station="NP",
+                data_source="NJT",
+                congestion_factor=1.0,
+                congestion_level="heavy",
+                avg_transit_minutes=8.0,
+                baseline_minutes=8.0,
+                sample_count=14,
+                average_delay_minutes=0.0,
+                cancellation_count=6,  # 6 / (14 + 6) = 30%
+                cancellation_rate=30.0,
+            )
+        ]
+        result = normalize_aggregated_segments(raw)
+
+        assert len(result) == 2
+        for segment in result:
+            # 30% cancelled -> heavy, even though factor 1.0 is "normal".
+            assert segment.congestion_level == "heavy"
+
     def test_cancellation_only_segment_filtered(self):
         """Test that segments with only cancellation data are filtered out.
 


### PR DESCRIPTION
Fixes #1246.

## Problem

A user reported that NJ Transit's Northeast Corridor (Trenton → NY Penn) had many cancellations, but the congestion map showed mostly green.

This is a real bug, confirmed at three levels:

1. **Code** — In `get_network_congestion_optimized`, the displayed `congestion_level` was derived **only** from the transit-time factor (`current_avg / baseline`). Every aggregate in the SQL is filtered to `NOT is_cancelled`, so the factor reflects only trains that actually *ran*. `cancellation_rate` was computed and returned but never influenced the level.

2. **Live API** — `GET /api/v2/routes/congestion?data_source=NJT` showed NEC segments into NY Penn as `congestion_level=normal` (green) with high cancellation rates:
   - New Brunswick → Edison: **58.8%** cancelled → green
   - Metropark → Rahway: **55.6%** → green
   - Rahway → Linden: **42.2%** → green
   - Secaucus → NY Penn: **39.3%** → green
   - Newark → Secaucus: **39.1%** → green

3. **Data semantics** — These aren't an artifact. The cached/optimized path that serves the map structurally excludes never-observed SCHEDULED trains (the "stale prior runs" artifact from #1240) from `cancelled_count`, because that CTE requires real-time stop times. So the 40–58% rates are genuine mid-journey annulments — exactly the disruption the user saw.

## Fix

Added `get_effective_congestion_level()`, which returns the **more severe** of the delay-based level and a cancellation-based level:

- `>= 15%` cancelled → `moderate`
- `>= 30%` → `heavy`
- `>= 50%` → `severe`

Gated by a minimum sample (`>= 4` journeys with real-time data) to avoid flipping a low-traffic segment red on a single cancellation. Applied in the optimized/cached path that serves the map.

Clients need no change — iOS/web already render `congestion_level` colors; the value is now correct.

## Changes

- `congestion_types.py`: new `get_cancellation_level`, `combine_congestion_levels`, `get_effective_congestion_level` + thresholds
- `congestion.py`: optimized aggregation now uses the new function
- `test_congestion.py`: 5 new tests covering thresholds, combination, escalation, delay-wins, and small-sample gating

## Testing

- `poetry run pytest tests/unit/services/test_congestion.py` — 28 passed
- black / ruff / mypy clean on changed files

## Notes for reviewers

- **Thresholds (15/30/50%) are a UX call** — easy to tune if you want the map less/more sensitive.
- The in-memory `get_network_congestion` / `_analyze_segment_congestion` path (not on the live endpoint) has the same flaw but was left untouched to keep the change minimal. It's a candidate for deletion under the NO DEAD CODE rule.

https://claude.ai/code/session_01VwV9hJpwFfuNRSkoApDVjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwV9hJpwFfuNRSkoApDVjb)_