### PR TITLE
Issue #1282: Use live estimate for departure on-time in route summary

### DIFF
--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -957,13 +957,22 @@ class SummaryService:
                     # effective_njt_updated_times applies the NJT TIME/DEP_TIME
                     # inversion correction, which matters because the boarding
                     # station is often an intermediate stop of the train's journey.
+                    # Fall back to the arrival estimate when departure is absent
+                    # so GTFS-RT feeds that only carry arr.arrival_time (e.g. MTA
+                    # subway stops with no scheduled dwell) still register the
+                    # train as delayed, matching departures.py's gate:
+                    #   max(updated_departure, updated_arrival)
+                    #     if both else updated_departure or updated_arrival
                     _eff_arr, eff_dep = effective_njt_updated_times(
                         from_stop, journey.data_source
                     )
-                    if eff_dep is not None:
+                    eff_estimate = eff_dep if eff_dep is not None else _eff_arr
+                    if eff_estimate is not None:
                         delay = max(
                             0.0,
-                            (eff_dep - from_stop.scheduled_departure).total_seconds()
+                            (
+                                eff_estimate - from_stop.scheduled_departure
+                            ).total_seconds()
                             / 60,
                         )
                         total_delay += delay

--- a/backend_v2/src/trackrat/services/summary.py
+++ b/backend_v2/src/trackrat/services/summary.py
@@ -22,6 +22,7 @@ from trackrat.config.stations import expand_station_codes
 from trackrat.models.database import JourneyStop, TrainJourney
 from trackrat.services.congestion_types import FREQUENCY_FIRST_SOURCES
 from trackrat.utils.time import now_et
+from trackrat.utils.train import effective_njt_updated_times
 
 logger = get_logger(__name__)
 
@@ -949,36 +950,58 @@ class SummaryService:
                         on_time_count += 1
                     category = self._categorize_delay(delay)
                 else:
-                    # No actual departure yet - calculate how late based on current time
-                    time_since_scheduled = (
-                        current_time - from_stop.scheduled_departure
-                    ).total_seconds() / 60
-                    if time_since_scheduled <= ON_TIME_THRESHOLD_MINUTES:
-                        # Just scheduled, might still depart on time
-                        on_time_count += 1
-                        delay = 0.0
-                        category = DELAY_CATEGORY_ON_TIME
-                    else:
-                        # Past scheduled time with no actual departure data.
-                        # Check if journey data is fresh enough to trust the
-                        # absence of actual_departure as an indication of delay.
-                        data_age_seconds = (
-                            (current_time - journey.last_updated_at).total_seconds()
-                            if journey.last_updated_at
-                            else float("inf")
+                    # No actual departure yet. Prefer the live estimate — the same
+                    # source /api/v2/trains/departures uses — so the summary's
+                    # notion of "late" matches the per-train delay shown in the
+                    # departures list on the same screen (issue #1282).
+                    # effective_njt_updated_times applies the NJT TIME/DEP_TIME
+                    # inversion correction, which matters because the boarding
+                    # station is often an intermediate stop of the train's journey.
+                    _eff_arr, eff_dep = effective_njt_updated_times(
+                        from_stop, journey.data_source
+                    )
+                    if eff_dep is not None:
+                        delay = max(
+                            0.0,
+                            (eff_dep - from_stop.scheduled_departure).total_seconds()
+                            / 60,
                         )
-
-                        if data_age_seconds <= DATA_FRESHNESS_THRESHOLD_SECONDS:
-                            # Fresh data - trust that no departure means delayed
-                            delay = time_since_scheduled
-                            total_delay += time_since_scheduled
-                            category = self._categorize_delay(delay)
-                        else:
-                            # Stale data - don't assume delay; train may have
-                            # departed on time but we don't have the update.
+                        total_delay += delay
+                        if delay <= ON_TIME_THRESHOLD_MINUTES:
+                            on_time_count += 1
+                        category = self._categorize_delay(delay)
+                    else:
+                        # No live estimate yet - fall back to a wall-clock heuristic
+                        # based on how far past the scheduled time we are.
+                        time_since_scheduled = (
+                            current_time - from_stop.scheduled_departure
+                        ).total_seconds() / 60
+                        if time_since_scheduled <= ON_TIME_THRESHOLD_MINUTES:
+                            # Just scheduled, might still depart on time
                             on_time_count += 1
                             delay = 0.0
                             category = DELAY_CATEGORY_ON_TIME
+                        else:
+                            # Past scheduled time with no actual departure data.
+                            # Check if journey data is fresh enough to trust the
+                            # absence of actual_departure as an indication of delay.
+                            data_age_seconds = (
+                                (current_time - journey.last_updated_at).total_seconds()
+                                if journey.last_updated_at
+                                else float("inf")
+                            )
+
+                            if data_age_seconds <= DATA_FRESHNESS_THRESHOLD_SECONDS:
+                                # Fresh data - trust that no departure means delayed
+                                delay = time_since_scheduled
+                                total_delay += time_since_scheduled
+                                category = self._categorize_delay(delay)
+                            else:
+                                # Stale data - don't assume delay; train may have
+                                # departed on time but we don't have the update.
+                                on_time_count += 1
+                                delay = 0.0
+                                category = DELAY_CATEGORY_ON_TIME
 
                 trains_by_category[category].append(
                     TrainDelaySummary(

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -537,6 +537,8 @@ class TestSummaryService:
         origin_stop.stop_sequence = 1
         origin_stop.scheduled_departure = current_time - timedelta(minutes=30)
         origin_stop.actual_departure = None  # Not departed yet!
+        origin_stop.updated_departure = None  # No live estimate -> wall-clock fallback
+        origin_stop.updated_arrival = None
 
         dest_stop = Mock()
         dest_stop.station_code = "NP"
@@ -578,6 +580,8 @@ class TestSummaryService:
         origin_stop.stop_sequence = 1
         origin_stop.scheduled_departure = current_time - timedelta(minutes=30)
         origin_stop.actual_departure = None  # No departure data due to stale record
+        origin_stop.updated_departure = None  # No live estimate -> wall-clock fallback
+        origin_stop.updated_arrival = None
 
         dest_stop = Mock()
         dest_stop.station_code = "NP"
@@ -615,6 +619,8 @@ class TestSummaryService:
         origin_stop.stop_sequence = 1
         origin_stop.scheduled_departure = current_time - timedelta(minutes=3)
         origin_stop.actual_departure = None  # Not departed yet, but that's normal
+        origin_stop.updated_departure = None  # No live estimate -> wall-clock fallback
+        origin_stop.updated_arrival = None
 
         dest_stop = Mock()
         dest_stop.station_code = "NP"
@@ -629,6 +635,211 @@ class TestSummaryService:
         # Should be counted as on-time since it's only 3 minutes past scheduled
         assert stats.total_count == 1
         assert stats.on_time_percentage == 100.0
+
+    def test_calculate_departure_stats_uses_live_estimate_njt_intermediate(
+        self, summary_service
+    ):
+        """Regression for #1282: a not-yet-departed train that the live estimate
+        already shows as delayed must be counted as delayed, not on-time.
+
+        Before the fix, _calculate_departure_stats ignored the live estimate and
+        only compared scheduled-vs-now. A train scheduled 2 minutes ago (inside
+        the 5-min grace) with no actual_departure was counted on-time, even though
+        /api/v2/trains/departures already showed it ~13 min late on the same
+        screen. That contradiction is exactly what the user reported.
+
+        NJT twist: at an intermediate boarding stop, updated_departure holds the
+        immutable schedule (DEP_TIME) and updated_arrival holds the live estimate
+        (TIME). effective_njt_updated_times' max() must recover the live estimate,
+        otherwise reading updated_departure directly would re-introduce #1268.
+        """
+        current_time = datetime.now(UTC)
+
+        journey = Mock(spec=TrainJourney)
+        journey.id = 1
+        journey.train_id = "1620"
+        journey.is_cancelled = False
+        journey.data_source = "NJT"
+        journey.last_updated_at = current_time
+
+        # Boarding at an intermediate stop, scheduled 2 min ago — inside the grace
+        # window the old heuristic treated as on-time.
+        origin_stop = Mock()
+        origin_stop.station_code = "NH"
+        origin_stop.stop_sequence = 4
+        origin_stop.scheduled_departure = current_time - timedelta(minutes=2)
+        origin_stop.actual_departure = None  # Not departed yet
+        # NJT inversion: schedule in updated_departure, live estimate in
+        # updated_arrival. Live departure resolves to now + 11 min, i.e. 13 min
+        # after the 2-min-ago schedule.
+        origin_stop.updated_departure = current_time - timedelta(minutes=2)
+        origin_stop.updated_arrival = current_time + timedelta(minutes=11)
+
+        dest_stop = Mock()
+        dest_stop.station_code = "HB"
+        dest_stop.stop_sequence = 9
+
+        journey.stops = [origin_stop, dest_stop]
+
+        stats = summary_service._calculate_departure_stats(
+            [journey], "NH", current_time=current_time
+        )
+
+        assert stats.total_count == 1
+        # Was 100.0 before the fix; the live estimate makes it delayed.
+        assert stats.on_time_percentage == 0.0
+        assert 12 <= stats.average_delay_minutes <= 14  # ~13 min
+        assert len(stats.trains_by_category[DELAY_CATEGORY_ON_TIME]) == 0
+        assert len(stats.trains_by_category[DELAY_CATEGORY_SLIGHT_DELAY]) == 1
+
+    def test_calculate_departure_stats_uses_live_estimate_gtfs_rt(
+        self, summary_service
+    ):
+        """The fix is provider-agnostic: for GTFS-RT carriers updated_departure
+        is itself the live estimate, so a not-yet-departed delayed train must be
+        counted as delayed there too."""
+        current_time = datetime.now(UTC)
+
+        journey = Mock(spec=TrainJourney)
+        journey.id = 2
+        journey.train_id = "LIRR_1"
+        journey.is_cancelled = False
+        journey.data_source = "LIRR"
+        journey.last_updated_at = current_time
+
+        origin_stop = Mock()
+        origin_stop.station_code = "NY"
+        origin_stop.stop_sequence = 1
+        origin_stop.scheduled_departure = current_time - timedelta(minutes=1)
+        origin_stop.actual_departure = None
+        # Non-NJT: updated_departure is the genuine live estimate (now +19 →
+        # 20 min after the 1-min-ago schedule).
+        origin_stop.updated_departure = current_time + timedelta(minutes=19)
+        origin_stop.updated_arrival = None
+
+        dest_stop = Mock()
+        dest_stop.station_code = "JA"
+        dest_stop.stop_sequence = 5
+
+        journey.stops = [origin_stop, dest_stop]
+
+        stats = summary_service._calculate_departure_stats(
+            [journey], "NY", current_time=current_time
+        )
+
+        assert stats.total_count == 1
+        assert stats.on_time_percentage == 0.0
+        assert 19 <= stats.average_delay_minutes <= 21  # ~20 min
+        assert len(stats.trains_by_category[DELAY_CATEGORY_DELAYED]) == 1
+
+    def test_calculate_departure_stats_live_estimate_on_time(self, summary_service):
+        """A not-yet-departed train whose live estimate is within the on-time
+        threshold stays on-time — the fix must not over-report delays."""
+        current_time = datetime.now(UTC)
+
+        journey = Mock(spec=TrainJourney)
+        journey.id = 3
+        journey.train_id = "1622"
+        journey.is_cancelled = False
+        journey.data_source = "NJT"
+        journey.last_updated_at = current_time
+
+        origin_stop = Mock()
+        origin_stop.station_code = "NH"
+        origin_stop.stop_sequence = 4
+        origin_stop.scheduled_departure = current_time - timedelta(minutes=2)
+        origin_stop.actual_departure = None
+        # Live estimate only 3 min after schedule (now + 1 vs now - 2) → on-time.
+        origin_stop.updated_departure = current_time - timedelta(minutes=2)
+        origin_stop.updated_arrival = current_time + timedelta(minutes=1)
+
+        dest_stop = Mock()
+        dest_stop.station_code = "HB"
+        dest_stop.stop_sequence = 9
+
+        journey.stops = [origin_stop, dest_stop]
+
+        stats = summary_service._calculate_departure_stats(
+            [journey], "NH", current_time=current_time
+        )
+
+        assert stats.total_count == 1
+        assert stats.on_time_percentage == 100.0
+        assert stats.average_delay_minutes <= ON_TIME_THRESHOLD_MINUTES
+        assert len(stats.trains_by_category[DELAY_CATEGORY_ON_TIME]) == 1
+
+    def test_generate_route_summary_reflects_live_estimate_delay(
+        self, summary_service
+    ):
+        """End-to-end regression for #1282: when a recently-departed train was
+        on time but the next (not-yet-departed) train's live estimate says it's
+        delayed, the headline must NOT claim "100% on time".
+
+        With one on-time and one +13m train the weighted departure OTP is 50%,
+        so the headline reads "Past two hours: 50% on time" and the body says
+        the trains are delayed — matching the per-train delay shown in the
+        departures list on the same screen.
+        """
+        current_time = datetime.now(UTC)
+
+        def _make_njt_journey(train_id, sched_offset, *, departed, est_offset=None):
+            journey = Mock(spec=TrainJourney)
+            journey.id = train_id
+            journey.train_id = str(train_id)
+            journey.is_cancelled = False
+            journey.data_source = "NJT"
+            journey.last_updated_at = current_time
+
+            origin_stop = Mock()
+            origin_stop.station_code = "NH"
+            origin_stop.stop_sequence = 4
+            origin_stop.scheduled_departure = current_time + sched_offset
+            if departed:
+                # Departed on time (actual == scheduled).
+                origin_stop.actual_departure = current_time + sched_offset
+                origin_stop.updated_departure = None
+                origin_stop.updated_arrival = None
+            else:
+                origin_stop.actual_departure = None
+                # NJT inversion: schedule in updated_departure, live estimate in
+                # updated_arrival.
+                origin_stop.updated_departure = current_time + sched_offset
+                origin_stop.updated_arrival = current_time + est_offset
+
+            # Destination stop with no arrival data so arrival stats are skipped
+            # cleanly (scheduled_arrival None short-circuits the arrival branch).
+            dest_stop = Mock()
+            dest_stop.station_code = "HB"
+            dest_stop.stop_sequence = 9
+            dest_stop.scheduled_arrival = None
+            dest_stop.actual_arrival = None
+            dest_stop.arrival_source = None
+
+            journey.stops = [origin_stop, dest_stop]
+            return journey
+
+        # Train 1618: departed 40 min ago, on time.
+        on_time = _make_njt_journey(1618, timedelta(minutes=-40), departed=True)
+        # Train 1620: scheduled 2 min ago, not departed, live estimate +13m.
+        delayed = _make_njt_journey(
+            1620,
+            timedelta(minutes=-2),
+            departed=False,
+            est_offset=timedelta(minutes=11),
+        )
+
+        summary = summary_service._generate_route_summary(
+            [on_time, delayed], "NH", "HB"
+        )
+
+        assert summary.scope == "route"
+        # The bug produced "Past two hours: 100% on time"; the fix yields 50%.
+        assert summary.headline == "Past two hours: 50% on time"
+        assert "100%" not in summary.headline
+        assert "delayed" in summary.body.lower()
+        assert summary.metrics is not None
+        assert summary.metrics.on_time_percentage == 50.0
+        assert summary.metrics.train_count == 2
 
     def test_calculate_arrival_stats_excludes_scheduled_fallback(self, summary_service):
         """Regression: route arrival stats must not count scheduled_fallback

--- a/backend_v2/tests/unit/services/test_summary.py
+++ b/backend_v2/tests/unit/services/test_summary.py
@@ -732,6 +732,56 @@ class TestSummaryService:
         assert 19 <= stats.average_delay_minutes <= 21  # ~20 min
         assert len(stats.trains_by_category[DELAY_CATEGORY_DELAYED]) == 1
 
+    def test_calculate_departure_stats_uses_live_estimate_arrival_only(
+        self, summary_service
+    ):
+        """GTFS-RT feeds sometimes ingest stops with only `updated_arrival` set
+        (when the upstream protobuf entry omits ``stop_time_update.departure``).
+        ``/api/v2/trains/departures`` already surfaces those as delayed via its
+        ``updated_departure or updated_arrival`` gate; the summary must match,
+        otherwise a train scheduled inside the 5-min grace with a 20-min late
+        arrival estimate would be counted on-time here while the row on the same
+        screen shows the delay (codex P2 finding on PR #1290).
+        """
+        current_time = datetime.now(UTC)
+
+        journey = Mock(spec=TrainJourney)
+        journey.id = 4
+        journey.train_id = "SUBWAY_1"
+        journey.is_cancelled = False
+        journey.data_source = "SUBWAY"
+        journey.last_updated_at = current_time
+
+        origin_stop = Mock()
+        origin_stop.station_code = "S101"
+        origin_stop.stop_sequence = 1
+        origin_stop.scheduled_departure = current_time - timedelta(minutes=2)
+        origin_stop.actual_departure = None
+        # GTFS-RT shape: arrival-only live estimate (departure missing because
+        # the upstream protobuf entry didn't carry stop_time_update.departure).
+        # Live estimate is 20 min later than the 2-min-ago schedule.
+        origin_stop.updated_departure = None
+        origin_stop.updated_arrival = current_time + timedelta(minutes=18)
+
+        dest_stop = Mock()
+        dest_stop.station_code = "S142"
+        dest_stop.stop_sequence = 5
+
+        journey.stops = [origin_stop, dest_stop]
+
+        stats = summary_service._calculate_departure_stats(
+            [journey], "S101", current_time=current_time
+        )
+
+        assert stats.total_count == 1
+        # Wall-clock fallback would have counted this on-time (only 2 min past
+        # schedule, inside the 5-min grace). The arrival estimate gate makes it
+        # delayed.
+        assert stats.on_time_percentage == 0.0
+        assert 19 <= stats.average_delay_minutes <= 21  # ~20 min
+        assert len(stats.trains_by_category[DELAY_CATEGORY_ON_TIME]) == 0
+        assert len(stats.trains_by_category[DELAY_CATEGORY_DELAYED]) == 1
+
     def test_calculate_departure_stats_live_estimate_on_time(self, summary_service):
         """A not-yet-departed train whose live estimate is within the on-time
         threshold stays on-time — the fix must not over-report delays."""


### PR DESCRIPTION
## Summary

Closes #1282.

The route summary banner ("Past two hours: X% on time") and the departures list render on the same `RouteStatusView` screen but computed delay from **different fields**, so they contradicted each other at the "now" boundary:

- **Departures list** (`/api/v2/trains/departures`) uses the live estimate (`updated_*`, NJT-normalized via `max(...)`).
- **Summary** (`/api/v2/routes/summary`, `services/summary.py`) ignored `updated_*` entirely — `_calculate_departure_stats` derived "on time" from `scheduled_departure` vs `actual_departure` plus a 5-minute wall-clock grace. A not-yet-departed train within 5 min of its scheduled time was counted **on time** even when the live estimate already showed it delayed.

In the user's screenshots: clock 8:45, train 1620 scheduled ~8:43 (live estimate 8:56, +13m). The departures list showed `8:56 AM +13m`; the banner said "100% on time / Trains departing on time." See the [triage comment](https://github.com/trackrat-dev/TrackRat/issues/1282#issuecomment-4701816086) for the full analysis (which also corrects two earlier, incorrect root-cause guesses).

## Changes

- **`backend_v2/src/trackrat/services/summary.py`** — in `_calculate_departure_stats`, a not-yet-departed train now derives its delay from the live estimate via `effective_njt_updated_times(from_stop, journey.data_source)` (the helper added in #1271) before falling back to the existing wall-clock + freshness heuristic. Using the helper rather than raw `updated_departure` is required because the boarding station is often an **intermediate** stop, where NJT's `updated_departure` is the immutable schedule (`DEP_TIME`) and `updated_arrival` is the live estimate (`TIME`) — reading the raw field would re-introduce #1268. The `actual_departure` branch and the entire fallback are preserved unchanged.

- **`backend_v2/tests/unit/services/test_summary.py`**
  - Patched the 3 existing not-yet-departed tests to set `updated_* = None` (they exercise the no-live-estimate fallback, so this is faithful).
  - Added 4 tests: NJT intermediate-stop inversion → delayed (the #1282 regression); GTFS-RT provider → delayed (provider-agnostic); live estimate on-time → stays on-time (no over-reporting); and an **end-to-end** route-summary test asserting 1 on-time + 1 delayed(+13m) train yields `"Past two hours: 50% on time"` / "delayed" instead of "100% on time".

## Audit

`_calculate_arrival_stats` does **not** have this bug — it only counts journeys with `actual_arrival` set (completion-only), so it never mislabels an in-flight train. No change needed.

## Test coverage / verification

⚠️ **Tests were not run locally** (no `poetry` in this environment). Syntax validated with `py_compile`; expected values traced by hand against the code; line length / black-stability checked. The new tests should be confirmed in CI. The change is server-side only (no client release), so it can also be validated end-to-end on staging via the route-summary endpoint after deploy.

## Follow-ups (separate issues)

- #1288 — Ingest NJ Transit service alerts (the "disabled train at Westwood" alert never reaches TrackRat).
- #1289 — Latent iOS `StopV2.delayMinutes` NJT-inversion fragility (currently masked by #1271's server-side normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
