### PR TITLE
Fix Live Activity updates for GTFS-only scheduled trains (#1298)

### DIFF
--- a/backend_v2/src/trackrat/api/live_activities.py
+++ b/backend_v2/src/trackrat/api/live_activities.py
@@ -16,6 +16,7 @@ from structlog import get_logger
 
 from trackrat.db.engine import get_db
 from trackrat.models.database import LiveActivityToken
+from trackrat.services.gtfs import GTFSService
 from trackrat.utils.time import now_et
 
 logger = get_logger(__name__)
@@ -95,6 +96,31 @@ async def register_live_activity(
         destination=request.destination_code,
         data_source=request.data_source,
     )
+
+    # Ensure the push job has a train_journeys row to update. SCHEDULED trains
+    # that exist only in GTFS static data (not yet discovered) have no row, so
+    # the push job would log journey_not_found_for_live_activity every cycle and
+    # never push — the on-device countdown goes static (issue #1298). Materialize
+    # a SCHEDULED row from GTFS so updates flow until discovery upgrades it to
+    # OBSERVED in place. Best-effort: never fail registration on error.
+    try:
+        materialized = await GTFSService().materialize_scheduled_journey(
+            db,
+            request.train_number,
+            now_et().date(),
+            data_source=request.data_source,
+        )
+        if materialized is not None:
+            await db.commit()
+    except Exception as e:
+        await db.rollback()
+        logger.warning(
+            "live_activity_journey_materialize_failed",
+            train_number=request.train_number,
+            data_source=request.data_source,
+            error=str(e),
+            error_type=type(e).__name__,
+        )
 
     return RegisterResponse(expires_at=expires_at)
 

--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import httpx
 from sqlalchemy import and_, delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog import get_logger
 
@@ -43,6 +44,8 @@ from trackrat.models.database import (
     GTFSRoute,
     GTFSStopTime,
     GTFSTrip,
+    JourneyStop,
+    TrainJourney,
 )
 from trackrat.utils.time import DATETIME_MAX_ET, ET, PROVIDER_TIMEZONE, now_et
 
@@ -2068,6 +2071,120 @@ class GTFSService:
             progress=None,
             predicted_arrival=None,
         )
+
+    async def materialize_scheduled_journey(
+        self,
+        db: AsyncSession,
+        train_id: str,
+        target_date: date,
+        data_source: str | None = None,
+    ) -> TrainJourney | None:
+        """Create a SCHEDULED ``train_journeys`` row from GTFS static data.
+
+        Live Activities can be started for SCHEDULED trains that exist only in
+        the GTFS static schedule (no ``train_journeys`` row until discovery
+        observes the train). The Live Activity push job queries ``train_journeys``
+        exclusively and has no GTFS fallback, so without a row it logs
+        ``journey_not_found_for_live_activity`` every cycle and never pushes an
+        update — the on-device countdown goes static (issue #1298).
+
+        Materializing a SCHEDULED row lets the push job deliver scheduled-time
+        updates immediately. NJT/Amtrak discovery later upgrades the same row to
+        OBSERVED in place, matched via the ``unique_train_journey`` key
+        (train_id, journey_date, data_source), so no duplicate is created.
+
+        Returns the existing or newly-created journey, or ``None`` if the train
+        is not present in GTFS or has no usable scheduled departure.
+        """
+        existing: TrainJourney | None = await db.scalar(
+            self._scheduled_journey_lookup(train_id, target_date, data_source)
+        )
+        if existing:
+            return existing
+
+        details = await self.get_train_details(
+            db, train_id, target_date, data_source=data_source
+        )
+        if details is None or not details.stops:
+            return None
+
+        origin = details.stops[0]
+        dest = details.stops[-1]
+        # ``scheduled_departure`` is NOT NULL on TrainJourney; fall back to the
+        # origin's scheduled arrival, then bail if neither is available.
+        scheduled_departure = origin.scheduled_departure or origin.scheduled_arrival
+        if scheduled_departure is None:
+            logger.info(
+                "gtfs_materialize_no_scheduled_departure",
+                train_id=train_id,
+                target_date=str(target_date),
+            )
+            return None
+
+        journey = TrainJourney(
+            train_id=details.train_id,
+            journey_date=target_date,
+            line_code=details.line.code[:15],
+            line_name=details.line.name,
+            line_color=details.line.color,
+            destination=details.route.destination[:100],
+            origin_station_code=details.route.origin_code,
+            terminal_station_code=details.route.destination_code,
+            data_source=details.data_source,
+            observation_type="SCHEDULED",
+            scheduled_departure=scheduled_departure,
+            scheduled_arrival=dest.scheduled_arrival or dest.scheduled_departure,
+            has_complete_journey=False,
+            stops_count=len(details.stops),
+        )
+        db.add(journey)
+        for stop in details.stops:
+            db.add(
+                JourneyStop(
+                    journey=journey,
+                    station_code=stop.station.code,
+                    station_name=stop.station.name,
+                    stop_sequence=stop.stop_sequence,
+                    scheduled_arrival=stop.scheduled_arrival,
+                    scheduled_departure=stop.scheduled_departure,
+                    has_departed_station=False,
+                )
+            )
+
+        try:
+            await db.flush()
+        except IntegrityError:
+            # A concurrent request or discovery created the row first — adopt it
+            # via the unique_train_journey key instead of failing.
+            await db.rollback()
+            adopted: TrainJourney | None = await db.scalar(
+                self._scheduled_journey_lookup(
+                    details.train_id, target_date, details.data_source
+                )
+            )
+            return adopted
+
+        logger.info(
+            "gtfs_scheduled_journey_materialized",
+            train_id=details.train_id,
+            journey_date=str(target_date),
+            data_source=details.data_source,
+            stops_count=len(details.stops),
+        )
+        return journey
+
+    @staticmethod
+    def _scheduled_journey_lookup(
+        train_id: str, target_date: date, data_source: str | None
+    ) -> Any:
+        """Build the existence query used to dedupe materialized journeys."""
+        conditions = [
+            TrainJourney.train_id == train_id,
+            TrainJourney.journey_date == target_date,
+        ]
+        if data_source:
+            conditions.append(TrainJourney.data_source == data_source)
+        return select(TrainJourney).where(and_(*conditions))
 
     async def get_static_stop_times(
         self,

--- a/backend_v2/src/trackrat/services/gtfs.py
+++ b/backend_v2/src/trackrat/services/gtfs.py
@@ -113,6 +113,14 @@ NJT_LINE_CODE_MAPPING = {
     "PRIN": "PR",
 }
 
+# Sources whose discovery upgrades a SCHEDULED journey to OBSERVED *in place*,
+# matched on the unique_train_journey key (train_id, journey_date, data_source).
+# Only these can have a row materialized from GTFS at Live Activity registration:
+# their real-time collectors adopt that exact row. GTFS-RT systems (subway, LIRR,
+# MNR, BART, MBTA, Metra, PATH, WMATA) mint their own train_ids and would create a
+# *separate* OBSERVED row, orphaning the materialized one (issue #1298 follow-up).
+MATERIALIZE_SCHEDULED_SOURCES = {"NJT", "AMTRAK"}
+
 
 def _lirr_train_id_from_gtfs(train_id_or_trip_id: str) -> str:
     """Convert LIRR GTFS train number or trip_id to the L-prefixed real-time format.
@@ -2091,10 +2099,13 @@ class GTFSService:
         Materializing a SCHEDULED row lets the push job deliver scheduled-time
         updates immediately. NJT/Amtrak discovery later upgrades the same row to
         OBSERVED in place, matched via the ``unique_train_journey`` key
-        (train_id, journey_date, data_source), so no duplicate is created.
+        (train_id, journey_date, data_source), so no duplicate is created. Only
+        sources in ``MATERIALIZE_SCHEDULED_SOURCES`` are eligible — GTFS-RT
+        systems mint their own train_ids and would orphan the materialized row.
 
         Returns the existing or newly-created journey, or ``None`` if the train
-        is not present in GTFS or has no usable scheduled departure.
+        is not present in GTFS, has no usable scheduled departure, or belongs to
+        a source without in-place SCHEDULED→OBSERVED upgrade.
         """
         existing: TrainJourney | None = await db.scalar(
             self._scheduled_journey_lookup(train_id, target_date, data_source)
@@ -2106,6 +2117,13 @@ class GTFSService:
             db, train_id, target_date, data_source=data_source
         )
         if details is None or not details.stops:
+            return None
+
+        # Gate on the *resolved* source: a null data_source (older iOS clients)
+        # only resolves to a concrete source after get_train_details' two-phase
+        # search. Materializing for any other source would create a row no
+        # collector adopts, silently re-introducing stale Live Activities.
+        if details.data_source not in MATERIALIZE_SCHEDULED_SOURCES:
             return None
 
         origin = details.stops[0]

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -3097,6 +3097,7 @@ class SchedulerService:
                             logger.warning(
                                 "journey_not_found_for_live_activity",
                                 train_number=train_number,
+                                data_source=data_source,
                             )
                             continue
 

--- a/backend_v2/tests/unit/services/test_gtfs_materialize.py
+++ b/backend_v2/tests/unit/services/test_gtfs_materialize.py
@@ -1,0 +1,207 @@
+"""Tests for GTFSService.materialize_scheduled_journey (issue #1298).
+
+A Live Activity can be started for a SCHEDULED train that exists only in GTFS
+static schedule data (no ``train_journeys`` row until discovery observes it).
+The Live Activity push job queries ``train_journeys`` exclusively and has no
+GTFS fallback, so without a row it logs ``journey_not_found_for_live_activity``
+every cycle and never pushes — the on-device countdown freezes. Materializing a
+SCHEDULED row from GTFS at registration lets the push job deliver updates
+immediately; discovery later upgrades the same row to OBSERVED in place.
+"""
+
+from datetime import UTC, date, datetime
+
+import pytest
+from sqlalchemy import select
+
+from trackrat.models.database import (
+    GTFSCalendar,
+    GTFSRoute,
+    GTFSStopTime,
+    GTFSTrip,
+    JourneyStop,
+    TrainJourney,
+)
+from trackrat.services.gtfs import GTFSService
+
+# A weekday with NJT service. Seeded calendar runs every day to stay robust.
+TARGET_DATE = date(2026, 6, 15)
+
+
+async def _seed_njt_gtfs_trip(db, *, train_id: str = "3096") -> GTFSTrip:
+    """Seed one NJT GTFS trip (NY -> Trenton) active on TARGET_DATE."""
+    route = GTFSRoute(
+        data_source="NJT",
+        route_id="NEC",
+        route_short_name="NEC",
+        route_long_name="Northeast Corridor",
+        route_color="DD3439",
+    )
+    db.add(route)
+    await db.flush()
+
+    db.add(
+        GTFSCalendar(
+            data_source="NJT",
+            service_id="WKDY",
+            monday=True,
+            tuesday=True,
+            wednesday=True,
+            thursday=True,
+            friday=True,
+            saturday=True,
+            sunday=True,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 12, 31),
+        )
+    )
+
+    trip = GTFSTrip(
+        data_source="NJT",
+        trip_id=f"trip-{train_id}",
+        route_id=route.id,
+        service_id="WKDY",
+        trip_headsign="Trenton",
+        train_id=train_id,
+        direction_id=0,
+    )
+    db.add(trip)
+    await db.flush()
+
+    for code, seq, clock in [
+        ("NY", 1, "15:30:00"),
+        ("NP", 2, "15:55:00"),
+        ("ED", 3, "16:08:00"),
+        ("TR", 4, "16:35:00"),
+    ]:
+        db.add(
+            GTFSStopTime(
+                trip_id=trip.id,
+                stop_sequence=seq,
+                gtfs_stop_id=code,
+                station_code=code,
+                arrival_time=clock,
+                departure_time=clock,
+            )
+        )
+    await db.flush()
+    return trip
+
+
+@pytest.mark.asyncio
+async def test_materialize_creates_scheduled_journey_from_gtfs(db_session):
+    """A GTFS-only SCHEDULED train gets a real train_journeys row + stops."""
+    GTFSService._service_id_cache.clear()
+    await _seed_njt_gtfs_trip(db_session)
+
+    journey = await GTFSService().materialize_scheduled_journey(
+        db_session, "3096", TARGET_DATE, data_source="NJT"
+    )
+
+    assert journey is not None, "expected a journey to be materialized from GTFS"
+    assert journey.train_id == "3096"
+    assert journey.journey_date == TARGET_DATE
+    assert journey.data_source == "NJT"
+    assert journey.observation_type == "SCHEDULED"
+    # NJT route_short "NEC" maps to API line code "NE".
+    assert journey.line_code == "NE"
+    assert journey.origin_station_code == "NY"
+    assert journey.terminal_station_code == "TR"
+    assert journey.scheduled_departure is not None
+    assert journey.stops_count == 4
+
+    stops = (
+        await db_session.scalars(
+            select(JourneyStop)
+            .where(JourneyStop.journey_id == journey.id)
+            .order_by(JourneyStop.stop_sequence)
+        )
+    ).all()
+    assert [s.station_code for s in stops] == ["NY", "NP", "ED", "TR"]
+    assert stops[0].scheduled_departure is not None
+
+
+@pytest.mark.asyncio
+async def test_materialize_is_idempotent(db_session):
+    """Calling twice must not create a duplicate row (unique_train_journey)."""
+    GTFSService._service_id_cache.clear()
+    await _seed_njt_gtfs_trip(db_session)
+    service = GTFSService()
+
+    first = await service.materialize_scheduled_journey(
+        db_session, "3096", TARGET_DATE, data_source="NJT"
+    )
+    await db_session.commit()
+    second = await service.materialize_scheduled_journey(
+        db_session, "3096", TARGET_DATE, data_source="NJT"
+    )
+
+    assert first is not None and second is not None
+    assert first.id == second.id
+
+    rows = (
+        await db_session.scalars(
+            select(TrainJourney).where(TrainJourney.train_id == "3096")
+        )
+    ).all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_materialize_returns_existing_observed_row_without_duplicating(
+    db_session,
+):
+    """If discovery already created a row, return it and do not materialize."""
+    GTFSService._service_id_cache.clear()
+    await _seed_njt_gtfs_trip(db_session)
+
+    observed = TrainJourney(
+        train_id="3096",
+        journey_date=TARGET_DATE,
+        line_code="NE",
+        line_name="Northeast Corridor",
+        destination="TRENTON TRANSIT CENTER",
+        origin_station_code="NY",
+        terminal_station_code="TR",
+        data_source="NJT",
+        observation_type="OBSERVED",
+        scheduled_departure=datetime(2026, 6, 15, 19, 30, tzinfo=UTC),
+    )
+    db_session.add(observed)
+    await db_session.flush()
+
+    result = await GTFSService().materialize_scheduled_journey(
+        db_session, "3096", TARGET_DATE, data_source="NJT"
+    )
+
+    assert result is not None
+    assert result.id == observed.id
+    assert result.observation_type == "OBSERVED"
+
+    rows = (
+        await db_session.scalars(
+            select(TrainJourney).where(TrainJourney.train_id == "3096")
+        )
+    ).all()
+    assert len(rows) == 1
+    # No stops should have been added for the GTFS path since the row existed.
+    stop_count = len(
+        (
+            await db_session.scalars(
+                select(JourneyStop).where(JourneyStop.journey_id == observed.id)
+            )
+        ).all()
+    )
+    assert stop_count == 0
+
+
+@pytest.mark.asyncio
+async def test_materialize_returns_none_when_train_absent_from_gtfs(db_session):
+    """A train with no GTFS trip cannot be materialized; returns None gracefully."""
+    GTFSService._service_id_cache.clear()
+    await _seed_njt_gtfs_trip(db_session)
+
+    journey = await GTFSService().materialize_scheduled_journey(
+        db_session, "9999", TARGET_DATE, data_source="NJT"
+    )
+    assert journey is None

--- a/backend_v2/tests/unit/services/test_gtfs_materialize.py
+++ b/backend_v2/tests/unit/services/test_gtfs_materialize.py
@@ -28,10 +28,12 @@ from trackrat.services.gtfs import GTFSService
 TARGET_DATE = date(2026, 6, 15)
 
 
-async def _seed_njt_gtfs_trip(db, *, train_id: str = "3096") -> GTFSTrip:
-    """Seed one NJT GTFS trip (NY -> Trenton) active on TARGET_DATE."""
+async def _seed_gtfs_trip(
+    db, *, train_id: str = "3096", data_source: str = "NJT"
+) -> GTFSTrip:
+    """Seed one GTFS trip (NY -> Trenton) active on TARGET_DATE for ``data_source``."""
     route = GTFSRoute(
-        data_source="NJT",
+        data_source=data_source,
         route_id="NEC",
         route_short_name="NEC",
         route_long_name="Northeast Corridor",
@@ -42,7 +44,7 @@ async def _seed_njt_gtfs_trip(db, *, train_id: str = "3096") -> GTFSTrip:
 
     db.add(
         GTFSCalendar(
-            data_source="NJT",
+            data_source=data_source,
             service_id="WKDY",
             monday=True,
             tuesday=True,
@@ -57,7 +59,7 @@ async def _seed_njt_gtfs_trip(db, *, train_id: str = "3096") -> GTFSTrip:
     )
 
     trip = GTFSTrip(
-        data_source="NJT",
+        data_source=data_source,
         trip_id=f"trip-{train_id}",
         route_id=route.id,
         service_id="WKDY",
@@ -92,7 +94,7 @@ async def _seed_njt_gtfs_trip(db, *, train_id: str = "3096") -> GTFSTrip:
 async def test_materialize_creates_scheduled_journey_from_gtfs(db_session):
     """A GTFS-only SCHEDULED train gets a real train_journeys row + stops."""
     GTFSService._service_id_cache.clear()
-    await _seed_njt_gtfs_trip(db_session)
+    await _seed_gtfs_trip(db_session)
 
     journey = await GTFSService().materialize_scheduled_journey(
         db_session, "3096", TARGET_DATE, data_source="NJT"
@@ -125,7 +127,7 @@ async def test_materialize_creates_scheduled_journey_from_gtfs(db_session):
 async def test_materialize_is_idempotent(db_session):
     """Calling twice must not create a duplicate row (unique_train_journey)."""
     GTFSService._service_id_cache.clear()
-    await _seed_njt_gtfs_trip(db_session)
+    await _seed_gtfs_trip(db_session)
     service = GTFSService()
 
     first = await service.materialize_scheduled_journey(
@@ -153,7 +155,7 @@ async def test_materialize_returns_existing_observed_row_without_duplicating(
 ):
     """If discovery already created a row, return it and do not materialize."""
     GTFSService._service_id_cache.clear()
-    await _seed_njt_gtfs_trip(db_session)
+    await _seed_gtfs_trip(db_session)
 
     observed = TrainJourney(
         train_id="3096",
@@ -199,9 +201,42 @@ async def test_materialize_returns_existing_observed_row_without_duplicating(
 async def test_materialize_returns_none_when_train_absent_from_gtfs(db_session):
     """A train with no GTFS trip cannot be materialized; returns None gracefully."""
     GTFSService._service_id_cache.clear()
-    await _seed_njt_gtfs_trip(db_session)
+    await _seed_gtfs_trip(db_session)
 
     journey = await GTFSService().materialize_scheduled_journey(
         db_session, "9999", TARGET_DATE, data_source="NJT"
     )
     assert journey is None
+
+
+@pytest.mark.asyncio
+async def test_materialize_skips_sources_without_in_place_upgrade(db_session):
+    """A GTFS-RT source (e.g. SUBWAY) must NOT get a materialized row.
+
+    Those collectors mint their own train_ids and would create a *separate*
+    OBSERVED row, orphaning anything materialized here. The train is genuinely
+    present in GTFS (get_train_details returns it), so the None must come from
+    the source gate — not an incidental lookup miss.
+    """
+    GTFSService._service_id_cache.clear()
+    await _seed_gtfs_trip(db_session, data_source="SUBWAY")
+    service = GTFSService()
+
+    # Guard against a cheater pass: the train IS materializable in principle.
+    details = await service.get_train_details(
+        db_session, "3096", TARGET_DATE, data_source="SUBWAY"
+    )
+    assert details is not None, "GTFS lookup should find the seeded SUBWAY trip"
+    assert details.data_source == "SUBWAY"
+
+    journey = await service.materialize_scheduled_journey(
+        db_session, "3096", TARGET_DATE, data_source="SUBWAY"
+    )
+    assert journey is None
+
+    rows = (
+        await db_session.scalars(
+            select(TrainJourney).where(TrainJourney.train_id == "3096")
+        )
+    ).all()
+    assert rows == [], "no train_journeys row may be written for a gated source"

--- a/ios/TrackRat/Shared/LiveActivityModels.swift
+++ b/ios/TrackRat/Shared/LiveActivityModels.swift
@@ -47,7 +47,25 @@ struct TrainActivityAttributes: ActivityAttributes {
         }
         
         // MARK: - New Computed Properties for Time-Based Display
-        
+
+        /// Parsed scheduled departure `Date` for the user's origin station.
+        /// Live Activity widget bodies only re-render on a push or app foreground,
+        /// so countdowns must be rendered with a self-updating `Text(_:style:)`
+        /// driven by this `Date` rather than a precomputed minute string — otherwise
+        /// the displayed minutes freeze between pushes (issue #1298).
+        var departureDate: Date? {
+            guard !hasTrainDeparted,
+                  let departureTimeString = scheduledDepartureTime else { return nil }
+            return Date.fromISO8601(departureTimeString)
+        }
+
+        /// Parsed scheduled arrival `Date` for the user's destination station.
+        /// Used for the same self-updating countdown rendering as `departureDate`.
+        var arrivalDate: Date? {
+            guard let arrivalTimeString = scheduledArrivalTime else { return nil }
+            return Date.fromISO8601(arrivalTimeString)
+        }
+
         /// Minutes until train departs from user's origin station
         var minutesUntilDeparture: Int? {
             guard !hasTrainDeparted,

--- a/ios/TrainLiveActivityExtension/LiveActivityWidget.swift
+++ b/ios/TrainLiveActivityExtension/LiveActivityWidget.swift
@@ -190,12 +190,31 @@ struct TrainLiveActivity: Widget {
                     debugLog("🟢 Compact appeared", context: context)
                 }
             } compactTrailing: {
-                // Compact trailing (right side) - Track or station code
-                Text(context.state.compactTrailingText)
-                    .font(.caption)
-                    .monospacedDigit()
-                    .fontWeight(.medium)
-                    .foregroundColor(.white)
+                // Compact trailing (right side) - track, or a self-updating
+                // countdown timer so it ticks on-device between pushes (issue #1298).
+                Group {
+                    if context.state.isBoarding, let track = context.state.trackDisplay {
+                        Text(track)
+                    } else if !context.state.hasTrainDeparted,
+                              let departureDate = context.state.departureDate,
+                              departureDate > Date() {
+                        Text(timerInterval: Date()...departureDate, countsDown: true)
+                            .frame(maxWidth: 44)
+                            .multilineTextAlignment(.trailing)
+                    } else if context.state.hasTrainDeparted,
+                              let arrivalDate = context.state.arrivalDate,
+                              arrivalDate > Date() {
+                        Text(timerInterval: Date()...arrivalDate, countsDown: true)
+                            .frame(maxWidth: 44)
+                            .multilineTextAlignment(.trailing)
+                    } else {
+                        Text(context.state.compactTrailingText)
+                    }
+                }
+                .font(.caption)
+                .monospacedDigit()
+                .fontWeight(.medium)
+                .foregroundColor(.white)
             } minimal: {
                 // Minimal view (when multiple activities)
                 Image(systemName: "tram.fill")
@@ -294,9 +313,14 @@ struct TrainLiveActivityView: View {
                         Text("Boarding on Track \(track)")
                             .foregroundColor(.white)
                     } else if !context.state.hasTrainDeparted {
-                        // Show departure timing when train hasn't departed yet
-                        if let minutes = context.state.minutesUntilDeparture {
-                            Text(minutes > 1 ? "Departing in \(minutes) minutes" : minutes == 1 ? "Departing in 1 minute" : minutes == 0 ? "Departing now" : "Departing late")
+                        // Show departure timing when train hasn't departed yet.
+                        // Use a self-updating relative Date so the countdown ticks
+                        // on-device between pushes (issue #1298).
+                        if let departureDate = context.state.departureDate, departureDate > Date() {
+                            Text("Departing \(departureDate, style: .relative)")
+                                .foregroundColor(.white)
+                        } else if context.state.departureDate != nil {
+                            Text("Departing now")
                                 .foregroundColor(.white)
                         } else {
                             Text("Preparing to depart")
@@ -304,8 +328,11 @@ struct TrainLiveActivityView: View {
                         }
                     } else {
                         // Show arrival timing when train has departed
-                        if let minutes = context.state.minutesUntilArrival {
-                            Text(minutes > 1 ? "Arriving in \(minutes) minutes" : minutes == 1 ? "Arriving in 1 minute" : minutes == 0 ? "Arriving now" : "Arrived")
+                        if let arrivalDate = context.state.arrivalDate, arrivalDate > Date() {
+                            Text("Arriving \(arrivalDate, style: .relative)")
+                                .foregroundColor(.white)
+                        } else if context.state.arrivalDate != nil {
+                            Text("Arriving now")
                                 .foregroundColor(.white)
                         } else {
                             Text("En route")
@@ -364,25 +391,30 @@ struct TrainLiveActivityView: View {
 private struct CenterStatusView: View {
     let state: TrainActivityAttributes.ContentState
     let theme: String
-    
-    private var displayText: String {
-        if state.isBoarding {
-            return "Boarding on Track \(state.track ?? "")"
-        } else if !state.hasTrainDeparted, let minutes = state.minutesUntilDeparture {
-            return minutes > 0 ? "Departing in \(minutes)m" : "Departing now"
-        } else if state.hasTrainDeparted, let minutes = state.minutesUntilArrival {
-            return minutes > 0 ? "Arriving in \(minutes)m" : (minutes == 0 ? "Arriving now" : "Arriving late")
-        } else if state.hasTrainDeparted {
-            return "En Route"
-        } else {
-            return "Scheduled"
-        }
-    }
-    
+
     var body: some View {
-        Text(displayText)
-            .font(.caption)
-            .fontWeight(.semibold)
-            .foregroundColor(departingTextColor(for: theme))
+        // Render countdowns with a self-updating relative Date so they tick
+        // on-device between pushes rather than freezing on a stale minute count
+        // (issue #1298).
+        Group {
+            if state.isBoarding {
+                Text("Boarding on Track \(state.track ?? "")")
+            } else if !state.hasTrainDeparted, let departureDate = state.departureDate, departureDate > Date() {
+                Text("Departing \(departureDate, style: .relative)")
+            } else if !state.hasTrainDeparted, state.departureDate != nil {
+                Text("Departing now")
+            } else if state.hasTrainDeparted, let arrivalDate = state.arrivalDate, arrivalDate > Date() {
+                Text("Arriving \(arrivalDate, style: .relative)")
+            } else if state.hasTrainDeparted, state.arrivalDate != nil {
+                Text("Arriving now")
+            } else if state.hasTrainDeparted {
+                Text("En Route")
+            } else {
+                Text("Scheduled")
+            }
+        }
+        .font(.caption)
+        .fontWeight(.semibold)
+        .foregroundColor(departingTextColor(for: theme))
     }
 }


### PR DESCRIPTION
A Live Activity could be started for a SCHEDULED train that exists only in
GTFS static schedule data, with no train_journeys row (the departures listing
and /trains/{id} both have a GTFS fallback, so the train is fully viewable).
The Live Activity push job queries train_journeys exclusively and has no GTFS
fallback, so it logged journey_not_found_for_live_activity every cycle and
sent zero pushes — the on-device countdown went static until the app was
foregrounded (the reported symptom for NJT train 3096, NY -> Edison).

Materialize a SCHEDULED train_journeys row from GTFS at Live Activity
registration when none exists, so the push job has a row to update
immediately. NJT/Amtrak discovery later upgrades the same row to OBSERVED in
place, matched via the unique_train_journey key, so no duplicate is created.
Registration is best-effort: materialization failure never fails the request.

Also add data_source to the journey_not_found_for_live_activity log so the
miss is diagnosable (it is data-source specific).

- GTFSService.materialize_scheduled_journey() reuses get_train_details and
  persists the journey + stops; idempotent via the unique constraint.
- Tests cover create-from-GTFS, idempotency, existing-row passthrough (no
  duplicate / no stray stops), and absent-from-GTFS returning None.