### PR TITLE
fix: align STALE_PRIOR_RUN tests with production's Eastern Time gate

### DIFF
--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -782,7 +782,11 @@ class TestStalePriorRunDetection:
 
         journey = TrainJourney(
             train_id="4250",
-            journey_date=date.today() - timedelta(days=1),  # yesterday
+            # Use now_et().date() so the prior-day gate in production code
+            # (stored_journey.journey_date < now_et().date()) sees this row as
+            # yesterday in ET. Mixing date.today() (UTC) with now_et()-based
+            # comparisons fails when CI runs after 8pm ET / midnight UTC.
+            journey_date=now_et().date() - timedelta(days=1),
             line_code="NE",
             line_name="Northeast Corridor",
             destination="Trenton",
@@ -848,7 +852,7 @@ class TestStalePriorRunDetection:
 
         journey = TrainJourney(
             train_id="4244",
-            journey_date=date.today() - timedelta(days=1),
+            journey_date=now_et().date() - timedelta(days=1),
             line_code="NE",
             line_name="Northeast Corridor",
             destination="Trenton",
@@ -941,7 +945,7 @@ class TestStalePriorRunDetection:
 
         journey = TrainJourney(
             train_id="5517",
-            journey_date=date.today() - timedelta(days=1),
+            journey_date=now_et().date() - timedelta(days=1),
             line_code="NE",
             line_name="Northeast Corridor",
             destination="Trenton",
@@ -1023,7 +1027,7 @@ class TestStalePriorRunDetection:
 
         journey = TrainJourney(
             train_id="1720",
-            journey_date=date.today() - timedelta(days=1),
+            journey_date=now_et().date() - timedelta(days=1),
             line_code="NE",
             line_name="Northeast Corridor",
             destination="Trenton",


### PR DESCRIPTION
## Summary

Backend Tests on PR #1300 (and intermittently other PRs) fail the four `TestStalePriorRunDetection` cases with the assertion:

> A ~24h first-stop displacement is daily train_id reuse, not a delay — it must be classified as STALE_PRIOR_RUN…
> `assert <JourneyMatchResult.DEPARTURE_TIME_MISMATCH> is <JourneyMatchResult.STALE_PRIOR_RUN>`

The test fixtures set `journey_date=date.today() - timedelta(days=1)`, but the production gate in `collectors/njt/journey.py` is `stored_journey.journey_date < now_et().date()`. When CI runs after 8pm ET (midnight UTC), `date.today()` has already rolled over to the next UTC day while `now_et().date()` hasn't — so `journey_date == now_et().date()` instead of being strictly less, the gate fails, and the classifier returns `DEPARTURE_TIME_MISMATCH` instead of `STALE_PRIOR_RUN`.

PR #1300 was created at 2026-06-16 03:28 UTC = 23:28 EDT, which hit this window exactly.

## Files modified

- `backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py` — replace `date.today() - timedelta(days=1)` with `now_et().date() - timedelta(days=1)` in the four affected `TestStalePriorRunDetection` tests so the prior-day gate evaluates consistently regardless of when CI runs.

## Tests covered

- `test_full_day_displacement_classified_as_stale_prior_run`
- `test_threshold_boundary_separates_delay_from_prior_run`
- `test_collect_journey_details_expires_stale_prior_run`
- `test_collect_journey_details_completes_stale_prior_run_when_backstop_fires`

The same-day tests (`test_same_day_large_skew_classified_as_departure_time_mismatch`, `test_collect_journey_details_keeps_same_day_running_train`) keep `date.today()` because their assertions expect `DEPARTURE_TIME_MISMATCH` regardless of which day `date.today()` falls on — the bug only breaks the prior-day case.

## Design decisions

- Targeted change only to the 4 failing fixtures; did not modify production code because the production code is correct (ET is the system's canonical time zone) — the tests were inconsistent with it.
- Kept `date.today()` in the same-day tests so the diff is minimal and the unaffected tests remain untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_014boNu66h1HLbJBokqGn61D)_