### PR TITLE
docs: weekly audit - Live Activity GTFS materialization + iOS countdown

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -774,6 +774,8 @@ The backend is organized into service classes for better maintainability:
 ## Recent Improvements & Known Issues
 
 ### Recent Improvements (June 2026)
+- ✅ Live Activity materializes a SCHEDULED `train_journeys` row from GTFS at registration when none exists, so the push job has a row to update immediately instead of logging `journey_not_found_for_live_activity` every cycle (issue #1298, `api/live_activities.py`, `services/gtfs.py::GTFSService.materialize_scheduled_journey`)
+- ✅ Live Activity materialization gated to `MATERIALIZE_SCHEDULED_SOURCES = {NJT, AMTRAK}` — GTFS-RT systems mint their own train_ids on discovery and would orphan the materialized row (issue #1298 follow-up, `services/gtfs.py`)
 - ✅ Retention sweep extended to inactive `service_alerts` so long-resolved alerts no longer accumulate (issue #1269, `services/scheduler.py`)
 - ✅ NJT `updated_arrival` / `updated_departure` inversion normalized at the `/trains/{train_id}` endpoint via `utils/train.py` so consumers don't have to apply `max(updated_departure, updated_arrival)` themselves (issue #1268, `api/trains.py`)
 - ✅ Route summary uses live estimate for boarding-stop departure on-time calculation; falls back to arrival estimate when departure is absent (issue #1282, `services/summary.py`)

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -130,6 +130,7 @@ xcodebuild -scheme TrackRat -sdk iphonesimulator build \
 - Push notifications for status changes
 - Journey progress with interpolation
 - Track/platform prediction shown on the Lock Screen when available (`predictedTrack` / `predictedTrackConfidence`)
+- Countdown ticks on-device every second via self-updating SwiftUI Date views (`Text(date, style: .relative)` / `Text(timerInterval:countsDown:)`) driven by `departureDate` / `arrivalDate` on `ContentState` — does not freeze between backend pushes (issue #1298)
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Weekly documentation audit. Past 7 days of commits had two doc-affecting changes (both tracking issue #1298); everything else was dependency bumps or test-only fixes that don't surface in the docs.

- `backend_v2/CLAUDE.md`: add June 2026 entries for the Live Activity push fixes shipped this week — GTFS materialization of a SCHEDULED `train_journeys` row at LA registration (#1299), and the follow-up gating to `MATERIALIZE_SCHEDULED_SOURCES = {NJT, AMTRAK}` so GTFS-RT systems don't orphan the materialized row (#1294).
- `ios/CLAUDE.md`: note that the Live Activity countdown ticks on-device every second via self-updating SwiftUI Date views (`Text(date, style: .relative)` / `Text(timerInterval:countsDown:)`) — no longer freezes between backend pushes.

## Audit scope

Reviewed all CLAUDE.md and README.md files (`/`, `.claude/`, `backend_v2/`, `ios/`, `android/`, `webpage_v2/`, `infra_v2/`) against `git log --since="7 days ago"`. Verified:

- File paths & key locations — current
- Documented API endpoints match `backend_v2/src/trackrat/api/` — no new endpoints
- Scripts (`scripts/validate-staging.sh`, `ground-truth-validate.py`, `server-usage.sh`, etc.) — unchanged
- Collector architecture descriptions — no new transit systems or collector changes
- Env vars — no new vars added
- `webpage_v2/CLAUDE.md` tech-stack versions still match `package.json` (vite 8.0.x, tailwind 4.3, react-router 7.16, date-fns 4.4 — last week's audit covered the bumps)
- iOS version bump to 3.5 isn't pinned in any doc, so nothing to update

## Test plan

- [ ] Verify rendered markdown reads cleanly in the GitHub diff view


---
_Generated by [Claude Code](https://claude.ai/code/session_01DMNDLzsFASU7JanTPrTcn9)_