### PR TITLE
Fix #1329: NJT duplicate "Train TBD" from schedule/real-time destination mismatch

### DIFF
--- a/backend_v2/src/trackrat/collectors/njt/discovery.py
+++ b/backend_v2/src/trackrat/collectors/njt/discovery.py
@@ -20,7 +20,7 @@ from trackrat.db.engine import get_session
 from trackrat.models.database import DiscoveryRun, JourneyStop, TrainJourney
 from trackrat.utils.sanitize import sanitize_track
 from trackrat.utils.time import now_et, parse_njt_time, validate_journey_date
-from trackrat.utils.train import is_amtrak_train
+from trackrat.utils.train import is_amtrak_train, normalize_njt_destination
 
 logger = get_logger(__name__)
 
@@ -382,6 +382,13 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
 
         Follows the same pattern as PATH's _find_matching_journey().
 
+        Destination comparison strips the generic schedule-API " TRANSIT
+        CENTER" suffix (see ``normalize_njt_destination``) — the schedule API
+        returns "TRENTON TRANSIT CENTER" while the real-time feed returns
+        "Trenton" for the same station, and without normalization the two
+        never match here, leaving a duplicate "Train TBD" SCHEDULED row
+        alongside the real OBSERVED train (issue #1329).
+
         Args:
             session: Database session
             station_code: Discovery station code
@@ -396,6 +403,7 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
         time_window = timedelta(minutes=time_tolerance_minutes)
         time_min = scheduled_departure - time_window
         time_max = scheduled_departure + time_window
+        dest_normalized = normalize_njt_destination(destination)
 
         stmt = (
             select(TrainJourney)
@@ -406,8 +414,12 @@ class TrainDiscoveryCollector(BaseDiscoveryCollector):
                     TrainJourney.journey_date == journey_date,
                     TrainJourney.observation_type == "SCHEDULED",
                     TrainJourney.is_cancelled.is_(False),
-                    func.lower(func.trim(TrainJourney.destination))
-                    == func.lower(destination.strip()),
+                    func.regexp_replace(
+                        func.lower(func.trim(TrainJourney.destination)),
+                        r"\s+transit center$",
+                        "",
+                    )
+                    == dest_normalized,
                     JourneyStop.station_code == station_code,
                     JourneyStop.scheduled_departure.is_not(None),
                     JourneyStop.scheduled_departure >= time_min,

--- a/backend_v2/src/trackrat/collectors/njt/journey.py
+++ b/backend_v2/src/trackrat/collectors/njt/journey.py
@@ -34,7 +34,7 @@ from trackrat.utils.time import (
     now_et,
     parse_njt_time,
 )
-from trackrat.utils.train import is_njt_stop_cancelled
+from trackrat.utils.train import is_njt_stop_cancelled, normalize_njt_destination
 
 logger = get_logger(__name__)
 
@@ -526,6 +526,7 @@ class JourneyCollector(BaseJourneyCollector):
         - "New York -SEC &#9992" -> "new york"
         - "Penn Station New York" -> "new york"
         - "Trenton" -> "trenton"
+        - "TRENTON TRANSIT CENTER" -> "trenton"
         """
         if not destination:
             return ""
@@ -544,7 +545,14 @@ class JourneyCollector(BaseJourneyCollector):
         # Remove extra whitespace
         normalized = " ".join(normalized.split())
 
-        return normalized.strip()
+        # Collapse NJT's schedule-API " TRANSIT CENTER" suffix so the full
+        # official name ("TRENTON TRANSIT CENTER") and the real-time short
+        # name ("Trenton") for the same station compare equal. A journey
+        # merged/promoted from a SCHEDULED row carries the schedule-API
+        # destination; without this it would be falsely flagged as a
+        # DESTINATION_MISMATCH and expired on the next collection pass before
+        # update_journey_metadata could heal the field (issue #1329).
+        return normalize_njt_destination(normalized)
 
     async def _is_same_journey(
         self,

--- a/backend_v2/src/trackrat/services/departure.py
+++ b/backend_v2/src/trackrat/services/departure.py
@@ -40,6 +40,7 @@ from trackrat.utils.train import (
     get_effective_observation_type,
     is_amtrak_train,
     is_njt_stop_cancelled,
+    normalize_njt_destination,
 )
 
 logger = get_logger(__name__)
@@ -58,8 +59,10 @@ def _destination_prefix(destination: str | None) -> str:
     """Normalize a destination string for similarity comparison.
 
     NJT's schedule API and real-time API sometimes return the same terminus
-    with different suffixes ("Suffern" vs "Suffern via Hoboken"). Lowercase
-    the string, trim whitespace, and strip any " via ..." suffix so the two
+    with different suffixes ("Suffern" vs "Suffern via Hoboken", "Trenton"
+    vs "TRENTON TRANSIT CENTER"). Lowercase the string, trim whitespace,
+    strip any " via ..." suffix, and strip the generic NJT schedule-API
+    " TRANSIT CENTER" suffix (see ``normalize_njt_destination``) so the two
     forms compare equal — but preserve the rest of the destination so that
     distinct termini sharing a leading word ("Long Branch" vs "Long Island",
     "Atlantic City" vs "Atlantic Highlands") still compare unequal. Empty
@@ -71,7 +74,7 @@ def _destination_prefix(destination: str | None) -> str:
     via_idx = normalized.find(" via ")
     if via_idx > 0:
         normalized = normalized[:via_idx].rstrip()
-    return normalized
+    return normalize_njt_destination(normalized)
 
 
 # Tracks station codes currently being refreshed in background tasks.

--- a/backend_v2/src/trackrat/utils/train.py
+++ b/backend_v2/src/trackrat/utils/train.py
@@ -151,3 +151,26 @@ def is_njt_stop_cancelled(status: str | None) -> bool:
     if not status:
         return False
     return status.strip().upper() in ("CANCELLED", "CANCELED")
+
+
+def normalize_njt_destination(destination: str | None) -> str:
+    """Normalize an NJT destination string for cross-source matching.
+
+    NJT's daily schedule API (``getTrainSchedule`` used for schedule
+    generation) returns the full official station name as ``DESTINATION``
+    (e.g. "TRENTON TRANSIT CENTER"), while the real-time discovery feed
+    returns the short common name for the same station (e.g. "Trenton").
+    Without normalization, SCHEDULED rows created from the schedule API
+    never match the OBSERVED row created from the real-time feed for the
+    same physical train — the discovery merge misses it (creating a
+    duplicate journey) and the departures dedup safety net also misses it
+    (leaving the stale "Train TBD" row visible alongside the real train).
+    Strip the generic " TRANSIT CENTER" suffix so both forms compare equal.
+    """
+    if not destination:
+        return ""
+    normalized = destination.strip().lower()
+    suffix = " transit center"
+    if normalized.endswith(suffix):
+        normalized = normalized[: -len(suffix)]
+    return normalized

--- a/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
+++ b/backend_v2/tests/unit/collectors/njt/test_journey_mismatch_detection.py
@@ -220,6 +220,68 @@ class TestStaleOriginDetection:
         ), "Different destination should be detected as a destination mismatch"
 
     @pytest.mark.asyncio
+    async def test_transit_center_suffix_not_treated_as_mismatch(
+        self, db_session: AsyncSession, journey_collector
+    ):
+        """A row merged/promoted from a SCHEDULED record carries NJT's
+        schedule-API destination ("TRENTON TRANSIT CENTER") while the
+        getTrainStopList feed returns the short name ("Trenton"). These name
+        the same station and must compare equal — otherwise the journey is
+        falsely expired on the next collection pass before
+        update_journey_metadata can heal the destination field (issue #1329).
+        """
+        base_time = now_et().replace(hour=19, minute=20, second=0, microsecond=0)
+
+        journey = TrainJourney(
+            train_id="3865",
+            journey_date=date.today(),
+            line_code="NE",
+            line_name="Northeast Corridor",
+            destination="TRENTON TRANSIT CENTER",  # schedule-API form (merged row)
+            origin_station_code="NY",
+            terminal_station_code="TR",
+            data_source="NJT",
+            scheduled_departure=base_time,
+            has_complete_journey=True,
+            is_completed=False,
+            observation_type="OBSERVED",
+        )
+        db_session.add(journey)
+        await db_session.flush()
+
+        stop = JourneyStop(
+            journey_id=journey.id,
+            station_code="NY",
+            station_name="New York Penn Station",
+            stop_sequence=0,
+            scheduled_departure=base_time,
+        )
+        db_session.add(stop)
+        await db_session.flush()
+
+        builder = StopBuilder()
+        api_response = create_stop_list_response(
+            train_id="3865",
+            line_code="NE",
+            destination="Trenton",  # real-time short form
+            stops=[
+                builder.build_stop(
+                    "NY", "New York Penn Station", base_time.strftime(NJT_TIME_FORMAT)
+                ),
+            ],
+        )
+
+        result = await journey_collector._is_same_journey(
+            db_session, journey, api_response
+        )
+
+        assert result is JourneyMatchResult.MATCH, (
+            "'TRENTON TRANSIT CENTER' (schedule API) and 'Trenton' (real-time) "
+            "name the same station and must not be flagged as a destination "
+            "mismatch"
+        )
+
+    @pytest.mark.asyncio
     async def test_correct_origin_still_works(
         self, db_session: AsyncSession, journey_collector
     ):

--- a/backend_v2/tests/unit/services/test_departure_dedup.py
+++ b/backend_v2/tests/unit/services/test_departure_dedup.py
@@ -64,6 +64,14 @@ class TestDestinationPrefix:
     def test_via_suffix_with_multi_word_origin(self):
         assert _destination_prefix("Bay Head via Long Branch") == "bay head"
 
+    def test_strips_transit_center_suffix(self):
+        """NJT schedule API 'TRENTON TRANSIT CENTER' vs real-time 'Trenton'."""
+        assert _destination_prefix("TRENTON TRANSIT CENTER") == "trenton"
+        assert _destination_prefix("Trenton") == "trenton"
+        assert _destination_prefix("TRENTON TRANSIT CENTER") == _destination_prefix(
+            "Trenton"
+        )
+
 
 class TestMakeDedupKeys:
     """Tests for _make_dedup_keys function."""
@@ -664,6 +672,33 @@ class TestDedupeScheduledObservedCollisions:
 
         assert len(result) == 1
         assert result[0].train_id == "1234"
+
+    def test_matches_destination_with_transit_center_suffix(self):
+        """NJT schedule API 'TRENTON TRANSIT CENTER' vs real-time 'Trenton' (issue #1329)."""
+        observed_time = ET.localize(datetime(2026, 6, 24, 19, 10))
+        scheduled_time = ET.localize(datetime(2026, 6, 24, 19, 11))
+
+        deps = [
+            self._create_departure(
+                train_id="3865",
+                line_code="NE",
+                scheduled_time=observed_time,
+                observation_type="OBSERVED",
+                destination="Trenton",
+            ),
+            self._create_departure(
+                train_id="UNKNOWN",
+                line_code="NE",
+                scheduled_time=scheduled_time,
+                observation_type="SCHEDULED",
+                destination="TRENTON TRANSIT CENTER",
+            ),
+        ]
+
+        result = self.service._dedupe_scheduled_observed_collisions(deps)
+
+        assert len(result) == 1
+        assert result[0].train_id == "3865"
 
     def test_does_not_collapse_two_observed_rows(self):
         """Two OBSERVED rows at same line/time are presumed real distinct trains."""

--- a/backend_v2/tests/unit/test_normalize_njt_destination.py
+++ b/backend_v2/tests/unit/test_normalize_njt_destination.py
@@ -1,0 +1,60 @@
+"""Tests for ``normalize_njt_destination`` — the helper that bridges NJT's
+two destination formats so SCHEDULED and OBSERVED rows for the same physical
+train compare equal.
+
+Background (regression-protects issue #1329):
+  NJT's daily ``getTrainSchedule`` API (used for schedule generation) returns
+  the full official station name as ``DESTINATION`` (e.g. "TRENTON TRANSIT
+  CENTER"), while the real-time discovery feed returns the short common name
+  for the same station (e.g. "Trenton"). Without normalization, the SCHEDULED
+  row created from the schedule API never matches the OBSERVED row created
+  from the real-time feed — the discovery-time merge in
+  ``collectors/njt/discovery.py`` misses it (creating a duplicate journey),
+  and the departures dedup safety net in ``services/departure.py`` also
+  misses it (leaving a stale "Train TBD" row visible alongside the real
+  train, as reported by a user for train 3865 NY->Trenton).
+"""
+
+from __future__ import annotations
+
+from trackrat.utils.train import normalize_njt_destination
+
+
+class TestNormalizeNjtDestination:
+    def test_strips_transit_center_suffix(self) -> None:
+        assert normalize_njt_destination("TRENTON TRANSIT CENTER") == "trenton"
+
+    def test_short_name_unchanged_other_than_case(self) -> None:
+        assert normalize_njt_destination("Trenton") == "trenton"
+
+    def test_schedule_and_realtime_forms_match(self) -> None:
+        assert normalize_njt_destination(
+            "TRENTON TRANSIT CENTER"
+        ) == normalize_njt_destination("Trenton")
+
+    def test_other_transit_center_stations_also_match(self) -> None:
+        assert normalize_njt_destination(
+            "PENNSAUKEN TRANSIT CENTER"
+        ) == normalize_njt_destination("Pennsauken")
+
+    def test_strips_whitespace(self) -> None:
+        assert normalize_njt_destination("  Trenton  ") == "trenton"
+
+    def test_none_returns_empty_string(self) -> None:
+        assert normalize_njt_destination(None) == ""
+
+    def test_empty_string_returns_empty_string(self) -> None:
+        assert normalize_njt_destination("") == ""
+
+    def test_does_not_strip_suffix_mid_string(self) -> None:
+        """Only a trailing ' transit center' should be stripped, not an
+        occurrence elsewhere in the destination."""
+        assert (
+            normalize_njt_destination("Transit Center Junction")
+            == "transit center junction"
+        )
+
+    def test_distinct_destinations_remain_distinct(self) -> None:
+        assert normalize_njt_destination(
+            "TRENTON TRANSIT CENTER"
+        ) != normalize_njt_destination("Hamilton")


### PR DESCRIPTION
## Issue

Reported via in-app feedback (route NY Penn → Princeton Junction, `train_list` screen): a duplicate **"Train TBD"** showing alongside the real **Train 3865**.

## Root cause

NJT exposes the same physical station under two different destination strings:

- **Daily schedule API** (`getTrainSchedule`, used for SCHEDULED journey generation) returns the full official name — `"TRENTON TRANSIT CENTER"`.
- **Real-time discovery feed** returns the short common name — `"Trenton"`.

The iOS app renders any NJT/Amtrak `SCHEDULED` journey's label as literally `"Train TBD"`, so the duplicate the user saw is a stale, un-merged SCHEDULED row.

Three independent destination-comparison sites all required exact (case/whitespace-insensitive) string equality, so for Trenton-bound trains (and other `… TRANSIT CENTER` stations like Pennsauken, Wayne-Route 23) they never matched:

1. **`collectors/njt/discovery.py` → `_find_matching_scheduled_train`** — the discovery-time merge that should promote the existing SCHEDULED row to OBSERVED. On a miss it creates a *second* journey row, producing the duplicate.
2. **`services/departure.py` → `_destination_prefix`** — the dedup safety net that should drop a SCHEDULED row colliding with an OBSERVED one. On a miss the stale `"Train TBD"` row survives into the API response.
3. **`collectors/njt/journey.py` → `_is_same_journey`** — the per-collection identity check. With (1) now merging these rows, a merged row carries the schedule-API name `"TRENTON TRANSIT CENTER"`; on the next `getTrainStopList` pass it was compared against `"Trenton"`, flagged `DESTINATION_MISMATCH`, and the journey was **expired** — before `update_journey_metadata` could heal the field.

## Fix

Add a single shared normalizer `normalize_njt_destination()` in `utils/train.py` that strips the generic `" TRANSIT CENTER"` suffix, and route all three sites through it (the SQL site via an equivalent `regexp_replace`). No code duplication; distinct termini that merely share a leading word still compare unequal.

Once `_is_same_journey` matches, the existing `update_journey_metadata` rewrites the stored destination to the real-time short name, so the merged train's display self-heals.

## Tests

- `tests/unit/test_normalize_njt_destination.py` — new, covers the shared helper (suffix strip, symmetry, whitespace/None, no mid-string stripping, distinct destinations stay distinct).
- `test_departure_dedup.py` — `_destination_prefix` suffix case + an end-to-end `TestDedupeScheduledObservedCollisions` collapse for `"TRENTON TRANSIT CENTER"` (SCHEDULED) vs `"Trenton"` (OBSERVED).
- `test_journey_mismatch_detection.py` — new case asserting the two forms are **not** treated as a `DESTINATION_MISMATCH` (regression guard against false expiry).

All non-DB unit tests pass; `black`/`ruff`/`mypy` clean on the changed source files (pre-existing unused-import lint in the touched test files is unrelated and left as-is). DB-backed tests require a Postgres test database not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015pCXuNMSV2VdMnKntvX7AM)_