### PR TITLE
Include client IP in feedback GitHub issues

### DIFF
--- a/backend_v2/src/trackrat/api/feedback.py
+++ b/backend_v2/src/trackrat/api/feedback.py
@@ -6,9 +6,11 @@ Collects user feedback about data issues and logs it for review.
 
 from datetime import datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import BaseModel
 from structlog import get_logger
+
+from trackrat.api.utils import get_client_ip
 
 # Use a dedicated logger name for easy filtering in GCP Logs Explorer
 # Filter with: jsonPayload.logger="trackrat.api.feedback"
@@ -37,7 +39,9 @@ class FeedbackResponse(BaseModel):
 
 
 @router.post("", response_model=FeedbackResponse)
-async def submit_feedback(request: FeedbackRequest) -> FeedbackResponse:
+async def submit_feedback(
+    request: FeedbackRequest, http_request: Request
+) -> FeedbackResponse:
     """Submit user feedback about data accuracy or other issues."""
     logger.info(
         "user_feedback_submitted",
@@ -48,6 +52,7 @@ async def submit_feedback(request: FeedbackRequest) -> FeedbackResponse:
         destination_code=request.destination_code,
         app_version=request.app_version,
         device_model=request.device_model,
+        client_ip=get_client_ip(http_request),
         timestamp=datetime.utcnow().isoformat(),
     )
 

--- a/backend_v2/src/trackrat/api/utils.py
+++ b/backend_v2/src/trackrat/api/utils.py
@@ -18,13 +18,22 @@ logger = get_logger(__name__)
 def get_client_ip(request: Request) -> str:
     """Return the originating client IP for a request.
 
-    Behind GCP's HTTP(S) load balancer the direct peer is the load balancer, so
-    the real client IP is the first entry of the ``X-Forwarded-For`` header. Fall
-    back to the direct peer address, then ``"unknown"`` when neither is present.
+    Behind GCP's external HTTP(S) load balancer the LB appends
+    ``"<client-ip>,<lb-ip>"`` to any existing ``X-Forwarded-For`` header rather
+    than overwriting it, so the trusted client IP is the second-to-last entry.
+    Earlier entries can be forged by the client. When the header is missing or
+    has only one entry (e.g. local dev — the LB would always have added its own
+    pair in production), fall back to the direct peer.
+
+    See https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header
     """
-    forwarded = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-    if forwarded:
-        return forwarded
+    forwarded = [
+        part.strip()
+        for part in request.headers.get("x-forwarded-for", "").split(",")
+        if part.strip()
+    ]
+    if len(forwarded) >= 2:
+        return forwarded[-2]
     return request.client.host if request.client else "unknown"
 
 

--- a/backend_v2/src/trackrat/api/utils.py
+++ b/backend_v2/src/trackrat/api/utils.py
@@ -6,13 +6,26 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Any
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from sqlalchemy.exc import DatabaseError, OperationalError
 from structlog import get_logger
 
 from trackrat.collectors.njt.client import NJTransitAPIError
 
 logger = get_logger(__name__)
+
+
+def get_client_ip(request: Request) -> str:
+    """Return the originating client IP for a request.
+
+    Behind GCP's HTTP(S) load balancer the direct peer is the load balancer, so
+    the real client IP is the first entry of the ``X-Forwarded-For`` header. Fall
+    back to the direct peer address, then ``"unknown"`` when neither is present.
+    """
+    forwarded = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
+    if forwarded:
+        return forwarded
+    return request.client.host if request.client else "unknown"
 
 
 def handle_errors(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/backend_v2/src/trackrat/main.py
+++ b/backend_v2/src/trackrat/main.py
@@ -32,6 +32,7 @@ from trackrat.api import (
     trips,
     validation,
 )
+from trackrat.api.utils import get_client_ip
 from trackrat.db.database import init_database, shutdown_database
 from trackrat.db.engine import close_engine, get_session
 from trackrat.services.apns import SimpleAPNSService
@@ -284,10 +285,7 @@ async def request_stats_middleware(
     # Skip noisy internal paths
     if path_template not in {"/health", "/health/live", "/health/ready", "/metrics"}:
         query_params = dict(request.query_params)
-        # Prefer X-Forwarded-For (set by GCP load balancer) over direct client IP
-        client_ip = request.headers.get("x-forwarded-for", "").split(",")[
-            0
-        ].strip() or (request.client.host if request.client else "unknown")
+        client_ip = get_client_ip(request)
         get_request_stats().record_request(
             path_template=path_template,
             status_code=response.status_code,

--- a/backend_v2/tests/unit/api/test_feedback.py
+++ b/backend_v2/tests/unit/api/test_feedback.py
@@ -26,19 +26,48 @@ def _make_request(
 
 
 class TestGetClientIp:
-    """Unit tests for the X-Forwarded-For aware client-IP helper."""
+    """Unit tests for the X-Forwarded-For aware client-IP helper.
 
-    def test_prefers_first_forwarded_for_entry(self) -> None:
-        """Behind GCP's LB the real client IP is the first XFF entry."""
+    GCP's external HTTP(S) load balancer appends ``"<client-ip>,<lb-ip>"`` to
+    any existing X-Forwarded-For header, so the trusted client IP is the
+    second-to-last entry and any earlier entries may have been forged by the
+    caller.
+    """
+
+    def test_returns_second_to_last_entry_behind_gcp_lb(self) -> None:
+        """The LB-appended pair is at the tail; the real client IP is at -2."""
         request = _make_request(
             headers={"x-forwarded-for": "203.0.113.7, 35.191.0.1"},
             client=("10.0.0.1", 5000),
         )
         assert get_client_ip(request) == "203.0.113.7"
 
-    def test_strips_whitespace_from_forwarded_entry(self) -> None:
-        request = _make_request(headers={"x-forwarded-for": "  203.0.113.7  "})
+    def test_ignores_spoofed_entries_before_lb_appended_pair(self) -> None:
+        """Client-supplied XFF entries appear before the LB-appended pair and
+        must not be trusted; only the LB's recorded client IP (position -2)
+        counts."""
+        request = _make_request(
+            headers={
+                "x-forwarded-for": "1.2.3.4, 5.6.7.8, 203.0.113.7, 35.191.0.1"
+            },
+            client=("10.0.0.1", 5000),
+        )
         assert get_client_ip(request) == "203.0.113.7"
+
+    def test_strips_whitespace_around_entries(self) -> None:
+        request = _make_request(
+            headers={"x-forwarded-for": "  203.0.113.7  ,  35.191.0.1  "}
+        )
+        assert get_client_ip(request) == "203.0.113.7"
+
+    def test_single_xff_entry_falls_back_to_direct_peer(self) -> None:
+        """A single XFF entry can't be the LB-appended pair (the LB always adds
+        its own), so it isn't trusted — fall back to the direct peer."""
+        request = _make_request(
+            headers={"x-forwarded-for": "203.0.113.7"},
+            client=("10.0.0.1", 5000),
+        )
+        assert get_client_ip(request) == "10.0.0.1"
 
     def test_falls_back_to_direct_peer_without_header(self) -> None:
         request = _make_request(client=("198.51.100.4", 443))

--- a/backend_v2/tests/unit/api/test_feedback.py
+++ b/backend_v2/tests/unit/api/test_feedback.py
@@ -1,0 +1,73 @@
+"""Tests for the feedback endpoint and the shared client-IP helper.
+
+The client IP is derived server-side and attached to the structured
+``user_feedback_submitted`` log event, which the feedback-notifier Cloud
+Function later renders into the GitHub issue. These tests cover both the
+extraction logic and that the endpoint logs the resolved IP.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from trackrat.api.utils import get_client_ip
+
+
+def _make_request(
+    headers: dict[str, str] | None = None,
+    client: tuple[str, int] | None = None,
+) -> Request:
+    """Build a minimal Starlette Request for helper-level tests."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request({"type": "http", "headers": raw_headers, "client": client})
+
+
+class TestGetClientIp:
+    """Unit tests for the X-Forwarded-For aware client-IP helper."""
+
+    def test_prefers_first_forwarded_for_entry(self) -> None:
+        """Behind GCP's LB the real client IP is the first XFF entry."""
+        request = _make_request(
+            headers={"x-forwarded-for": "203.0.113.7, 35.191.0.1"},
+            client=("10.0.0.1", 5000),
+        )
+        assert get_client_ip(request) == "203.0.113.7"
+
+    def test_strips_whitespace_from_forwarded_entry(self) -> None:
+        request = _make_request(headers={"x-forwarded-for": "  203.0.113.7  "})
+        assert get_client_ip(request) == "203.0.113.7"
+
+    def test_falls_back_to_direct_peer_without_header(self) -> None:
+        request = _make_request(client=("198.51.100.4", 443))
+        assert get_client_ip(request) == "198.51.100.4"
+
+    def test_empty_header_falls_back_to_direct_peer(self) -> None:
+        request = _make_request(
+            headers={"x-forwarded-for": ""}, client=("198.51.100.4", 443)
+        )
+        assert get_client_ip(request) == "198.51.100.4"
+
+    def test_returns_unknown_when_nothing_available(self) -> None:
+        request = _make_request()
+        assert get_client_ip(request) == "unknown"
+
+
+class TestSubmitFeedback:
+    """Endpoint-level tests for /api/v2/feedback."""
+
+    def test_logs_forwarded_client_ip(self, client: TestClient, caplog) -> None:
+        """The endpoint records the X-Forwarded-For client IP on the log event."""
+        caplog.set_level(logging.INFO)
+        resp = client.post(
+            "/api/v2/feedback",
+            json={"message": "Wrong arrival time", "screen": "train_details"},
+            headers={"x-forwarded-for": "203.0.113.7, 35.191.0.1"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "received"
+        assert "user_feedback_submitted" in caplog.text
+        assert "client_ip=203.0.113.7" in caplog.text

--- a/infra_v2/functions/feedback_notifier/main.py
+++ b/infra_v2/functions/feedback_notifier/main.py
@@ -28,6 +28,7 @@ def format_github_issue(payload):
     device = payload.get("device_model", "unknown")
     train_id = payload.get("train_id") or "N/A"
     app_version = payload.get("app_version") or "unknown"
+    client_ip = payload.get("client_ip") or "unknown"
     timestamp = payload.get("timestamp", "unknown")
 
     is_suggestion = message.startswith("[Improvement Suggestion] ")
@@ -60,6 +61,7 @@ def format_github_issue(payload):
         f"| **Train** | {train_id} |",
         f"| **Device** | {device} |",
         f"| **App Version** | {app_version} |",
+        f"| **Client IP** | {client_ip} |",
         f"| **Submitted** | {timestamp} |",
         "",
         "---",

--- a/infra_v2/functions/feedback_notifier/test_main.py
+++ b/infra_v2/functions/feedback_notifier/test_main.py
@@ -125,6 +125,33 @@ def test_partial_route_info():
     print("PASS: test_partial_route_info")
 
 
+def test_client_ip_rendered_when_present():
+    """format_github_issue includes the client IP row when supplied."""
+    payload = {
+        "message": "Departures not loading",
+        "screen": "train_list",
+        "client_ip": "203.0.113.7",
+    }
+
+    _, body = format_github_issue(payload)
+
+    assert "| **Client IP** | 203.0.113.7 |" in body
+    print("PASS: test_client_ip_rendered_when_present")
+
+
+def test_client_ip_defaults_to_unknown_when_missing():
+    """format_github_issue falls back to 'unknown' when no client IP is supplied."""
+    payload = {
+        "message": "Departures not loading",
+        "screen": "train_list",
+    }
+
+    _, body = format_github_issue(payload)
+
+    assert "| **Client IP** | unknown |" in body
+    print("PASS: test_client_ip_defaults_to_unknown_when_missing")
+
+
 if __name__ == "__main__":
     test_issue_report_formatting()
     test_improvement_suggestion_formatting()
@@ -132,4 +159,6 @@ if __name__ == "__main__":
     test_missing_optional_fields()
     test_newlines_in_message_stripped_from_title()
     test_partial_route_info()
+    test_client_ip_rendered_when_present()
+    test_client_ip_defaults_to_unknown_when_missing()
     print("\nAll tests passed!")


### PR DESCRIPTION
Capture the originating client IP on the feedback endpoint and surface it
in the auto-created GitHub issue.

- Add shared get_client_ip() helper in api/utils.py (X-Forwarded-For aware,
  falls back to direct peer then "unknown") and reuse it in the request-stats
  middleware to remove the duplicated inline extraction.
- Attach client_ip to the user_feedback_submitted log event so it flows
  through the existing log -> Pub/Sub -> Cloud Function pipeline.
- Render a "Client IP" row in the feedback-notifier GitHub issue body.
- Tests for the helper, the endpoint, and the issue formatting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ikHTCftJVW9GShKizW7D8