### PR TITLE
Fix staging deploy: inherit staging disk size from prod snapshot

### DIFF
--- a/infra_v2/README.md
+++ b/infra_v2/README.md
@@ -136,7 +136,7 @@ Manual deploy from the repo root:
 | `region` | us-east4 | GCP region |
 | `zone` | us-east4-a | GCP zone |
 | `machine_type` | t2d-standard-2 | VM machine type |
-| `disk_size_gb` | 40 | Persistent disk size |
+| `disk_size_gb` | 60 | Persistent disk size |
 | `snapshot_retention_days` | 35 | Snapshot retention period |
 
 **Note:** Staging uses spot VMs for cost savings; production uses on-demand VMs for stability.

--- a/infra_v2/cloudbuild-staging.yaml
+++ b/infra_v2/cloudbuild-staging.yaml
@@ -111,13 +111,13 @@ steps:
           fi
 
           # Create new staging disk from production snapshot
-          # Size must be >= source snapshot; 40GB matches production for WAL and growth
+          # Size is inherited from the snapshot so staging always matches production
+          # (never hardcode --size — a smaller value breaks once the prod disk grows).
           echo "Creating new staging disk from production snapshot..."
           if ! gcloud compute disks create ${_STAGING_DISK} \
             --source-snapshot=staging-clone-${BUILD_ID} \
             --zone=${_ZONE} \
             --type=pd-ssd \
-            --size=40GB \
             --labels=app=trackrat,environment=staging; then
             echo "ERROR: Failed to create staging disk. Cleaning up snapshot..."
             gcloud compute snapshots delete staging-clone-${BUILD_ID} --quiet || true

--- a/infra_v2/terraform/variables.tf
+++ b/infra_v2/terraform/variables.tf
@@ -42,7 +42,7 @@ variable "machine_type" {
 variable "disk_size_gb" {
   description = "Persistent disk size in GB"
   type        = number
-  default     = 40
+  default     = 60
 }
 
 variable "snapshot_retention_days" {


### PR DESCRIPTION
## Problem

The staging deploy (`cloudbuild-staging.yaml`) hardcoded `--size=40GB` when cloning the production disk into staging. Production's data disk has since grown to **60GB**, so creating a 40GB disk from the 60GB snapshot fails:

```
ERROR: (gcloud.compute.disks.create) Invalid value for field 'resource.sizeGb': '40'.
Requested disk size cannot be smaller than the snapshot size (60 GB)
```

Because the script deletes the old staging disk *before* creating the new one, the failure leaves staging with **no data disk** and the MIG scaled to 0.

## Changes

- **`cloudbuild-staging.yaml`**: drop `--size=40GB`. When creating from `--source-snapshot`, gcloud inherits the snapshot's size, so the staging disk always matches production — no future breakage when the prod disk grows again.
- **`terraform/variables.tf`**: bump `disk_size_gb` default `40 → 60` to match the real production disk. This also removes a latent hazard: `google_compute_disk` force-replaces on a size *decrease*, so the prior 40 default vs. the actual 60 disk meant a production terraform apply could try to destroy/recreate the prod data disk (data loss).
- **`README.md`**: update the documented default to 60.

## Notes / follow-ups (not in this PR)

- Staging is currently down (no data disk, MIG at 0). It self-heals on the next staging deploy once this merges — Phase 1 tolerates the missing disk, re-clones prod at 60GB, and resizes the MIG to 1.
- An orphaned `staging-clone-1a1df1db-…` 40GB snapshot remains to be cleaned up.
- Before applying terraform to production, confirm the plan is a **no-op** on `google_compute_disk.data` (config 60 = actual 60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)