### PR TITLE
Cut data retention to 60 days and reclaim journey-table disk bloat

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -490,7 +490,7 @@ TRACKRAT_API_HOST=0.0.0.0                        # API bind host
 TRACKRAT_API_PORT=8000                           # API bind port
 TRACKRAT_SKIP_MIGRATIONS=false                   # Skip auto-migrations on startup
 TRACKRAT_BACKUP_INTERVAL_SECONDS=300             # GCS backup frequency (default 5min)
-TRACKRAT_RETENTION_DAYS=120                      # Days to retain journey data (min 30)
+TRACKRAT_RETENTION_DAYS=60                       # Days to retain journey data (min 30)
 
 # APNS Auth Key Content (alternative to file path)
 APNS_AUTH_KEY=                                   # Raw P8 key content (fallback if APNS_AUTH_KEY_PATH unavailable)

--- a/backend_v2/README.md
+++ b/backend_v2/README.md
@@ -91,7 +91,7 @@ poetry run uvicorn trackrat.main:app --reload
 - **Every 5 minutes**: Update checks for active journeys
 - **Every 5 minutes**: Route alert evaluation and push notifications
 - **Hourly at :05**: Validation across key routes
-- **Daily 3:30 AM ET**: Data retention cleanup (deletes journeys, discovery runs, validation results, and inactive service alerts older than `TRACKRAT_RETENTION_DAYS`, default 120 days; active service alerts are kept regardless of age)
+- **Daily 3:30 AM ET**: Data retention cleanup (deletes journeys, discovery runs, validation results, and inactive service alerts older than `TRACKRAT_RETENTION_DAYS`, default 60 days; active service alerts are kept regardless of age)
 - Monitor scheduler status at `/scheduler/status` endpoint
 
 **Note**: PATH, LIRR, Metro-North, NYC Subway, BART, MBTA, Metra, and WMATA each use unified collectors that handle both discovery and journey updates in a single pass. LIRR, Metro-North, Subway, BART, MBTA, and Metra use GTFS-RT feeds with shared logic in `mta_common.py`. WMATA uses its REST API. PATCO uses GTFS static schedules only (no real-time API).

--- a/backend_v2/src/trackrat/db/migrations/versions/20260630_2021-d8c07a8efd43_drop_unused_idx_track_occupancy_lookup_.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260630_2021-d8c07a8efd43_drop_unused_idx_track_occupancy_lookup_.py
@@ -1,0 +1,70 @@
+"""drop unused idx_track_occupancy_lookup and tune autovacuum
+
+Drops idx_track_occupancy_lookup on journey_stops. It was created to serve
+track_occupancy.py, but that query filters station_code + a 2-hour
+scheduled_departure window, which the planner satisfies with idx_station_times
+(station_code, scheduled_departure) and cheap post-filters. The middle
+has_departed_station column (queried as IS NOT TRUE, a non-equality) makes this
+index strictly worse than idx_station_times for the query, so it is never
+chosen — pg_stat_user_indexes shows 0 scans against a backdrop of billions on
+production. A prior cleanup (d170389c0848) deferred dropping it on the theory
+that the 0 scans came from stale planner stats; two months of fresh stats with
+still-zero scans disproves that, and the index had bloated to ~4 GB.
+
+Also lowers the autovacuum scale factors on the three high-churn journey tables
+so dead tuples (and the index bloat they cause) are reclaimed at ~2% turnover
+instead of the 20% default, which on multi-million-row tables let bloat grow
+for too long between vacuums.
+
+Revision ID: d8c07a8efd43
+Revises: 896c9fb11394
+Create Date: 2026-06-30 20:21:45.083464
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d8c07a8efd43"
+down_revision = "896c9fb11394"
+branch_labels = None
+depends_on = None
+
+
+# Tables whose autovacuum thresholds we tighten. They are UPDATE-heavy during
+# collection (times, track, flags churn through each train's life), so the
+# 20% default scale factor lets bloat accumulate before autovacuum fires.
+_CHURN_TABLES = ("journey_stops", "segment_transit_times", "train_journeys")
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    # IF EXISTS so this is a no-op if the index was already dropped manually
+    # (e.g. via DROP INDEX CONCURRENTLY during an emergency disk reclaim).
+    op.execute("DROP INDEX IF EXISTS idx_track_occupancy_lookup")
+
+    for table in _CHURN_TABLES:
+        op.execute(
+            f"ALTER TABLE {table} SET ("
+            "autovacuum_vacuum_scale_factor = 0.02, "
+            "autovacuum_analyze_scale_factor = 0.02"
+            ")"
+        )
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    for table in _CHURN_TABLES:
+        op.execute(
+            f"ALTER TABLE {table} RESET ("
+            "autovacuum_vacuum_scale_factor, "
+            "autovacuum_analyze_scale_factor"
+            ")"
+        )
+
+    op.create_index(
+        "idx_track_occupancy_lookup",
+        "journey_stops",
+        ["station_code", "has_departed_station", "scheduled_departure"],
+        unique=False,
+    )

--- a/backend_v2/src/trackrat/db/migrations/versions/20260630_2303-fd85e7f3abb3_drop_redundant_prefix_indexes_create_.py
+++ b/backend_v2/src/trackrat/db/migrations/versions/20260630_2303-fd85e7f3abb3_drop_redundant_prefix_indexes_create_.py
@@ -1,0 +1,74 @@
+"""drop redundant prefix indexes, create idx_delay_forecaster, autovacuum throughput
+
+Index hygiene follow-up to d8c07a8efd43. Reconciles the model with production
+and removes redundant indexes that only added write amplification (and therefore
+bloat) on the two churniest tables.
+
+Drops three indexes, each a strict leading-column prefix of a wider index that
+already serves the same predicates:
+  - idx_journey_date (journey_date)        -> idx_journey_date_source (journey_date, data_source)
+  - idx_journey_sequence (journey_id, stop_sequence)
+        -> idx_journey_stops_sequence_lookup (journey_id, stop_sequence, station_code)
+  - idx_last_updated (last_updated_at)
+        -> idx_congestion_journey_lookup (last_updated_at, is_cancelled, data_source)
+
+Creates idx_delay_forecaster, which the model has always declared but no
+migration ever created, so production has been missing it. Its query
+(delay_forecaster._get_train_id_stats: train_id + origin_station_code +
+data_source + journey_date >= cutoff) matches the index exactly, and all four
+columns are static so it does not bloat from last_updated_at churn.
+
+Also raises autovacuum_vacuum_cost_limit on the three high-churn tables so the
+(now more frequent, per d8c07a8efd43) autovacuums have the I/O budget to keep
+pace instead of falling behind and letting bloat accumulate.
+
+DROP/CREATE use IF [NOT] EXISTS so this is a no-op for objects already changed
+by hand on production (e.g. via DROP/CREATE INDEX CONCURRENTLY during reclaim).
+
+Revision ID: fd85e7f3abb3
+Revises: d8c07a8efd43
+Create Date: 2026-06-30 23:03:16.997321
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fd85e7f3abb3"
+down_revision = "d8c07a8efd43"
+branch_labels = None
+depends_on = None
+
+
+_CHURN_TABLES = ("journey_stops", "segment_transit_times", "train_journeys")
+
+
+def upgrade() -> None:
+    """Apply migration."""
+    # Create the index the model has always declared but prod never had.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_delay_forecaster ON train_journeys "
+        "(train_id, origin_station_code, data_source, journey_date)"
+    )
+
+    # Drop redundant prefix indexes (superseded by wider indexes above).
+    op.execute("DROP INDEX IF EXISTS idx_journey_date")
+    op.execute("DROP INDEX IF EXISTS idx_journey_sequence")
+    op.execute("DROP INDEX IF EXISTS idx_last_updated")
+
+    for table in _CHURN_TABLES:
+        op.execute(f"ALTER TABLE {table} SET (autovacuum_vacuum_cost_limit = 1000)")
+
+
+def downgrade() -> None:
+    """Revert migration."""
+    for table in _CHURN_TABLES:
+        op.execute(f"ALTER TABLE {table} RESET (autovacuum_vacuum_cost_limit)")
+
+    op.create_index("idx_journey_date", "train_journeys", ["journey_date"])
+    op.create_index(
+        "idx_journey_sequence", "journey_stops", ["journey_id", "stop_sequence"]
+    )
+    op.create_index("idx_last_updated", "train_journeys", ["last_updated_at"])
+
+    op.execute("DROP INDEX IF EXISTS idx_delay_forecaster")

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -124,14 +124,26 @@ class TrainJourney(Base):
         UniqueConstraint(
             "train_id", "journey_date", "data_source", name="unique_train_journey"
         ),
-        Index("idx_journey_date", "journey_date"),
         Index("idx_train_id", "train_id"),
-        Index("idx_last_updated", "last_updated_at"),
         Index("idx_data_source", "data_source"),
         Index("idx_active_journeys", "is_completed", "is_expired", "is_cancelled"),
-        # Composite index for queries filtering by date + source (congestion, history, forecaster)
+        # Composite index for date + source queries (congestion, history, forecaster).
+        # Supersedes a standalone idx_journey_date: journey_date is the leading
+        # column, so date-only predicates (e.g. the retention sweep) use it too.
         Index("idx_journey_date_source", "journey_date", "data_source"),
-        # Composite index for delay forecaster 365-day lookback queries
+        # Composite index for congestion queries:
+        #   last_updated_at >= cutoff AND is_cancelled = false AND data_source = ?
+        # Supersedes a standalone idx_last_updated (last_updated_at leads). Created
+        # in production by migration 5b4681856a79.
+        Index(
+            "idx_congestion_journey_lookup",
+            "last_updated_at",
+            "is_cancelled",
+            "data_source",
+        ),
+        # Composite index for delay forecaster lookback queries:
+        #   train_id = ? AND origin_station_code = ? AND data_source = ?
+        #   AND journey_date >= cutoff
         Index(
             "idx_delay_forecaster",
             "train_id",
@@ -218,7 +230,22 @@ class JourneyStop(Base):
     __table_args__ = (
         UniqueConstraint("journey_id", "station_code", name="unique_journey_stop"),
         Index("idx_station_times", "station_code", "scheduled_departure"),
-        Index("idx_journey_sequence", "journey_id", "stop_sequence"),
+        # Covering index for the consecutive-stop self-join in congestion
+        # analytics. Supersedes a standalone idx_journey_sequence
+        # (journey_id, stop_sequence) — it is the leading-column prefix here.
+        # Created in production by migration 5b4681856a79.
+        Index(
+            "idx_journey_stops_sequence_lookup",
+            "journey_id",
+            "stop_sequence",
+            "station_code",
+            postgresql_include=[
+                "scheduled_departure",
+                "scheduled_arrival",
+                "actual_departure",
+                "actual_arrival",
+            ],
+        ),
         Index("idx_stop_track_distribution", "station_code", "track"),
         Index("idx_stop_delay_forecaster", "station_code", "journey_id"),
         Index(

--- a/backend_v2/src/trackrat/models/database.py
+++ b/backend_v2/src/trackrat/models/database.py
@@ -219,12 +219,6 @@ class JourneyStop(Base):
         UniqueConstraint("journey_id", "station_code", name="unique_journey_stop"),
         Index("idx_station_times", "station_code", "scheduled_departure"),
         Index("idx_journey_sequence", "journey_id", "stop_sequence"),
-        Index(
-            "idx_track_occupancy_lookup",
-            "station_code",
-            "has_departed_station",
-            "scheduled_departure",
-        ),
         Index("idx_stop_track_distribution", "station_code", "track"),
         Index("idx_stop_delay_forecaster", "station_code", "journey_id"),
         Index(

--- a/backend_v2/src/trackrat/services/delay_forecaster.py
+++ b/backend_v2/src/trackrat/services/delay_forecaster.py
@@ -34,8 +34,11 @@ ON_TIME_THRESHOLD = 5
 SLIGHT_DELAY_THRESHOLD = 15
 SIGNIFICANT_DELAY_THRESHOLD = 30
 
-# Historical lookback period (days)
-HISTORICAL_LOOKBACK_DAYS = 365
+# Historical lookback period (days). Capped at the data retention window
+# (TRACKRAT_RETENTION_DAYS, default 60) — older journeys are deleted by the
+# nightly retention sweep, so looking back further only adds query cost for
+# rows that no longer exist.
+HISTORICAL_LOOKBACK_DAYS = 60
 
 
 @dataclass

--- a/backend_v2/src/trackrat/services/historical_track_predictor.py
+++ b/backend_v2/src/trackrat/services/historical_track_predictor.py
@@ -33,9 +33,11 @@ TIME_WINDOW_MINUTES = 30
 # Bound distribution queries to recent history so Postgres can use the
 # journey_date index and avoid sorting/hashing the full retention window
 # (which exhausted /dev/shm and surfaced as DiskFullError on staging —
-# issue #1168). Track patterns are stable, so 90 days is far above all
-# MIN_*_RECORDS thresholds at every modeled station.
-HISTORICAL_LOOKBACK_DAYS = 90
+# issue #1168). Track patterns are stable, so 60 days is far above all
+# MIN_*_RECORDS thresholds at every modeled station, and it stays within
+# the data retention window (TRACKRAT_RETENTION_DAYS, default 60) so the
+# query never scans for journeys the retention sweep has already deleted.
+HISTORICAL_LOOKBACK_DAYS = 60
 
 
 class HistoricalTrackPredictor:

--- a/backend_v2/src/trackrat/settings.py
+++ b/backend_v2/src/trackrat/settings.py
@@ -152,7 +152,7 @@ class Settings(BaseSettings):
 
     # Retention Settings
     retention_days: int = Field(
-        default=120,
+        default=60,
         description="Days to retain train journey data before cleanup (min 30)",
         ge=30,
     )

--- a/backend_v2/tests/unit/services/test_track_predictor_lookback.py
+++ b/backend_v2/tests/unit/services/test_track_predictor_lookback.py
@@ -55,8 +55,15 @@ async def _capture_query(predictor: HistoricalTrackPredictor, coro):
 def test_historical_lookback_days_is_positive():
     """The lookback constant must be a sensible positive value."""
     assert HISTORICAL_LOOKBACK_DAYS > 0
-    # Anything beyond the default retention (120 days) would be a no-op cap.
-    assert HISTORICAL_LOOKBACK_DAYS <= 120
+    # Lookback must not exceed the data retention window: older journeys are
+    # deleted by the nightly retention sweep, so a larger lookback would only
+    # scan for rows that no longer exist.
+    from trackrat.settings import Settings
+
+    retention_days = Settings(
+        database_url="postgresql+asyncpg://x:x@localhost/x"
+    ).retention_days
+    assert HISTORICAL_LOOKBACK_DAYS <= retention_days
 
 
 @pytest.mark.asyncio

--- a/backend_v2/tests/unit/test_drop_unused_indexes.py
+++ b/backend_v2/tests/unit/test_drop_unused_indexes.py
@@ -39,7 +39,6 @@ DROPPED_INDEXES = {
 RETAINED_INDEXES = {
     "idx_station_times",
     "idx_journey_sequence",
-    "idx_track_occupancy_lookup",
     "idx_stop_track_distribution",
     "idx_stop_delay_forecaster",
     "idx_stop_journey_station_seq",
@@ -127,7 +126,6 @@ def test_retained_indexes_still_present_on_journey_stops():
     expected = {
         "idx_station_times",
         "idx_journey_sequence",
-        "idx_track_occupancy_lookup",
         "idx_stop_track_distribution",
         "idx_stop_delay_forecaster",
         "idx_stop_journey_station_seq",
@@ -139,13 +137,18 @@ def test_retained_indexes_still_present_on_journey_stops():
     )
 
 
-def test_track_occupancy_lookup_explicitly_retained():
-    """idx_track_occupancy_lookup must be kept — track_occupancy.py uses it."""
+def test_track_occupancy_lookup_dropped():
+    """idx_track_occupancy_lookup was dropped (migration d8c07a8efd43).
+
+    Reverses the earlier decision to retain it: track_occupancy.py filters
+    station_code + a scheduled_departure window, which idx_station_times serves,
+    so the planner never used this index (0 scans on production against billions
+    elsewhere) and it had bloated to ~4 GB.
+    """
     indexes = _get_index_names(JourneyStop)
-    assert "idx_track_occupancy_lookup" in indexes, (
-        "idx_track_occupancy_lookup must NOT be dropped; "
-        "track_occupancy.py queries on (station_code, has_departed_station, "
-        "scheduled_departure)"
+    assert "idx_track_occupancy_lookup" not in indexes, (
+        "idx_track_occupancy_lookup should be removed from JourneyStop; "
+        "it is redundant with idx_station_times for the track-occupancy query"
     )
 
 
@@ -252,8 +255,12 @@ def test_migration_drops_exactly_eleven_indexes():
     assert len(calls) == 11, f"Expected 11 drop_index calls, got {len(calls)}"
 
 
-def test_migration_does_not_drop_track_occupancy_lookup():
-    """idx_track_occupancy_lookup must NOT be in the migration drop list."""
+def test_d170389c0848_does_not_drop_track_occupancy_lookup():
+    """The #986 cleanup (d170389c0848) deferred dropping this index.
+
+    Historical guard: that migration left idx_track_occupancy_lookup in place.
+    The drop happens later in d8c07a8efd43 — see the test below.
+    """
     migration = importlib.import_module(
         "trackrat.db.migrations.versions."
         "20260423_1749-d170389c0848_drop_unused_indexes"
@@ -274,10 +281,36 @@ def test_migration_does_not_drop_track_occupancy_lookup():
         else:
             delattr(migration, "op")
 
-    assert "idx_track_occupancy_lookup" not in calls, (
-        "Migration must NOT drop idx_track_occupancy_lookup; "
-        "it is actively used by track_occupancy.py"
+    assert "idx_track_occupancy_lookup" not in calls
+
+
+def test_d8c07a8efd43_drops_track_occupancy_lookup_and_tunes_autovacuum():
+    """The new migration drops the dead index and tightens autovacuum."""
+    migration = importlib.import_module(
+        "trackrat.db.migrations.versions."
+        "20260630_2021-d8c07a8efd43_drop_unused_idx_track_occupancy_lookup_"
     )
+    assert migration.revision == "d8c07a8efd43"
+    assert migration.down_revision == "896c9fb11394"
+
+    statements: list[str] = []
+    mock_op = types.SimpleNamespace(execute=lambda sql: statements.append(str(sql)))
+
+    original_op = getattr(migration, "op", None)
+    try:
+        migration.op = mock_op
+        migration.upgrade()
+    finally:
+        migration.op = original_op
+
+    joined = "\n".join(statements)
+    assert "DROP INDEX IF EXISTS idx_track_occupancy_lookup" in joined
+    # Autovacuum tightened on all three high-churn tables.
+    for table in ("journey_stops", "segment_transit_times", "train_journeys"):
+        assert any(
+            table in s and "autovacuum_vacuum_scale_factor = 0.02" in s
+            for s in statements
+        ), f"missing autovacuum tuning for {table}"
 
 
 def test_migration_downgrade_recreates_all_eleven_indexes():

--- a/backend_v2/tests/unit/test_drop_unused_indexes.py
+++ b/backend_v2/tests/unit/test_drop_unused_indexes.py
@@ -19,6 +19,7 @@ from trackrat.models.database import (
     SchedulerTaskRun,
     ServiceAlert,
     StationDwellTime,
+    TrainJourney,
     ValidationResult,
 )
 
@@ -38,7 +39,6 @@ DROPPED_INDEXES = {
 
 RETAINED_INDEXES = {
     "idx_station_times",
-    "idx_journey_sequence",
     "idx_stop_track_distribution",
     "idx_stop_delay_forecaster",
     "idx_stop_journey_station_seq",
@@ -125,10 +125,11 @@ def test_retained_indexes_still_present_on_journey_stops():
     indexes = _get_index_names(JourneyStop)
     expected = {
         "idx_station_times",
-        "idx_journey_sequence",
         "idx_stop_track_distribution",
         "idx_stop_delay_forecaster",
         "idx_stop_journey_station_seq",
+        # Covering index that supersedes the dropped idx_journey_sequence.
+        "idx_journey_stops_sequence_lookup",
     }
     missing = expected - indexes
     assert not missing, (
@@ -343,3 +344,73 @@ def test_migration_downgrade_recreates_all_eleven_indexes():
         f"but created {created_names}"
     )
     assert len(calls) == 11, f"Expected 11 create_index calls, got {len(calls)}"
+
+
+# ---------------------------------------------------------------------------
+# Redundant prefix-index reconciliation (migration fd85e7f3abb3)
+# ---------------------------------------------------------------------------
+
+# Indexes dropped because they are a strict leading-column prefix of a wider
+# index that already serves the same predicates.
+REDUNDANT_PREFIX_DROPPED = {
+    "idx_journey_date",  # -> idx_journey_date_source
+    "idx_journey_sequence",  # -> idx_journey_stops_sequence_lookup
+    "idx_last_updated",  # -> idx_congestion_journey_lookup
+}
+
+
+def test_redundant_prefix_indexes_removed_from_models():
+    """The three superseded prefix indexes must be gone from the models."""
+    train_journey_idx = _get_index_names(TrainJourney)
+    journey_stop_idx = _get_index_names(JourneyStop)
+    all_idx = train_journey_idx | journey_stop_idx
+    overlap = REDUNDANT_PREFIX_DROPPED & all_idx
+    assert not overlap, f"Models still declare dropped prefix indexes: {overlap}"
+
+
+def test_superseding_indexes_present_in_models():
+    """The wider indexes that absorb the dropped prefixes must be declared.
+
+    These existed in production (migration 5b4681856a79) but were missing from
+    the models, which is what made the prefix indexes look load-bearing.
+    """
+    train_journey_idx = _get_index_names(TrainJourney)
+    journey_stop_idx = _get_index_names(JourneyStop)
+    assert "idx_journey_date_source" in train_journey_idx
+    assert "idx_congestion_journey_lookup" in train_journey_idx
+    assert "idx_journey_stops_sequence_lookup" in journey_stop_idx
+
+
+def test_idx_delay_forecaster_declared_in_model():
+    """idx_delay_forecaster stays in the model; the migration creates it in prod."""
+    assert "idx_delay_forecaster" in _get_index_names(TrainJourney)
+
+
+def test_fd85e7f3abb3_upgrade_statements():
+    """The migration creates idx_delay_forecaster, drops the prefixes, tunes vacuum."""
+    migration = importlib.import_module(
+        "trackrat.db.migrations.versions."
+        "20260630_2303-fd85e7f3abb3_drop_redundant_prefix_indexes_create_"
+    )
+    assert migration.revision == "fd85e7f3abb3"
+    assert migration.down_revision == "d8c07a8efd43"
+
+    statements: list[str] = []
+    mock_op = types.SimpleNamespace(execute=lambda sql: statements.append(str(sql)))
+
+    original_op = getattr(migration, "op", None)
+    try:
+        migration.op = mock_op
+        migration.upgrade()
+    finally:
+        migration.op = original_op
+
+    joined = "\n".join(statements)
+    assert "CREATE INDEX IF NOT EXISTS idx_delay_forecaster" in joined
+    for name in REDUNDANT_PREFIX_DROPPED:
+        assert f"DROP INDEX IF EXISTS {name}" in joined, f"missing drop for {name}"
+    for table in ("journey_stops", "segment_transit_times", "train_journeys"):
+        assert any(
+            table in s and "autovacuum_vacuum_cost_limit = 1000" in s
+            for s in statements
+        ), f"missing cost_limit tuning for {table}"

--- a/backend_v2/tests/unit/test_retention_cleanup.py
+++ b/backend_v2/tests/unit/test_retention_cleanup.py
@@ -18,9 +18,9 @@ class TestRetentionSettings:
     """Test retention_days setting configuration."""
 
     def test_default_retention_days(self):
-        """Default retention_days should be 120."""
+        """Default retention_days should be 60."""
         settings = Settings(database_url="postgresql+asyncpg://x:x@localhost/x")
-        assert settings.retention_days == 120
+        assert settings.retention_days == 60
 
     def test_custom_retention_days(self):
         """retention_days should be configurable via environment."""


### PR DESCRIPTION
## Summary

Production's data disk had grown to **49 GB used (86% of 59 GB)**. Investigation showed the bulk is **index bloat on the high-churn journey tables**, not raw row volume. This PR lowers data retention, removes a dead index and three redundant ones, reconciles a model↔production schema drift that hid the redundancy, creates a useful index production was silently missing, and tunes autovacuum so the bloat doesn't come back.

`journey_snapshots` — the table I'd initially have guessed — is a non-issue at 318 MB.

## Diagnosis (production `pg_stat_user_tables` / `pg_stat_user_indexes`)

| table | total | heap | indexes |
|---|---|---|---|
| `journey_stops` | 33 GB | 6.4 GB | **27 GB** |
| `segment_transit_times` | 9 GB | 2.7 GB | 6.2 GB |
| `train_journeys` | 3.4 GB | 0.4 GB | 3.0 GB |

These three are ~45 GB of the 48 GB database. For each, the index footprint dwarfs the heap — classic index bloat from frequent `UPDATE`s to indexed columns during collection, with autovacuum running too infrequently (20% default scale factor on multi-million-row tables).

Standouts in the index list:
- `idx_track_occupancy_lookup` — **4 GB, 0 scans** against a backdrop of billions elsewhere.
- `idx_journey_stops_sequence_lookup` — 8.3 GB covering index, heavily used (403 M scans) but bloated because its `INCLUDE`d `actual_*` columns churn.

## Changes

### 1. Retention 120 → 60 days
- `TRACKRAT_RETENTION_DAYS` default lowered to 60 (min 30 still enforced). Halves steady-state row counts. The nightly 3:30 AM sweep already cascades `train_journeys` deletes to `journey_stops`, `journey_snapshots`, `journey_progress`, `segment_transit_times`, `station_dwell_times`.

### 2. Drop the dead index `idx_track_occupancy_lookup`
- `track_occupancy.py` filters `station_code` + a 2-hour `scheduled_departure` window, which `idx_station_times (station_code, scheduled_departure)` serves; the index's middle `has_departed_station` column (queried `IS NOT TRUE`, a non-equality) makes it strictly worse, so the planner never picks it.
- A prior cleanup (`d170389c0848`) deferred dropping it, blaming stale planner stats from a scheduler leak. Two months of fresh stats with still-zero scans disprove that.

### 3. Reconcile model ↔ production index drift
The model and prod had diverged, which is what made redundant indexes look load-bearing:
- The model declared `idx_delay_forecaster` but **no migration ever created it**, so production lacked it.
- Production had `idx_journey_stops_sequence_lookup` and `idx_congestion_journey_lookup` (from migration `5b4681856a79`) that were **never added to the model**.

Both prod-only indexes are now declared in the model (verified the generated DDL matches prod exactly), so future `--autogenerate` won't propose phantom drops/creates.

### 4. Drop three redundant prefix indexes
Each is a strict leading-column prefix of a wider index that already serves the same predicates, so they only added write amplification (and bloat) on the two churniest tables:
- `idx_journey_date` ⊂ `idx_journey_date_source (journey_date, data_source)`
- `idx_journey_sequence` ⊂ `idx_journey_stops_sequence_lookup (journey_id, stop_sequence, station_code)`
- `idx_last_updated` ⊂ `idx_congestion_journey_lookup (last_updated_at, is_cancelled, data_source)`

### 5. Create the missing `idx_delay_forecaster` in production
- `delay_forecaster._get_train_id_stats` filters `train_id + origin_station_code + data_source + journey_date >= cutoff` — an exact match. All four columns are static (set at journey creation), so this index does **not** bloat from `last_updated_at` churn. It's a genuinely useful index prod has been missing.

### 6. Cap historical lookback at the retention window
- `HISTORICAL_LOOKBACK_DAYS`: `delay_forecaster.py` 365 → 60, `historical_track_predictor.py` 90 → 60. Beyond retention the queries would only scan for journeys the sweep has already deleted. The lookback test now asserts the constant stays within `Settings().retention_days`.

### 7. Tune autovacuum so bloat doesn't recur
On `journey_stops`, `segment_transit_times`, `train_journeys`:
- `autovacuum_vacuum_scale_factor` / `autovacuum_analyze_scale_factor` 0.20 → 0.02 (vacuum at ~2% turnover instead of 20%).
- `autovacuum_vacuum_cost_limit` → 1000 so the more frequent vacuums have the I/O budget to keep pace.

## Migrations

- `d8c07a8efd43` — drop `idx_track_occupancy_lookup`; set autovacuum scale factors.
- `fd85e7f3abb3` — create `idx_delay_forecaster`; drop `idx_journey_date` / `idx_journey_sequence` / `idx_last_updated`; set autovacuum cost_limit.

Both use `DROP/CREATE INDEX IF [NOT] EXISTS`, so they are **no-ops for objects already changed by hand on production** during the manual reclaim below. Single Alembic head (`fd85e7f3abb3`); both compile offline and chain cleanly. (The repo's full `alembic upgrade head --sql` fails on a pre-existing online-only migration `7f9960a4f7c3` that calls `sa.inspect(conn)` — unrelated to this PR.)

## Production reclaim runbook

`DELETE`/`DROP` don't return space to the OS on their own, and `VACUUM FULL`/`pg_repack` can't run at 8.3 GB free (they need ~table-size headroom). So reclamation is done online, drops first (instant) then reindex:

```sql
DROP INDEX CONCURRENTLY IF EXISTS idx_station_times_ccnew;        -- cleanup a cancelled reindex
-- ~7 GB instant:
DROP INDEX CONCURRENTLY IF EXISTS idx_track_occupancy_lookup;     -- ~4.1 GB, 0 scans
DROP INDEX CONCURRENTLY IF EXISTS idx_journey_sequence;          -- ~1.9 GB
DROP INDEX CONCURRENTLY IF EXISTS idx_last_updated;              -- ~1.1 GB
DROP INDEX CONCURRENTLY IF EXISTS idx_journey_date;             -- ~0.08 GB
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_delay_forecaster
  ON train_journeys (train_id, origin_station_code, data_source, journey_date);
-- bloat squeeze (overnight, I/O heavy):
REINDEX INDEX CONCURRENTLY idx_journey_stops_sequence_lookup;     -- 8.3 GB -> ~2-3 GB
REINDEX TABLE CONCURRENTLY journey_stops;
REINDEX TABLE CONCURRENTLY segment_transit_times;
REINDEX TABLE CONCURRENTLY train_journeys;
```

Expected total reclaim ~25–27 GB (≈7 from drops + ~18 from reindex): roughly 49 G → ~23 G. The 60-day retention sweep then halves ongoing growth.

The running container keeps 120-day retention until this is deployed (push to `production`) or `TRACKRAT_RETENTION_DAYS=60` is set and the container restarted.

## Testing

- `tests/unit/test_retention_cleanup.py`, `tests/unit/test_drop_unused_indexes.py`, `tests/unit/services/test_track_predictor_lookback.py` — all green (56 tests).
- New tests assert: the dropped indexes are gone from the models, the superseding/reconciled indexes are present, the lookback constant stays within retention, and each migration emits the expected `CREATE`/`DROP`/`ALTER` statements.
- `black` + `ruff` clean on changed files (pre-existing F541s in the test file left untouched). New index DDL verified against the PostgreSQL dialect to match the existing production definitions.

## Known residual

`idx_journey_stops_sequence_lookup` `INCLUDE`s the volatile `actual_departure`/`actual_arrival` columns, so it re-bloats fastest even with tuned autovacuum. Mitigated here but not eliminated; if it balloons again, the real fix is reconsidering those INCLUDE columns — a perf-sensitive change to a 403 M-scan index that warrants measuring the congestion self-join first. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyUbwx6KpFKFVQXp5vbkPW)_