### PR TITLE
Issue #1279: Fix invisible Retry button label in ErrorView

### DIFF
--- a/ios/TrackRat/Views/Screens/TrainListView.swift
+++ b/ios/TrackRat/Views/Screens/TrainListView.swift
@@ -864,10 +864,14 @@ struct ErrorView: View {
                 .multilineTextAlignment(.center)
                 .foregroundColor(.white)
             
-            Button("Retry") {
+            Button {
                 retry()
+            } label: {
+                Text("Retry")
+                    .foregroundColor(.white)
             }
             .buttonStyle(.borderedProminent)
+            .tint(TrackRatTheme.Colors.accent)
         }
         .padding()
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary

Fixes the iOS "No internet connection" error view's Retry button rendering with invisible (white-on-white) label text.

`ThemeManager.tintColor` returns `.white`, which is applied app-wide via `.tint(themeManager.tintColor)` in `TrackRatApp.swift`. The `ErrorView`'s Retry button declared just `.buttonStyle(.borderedProminent)` with no local tint, so it inherited the global white tint — `.borderedProminent` filled the button white and the auto-contrast label ended up indistinguishable from the fill.

## Change

`ios/TrackRat/Views/Screens/TrainListView.swift` — `ErrorView`:

- Anchor the button's tint to `TrackRatTheme.Colors.accent` (orange) so the button has a colored fill regardless of the inherited tint.
- Set the label foreground explicitly to `.white` so the text remains visible on the orange fill regardless of any parent `foregroundColor` overrides.
- Matches the pattern already used by `NoDirectRouteView` in the same file (line ~925).

## Files Modified

- `ios/TrackRat/Views/Screens/TrainListView.swift` (+5 / -1)

## Test Coverage

This is a one-line SwiftUI styling fix with no behavioral surface area. The existing `BuildTests.swift` in `ios/TrackRatTests/` covers the compile-time guarantee (the project must build for any test to run); adding a unit test that asserts a Button's tint color would only verify the literal value just written and would not catch a regression in the actual rendering pipeline. The fix should be verified visually on-device by triggering an offline state and confirming the "Retry" label is legible against the orange button fill.

## Design Decisions

- **Did not change `ThemeManager.tintColor`** even though `.white` is the root cause. Changing it to orange would re-style every `.tint(...)`-sensitive control across all 18 screens and several components, which is far beyond this issue's scope.
- **Did not touch the other `.borderedProminent` buttons** (`FeedbackButton.swift`, `JourneyFeedbackPromptView.swift`). The user reported only the Retry button; the other instances should be audited separately if visually affected.
- **Kept the label as explicit `Text(...).foregroundColor(.white)`** instead of `Button("Retry")` so the foreground style is anchored locally and cannot be overridden by parent `foregroundColor` chains.

Closes #1279

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTgdQnKHasZEWwi9sx9RCk)_