### PR TITLE
docs: weekly audit - June 2026 Live Activity GTFS materialization

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -774,6 +774,7 @@ The backend is organized into service classes for better maintainability:
 ## Recent Improvements & Known Issues
 
 ### Recent Improvements (June 2026)
+- ✅ Live Activity registration materializes a SCHEDULED `train_journeys` row from GTFS when none exists, so the push job has a row to update on the next cycle (fixes frozen countdown for GTFS-only scheduled trains like NJT 3096). Gated to NJT/Amtrak via `MATERIALIZE_SCHEDULED_SOURCES` because only their discovery upgrades a SCHEDULED row in place; GTFS-RT systems mint separate OBSERVED rows and would orphan the materialized one (issue #1298, `services/gtfs.py::materialize_scheduled_journey`, `api/live_activities.py`)
 - ✅ Retention sweep extended to inactive `service_alerts` so long-resolved alerts no longer accumulate (issue #1269, `services/scheduler.py`)
 - ✅ NJT `updated_arrival` / `updated_departure` inversion normalized at the `/trains/{train_id}` endpoint via `utils/train.py` so consumers don't have to apply `max(updated_departure, updated_arrival)` themselves (issue #1268, `api/trains.py`)
 - ✅ Route summary uses live estimate for boarding-stop departure on-time calculation; falls back to arrival estimate when departure is absent (issue #1282, `services/summary.py`)

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -130,6 +130,7 @@ xcodebuild -scheme TrackRat -sdk iphonesimulator build \
 - Push notifications for status changes
 - Journey progress with interpolation
 - Track/platform prediction shown on the Lock Screen when available (`predictedTrack` / `predictedTrackConfidence`)
+- Countdown self-updates on-device via SwiftUI relative-time text and `Text(timerInterval:countsDown:)` driven by `departureDate`/`arrivalDate` in `ContentState`, so the minute count ticks every second without a backend push
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Weekly documentation audit covering changes landed since the previous audit (`e4d7bcb`, June 15):

- **backend_v2/CLAUDE.md** — adds a June 2026 changelog entry for the Live Activity GTFS materialization fix. `materialize_scheduled_journey` now creates a SCHEDULED `train_journeys` row from GTFS at Live Activity registration when none exists, so the push job has a row to update on the next cycle (fixes frozen countdown for GTFS-only scheduled trains like NJT 3096). Gated to NJT/Amtrak via `MATERIALIZE_SCHEDULED_SOURCES` because only those discovery paths upgrade a SCHEDULED row in place; GTFS-RT systems would orphan the materialized row (PRs #1299, #1302; issue #1298).
- **ios/CLAUDE.md** — notes that the Live Activity countdown now self-updates on-device via SwiftUI relative-time text and `Text(timerInterval:countsDown:)` driven by `departureDate`/`arrivalDate` in `ContentState`, instead of relying solely on backend pushes (PR #1298 iOS side).

Other commits in the window had no doc impact: PyJWT bump (#1300), Vite 8.0.14→8.0.16 (#1304, still "Vite 8.0" in tech stack), STALE_PRIOR_RUN test-only alignment (#1302), iOS version bump to 3.5 (not surfaced in any doc).

## Test plan

- [ ] Skim `backend_v2/CLAUDE.md` June 2026 section — matches the format of existing entries (file paths + issue numbers).
- [ ] Skim `ios/CLAUDE.md` Live Activities bullet list — wording fits adjacent bullets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AskA8VpesHXFjYYaBjrHga)_