### PR TITLE
docs: weekly audit - May 2026 late-month backend changes

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This guide provides comprehensive information for Claude Code when working with the TrackRat Backend V2, a radical simplification of the train tracking system that reduces API calls by ~95% while maintaining production robustness.
 
-**Last Updated:** April 2026
+**Last Updated:** May 2026
 **Database:** PostgreSQL with asyncpg (production-ready)
 **Key Features:** Multi-transit support (NJT, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, WMATA), track/delay predictions, route alerts, API caching, schedule generation, GTFS integration
 
@@ -780,6 +780,10 @@ The backend is organized into service classes for better maintainability:
 - ✅ Trip search surfaces PATH trains from Newark Penn Station (`services/trip_search.py`)
 - ✅ Merge Hoboken / Hoboken PATH into one canonical station; PHO/PNK resolve to canonical (`config/stations/common.py`)
 - ✅ Service alert evaluator: fix merged Hoboken PATH alerts (`services/alert_evaluator.py`)
+- ✅ Add ALB (Albany-Rensselaer) to Amtrak `DISCOVERY_HUBS` so post-NYP Empire / Adirondack / Maple Leaf / Ethan Allen / Lake Shore Limited trains aren't silently dropped from discovery (issue #1230, `collectors/amtrak/discovery.py`)
+- ✅ Trip search: short-circuit `_has_shared_line` for same-line pairs, expand subway-only systems via `other_code` to fix cross-modal pairs like TR↔S128, and fall back to `best(departure) + FALLBACK_TRANSIT_MINUTES` for subway legs with null intermediate arrivals (issue #1231 + PR #1235 codex follow-up, `services/trip_search.py`)
+- ✅ NJT cross-day reused-train-id handling: classify whole-service-day displacement (>6h, prior-day row) as `JourneyMatchResult.STALE_PRIOR_RUN` and finalize the row instead of re-polling every cycle (issues #1238 / #1240, `collectors/njt/journey.py`)
+- ✅ Postgres `/dev/shm` raised to 1GB and `max_parallel_workers_per_gather=1` on the db service to fix asyncpg `DiskFullError` on `predict_track` / `operations_summary` / route alert evaluation under concurrent parallel queries (issue #1232, `backend_v2/docker-compose.yml`)
 
 ### Recent Improvements (April 2026)
 - ✅ Intra-system transfers for PATH, BART, NJT, LIRR, MBTA, Metra trip search


### PR DESCRIPTION
## Summary

Weekly docs audit. Backend `CLAUDE.md` had not been touched since PR #1239 (May 18), but four issues landed between May 24–25 that affect documented behavior. This PR backfills them and bumps the "Last Updated" header.

Added to `backend_v2/CLAUDE.md` → Recent Improvements (May 2026):

- **#1230** — Add `ALB` (Albany-Rensselaer) to Amtrak `DISCOVERY_HUBS`. Post-NYP Empire / Adirondack / Maple Leaf / Ethan Allen / Lake Shore Limited trains were being silently dropped from discovery because the Amtraker `/v3/trains` feed trims passed stops.
- **#1231 + PR #1235 codex follow-up** — Trip-search fixes: `_has_shared_line` same-line shortcut, `_systems_for_station` `other_code` parameter for cross-modal pairs (TR↔S128, PHO↔PWC), `_resolve_arrival_time` fallback for subway legs with null intermediate arrivals.
- **#1238 / #1240** — NJT `STALE_PRIOR_RUN` classification gated on prior-day journey_date + >6h skew. Finalizes cross-day reused-train-id rows instead of re-polling each cycle.
- **#1232** — `shm_size: 1gb` and `max_parallel_workers_per_gather=1` on the db service in `backend_v2/docker-compose.yml` to clear asyncpg `DiskFullError` from `/dev/shm` exhaustion on `predict_track` / `operations_summary` / route alert evaluation.

Verified the rest of `CLAUDE.md` / `README.md` files across `backend_v2/`, `webpage_v2/`, `ios/`, `android/`, `infra_v2/`, and root against the current codebase — endpoint list, collector inventory, scheduler intervals, scripts, env vars, iOS service/screen/component counts, web routes, and infra structure all match. No other drift found.

## Test plan
- [x] `git diff` review shows only the intended additions
- [ ] Reviewer sanity-checks that the four bullets accurately describe what those PRs shipped

https://claude.ai/code/session_01U2aSssx3vM9ufVJbYi8Epb

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2aSssx3vM9ufVJbYi8Epb)_