### PR TITLE
docs: weekly audit - June 2026 retention sweep + webpage version bumps

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This guide provides comprehensive information for Claude Code when working with the TrackRat Backend V2, a radical simplification of the train tracking system that reduces API calls by ~95% while maintaining production robustness.
 
-**Last Updated:** May 2026
+**Last Updated:** June 2026
 **Database:** PostgreSQL with asyncpg (production-ready)
 **Key Features:** Multi-transit support (NJT, Amtrak, PATH, PATCO, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, WMATA), track/delay predictions, route alerts, API caching, schedule generation, GTFS integration
 
@@ -287,7 +287,7 @@ The APScheduler runs in-process and handles:
 - **Daily at 12:45 AM ET**: Amtrak pattern-based schedule generation
 - **Daily at 1:00 AM ET**: Lock manager cleanup
 - **Daily at 3:00 AM ET**: GTFS static schedule refresh
-- **Daily at 3:30 AM ET**: Data retention cleanup (deletes journeys older than `TRACKRAT_RETENTION_DAYS`)
+- **Daily at 3:30 AM ET**: Data retention cleanup (deletes journeys, discovery runs, validation results, and inactive service alerts older than `TRACKRAT_RETENTION_DAYS`; active alerts are kept regardless of age)
 - **Every 30 min**: NJT and Amtrak train discovery from major stations
 - **Every 4 min**: PATH collection (unified, RidePATH API)
 - **Every 4 min**: LIRR collection (unified, MTA GTFS-RT)
@@ -772,6 +772,13 @@ The backend is organized into service classes for better maintainability:
 - **BackupService** (`services/backup_service.py`): GCS backup management (optional)
 
 ## Recent Improvements & Known Issues
+
+### Recent Improvements (June 2026)
+- ✅ Retention sweep extended to inactive `service_alerts` so long-resolved alerts no longer accumulate (issue #1269, `services/scheduler.py`)
+- ✅ NJT `updated_arrival` / `updated_departure` inversion normalized at the `/trains/{train_id}` endpoint via `utils/train.py` so consumers don't have to apply `max(updated_departure, updated_arrival)` themselves (issue #1268, `api/trains.py`)
+- ✅ Route summary uses live estimate for boarding-stop departure on-time calculation; falls back to arrival estimate when departure is absent (issue #1282, `services/summary.py`)
+- ✅ Congestion map level now reflects cancellations alongside delays (issue #1246, `services/congestion.py`, `services/congestion_types.py`, `services/segment_normalizer.py`)
+- ✅ Metra UP-NW line code length increased on departures endpoint to prevent truncation (issue #1241, `models/api.py`)
 
 ### Recent Improvements (May 2026)
 - ✅ Train share metadata now includes route times for richer link previews (`api/share.py`)

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -91,7 +91,7 @@ poetry run uvicorn trackrat.main:app --reload
 - **Every 5 minutes**: Update checks for active journeys
 - **Every 5 minutes**: Route alert evaluation and push notifications
 - **Hourly at :05**: Validation across key routes
-- **Daily 3:30 AM ET**: Data retention cleanup (deletes journeys older than `TRACKRAT_RETENTION_DAYS`, default 120 days)
+- **Daily 3:30 AM ET**: Data retention cleanup (deletes journeys, discovery runs, validation results, and inactive service alerts older than `TRACKRAT_RETENTION_DAYS`, default 120 days; active service alerts are kept regardless of age)
 - Monitor scheduler status at `/scheduler/status` endpoint
 
 **Note**: PATH, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, and WMATA each use unified collectors that handle both discovery and journey updates in a single pass. LIRR, Metro-North, Subway, BART, MBTA, and Metra use GTFS-RT feeds with shared logic in `mta_common.py`. WMATA uses its REST API. PATCO uses GTFS static schedules only (no real-time API).

--- a/webpage_v2/CLAUDE.md
+++ b/webpage_v2/CLAUDE.md
@@ -6,10 +6,10 @@
 
 - **Framework**: React 19.2 + TypeScript 6.0 + PWA (vite-plugin-pwa)
 - **Build Tool**: Vite 8.0 (fast dev server, optimized builds)
-- **Styling**: Tailwind CSS 4.2 (utility-first, custom design system)
+- **Styling**: Tailwind CSS 4.3 (utility-first, custom design system)
 - **State Management**: Zustand 5.0 (lightweight, no boilerplate)
-- **Routing**: React Router DOM 7.14
-- **Date Handling**: date-fns 4.1
+- **Routing**: React Router DOM 7.16
+- **Date Handling**: date-fns 4.4
 - **HTTP Client**: Native `fetch` (no axios)
 - **Maps**: MapLibre GL 5.22 + react-map-gl 8.1
 - **Deployment**: GCS static hosting (`scripts/deploy-webpage.sh`)


### PR DESCRIPTION
## Summary

Weekly documentation audit covering drift introduced in the past ~7 days.

### Backend (`backend_v2/CLAUDE.md`, `backend_v2/README.md`)
- The 3:30 AM ET retention sweep was extended by #1269 (PR #1273) to also prune `discovery_runs`, `validation_results`, and inactive `service_alerts`. The docs still said it only deleted journeys — updated both files to describe all four phases and call out that active service alerts are kept regardless of age.
- Bumped "Last Updated" to June 2026 and added a June 2026 changelog entry covering this week's merged issues: #1241 (Metra UP-NW line code overflow), #1246 (cancellations in congestion level), #1268 (NJT updated-times normalization at the train-details endpoint), #1269 (service-alert retention), and #1282 (route summary departure-on-time live estimate / arrival fallback).

### Web (`webpage_v2/CLAUDE.md`)
- Dependabot bumps this week pulled Tailwind, React Router, and date-fns past what the tech-stack table claimed. Updated to match `package.json`: Tailwind 4.2 → 4.3, React Router 7.14 → 7.16, date-fns 4.1 → 4.4.

### Audited but unchanged
- Root `CLAUDE.md` / `README.md`, `ios/CLAUDE.md` / `README.md`, `android/CLAUDE.md` / `README.md`, `infra_v2/README.md`, `webpage_v2/README.md`, `.claude/CLAUDE.md`.
- Verified: 18 iOS screens, 28 iOS components, 15 iOS services, 9 web pages, 20 web components all match documented counts. All 12 backend routers, ~25 scheduler tasks, 21 backend services, 10 transit collectors + service alerts collector, and every documented env var line up with `settings.py`. All documented scripts in `scripts/` exist.

## Test plan
- [ ] Docs-only change — no code paths touched, no tests to run
- [ ] Spot-check rendered markdown on GitHub for the three edited files


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk2Mb9VKpEnXFZpVqp4Tgy)_