### PR TITLE
Fix #1296: generate all lines at intra-system junctions (Secaucus/Jamaica transfers)

### DIFF
--- a/backend_v2/src/trackrat/config/transfer_points.py
+++ b/backend_v2/src/trackrat/config/transfer_points.py
@@ -228,37 +228,44 @@ def _generate_transfer_points() -> tuple[TransferPoint, ...]:
     # --- Source 5: Intra-system junctions for branching route systems ---
     # At junction stations where different routes within the same system meet,
     # create transfer points so trip search can route across branches.
-    # E.g., PATH Journal Sq (PJS) where NWK-WTC meets JSQ-33.
+    # E.g., PATH Journal Sq (PJS) where NWK-WTC meets JSQ-33, or NJT Secaucus
+    # where six lines interchange.
+    #
+    # A junction is emitted as a single transfer carrying *every* line that
+    # meets here on both sides. Because both sides are the same physical
+    # station, the per-side distinction is meaningless; trip search's relevance
+    # test (one side shares lines with the origin, the other with the
+    # destination) then reduces to "origin and destination both stop here",
+    # which is exactly the condition for a valid same-station interchange.
+    # Emitting one all-lines transfer (rather than one per line-pair) keeps the
+    # transfer set compact at large interchanges and, crucially, avoids the
+    # _add dedup collapsing many same-station/same-system pairs down to a
+    # single arbitrary line-pair and silently dropping the rest (#1296).
     for system, system_lines in _SYSTEM_STATION_LINES.items():
-        # Find stations served by multiple distinct line-code sets
-        for station_code, _lines in system_lines.items():
+        for station_code, station_line_codes in system_lines.items():
             if station_code not in station_systems:
                 continue
             if system not in station_systems[station_code]:
                 continue
-            # Get all routes through this station
+            # Count distinct lines (route groups) through this station; a single
+            # line with a legacy-alias code set counts once.
             route_groups: list[frozenset[str]] = []
             for route in ALL_ROUTES:
                 if route.data_source == system and station_code in route.stations:
                     if route.line_codes not in route_groups:
                         route_groups.append(route.line_codes)
-            # If station is served by 2+ distinct route groups, it's a junction
+            # 2+ distinct lines meeting here => interchange.
             if len(route_groups) >= 2:
-                # Merge all line codes reachable from each route group
-                # into two sides: routes that share codes vs those that don't
-                for i, codes_a in enumerate(route_groups):
-                    for codes_b in route_groups[i + 1 :]:
-                        # Same station, same system, different route groups
-                        _add(
-                            station_code,
-                            system,
-                            station_code,
-                            system,
-                            0.0,
-                            True,
-                            lines_a=codes_a,
-                            lines_b=codes_b,
-                        )
+                _add(
+                    station_code,
+                    system,
+                    station_code,
+                    system,
+                    0.0,
+                    True,
+                    lines_a=station_line_codes,
+                    lines_b=station_line_codes,
+                )
 
     return tuple(sorted(transfers, key=lambda t: (t.system_a, t.system_b, t.station_a)))
 

--- a/backend_v2/src/trackrat/services/trip_search.py
+++ b/backend_v2/src/trackrat/services/trip_search.py
@@ -341,18 +341,25 @@ def _rank_transfer_points(
     """Rank transfer points so truncation is deterministic and direction-symmetric.
 
     Sorting keys (ascending = better):
-    1. same_station transfers first (in-station is faster than walking)
-    2. walk_minutes ascending (shorter walks preferred)
-    3. stable tiebreaker on station/system codes (ensures identical ordering
+    1. intra-system transfers first. ``_find_relevant_transfer_points`` only
+       adds an intra-system transfer after verifying its lines connect the
+       origin to the destination, whereas cross-system transfers are added
+       unconditionally for the system pair. Prioritizing the relevance-verified
+       intra-system transfers keeps them inside the MAX_TRANSFER_QUERIES budget
+       instead of being crowded out by speculative cross-system points (#1296).
+    2. same_station transfers first (in-station is faster than walking)
+    3. walk_minutes ascending (shorter walks preferred)
+    4. stable tiebreaker on station/system codes (ensures identical ordering
        regardless of which direction the search runs)
     """
 
-    def _sort_key(tp: TransferPoint) -> tuple[int, int, str, str, str, str]:
+    def _sort_key(tp: TransferPoint) -> tuple[int, int, int, str, str, str, str]:
         # Canonical alphabetical order of the two sides for direction symmetry
         side_a = (tp.station_a, tp.system_a)
         side_b = (tp.station_b, tp.system_b)
         canonical = tuple(sorted([side_a, side_b]))
         return (
+            0 if tp.system_a == tp.system_b else 1,
             0 if tp.same_station else 1,
             tp.walk_minutes,
             canonical[0][0],

--- a/backend_v2/tests/unit/config/test_transfer_points.py
+++ b/backend_v2/tests/unit/config/test_transfer_points.py
@@ -283,10 +283,11 @@ class TestLookupIndexes:
         assert get_transfer_points("WMATA", "WMATA") == []
 
     def test_get_transfer_points_njt_njt_has_junction_transfers(self):
-        """NJT intra-system should return junction transfers (e.g., NE/NC at Newark Penn)."""
+        """NJT intra-system should return junction transfers (e.g., Secaucus)."""
         tps = get_transfer_points("NJT", "NJT")
         assert len(tps) > 0, "Expected NJT intra-system junction transfers"
-        # All should be same-station, same-system with different line groups
+        # Each junction is one same-station transfer carrying every line that
+        # meets there on both sides (#1296), so lines_a == lines_b with 2+ lines.
         for tp in tps:
             assert tp.system_a == "NJT" and tp.system_b == "NJT"
             assert (
@@ -294,8 +295,43 @@ class TestLookupIndexes:
             ), f"Intra-system junction should be same station, got {tp.station_a} != {tp.station_b}"
             assert tp.same_station is True
             assert (
-                tp.lines_a != tp.lines_b
-            ), f"Junction should connect different line groups at {tp.station_a}"
+                tp.lines_a == tp.lines_b
+            ), f"Junction should carry all lines on both sides at {tp.station_a}"
+            assert (
+                len(tp.lines_a) >= 2
+            ), f"Junction at {tp.station_a} should have 2+ lines, got {sorted(tp.lines_a)}"
+
+    def test_njt_secaucus_junction_connects_pascack_and_nec(self):
+        """Regression for #1296: Secaucus (SE) must carry Pascack Valley AND the
+        NEC so trip search can route New Bridge Landing -> NY Penn. The old
+        per-line-pair emission collapsed under the _add dedup, dropping every
+        SE line-pair except the first one ({NE}<->{NC})."""
+        se = [
+            tp
+            for tp in get_transfer_points("NJT", "NJT")
+            if tp.station_a == "SE" and tp.station_b == "SE"
+        ]
+        assert len(se) == 1, f"Expected exactly one SE junction transfer, got {len(se)}"
+        lines = se[0].lines_a
+        # Pascack Valley (PV), NEC (NE), and NJCL (NC) all interchange at SE.
+        assert "PV" in lines, f"SE junction missing Pascack Valley, got {sorted(lines)}"
+        assert "NE" in lines, f"SE junction missing NEC, got {sorted(lines)}"
+        assert "NC" in lines, f"SE junction missing NJCL, got {sorted(lines)}"
+
+    def test_lirr_jamaica_junction_carries_all_branches(self):
+        """Regression for #1296: Jamaica (JAM) is where ~all LIRR branches meet.
+        The junction transfer must carry every branch line so any branch->branch
+        transfer resolves, not just the first-generated pair."""
+        jam = [
+            tp
+            for tp in get_transfer_points("LIRR", "LIRR")
+            if tp.station_a == "JAM" and tp.station_b == "JAM"
+        ]
+        assert len(jam) == 1, f"Expected one JAM junction transfer, got {len(jam)}"
+        lines = jam[0].lines_a
+        # Babylon, Ronkonkoma, and Long Beach are distinct branches via JAM.
+        for branch in ("LIRR-BB", "LIRR-RK", "LIRR-LB"):
+            assert branch in lines, f"JAM missing {branch}, got {sorted(lines)}"
 
     def test_get_transfer_points_subway_subway_has_results(self):
         """SUBWAY <-> SUBWAY should return intra-subway transfer points."""

--- a/backend_v2/tests/unit/services/test_trip_search.py
+++ b/backend_v2/tests/unit/services/test_trip_search.py
@@ -254,6 +254,39 @@ class TestFindRelevantTransferPoints:
         assert frozenset({"GCT", "S723"}) in station_pairs
         assert frozenset({"GCT", "S901"}) in station_pairs
 
+    def test_njt_pascack_to_nec_finds_secaucus_junction(self):
+        """Regression #1296: Pascack Valley (NH) -> NEC (NY) must surface the
+        Secaucus (SE) intra-NJT junction. Before the fix, the junction only
+        carried the first-generated line-pair ({NE}<->{NC}), which doesn't
+        connect Pascack Valley, so this returned nothing."""
+        transfers = _find_relevant_transfer_points(
+            {"NJT"}, {"NJT"}, from_station="NH", to_station="NY"
+        )
+        assert any(
+            tp.station_a == "SE" and tp.station_b == "SE" and tp.system_a == "NJT"
+            for tp in transfers
+        ), "Expected a Secaucus intra-NJT junction transfer for NH->NY"
+
+    def test_njt_morris_essex_to_nec_finds_secaucus_junction(self):
+        """Regression #1296: Madison (M&E) -> Trenton (NEC) also routes via SE."""
+        transfers = _find_relevant_transfer_points(
+            {"NJT"}, {"NJT"}, from_station="MA", to_station="TR"
+        )
+        assert any(
+            tp.station_a == "SE" and tp.station_b == "SE" for tp in transfers
+        ), "Expected a Secaucus junction transfer for Madison->Trenton"
+
+    def test_lirr_branch_to_branch_finds_jamaica_junction(self):
+        """Regression #1296: Ronkonkoma (RON) -> Long Beach (LBH) must surface
+        the Jamaica (JAM) junction. Only the first branch-pair survived before
+        the fix, so most LIRR inter-branch transfers were dropped."""
+        transfers = _find_relevant_transfer_points(
+            {"LIRR"}, {"LIRR"}, from_station="RON", to_station="LBH"
+        )
+        assert any(
+            tp.station_a == "JAM" and tp.station_b == "JAM" for tp in transfers
+        ), "Expected a Jamaica junction transfer for Ronkonkoma->Long Beach"
+
 
 class TestStationLinesExpanded:
     """Test line lookup across physical station equivalences."""
@@ -1078,6 +1111,70 @@ class TestRankTransferPoints:
         result = _rank_transfer_points([tp], "A", "B", {"NJT"}, {"PATH"})
         assert len(result) == 1
         assert result[0] is tp
+
+    def test_intra_system_ranked_before_cross_system(self):
+        """Regression #1296: a relevance-verified intra-system junction must
+        rank ahead of speculative cross-system transfers, even when the
+        cross-system points sort earlier by station code. Otherwise the only
+        useful transfer gets crowded out of the MAX_TRANSFER_QUERIES budget."""
+        intra = self._make_tp(
+            station_a="SE",
+            system_a="NJT",
+            station_b="SE",
+            system_b="NJT",
+            walk_minutes=5,
+            same_station=True,
+        )
+        # Cross-system same-station transfers whose codes sort before "SE".
+        cross = [
+            self._make_tp(
+                station_a=code,
+                system_a="NJT",
+                station_b=code,
+                system_b="AMTRAK",
+                walk_minutes=5,
+                same_station=True,
+            )
+            for code in ("MP", "NB", "NP", "NY", "PH", "PJ")
+        ]
+        ranked = _rank_transfer_points(
+            cross + [intra], "NH", "NY", {"NJT"}, {"NJT", "AMTRAK"}
+        )
+        assert ranked[0] is intra, "Intra-system junction must rank first"
+
+
+class TestSecaucusJunctionBudget:
+    """End-to-end transfer-selection regression for issue #1296.
+
+    Combines the real route topology, _find_relevant_transfer_points, and
+    _rank_transfer_points to confirm the Secaucus junction is actually queried
+    for the reported New Bridge Landing -> NY Penn search in both the
+    single-system and default multi-system cases.
+    """
+
+    def _secaucus_in_budget(
+        self, from_systems: set[str], to_systems: set[str]
+    ) -> bool:
+        transfers = _find_relevant_transfer_points(
+            from_systems, to_systems, from_station="NH", to_station="NY"
+        )
+        ranked = _rank_transfer_points(
+            transfers, "NH", "NY", from_systems, to_systems
+        )
+        budget = MAX_TRANSFER_QUERIES // 2
+        return any(
+            tp.station_a == "SE" and tp.station_b == "SE" and tp.system_a == "NJT"
+            for tp in ranked[:budget]
+        )
+
+    def test_njt_only(self):
+        """With data_sources=NJT, the Secaucus junction is selected."""
+        assert self._secaucus_in_budget({"NJT"}, {"NJT"})
+
+    def test_multi_source_not_crowded_out(self):
+        """With no filter (NJT+AMTRAK+LIRR), Amtrak-shared stations must not
+        crowd Secaucus out of the queried budget."""
+        assert self._secaucus_in_budget({"NJT"}, {"NJT", "AMTRAK", "LIRR"})
 
 
 class TestMaxTransferQueriesIncreased:


### PR DESCRIPTION
## Summary

Fixes #1296 — trip search returned "no trains available" for common transfer routes such as **New Bridge Landing → NY Penn** (Pascack Valley → NEC, transfer at Secaucus).

## Root cause

The triage note guessed a Secaucus upper/lower-level code mismatch, but the codes were already aligned (both routes use `SE`). The real bug is a **dedup-key collision in the transfer-point generator** (`config/transfer_points.py`):

```python
key = frozenset({(code_a, sys_a), (code_b, sys_b)})
```

For an intra-system junction, both sides are the *same* `(station, system)` and differ only by line — so this frozenset collapses to a **single element**, and the line codes aren't in the key. The generator emitted one transfer per line-pair (N-choose-2 at an N-line junction), but every pair after the first was silently dropped as "already seen."

At Secaucus the lone survivor was `{NE}↔{NC}` (NEC↔NJCL), which doesn't connect Pascack Valley — so the search found `no_transfer_points`. It was **systemic**: at every multi-branch junction (NJT Secaucus/Newark/Hoboken, LIRR Jamaica, …) only the first-generated branch-pair worked.

### Reproduced against production

| Trip | Line pair at junction | Before |
|------|----------------------|--------|
| NH→NY (New Bridge Landing→Penn) | PV ↔ NE | `no_transfer_points` |
| MA→TR (Madison→Trenton) | ME ↔ NE | `no_transfer_points` |
| TR→LB (Trenton→Long Branch) | NE ↔ NC (the survivor) | transfer, 3 trips ✅ |
| RON→LBH / RON→LHEM / LBH→LHEM (LIRR via Jamaica) | various | `no_transfer_points` |
| BTA→LHEM (Babylon→Hempstead, first pair) | BB ↔ HB | transfer, 3 trips ✅ |

## Changes

**1. `config/transfer_points.py` — the core fix.** Emit **one** transfer per junction station carrying *every* line on both sides instead of one per line-pair. Both sides are the same physical station, so the per-side distinction is meaningless; trip search's relevance test (`one side shares lines with origin, the other with destination`) reduces to "origin and destination both stop here" — exactly the condition for a valid same-station interchange. This keeps the transfer set compact (one per junction — the same count as the buggy collapsed behavior, but with the correct lines).

**2. `services/trip_search.py` — `_rank_transfer_points`.** Prioritize intra-system transfers in the ranking. They're already relevance-verified (lines connect origin↔dest), whereas cross-system transfers are added unconditionally. Without this, in the default no-filter search the Amtrak-shared stations (`MP, NB, NP, NY, PH, PJ`) sort before `SE` and crowd Secaucus out of the `MAX_TRANSFER_QUERIES` budget.

## Tests

- `test_transfer_points.py`: updated the junction test for the new `lines_a == lines_b` semantics; added regression tests that **SE** carries `PV`/`NE`/`NC` and **JAM** carries the LIRR branches.
- `test_trip_search.py`: NH→NY and MA→TR find the Secaucus junction; RON→LBH finds Jamaica; intra-system ranks before cross-system; and `TestSecaucusJunctionBudget` confirms (using real topology) that Secaucus survives the query budget in **both** the NJT-only and multi-source cases.

## Safety / regression notes

- The new sort key is direction-independent — the existing direction-symmetry tests are unaffected.
- Only `trip_search.py` consumes `lines_a`/`lines_b`; both uses are safe when they're equal at a same-station junction (orient is a no-op since `station_a == station_b`).
- Lines are never surfaced to clients (`TransferInfo` doesn't carry them).
- Junction count is unchanged, so `test_total_count_reasonable` holds; subway intra-transfers (Source 4) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
