### PR TITLE
Issue #1334: rollback session on digest summary failure

### DIFF
--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -1092,9 +1092,17 @@ async def evaluate_morning_digests(
 
         if sent:
             # Assignment is safe on an expired ORM instance: it sets the
-            # pending value without triggering a refresh. The UPDATE is
-            # issued at commit() below.
+            # pending value without triggering a refresh.
+            #
+            # Commit immediately rather than batching at the end of the loop:
+            # a later subscription's summary failure triggers db.rollback()
+            # inside _generate_digest_summary, which would discard any
+            # uncommitted last_digest_at assignments from prior iterations.
+            # The push has already been delivered to APNS at that point, so
+            # losing the timestamp would cause the same digest to re-fire on
+            # the next 5-minute scheduler tick.
             sub.last_digest_at = datetime.now(UTC)
+            await db.commit()
             digests_sent += 1
 
             logger.info(
@@ -1104,9 +1112,6 @@ async def evaluate_morning_digests(
                 line_id=snap.line_id,
                 route_name=snap.route_name,
             )
-
-    if digests_sent > 0:
-        await db.commit()
 
     logger.info("morning_digest_evaluation_complete", digests_sent=digests_sent)
     return digests_sent

--- a/backend_v2/src/trackrat/services/alert_evaluator.py
+++ b/backend_v2/src/trackrat/services/alert_evaluator.py
@@ -7,6 +7,7 @@ or when train frequency drops significantly below normal levels.
 """
 
 import hashlib
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
@@ -112,7 +113,9 @@ def _is_system_wide(sub: RouteAlertSubscription) -> bool:
     )
 
 
-def _route_contains_station_pair(route: Route, from_station: str, to_station: str) -> bool:
+def _route_contains_station_pair(
+    route: Route, from_station: str, to_station: str
+) -> bool:
     """Check a route for a station pair, honoring station equivalence groups."""
     to_codes = expand_station_codes(to_station)
     for from_code in expand_station_codes(from_station):
@@ -953,6 +956,29 @@ def _build_train_alert_message(
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True, slots=True)
+class _DigestWorkItem:
+    """Snapshot of one subscription's data needed for digest evaluation.
+
+    See ``evaluate_morning_digests`` for why we materialize subscription
+    fields up front instead of reading them inside the loop body.
+    """
+
+    device_id: str | None
+    apns_token: str | None
+    digest_time_minutes: int | None
+    timezone: str | None
+    active_days: int
+    last_digest_at: datetime | None
+    data_source: str | None
+    line_id: str | None
+    direction: str | None
+    from_station_code: str | None
+    to_station_code: str | None
+    train_id: str | None
+    route_name: str
+
+
 async def evaluate_morning_digests(
     db: AsyncSession, apns_service: SimpleAPNSService
 ) -> int:
@@ -969,76 +995,115 @@ async def evaluate_morning_digests(
     )
     devices = result.scalars().all()
 
+    # Materialize the work list into plain (sub, snapshot) pairs up front.
+    # _generate_digest_summary calls db.rollback() on error (issue #1334)
+    # which expires every ORM instance attached to this session; later reads
+    # of `sub.X` / `device.X` would then trigger an implicit refresh from
+    # sync attribute access and raise MissingGreenlet. Keeping the data in
+    # plain snapshots decouples loop iteration from ORM state. `sub` is
+    # still kept around as a handle for the eventual last_digest_at write —
+    # attribute *assignment* on an expired instance is safe; only reads
+    # trigger a refresh.
+    work_items: list[tuple[RouteAlertSubscription, _DigestWorkItem]] = []
+    for device in devices:
+        for sub in device.subscriptions:
+            work_items.append(
+                (
+                    sub,
+                    _DigestWorkItem(
+                        device_id=device.device_id,
+                        apns_token=device.apns_token,
+                        digest_time_minutes=sub.digest_time_minutes,
+                        timezone=sub.timezone,
+                        active_days=sub.active_days or 0,
+                        last_digest_at=sub.last_digest_at,
+                        data_source=sub.data_source,
+                        line_id=sub.line_id,
+                        direction=sub.direction,
+                        from_station_code=sub.from_station_code,
+                        to_station_code=sub.to_station_code,
+                        train_id=sub.train_id,
+                        route_name=_get_route_name(sub),
+                    ),
+                )
+            )
+
     summary_service = SummaryService()
     digests_sent = 0
 
-    for device in devices:
-        for sub in device.subscriptions:
-            if sub.digest_time_minutes is None or not sub.timezone:
+    for sub, snap in work_items:
+        if snap.digest_time_minutes is None or not snap.timezone:
+            continue
+
+        try:
+            local_now = datetime.now(ZoneInfo(snap.timezone))
+        except (KeyError, ValueError):
+            continue
+
+        # Check if within ±2 min window of digest time
+        current_minutes = local_now.hour * 60 + local_now.minute
+        diff = abs(current_minutes - snap.digest_time_minutes)
+        # Handle midnight wrap (e.g., current=1438, digest=2 → diff should be 4)
+        if diff > 720:
+            diff = 1440 - diff
+        if diff > 2:
+            continue
+
+        # Day-of-week check
+        day_bit = 1 << local_now.weekday()
+        if not (snap.active_days & day_bit):
+            continue
+
+        # Already sent today?
+        if snap.last_digest_at:
+            last_digest_local = snap.last_digest_at.astimezone(ZoneInfo(snap.timezone))
+            if last_digest_local.date() == local_now.date():
                 continue
 
-            try:
-                local_now = datetime.now(ZoneInfo(sub.timezone))
-            except (KeyError, ValueError):
-                continue
+        summary = await _generate_digest_summary(
+            db,
+            summary_service,
+            data_source=snap.data_source,
+            line_id=snap.line_id,
+            direction=snap.direction,
+            from_station_code=snap.from_station_code,
+            to_station_code=snap.to_station_code,
+            train_id=snap.train_id,
+        )
 
-            # Check if within ±2 min window of digest time
-            current_minutes = local_now.hour * 60 + local_now.minute
-            diff = abs(current_minutes - sub.digest_time_minutes)
-            # Handle midnight wrap (e.g., current=1438, digest=2 → diff should be 4)
-            if diff > 720:
-                diff = 1440 - diff
-            if diff > 2:
-                continue
+        if not summary or not snap.apns_token:
+            continue
 
-            # Day-of-week check
-            day_bit = 1 << local_now.weekday()
-            if not ((sub.active_days or 0) & day_bit):
-                continue
-
-            # Already sent today?
-            if sub.last_digest_at:
-                last_digest_local = sub.last_digest_at.astimezone(
-                    ZoneInfo(sub.timezone)
-                )
-                if last_digest_local.date() == local_now.date():
-                    continue
-
-            # Generate summary
-            route_name = _get_route_name(sub)
-            summary = await _generate_digest_summary(db, sub, summary_service)
-
-            if not summary or not device.apns_token:
-                continue
-
-            title = route_name
-            custom_data = {
-                "route_alert": {
-                    "data_source": sub.data_source,
-                    "line_id": sub.line_id,
-                    "direction": sub.direction,
-                    "from_station_code": sub.from_station_code,
-                    "to_station_code": sub.to_station_code,
-                    "train_id": sub.train_id,
-                    "alert_type": "digest",
-                }
+        custom_data = {
+            "route_alert": {
+                "data_source": snap.data_source,
+                "line_id": snap.line_id,
+                "direction": snap.direction,
+                "from_station_code": snap.from_station_code,
+                "to_station_code": snap.to_station_code,
+                "train_id": snap.train_id,
+                "alert_type": "digest",
             }
-            body = f"Daily digest: {summary}"
-            sent = await apns_service.send_alert_notification(
-                device.apns_token, title, body, custom_data=custom_data
+        }
+        body = f"Daily digest: {summary}"
+        sent = await apns_service.send_alert_notification(
+            snap.apns_token, snap.route_name, body, custom_data=custom_data
+        )
+
+        if sent:
+            # Assignment is safe on an expired ORM instance: it sets the
+            # pending value without triggering a refresh. The UPDATE is
+            # issued at commit() below.
+            sub.last_digest_at = datetime.now(UTC)
+            digests_sent += 1
+
+            logger.info(
+                "morning_digest_sent",
+                device_id=snap.device_id,
+                data_source=snap.data_source,
+                line_id=snap.line_id,
+                route_name=snap.route_name,
             )
-
-            if sent:
-                sub.last_digest_at = datetime.now(UTC)
-                digests_sent += 1
-
-                logger.info(
-                    "morning_digest_sent",
-                    device_id=device.device_id,
-                    data_source=sub.data_source,
-                    line_id=sub.line_id,
-                    route_name=route_name,
-                )
 
     if digests_sent > 0:
         await db.commit()
@@ -1049,43 +1114,55 @@ async def evaluate_morning_digests(
 
 async def _generate_digest_summary(
     db: AsyncSession,
-    sub: RouteAlertSubscription,
     summary_service: "SummaryService",
+    *,
+    data_source: str | None,
+    line_id: str | None,
+    direction: str | None,
+    from_station_code: str | None,
+    to_station_code: str | None,
+    train_id: str | None,
 ) -> str | None:
-    """Generate digest text for a subscription using SummaryService."""
+    """Generate digest text for a subscription using SummaryService.
+
+    Accepts primitive subscription fields (not the ORM instance) because the
+    caller's loop runs over many subs sharing one session: a SQL failure here
+    triggers `db.rollback()` (issue #1334), which expires every ORM instance
+    attached to the session. Reading expired attributes from sync code in the
+    next iteration would raise MissingGreenlet, so the caller pre-materializes
+    the values it needs.
+    """
     try:
-        if sub.line_id:
-            route = _ROUTES_BY_ID.get(sub.line_id)
+        if line_id:
+            route = _ROUTES_BY_ID.get(line_id)
             if not route:
                 return None
             stations = route.stations
-            from_station = (
-                stations[0] if sub.direction == stations[-1] else stations[-1]
-            )
-            to_station = sub.direction or stations[-1]
+            from_station = stations[0] if direction == stations[-1] else stations[-1]
+            to_station = direction or stations[-1]
             result = await summary_service.get_route_summary(
                 db,
                 from_station=from_station,
                 to_station=to_station,
-                data_source=sub.data_source,
+                data_source=data_source,
             )
-        elif sub.from_station_code and sub.to_station_code:
+        elif from_station_code and to_station_code:
             result = await summary_service.get_route_summary(
                 db,
-                from_station=sub.from_station_code,
-                to_station=sub.to_station_code,
-                data_source=sub.data_source,
+                from_station=from_station_code,
+                to_station=to_station_code,
+                data_source=data_source,
             )
-        elif sub.train_id:
+        elif train_id:
             result = await summary_service.get_train_summary(
                 db,
-                train_id=sub.train_id,
+                train_id=train_id,
             )
         else:
             # System-wide: use network summary for the data source
             result = await summary_service.get_network_summary(
                 db,
-                data_source=sub.data_source,
+                data_source=data_source,
             )
 
         # For push notifications, use body (descriptive) over headline (terse)
@@ -1097,10 +1174,24 @@ async def _generate_digest_summary(
             return result.headline
         return None
     except Exception:
+        # Roll back so the next subscription in the loop reuses a clean
+        # session. Without this, any SQL failure (timeout, deadlock, etc.)
+        # inside summary_service leaves the asyncpg connection's transaction
+        # in an invalid state and subsequent queries fail with "Can't
+        # reconnect until invalid transaction is rolled back."
+        try:
+            await db.rollback()
+        except Exception:
+            logger.warning(
+                "digest_summary_rollback_failed",
+                data_source=data_source,
+                line_id=line_id,
+                exc_info=True,
+            )
         logger.warning(
             "digest_summary_generation_failed",
-            data_source=sub.data_source,
-            line_id=sub.line_id,
+            data_source=data_source,
+            line_id=line_id,
             exc_info=True,
         )
         return None

--- a/backend_v2/tests/unit/services/test_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_alert_evaluator.py
@@ -2466,3 +2466,98 @@ class TestMorningDigestRollback:
         assert sent == 1, f"Exactly one digest should send (the second sub); got {sent}"
         apns.send_alert_notification.assert_called_once()
         print("  Verified: digest loop continues after one subscription errors")
+
+    async def test_earlier_digest_timestamp_survives_later_rollback(
+        self, db_session: AsyncSession
+    ):
+        """If sub A's digest sends successfully and sub B's summary then
+        raises, sub A's `last_digest_at` must still be persisted. Without
+        per-iteration commit, sub B's rollback discards sub A's pending
+        ORM assignment and the same digest re-fires on the next 5-minute
+        scheduler tick — exactly what the user has already received via
+        APNS once.
+        """
+        local_now = datetime.now(ZoneInfo("America/New_York"))
+        current_minutes = local_now.hour * 60 + local_now.minute
+        weekday_mask = 1 << local_now.weekday()
+
+        # Sub A is created first and succeeds; sub B is iterated second and
+        # raises. Insertion order is also iteration order because both
+        # devices come back from the same selectinload query, and the
+        # subscriptions are flat-iterated in device order.
+        _, sub_a = _make_device_and_sub(
+            db_session,
+            device_id="digest-persist-ok",
+            apns_token="fake-token-ok",
+            data_source="NJT",
+            from_station="NP",
+            to_station="TR",
+            digest_time_minutes=current_minutes,
+            active_days=weekday_mask,
+            timezone="America/New_York",
+        )
+        _, sub_b = _make_device_and_sub(
+            db_session,
+            device_id="digest-persist-fail",
+            apns_token="fake-token-fail",
+            data_source="NJT",
+            from_station="NY",
+            to_station="TR",
+            digest_time_minutes=current_minutes,
+            active_days=weekday_mask,
+            timezone="America/New_York",
+        )
+        await db_session.commit()
+
+        apns = _make_apns()
+
+        # First summary call succeeds (sub A), second raises (sub B).
+        call_count = 0
+        ok_result = AsyncMock()
+        ok_result.body = "Service running normally."
+        ok_result.headline = "On time"
+
+        async def fake_get_route_summary(db, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ok_result
+            raise Exception("simulated SQL failure on sub B")
+
+        sub_a_id = sub_a.id
+        sub_b_id = sub_b.id
+
+        with patch("trackrat.services.summary.SummaryService") as MockSvc:
+            MockSvc.return_value.get_route_summary = AsyncMock(
+                side_effect=fake_get_route_summary
+            )
+            sent = await evaluate_morning_digests(db_session, apns)
+
+        assert sent == 1, f"Exactly one digest should send (sub A); got {sent}"
+        assert call_count == 2, (
+            f"Both subscriptions must invoke get_route_summary; got " f"{call_count}"
+        )
+
+        # Re-read sub_a from the database in a fresh transaction to confirm
+        # the timestamp was actually committed, not just left as an
+        # uncommitted in-memory ORM assignment that would later be lost.
+        await db_session.rollback()
+        result = await db_session.execute(
+            select(RouteAlertSubscription).where(RouteAlertSubscription.id == sub_a_id)
+        )
+        sub_a_after = result.scalar_one()
+        assert sub_a_after.last_digest_at is not None, (
+            "sub A's last_digest_at must be persisted to the DB even when "
+            "sub B's later summary call triggered a rollback. Without "
+            "per-iteration commit this is None and the digest re-fires next tick."
+        )
+
+        # Sub B never sent, so its timestamp must remain None.
+        result = await db_session.execute(
+            select(RouteAlertSubscription).where(RouteAlertSubscription.id == sub_b_id)
+        )
+        sub_b_after = result.scalar_one()
+        assert (
+            sub_b_after.last_digest_at is None
+        ), "sub B never sent a digest; last_digest_at must remain None"
+        print("  Verified: earlier digest timestamp survives later rollback")

--- a/backend_v2/tests/unit/services/test_alert_evaluator.py
+++ b/backend_v2/tests/unit/services/test_alert_evaluator.py
@@ -29,6 +29,7 @@ from trackrat.services.alert_evaluator import (
     _compute_alert_hash,
     _compute_train_alert_hash,
     _filter_by_direction,
+    _generate_digest_summary,
     _is_significantly_delayed,
     _is_within_time_window,
     evaluate_morning_digests,
@@ -2344,3 +2345,124 @@ class TestNotifyTypeToggles:
         assert count == 0, "Train delay alert suppressed when notify_delay=False"
         apns.send_alert_notification.assert_not_called()
         print("  Verified: train notify_delay=False suppresses delay")
+
+
+@pytest.mark.asyncio
+class TestMorningDigestRollback:
+    """Regression tests for issue #1334 — morning_digest_evaluation must
+    rollback when summary generation fails so the shared session can be
+    reused by subsequent subscriptions in the loop. Without rollback,
+    asyncpg refuses further queries with "Can't reconnect until invalid
+    transaction is rolled back."
+    """
+
+    async def test_generate_digest_summary_rolls_back_on_summary_error(
+        self, db_session: AsyncSession
+    ):
+        """When SummaryService raises, _generate_digest_summary must call
+        db.rollback() before returning None. Otherwise the shared loop
+        session stays in an invalid-transaction state and every subsequent
+        subscription fails."""
+        mock_summary_service = AsyncMock()
+        mock_summary_service.get_route_summary = AsyncMock(
+            side_effect=Exception("simulated SQL failure")
+        )
+
+        rollback_calls = 0
+        original_rollback = db_session.rollback
+
+        async def spy_rollback() -> None:
+            nonlocal rollback_calls
+            rollback_calls += 1
+            await original_rollback()
+
+        with patch.object(db_session, "rollback", side_effect=spy_rollback):
+            result = await _generate_digest_summary(
+                db_session,
+                mock_summary_service,
+                data_source="NJT",
+                line_id=None,
+                direction=None,
+                from_station_code="NY",
+                to_station_code="TR",
+                train_id=None,
+            )
+
+        assert result is None, "summary should return None on error"
+        assert rollback_calls == 1, (
+            f"db.rollback() must be called exactly once on summary error; "
+            f"got {rollback_calls}"
+        )
+        print("  Verified: digest summary rolls back on error")
+
+    async def test_digest_loop_continues_after_one_subscription_errors(
+        self, db_session: AsyncSession
+    ):
+        """If one subscription's summary call raises, subsequent subscriptions
+        in the same loop must still be evaluated successfully. This is the
+        end-to-end behavior protected by the rollback fix in
+        _generate_digest_summary."""
+        # Choose a digest_time_minutes that matches "now" so both subs evaluate
+        local_now = datetime.now(ZoneInfo("America/New_York"))
+        current_minutes = local_now.hour * 60 + local_now.minute
+        weekday_mask = 1 << local_now.weekday()
+
+        _make_device_and_sub(
+            db_session,
+            device_id="digest-rb-fail",
+            apns_token="fake-token-fail",
+            data_source="NJT",
+            from_station="NY",
+            to_station="TR",
+            digest_time_minutes=current_minutes,
+            active_days=weekday_mask,
+            timezone="America/New_York",
+        )
+        _make_device_and_sub(
+            db_session,
+            device_id="digest-rb-ok",
+            apns_token="fake-token-ok",
+            data_source="NJT",
+            from_station="NP",
+            to_station="TR",
+            digest_time_minutes=current_minutes,
+            active_days=weekday_mask,
+            timezone="America/New_York",
+        )
+        # Commit setup before evaluation: the production fix calls
+        # db.rollback() on the first sub's failure, which would otherwise
+        # wipe uncommitted test fixtures and mask the real assertion.
+        await db_session.commit()
+
+        apns = _make_apns()
+
+        # First subscription's summary call raises; second returns a usable
+        # body. Both reuse the same session, so without rollback the second
+        # call would fail with "invalid transaction".
+        call_count = 0
+        ok_result = AsyncMock()
+        ok_result.body = "Service running normally."
+        ok_result.headline = "On time"
+
+        async def fake_get_route_summary(db, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("simulated SQL failure")
+            return ok_result
+
+        # SummaryService is imported inside evaluate_morning_digests, so patch
+        # the source module (trackrat.services.summary).
+        with patch("trackrat.services.summary.SummaryService") as MockSvc:
+            MockSvc.return_value.get_route_summary = AsyncMock(
+                side_effect=fake_get_route_summary
+            )
+            sent = await evaluate_morning_digests(db_session, apns)
+
+        assert call_count == 2, (
+            f"Both subscriptions must invoke get_route_summary; got "
+            f"{call_count} call(s) — the loop bailed out after the first error"
+        )
+        assert sent == 1, f"Exactly one digest should send (the second sub); got {sent}"
+        apns.send_alert_notification.assert_called_once()
+        print("  Verified: digest loop continues after one subscription errors")


### PR DESCRIPTION
Closes #1334 (cluster A — `morning_digest_evaluation` "Can't reconnect until invalid transaction is rolled back").

## Summary

`evaluate_morning_digests` reuses a single `AsyncSession` across every device's subscription loop. When `SummaryService.get_route_summary` raised a SQL error inside `_generate_digest_summary`, the asyncpg connection's transaction was left in an invalid state. Every subsequent subscription in the same call then failed with `Can't reconnect until invalid transaction is rolled back`, which the scheduler logged as `task_execution_failed task=morning_digest_evaluation` — ~7×/24h in production.

The fix is twofold:

1. Roll back inside the `except Exception` block of `_generate_digest_summary` so the session's transaction is usable for the next subscription.
2. Materialize each subscription's needed fields into a frozen `_DigestWorkItem` snapshot up front. `db.rollback()` expires every ORM instance attached to the session, so subsequent reads of `sub.X` from the loop body (sync code) would otherwise raise `MissingGreenlet`. Snapshotting decouples loop iteration from ORM state. `last_digest_at` is still written via the kept ORM handle; attribute *assignment* on an expired instance is safe.

## Files changed

- `backend_v2/src/trackrat/services/alert_evaluator.py` — add `_DigestWorkItem` dataclass; pre-materialize subscription data; switch `_generate_digest_summary` to take primitive kwargs; rollback in its except block.
- `backend_v2/tests/unit/services/test_alert_evaluator.py` — new `TestMorningDigestRollback` class with two regression tests.

## Test coverage

New tests in `TestMorningDigestRollback`:

- `test_generate_digest_summary_rolls_back_on_summary_error` — patches `db.rollback` as a spy, makes `SummaryService.get_route_summary` raise, and asserts rollback is invoked exactly once and the function returns `None`.
- `test_digest_loop_continues_after_one_subscription_errors` — sets up two committed subscriptions, makes the first summary call raise and the second succeed, and asserts both subs are evaluated and exactly one digest sends. This was the regression: without the fix the second call would raise `MissingGreenlet` (the symptom the production logs exposed as the "invalid transaction" cascade).

All 81 tests in `tests/unit/services/test_alert_evaluator.py` and 29 tests in `tests/unit/services/test_scheduler.py` pass locally. `ruff`, `mypy`, and `black --check` are clean on the modified file.

## Design notes

- Clusters B (`timeout_get_operations_summary`) and C (`station_refresh_failed`) from issue #1334 are deliberately left out — both need deeper investigation (query optimization for B, race-condition analysis for C) and would muddle the diff.
- The dataclass is `frozen=True, slots=True` to make it cheap and unambiguously read-only; the loop should never mutate the snapshot.
- Logging in the except block uses the snapshot fields (`data_source`, `line_id`) so the warning never triggers an ORM refresh of an expired instance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi7zwgg5PgDEzW7iSken6Y)_