### PR TITLE
Prune SUBWAY journey data on a shorter (14-day) retention window

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -287,7 +287,7 @@ The APScheduler runs in-process and handles:
 - **Daily at 12:45 AM ET**: Amtrak pattern-based schedule generation
 - **Daily at 1:00 AM ET**: Lock manager cleanup
 - **Daily at 3:00 AM ET**: GTFS static schedule refresh
-- **Daily at 3:30 AM ET**: Data retention cleanup (deletes journeys, discovery runs, validation results, and inactive service alerts older than `TRACKRAT_RETENTION_DAYS`; active alerts are kept regardless of age)
+- **Daily at 3:30 AM ET**: Data retention cleanup (deletes journeys, discovery runs, validation results, and inactive service alerts older than `TRACKRAT_RETENTION_DAYS`; active alerts are kept regardless of age). SUBWAY journeys use the shorter `TRACKRAT_SUBWAY_RETENTION_DAYS` window (it is ~70% of journey storage and real-time/frequency-based).
 - **Every 30 min**: NJT and Amtrak train discovery from major stations
 - **Every 4 min**: PATH collection (unified, RidePATH API)
 - **Every 4 min**: LIRR collection (unified, MTA GTFS-RT)
@@ -491,6 +491,7 @@ TRACKRAT_API_PORT=8000                           # API bind port
 TRACKRAT_SKIP_MIGRATIONS=false                   # Skip auto-migrations on startup
 TRACKRAT_BACKUP_INTERVAL_SECONDS=300             # GCS backup frequency (default 5min)
 TRACKRAT_RETENTION_DAYS=120                      # Days to retain journey data (min 30)
+TRACKRAT_SUBWAY_RETENTION_DAYS=14                # Days to retain SUBWAY journey data (shorter; high-volume/real-time, min 1)
 
 # APNS Auth Key Content (alternative to file path)
 APNS_AUTH_KEY=                                   # Raw P8 key content (fallback if APNS_AUTH_KEY_PATH unavailable)

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -2578,6 +2578,7 @@ class SchedulerService:
         """
         settings = get_settings()
         cutoff_days = settings.retention_days
+        subway_cutoff_days = settings.subway_retention_days
 
         async def do_retention_work() -> None:
             batch_size = 1000
@@ -2590,9 +2591,18 @@ class SchedulerService:
                 logger.info(
                     "starting_retention_cleanup",
                     cutoff_days=cutoff_days,
+                    subway_cutoff_days=subway_cutoff_days,
                 )
 
-                # Phase 1: Delete old train_journeys in batches
+                # Phase 1: Delete old train_journeys in batches.
+                # SUBWAY uses a shorter retention window than other providers: it
+                # is the highest-volume data source (~70% of journey storage) and
+                # is real-time / frequency-based, so old subway journeys have little
+                # analytical value. The per-provider cutoff is applied via a CASE
+                # so the batched subquery shape (and its index usage) is unchanged.
+                # Deletes cascade to journey_stops / segment_transit_times /
+                # station_dwell_times / journey_progress / journey_snapshots via
+                # ON DELETE CASCADE.
                 while True:
                     async with get_session() as db:
                         result = cast(
@@ -2602,11 +2612,18 @@ class SchedulerService:
                                     "DELETE FROM train_journeys "
                                     "WHERE id IN ("
                                     "  SELECT id FROM train_journeys "
-                                    "  WHERE journey_date < CURRENT_DATE - make_interval(days => :days) "
+                                    "  WHERE journey_date < CURRENT_DATE - make_interval(days => "
+                                    "    CASE WHEN data_source = 'SUBWAY' "
+                                    "         THEN :subway_days ELSE :days END"
+                                    "  ) "
                                     "  LIMIT :batch_size"
                                     ")"
                                 ),
-                                {"days": cutoff_days, "batch_size": batch_size},
+                                {
+                                    "days": cutoff_days,
+                                    "subway_days": subway_cutoff_days,
+                                    "batch_size": batch_size,
+                                },
                             ),
                         )
                         deleted = result.rowcount or 0

--- a/backend_v2/src/trackrat/settings.py
+++ b/backend_v2/src/trackrat/settings.py
@@ -156,6 +156,20 @@ class Settings(BaseSettings):
         description="Days to retain train journey data before cleanup (min 30)",
         ge=30,
     )
+    subway_retention_days: int = Field(
+        default=14,
+        description=(
+            "Days to retain SUBWAY journey data before cleanup. Subway is the "
+            "highest-volume data source (~70% of journey storage) and is "
+            "real-time / frequency-based, so old subway journeys have little "
+            "analytical value and are pruned on a shorter window than other "
+            "providers. Keep this >= ~3 days so the congestion/route-alert "
+            "frequency baseline (a per-hour average over the trailing subway "
+            "segment history, up to a 30-day window) still has samples to "
+            "average."
+        ),
+        ge=1,
+    )
 
     # Validation Settings
     internal_api_url: str = Field(

--- a/backend_v2/tests/unit/test_retention_cleanup.py
+++ b/backend_v2/tests/unit/test_retention_cleanup.py
@@ -52,6 +52,37 @@ class TestRetentionSettings:
         )
         assert settings.retention_days == 365
 
+    def test_default_subway_retention_days(self):
+        """Default subway_retention_days should be 14."""
+        settings = Settings(database_url="postgresql+asyncpg://x:x@localhost/x")
+        assert settings.subway_retention_days == 14
+
+    def test_custom_subway_retention_days(self):
+        """subway_retention_days should be configurable via environment."""
+        with patch.dict("os.environ", {"TRACKRAT_SUBWAY_RETENTION_DAYS": "21"}):
+            settings = Settings(database_url="postgresql+asyncpg://x:x@localhost/x")
+            assert settings.subway_retention_days == 21
+
+    def test_subway_retention_days_below_general_minimum_allowed(self):
+        """subway_retention_days may be below the 30-day general floor.
+
+        Subway is pruned more aggressively than other providers, so its floor is
+        only 1 (it does not share retention_days' ge=30 constraint).
+        """
+        settings = Settings(
+            database_url="postgresql+asyncpg://x:x@localhost/x",
+            subway_retention_days=14,
+        )
+        assert settings.subway_retention_days == 14
+
+    def test_subway_retention_days_zero_rejected(self):
+        """subway_retention_days below 1 should be rejected."""
+        with pytest.raises(Exception):
+            Settings(
+                database_url="postgresql+asyncpg://x:x@localhost/x",
+                subway_retention_days=0,
+            )
+
 
 class TestRetentionCleanupSchedulerRegistration:
     """Test that retention_cleanup is registered as a scheduler job."""
@@ -94,9 +125,10 @@ class TestRetentionCleanupBatchLogic:
 
     @pytest.fixture
     def mock_settings(self):
-        """Mock settings with retention_days=120."""
+        """Mock settings with retention_days=120, subway_retention_days=14."""
         settings = Mock()
         settings.retention_days = 120
+        settings.subway_retention_days = 14
         return settings
 
     @pytest.mark.asyncio
@@ -258,6 +290,7 @@ class TestRetentionCleanupBatchLogic:
 
         mock_settings = Mock()
         mock_settings.retention_days = 90
+        mock_settings.subway_retention_days = 14
 
         empty_result = Mock()
         empty_result.rowcount = 0
@@ -316,6 +349,86 @@ class TestRetentionCleanupBatchLogic:
             for params in executed_params:
                 assert params["days"] == 90
                 assert params["batch_size"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_subway_uses_shorter_retention_window(self):
+        """The train_journeys DELETE carries both the default and subway cutoffs.
+
+        Subway is pruned on a shorter window via a CASE in the train_journeys
+        DELETE; the other phases (discovery_runs, validation_results,
+        service_alerts) only ever use the default cutoff.
+        """
+        from trackrat.services.scheduler import SchedulerService
+
+        service = SchedulerService.__new__(SchedulerService)
+
+        mock_settings = Mock()
+        mock_settings.retention_days = 120
+        mock_settings.subway_retention_days = 14
+
+        empty_result = Mock(rowcount=0)
+        captured: list[tuple[str, dict]] = []
+
+        def make_capture_session():
+            session = AsyncMock()
+
+            async def capture_execute(stmt, params=None):
+                captured.append((str(stmt), dict(params) if params else {}))
+                return empty_result
+
+            session.execute = AsyncMock(side_effect=capture_execute)
+            return session
+
+        freshness_session = AsyncMock()
+
+        with (
+            patch(
+                "trackrat.services.scheduler.get_settings", return_value=mock_settings
+            ),
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check"
+            ) as mock_freshness,
+        ):
+
+            async def execute_task_func(
+                db, task_name, minimum_interval_seconds, task_func
+            ):
+                await task_func()
+                return True
+
+            mock_freshness.side_effect = execute_task_func
+
+            ctxs = []
+            ctx_fresh = AsyncMock()
+            ctx_fresh.__aenter__ = AsyncMock(return_value=freshness_session)
+            ctx_fresh.__aexit__ = AsyncMock(return_value=False)
+            ctxs.append(ctx_fresh)
+
+            for _ in range(4):
+                ctx = AsyncMock()
+                ctx.__aenter__ = AsyncMock(return_value=make_capture_session())
+                ctx.__aexit__ = AsyncMock(return_value=False)
+                ctxs.append(ctx)
+
+            mock_get_session.side_effect = ctxs
+
+            await service.retention_cleanup()
+
+        # One DELETE per phase (each returns rowcount 0 -> single batch).
+        assert len(captured) == 4
+
+        journey_stmt, journey_params = captured[0]
+        assert "DELETE FROM train_journeys" in journey_stmt
+        assert journey_params["days"] == 120
+        assert journey_params["subway_days"] == 14
+        assert journey_params["batch_size"] == 1000
+
+        # Remaining phases only carry the default cutoff, never subway_days.
+        for stmt, params in captured[1:]:
+            assert "train_journeys" not in stmt
+            assert params["days"] == 120
+            assert "subway_days" not in params
 
     @pytest.mark.asyncio
     async def test_cleanup_handles_exception_gracefully(self, mock_settings):
@@ -379,6 +492,18 @@ class TestRetentionCleanupSQLStatements:
         source = inspect.getsource(SchedulerService.retention_cleanup)
         assert "DELETE FROM train_journeys" in source
         assert "journey_date < CURRENT_DATE" in source
+
+    def test_cleanup_applies_subway_case_in_journey_delete(self):
+        """The train_journeys DELETE should branch SUBWAY onto its own cutoff."""
+        from trackrat.services.scheduler import SchedulerService
+        import inspect
+
+        source = inspect.getsource(SchedulerService.retention_cleanup)
+        assert "data_source = 'SUBWAY'" in source
+        assert ":subway_days" in source
+        # The CASE belongs only to the train_journeys phase; the other three
+        # DELETEs stay on the single default cutoff (:days).
+        assert source.count(":subway_days") == 1
 
     def test_cleanup_targets_discovery_runs_run_at(self):
         """The discovery_runs DELETE should filter on run_at."""
@@ -491,6 +616,7 @@ class TestServiceAlertsRetention:
     def mock_settings(self):
         settings = Mock()
         settings.retention_days = 120
+        settings.subway_retention_days = 14
         return settings
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a per-provider retention window for **SUBWAY**, pruning subway journey data after **14 days** while every other provider keeps the existing `retention_days` (default 120). This is the highest-leverage lever found in a VM disk/resource analysis: subway is ~71% of journey-table storage but has the least need for long history.

## Why

Production findings:
- The data disk is **86% full** (49 / 59 GB); the database itself is ~48 GB.
- `journey_stops` (33 GB) + `segment_transit_times` (8.9 GB) are ~87% of it.
- Attributing storage by provider: **SUBWAY ≈ 71%** (~33 GB); all 10 other providers combined ≈ 14 GB.
- Postgres pegs ~a full core (99%) churning through poorly-cached scans of those subway-heavy tables.

Tracing every historical reader of subway data: the **only** long-lookback dependency is the congestion / route-alert **frequency baseline** (`services/congestion.py`, `api/routes.py`), which averages trailing subway `segment_transit_times`. Subway gets **no** track/delay predictions (those are gated to rail via `STATION_PREDICTION_CONFIGS`). At 14 days that baseline stays well-sampled because subway runs every few minutes, so old subway journeys carry little value and are the dominant source of disk growth.

## Changes

- **`settings.py`**: new `subway_retention_days` (default 14, `ge=1`; `TRACKRAT_SUBWAY_RETENTION_DAYS`).
- **`services/scheduler.py`**: the retention sweep's `train_journeys` DELETE applies the cutoff via a `CASE WHEN data_source = 'SUBWAY' THEN :subway_days ELSE :days END`. The batched subquery shape and the other three phases (discovery_runs, validation_results, service_alerts) are unchanged. Deletes cascade to `journey_stops` / `segment_transit_times` / `station_dwell_times` / `journey_progress` / `journey_snapshots` via existing `ON DELETE CASCADE`.
- **Tests**: `tests/unit/test_retention_cleanup.py` — new settings tests, a behavioral test asserting the `train_journeys` DELETE carries both `days` and `subway_days` (and the other phases carry only `days`), and a source-level `CASE` assertion.
- **Docs**: `backend_v2/CLAUDE.md` env-var list and scheduler bullet.

No schema migration (logic + setting only).

## Test plan

- `poetry run pytest tests/unit/test_retention_cleanup.py tests/unit/services/test_scheduler.py` → 61 passed.
- `black` clean; `mypy src/trackrat/settings.py src/trackrat/services/scheduler.py` → no issues.

## Operational notes

- **First run is heavy**: the initial sweep deletes ~90 days of subway journeys (and their cascaded stops/segments) in one nightly pass. It's batched (1000/txn) and runs at 3:30 AM ET, but expect an I/O burst the first time.
- **Disk won't physically shrink** from this alone — `DELETE` lets Postgres reuse the space but doesn't return it to the filesystem, and `VACUUM FULL`/`pg_repack` can't run with current free space. This halts growth and improves cache hit ratio; reclaiming the filesystem is tracked in #1343.

## Follow-ups (filed separately)

- #1343 — partition `journey_stops`/`segment_transit_times` by month so retention reclaims disk space (+ one-time reclamation)
- #1344 — add disk-utilization / DB-size alerting (the 86% was found manually)
- #1345 — `journey_snapshots` appears write-only; remove or gate the writes
- #1346 — evaluate `pd-ssd` → `pd-balanced` for the data disk (cost)

## Heads-up on a global retention cut

If `retention_days` is lowered globally elsewhere: **rail providers need longer lookback than subway.** The track predictor uses 90 days (chosen to stay above its per-station record thresholds) and the delay forecaster up to 365 (currently capped at 120 by retention). A flat 60-day cut would degrade rail predictions while barely denting the subway problem — keep rail ≥ 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvgGrqu86d5TXJHA7ywERz)_