### PR TITLE
Issue #1269: Add retention sweep for inactive service_alerts

### DIFF
--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2573,7 +2573,8 @@ class SchedulerService:
         Deletes train_journeys older than retention_days (cascading to
         journey_stops, journey_snapshots, journey_progress,
         segment_transit_times, station_dwell_times via ON DELETE CASCADE).
-        Also prunes discovery_runs and validation_results.
+        Also prunes discovery_runs, validation_results, and inactive
+        service_alerts that haven't been refreshed by the collector.
         """
         settings = get_settings()
         cutoff_days = settings.retention_days
@@ -2583,6 +2584,7 @@ class SchedulerService:
             total_journeys = 0
             total_discovery = 0
             total_validation = 0
+            total_service_alerts = 0
 
             try:
                 logger.info(
@@ -2656,12 +2658,40 @@ class SchedulerService:
                     if deleted < batch_size:
                         break
 
+                # Phase 4: Delete old inactive service_alerts in batches.
+                # Active alerts are kept regardless of age — the collector
+                # marks alerts inactive when they disappear from the feed,
+                # so this prunes long-resolved alerts the collector has
+                # stopped refreshing.
+                while True:
+                    async with get_session() as db:
+                        result = cast(
+                            CursorResult[tuple[()]],
+                            await db.execute(
+                                text(
+                                    "DELETE FROM service_alerts "
+                                    "WHERE id IN ("
+                                    "  SELECT id FROM service_alerts "
+                                    "  WHERE is_active = false "
+                                    "    AND updated_at < NOW() - make_interval(days => :days) "
+                                    "  LIMIT :batch_size"
+                                    ")"
+                                ),
+                                {"days": cutoff_days, "batch_size": batch_size},
+                            ),
+                        )
+                        deleted = result.rowcount or 0
+                    total_service_alerts += deleted
+                    if deleted < batch_size:
+                        break
+
                 logger.info(
                     "retention_cleanup_completed",
                     cutoff_days=cutoff_days,
                     journeys_deleted=total_journeys,
                     discovery_runs_deleted=total_discovery,
                     validation_results_deleted=total_validation,
+                    service_alerts_deleted=total_service_alerts,
                 )
 
             except Exception as e:
@@ -2672,6 +2702,7 @@ class SchedulerService:
                     journeys_deleted_so_far=total_journeys,
                     discovery_runs_deleted_so_far=total_discovery,
                     validation_results_deleted_so_far=total_validation,
+                    service_alerts_deleted_so_far=total_service_alerts,
                 )
 
         async with get_session() as db:

--- a/backend_v2/tests/unit/test_retention_cleanup.py
+++ b/backend_v2/tests/unit/test_retention_cleanup.py
@@ -110,6 +110,7 @@ class TestRetentionCleanupBatchLogic:
             Mock(rowcount=500),  # journey batch
             Mock(rowcount=100),  # discovery batch
             Mock(rowcount=50),  # validation batch
+            Mock(rowcount=25),  # service_alerts batch
         ]
 
         freshness_session = AsyncMock()
@@ -169,6 +170,7 @@ class TestRetentionCleanupBatchLogic:
             Mock(rowcount=500),  # journey batch 2
             Mock(rowcount=0),  # discovery batch
             Mock(rowcount=0),  # validation batch
+            Mock(rowcount=0),  # service_alerts batch
         ]
 
         freshness_session = AsyncMock()
@@ -212,8 +214,9 @@ class TestRetentionCleanupBatchLogic:
 
             await service.retention_cleanup()
 
-            # 1 freshness + 2 journey batches + 1 discovery + 1 validation = 5 sessions
-            assert mock_get_session.call_count == 5
+            # 1 freshness + 2 journey batches + 1 discovery + 1 validation
+            # + 1 service_alerts = 6 sessions
+            assert mock_get_session.call_count == 6
 
     @pytest.mark.asyncio
     async def test_cleanup_skipped_when_still_fresh(self, mock_settings):
@@ -291,14 +294,14 @@ class TestRetentionCleanupBatchLogic:
 
             mock_freshness.side_effect = execute_task_func
 
-            # First call = freshness, then 3 batch sessions (one per table)
+            # First call = freshness, then 4 batch sessions (one per table)
             ctxs = []
             ctx_fresh = AsyncMock()
             ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
             ctx_fresh.__aexit__ = AsyncMock(return_value=False)
             ctxs.append(ctx_fresh)
 
-            for _ in range(3):
+            for _ in range(4):
                 ctx = AsyncMock()
                 ctx.__aenter__ = AsyncMock(return_value=make_capture_session())
                 ctx.__aexit__ = AsyncMock(return_value=False)
@@ -308,8 +311,8 @@ class TestRetentionCleanupBatchLogic:
 
             await service.retention_cleanup()
 
-            # All three DELETE calls should use days=90
-            assert len(executed_params) == 3
+            # All four DELETE calls should use days=90
+            assert len(executed_params) == 4
             for params in executed_params:
                 assert params["days"] == 90
                 assert params["batch_size"] == 1000
@@ -394,14 +397,26 @@ class TestRetentionCleanupSQLStatements:
         source = inspect.getsource(SchedulerService.retention_cleanup)
         assert "DELETE FROM validation_results" in source
 
+    def test_cleanup_targets_inactive_service_alerts(self):
+        """The service_alerts DELETE should only prune inactive rows by updated_at."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert "DELETE FROM service_alerts" in source
+        # Must gate on is_active=false so currently active alerts are preserved
+        assert "is_active = false" in source
+        # Must filter on updated_at so collector-refreshed alerts stay
+        assert "updated_at < NOW()" in source
+
     def test_cleanup_uses_batch_limit(self):
         """All DELETE statements should use LIMIT for batching."""
         from trackrat.services.scheduler import SchedulerService
         import inspect
 
         source = inspect.getsource(SchedulerService.retention_cleanup)
-        # Should have 3 LIMIT clauses (one per table)
-        assert source.count("LIMIT :batch_size") == 3
+        # Should have 4 LIMIT clauses (one per table)
+        assert source.count("LIMIT :batch_size") == 4
 
     def test_cleanup_uses_subquery_pattern(self):
         """DELETEs should use id IN (SELECT id ... LIMIT) for efficient batching."""
@@ -409,7 +424,7 @@ class TestRetentionCleanupSQLStatements:
         import inspect
 
         source = inspect.getsource(SchedulerService.retention_cleanup)
-        assert source.count("WHERE id IN (") == 3
+        assert source.count("WHERE id IN (") == 4
 
     def test_cascade_covers_all_dependent_tables(self):
         """All TrainJourney child tables should have ON DELETE CASCADE FKs."""
@@ -467,3 +482,281 @@ class TestRetentionCleanupFreshnessCheck:
 
         source = inspect.getsource(SchedulerService.retention_cleanup)
         assert 'task_name="retention_cleanup"' in source
+
+
+class TestServiceAlertsRetention:
+    """Test that the new service_alerts retention phase behaves correctly."""
+
+    @pytest.fixture
+    def mock_settings(self):
+        settings = Mock()
+        settings.retention_days = 120
+        return settings
+
+    @pytest.mark.asyncio
+    async def test_service_alerts_batch_runs_to_completion(self, mock_settings):
+        """service_alerts deletion should loop until a partial batch returns."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        # journey/discovery/validation each return empty in one batch.
+        # service_alerts: 1000 then 1000 then 200 (partial, stops loop).
+        execute_results = [
+            Mock(rowcount=0),  # journey
+            Mock(rowcount=0),  # discovery
+            Mock(rowcount=0),  # validation
+            Mock(rowcount=1000),  # service_alerts batch 1 (full)
+            Mock(rowcount=1000),  # service_alerts batch 2 (full)
+            Mock(rowcount=200),  # service_alerts batch 3 (partial)
+        ]
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch(
+                "trackrat.services.scheduler.get_settings", return_value=mock_settings
+            ),
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+        ):
+
+            async def execute_task_func(
+                db, task_name, minimum_interval_seconds, task_func
+            ):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for result in execute_results:
+                s = AsyncMock()
+                s.execute = AsyncMock(return_value=result)
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=s)
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            # 1 freshness + 1 journey + 1 discovery + 1 validation
+            # + 3 service_alerts = 7 sessions
+            assert mock_get_session.call_count == 7
+
+    @pytest.mark.asyncio
+    async def test_service_alerts_delete_passes_correct_params(self, mock_settings):
+        """The service_alerts DELETE should receive the same days/batch_size args."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        executed_statements: list[str] = []
+        executed_params: list[dict] = []
+
+        empty_result = Mock(rowcount=0)
+
+        def make_capture_session():
+            session = AsyncMock()
+
+            async def capture_execute(stmt, params=None):
+                executed_statements.append(str(stmt))
+                if params:
+                    executed_params.append(dict(params))
+                return empty_result
+
+            session.execute = AsyncMock(side_effect=capture_execute)
+            return session
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch(
+                "trackrat.services.scheduler.get_settings", return_value=mock_settings
+            ),
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+        ):
+
+            async def execute_task_func(
+                db, task_name, minimum_interval_seconds, task_func
+            ):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for _ in range(4):
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=make_capture_session())
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            # 4 statements expected, one per table — service_alerts is last.
+            assert len(executed_statements) == 4
+            assert "service_alerts" in executed_statements[-1]
+            assert "is_active = false" in executed_statements[-1]
+            assert "updated_at < NOW()" in executed_statements[-1]
+
+            # Every DELETE shares the same days + batch_size parameters.
+            assert len(executed_params) == 4
+            for params in executed_params:
+                assert params["days"] == 120
+                assert params["batch_size"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_completion_log_includes_service_alerts_count(self, mock_settings):
+        """The success log should report service_alerts_deleted."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        execute_results = [
+            Mock(rowcount=0),  # journey
+            Mock(rowcount=0),  # discovery
+            Mock(rowcount=0),  # validation
+            Mock(rowcount=42),  # service_alerts (partial in single batch)
+        ]
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch(
+                "trackrat.services.scheduler.get_settings", return_value=mock_settings
+            ),
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+            patch("trackrat.services.scheduler.logger") as mock_logger,
+        ):
+
+            async def execute_task_func(
+                db, task_name, minimum_interval_seconds, task_func
+            ):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for result in execute_results:
+                s = AsyncMock()
+                s.execute = AsyncMock(return_value=result)
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=s)
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            completion_calls = [
+                c
+                for c in mock_logger.info.call_args_list
+                if c.args and c.args[0] == "retention_cleanup_completed"
+            ]
+            assert len(completion_calls) == 1
+            kwargs = completion_calls[0].kwargs
+            assert kwargs["service_alerts_deleted"] == 42
+            assert kwargs["journeys_deleted"] == 0
+            assert kwargs["discovery_runs_deleted"] == 0
+            assert kwargs["validation_results_deleted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_failure_log_includes_service_alerts_so_far(self, mock_settings):
+        """If service_alerts DELETE raises, the partial count should be logged."""
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        # journey + discovery + validation succeed empty; service_alerts errors.
+        ok_result = Mock(rowcount=0)
+
+        call_idx = {"n": 0}
+
+        def make_session():
+            session = AsyncMock()
+
+            async def execute(stmt, params=None):
+                call_idx["n"] += 1
+                if call_idx["n"] == 4:  # 4th call is service_alerts
+                    raise RuntimeError("connection lost")
+                return ok_result
+
+            session.execute = AsyncMock(side_effect=execute)
+            return session
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch(
+                "trackrat.services.scheduler.get_settings", return_value=mock_settings
+            ),
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+            patch("trackrat.services.scheduler.logger") as mock_logger,
+        ):
+
+            async def execute_task_func(
+                db, task_name, minimum_interval_seconds, task_func
+            ):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for _ in range(4):
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=make_session())
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+            failure_calls = [
+                c
+                for c in mock_logger.error.call_args_list
+                if c.args and c.args[0] == "retention_cleanup_failed"
+            ]
+            assert len(failure_calls) == 1
+            kwargs = failure_calls[0].kwargs
+            assert "service_alerts_deleted_so_far" in kwargs
+            assert kwargs["service_alerts_deleted_so_far"] == 0


### PR DESCRIPTION
## Summary

The 2026-06-04 production health check (#1269) surfaced a Cloud SQL `DiskFullError` cascade. The triage comment identified `service_alerts` as one of the disk-growth culprits: it was upserted in place with **no retention at all**, so inactive alerts accumulated forever even after the collector stopped refreshing them.

This PR extends the daily `retention_cleanup` job with a 4th phase that batch-deletes inactive `service_alerts` older than `retention_days`. It mirrors the existing phases for `train_journeys`, `discovery_runs`, and `validation_results` exactly — same batching pattern, same param shape, same logging structure.

Cloud SQL disk allocation is still the immediate ops fix; this is the long-term code-side mitigation called out in the triage.

## Files changed

- `backend_v2/src/trackrat/services/scheduler.py`
  - New Phase 4 in `retention_cleanup`: batch DELETE of `service_alerts` where `is_active = false AND updated_at < NOW() - days`. Active alerts (currently-affecting riders) are preserved regardless of age. `updated_at` is touched by the collector on every sweep, so anything still in the live feed is never pruned.
  - Success log gains `service_alerts_deleted`; failure log gains `service_alerts_deleted_so_far` for partial-progress visibility.

- `backend_v2/tests/unit/test_retention_cleanup.py`
  - Updates existing batch-count assertions from 3 tables to 4.
  - Adds `test_cleanup_targets_inactive_service_alerts` to lock in the `is_active = false` + `updated_at < NOW()` gating.
  - Adds `TestServiceAlertsRetention` class with 4 new tests covering batching to completion, parameter passing, success-log payload, and failure-log payload.

## Test coverage

```
poetry run pytest tests/unit/test_retention_cleanup.py -v
26 passed in 0.40s

poetry run pytest tests/unit/services/test_scheduler.py -v
29 passed in 0.39s
```

`poetry run ruff check` and `poetry run black --check` both clean.

## Design notes

- **Why gate on `is_active = false`?** Active alerts are still being delivered to subscribed users — pruning them on age alone would drop ongoing planned-work notifications. The collector clears `is_active` only when an alert disappears from the GTFS-RT feed.
- **Why `updated_at` rather than `created_at`?** The collector upserts and bumps `updated_at` whenever the alert reappears in the feed. Filtering on `updated_at` means an alert briefly toggling inactive (e.g., feed glitch) doesn't fall off the retention edge if the collector refreshes it later.
- **Why the same `retention_days` knob?** Reusing the existing setting keeps operator surface area minimal and matches the issue triage's "lower retention default" suggestion — operators can tune all four tables in one place.
- **Scope**: This PR only addresses the `service_alerts` retention gap. The triage comment lists three other code-level follow-ups (periodic `VACUUM`, lower retention default, disk-pressure backpressure); those are intentionally out of scope here to keep the change reviewable.

Closes #1269

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uv6Bj7t6rLri5QzXopwvqA)_