### PR TITLE
Issue #1344: add data-disk and database-size alerting

### DIFF
--- a/backend_v2/CLAUDE.md
+++ b/backend_v2/CLAUDE.md
@@ -301,6 +301,7 @@ The APScheduler runs in-process and handles:
 - **Every 90 sec**: Departure cache pre-computation
 - **Every 5 min**: Route history cache pre-computation
 - **Every 15 min**: Congestion cache pre-computation
+- **Every 15 min**: Resource usage check (logs data-disk and database size for Cloud Monitoring alerting)
 - **Every 15 min**: Service alerts collection (MTA + NJT)
 - **Every 1 min**: Live Activity push notification updates
 - **Hourly**: Live Activity token cleanup
@@ -491,6 +492,7 @@ TRACKRAT_API_PORT=8000                           # API bind port
 TRACKRAT_SKIP_MIGRATIONS=false                   # Skip auto-migrations on startup
 TRACKRAT_BACKUP_INTERVAL_SECONDS=300             # GCS backup frequency (default 5min)
 TRACKRAT_RETENTION_DAYS=120                      # Days to retain journey data (min 30)
+TRACKRAT_DATA_DISK_PATH=/mnt/disks/data           # Mount path of the persistent data disk to monitor
 
 # APNS Auth Key Content (alternative to file path)
 APNS_AUTH_KEY=                                   # Raw P8 key content (fallback if APNS_AUTH_KEY_PATH unavailable)
@@ -774,6 +776,7 @@ The backend is organized into service classes for better maintainability:
 ## Recent Improvements & Known Issues
 
 ### Recent Improvements (June 2026)
+- ✅ Added periodic data-disk / database-size logging (`SchedulerService.check_resource_usage`) feeding new Terraform alert policies, so disk exhaustion is caught automatically instead of found by manually SSHing in (issue #1344, `services/scheduler.py`, `infra_v2/terraform/metrics.tf`, `infra_v2/terraform/monitoring.tf`). Also fixed `/health`, `/admin/stats`, and `/metrics` to check the mounted persistent disk (`TRACKRAT_DATA_DISK_PATH`) instead of the container's boot filesystem.
 - ✅ Live Activity materializes a SCHEDULED `train_journeys` row from GTFS at registration when none exists, so the push job has a row to update immediately instead of logging `journey_not_found_for_live_activity` every cycle (issue #1298, `api/live_activities.py`, `services/gtfs.py::GTFSService.materialize_scheduled_journey`)
 - ✅ Live Activity materialization gated to `MATERIALIZE_SCHEDULED_SOURCES = {NJT, AMTRAK}` — GTFS-RT systems mint their own train_ids on discovery and would orphan the materialized row (issue #1298 follow-up, `services/gtfs.py`)
 - ✅ Retention sweep extended to inactive `service_alerts` so long-resolved alerts no longer accumulate (issue #1269, `services/scheduler.py`)

--- a/backend_v2/docker-compose.yml
+++ b/backend_v2/docker-compose.yml
@@ -68,8 +68,12 @@ services:
       APNS_BUNDLE_ID: ${APNS_BUNDLE_ID}
       APNS_ENVIRONMENT: ${APNS_ENVIRONMENT:-prod}
       APNS_AUTH_KEY_PATH: ${APNS_AUTH_KEY_PATH:-}
+      # Resource monitoring - mount path must match the volume below (issue #1344)
+      TRACKRAT_DATA_DISK_PATH: ${DATA_DIR:-/mnt/disks/data}
     volumes:
       - ${DATA_DIR:-./}/compose/apns_auth_key.p8:/app/certs/apns_auth_key.p8:ro
+      # Read-only so the API can report data-disk usage without write access (issue #1344)
+      - ${DATA_DIR:-/mnt/disks/data}:${DATA_DIR:-/mnt/disks/data}:ro
     ports:
       - "8000:8000"
     restart: unless-stopped

--- a/backend_v2/src/trackrat/api/admin.py
+++ b/backend_v2/src/trackrat/api/admin.py
@@ -877,7 +877,7 @@ async def stats_page(
     request_data = get_request_stats().snapshot(hours=hours, ios_only=ios_only)
     db_data = await _db_stats(db)
     scheduler_jobs = _scheduler_stats()
-    system_data = get_system_stats()
+    system_data = get_system_stats(settings.data_disk_path)
     html = _render_html(
         request_data,
         db_data,
@@ -893,6 +893,7 @@ async def stats_page(
 @router.get("/admin/stats.json")
 async def stats_json(
     db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
     hours: int | None = Query(None, ge=1, le=168),
     ios_only: bool = Query(False),
 ) -> dict[str, Any]:
@@ -922,7 +923,7 @@ async def stats_json(
 
     # Include scheduler jobs and system metrics (JSON parity with HTML)
     request_data["scheduler_jobs"] = scheduler_jobs
-    request_data["system"] = get_system_stats()
+    request_data["system"] = get_system_stats(settings.data_disk_path)
 
     train_detail_views = {
         f"{entry['train_id']} ({get_station_name(entry['from'])} -> {get_station_name(entry['to'])})": entry[

--- a/backend_v2/src/trackrat/api/health.py
+++ b/backend_v2/src/trackrat/api/health.py
@@ -124,8 +124,8 @@ async def health_check(
     except Exception as e:
         health_status["checks"]["discovery"] = {"status": "unhealthy", "error": str(e)}
 
-    # Disk space check
-    disk = get_disk_usage("/")
+    # Disk space check (persistent data disk, not the container's boot filesystem)
+    disk = get_disk_usage(settings.data_disk_path)
     if disk:
         pct = disk["usage_percent"]
         if pct >= 95:

--- a/backend_v2/src/trackrat/services/scheduler.py
+++ b/backend_v2/src/trackrat/services/scheduler.py
@@ -47,6 +47,7 @@ from trackrat.utils.scheduler_utils import (
     commit_with_retry,
     run_with_freshness_check,
 )
+from trackrat.utils.system_stats import get_disk_usage
 from trackrat.utils.time import (
     ensure_timezone_aware,
     now_et,
@@ -294,6 +295,16 @@ class SchedulerService:
             trigger=IntervalTrigger(minutes=15, jitter=60),
             id="congestion_cache_precompute",
             name="Congestion Cache Pre-computation",
+            replace_existing=True,
+            max_instances=1,
+        )
+
+        # Schedule data disk / database size check (every 15 minutes)
+        self.scheduler.add_job(
+            self.check_resource_usage,
+            trigger=IntervalTrigger(minutes=15, jitter=60),
+            id="resource_usage_check",
+            name="Resource Usage Check",
             replace_existing=True,
             max_instances=1,
         )
@@ -2717,6 +2728,56 @@ class SchedulerService:
 
             if not executed:
                 logger.debug("retention_cleanup_skipped_still_fresh")
+
+    async def check_resource_usage(self) -> None:
+        """Log data-disk utilization and Postgres database size.
+
+        Emits structured log events that Terraform log-based metrics
+        (`infra_v2/terraform/metrics.tf`) turn into Cloud Monitoring alerts,
+        so disk exhaustion is caught automatically instead of found by
+        manually SSHing in and running `df -h` (issue #1344). Checks
+        `settings.data_disk_path` (the mounted persistent disk), not the
+        container's boot filesystem.
+        """
+        settings = get_settings()
+
+        async def do_check_work() -> None:
+            disk = get_disk_usage(settings.data_disk_path)
+            if disk:
+                logger.info(
+                    "data_disk_usage_check",
+                    usage_percent=disk["usage_percent"],
+                    used_gb=disk["used_gb"],
+                    total_gb=disk["total_gb"],
+                )
+            else:
+                logger.warning(
+                    "data_disk_usage_check_unavailable",
+                    path=settings.data_disk_path,
+                )
+
+            async with get_session() as db:
+                result = await db.execute(
+                    text("SELECT pg_database_size(current_database())")
+                )
+                size_bytes = result.scalar() or 0
+                logger.info(
+                    "database_size_check",
+                    size_gb=round(size_bytes / (1024**3), 2),
+                )
+
+        async with get_session() as db:
+            safe_interval = calculate_safe_interval(15)
+
+            executed = await run_with_freshness_check(
+                db=db,
+                task_name="resource_usage_check",
+                minimum_interval_seconds=safe_interval,
+                task_func=do_check_work,
+            )
+
+            if not executed:
+                logger.debug("resource_usage_check_skipped_still_fresh")
 
     # All GTFS feed sources — add new systems here
     GTFS_SOURCES = (

--- a/backend_v2/src/trackrat/settings.py
+++ b/backend_v2/src/trackrat/settings.py
@@ -157,6 +157,12 @@ class Settings(BaseSettings):
         ge=30,
     )
 
+    # Resource Monitoring
+    data_disk_path: str = Field(
+        default="/mnt/disks/data",
+        description="Mount path of the persistent data disk to monitor for usage alerts",
+    )
+
     # Validation Settings
     internal_api_url: str = Field(
         default="http://localhost:8000",

--- a/backend_v2/src/trackrat/utils/metrics.py
+++ b/backend_v2/src/trackrat/utils/metrics.py
@@ -86,13 +86,14 @@ system_cpu_load_1m = Gauge(
 
 def update_system_metrics() -> None:
     """Update system resource Prometheus gauges from /proc and shutil."""
+    from trackrat.settings import get_settings
     from trackrat.utils.system_stats import (
         get_cpu_load,
         get_disk_usage,
         get_memory_usage,
     )
 
-    disk = get_disk_usage("/")
+    disk = get_disk_usage(get_settings().data_disk_path)
     if disk:
         system_disk_usage_percent.set(disk["usage_percent"])
         system_disk_free_bytes.set(disk["free_gb"] * 1024**3)

--- a/backend_v2/src/trackrat/utils/system_stats.py
+++ b/backend_v2/src/trackrat/utils/system_stats.py
@@ -82,15 +82,20 @@ def get_cpu_load() -> dict[str, Any]:
         return {}
 
 
-def get_system_stats() -> dict[str, Any]:
+def get_system_stats(disk_path: str = "/") -> dict[str, Any]:
     """Collect all system-level metrics.
+
+    Args:
+        disk_path: Mount point to check disk usage for. Defaults to "/"
+            (the boot filesystem); pass the persistent data disk's mount
+            path to check the volume that actually holds application data.
 
     Returns a dict with disk, memory, and cpu sections.
     Only includes sections that could be read successfully.
     """
     stats: dict[str, Any] = {}
 
-    disk = get_disk_usage("/")
+    disk = get_disk_usage(disk_path)
     if disk:
         stats["disk"] = disk
 

--- a/backend_v2/tests/unit/services/test_scheduler.py
+++ b/backend_v2/tests/unit/services/test_scheduler.py
@@ -103,6 +103,7 @@ class TestSchedulerService:
                 ("live_activity_updates", IntervalTrigger, {"minutes": 1}),
                 ("live_activity_token_cleanup", IntervalTrigger, {"hours": 1}),
                 ("congestion_cache_precompute", IntervalTrigger, {"minutes": 15}),
+                ("resource_usage_check", IntervalTrigger, {"minutes": 15}),
                 ("departure_cache_precompute", IntervalTrigger, {"seconds": 90}),
                 ("route_history_cache_precompute", IntervalTrigger, {"minutes": 5}),
                 ("train_validation", IntervalTrigger, {"hours": 1}),
@@ -1521,3 +1522,140 @@ class TestCollectJourneyLogging:
                     train_id="9999",
                     error="No result returned from collection",
                 )
+
+
+class TestCheckResourceUsage:
+    """Tests for SchedulerService.check_resource_usage (issue #1344).
+
+    Verifies the disk-usage and database-size structured log events that
+    infra_v2/terraform/metrics.tf + monitoring.tf turn into Cloud Monitoring
+    alerts, since the production data disk previously filled to 86% with
+    no automated warning.
+    """
+
+    @pytest.fixture
+    def test_settings(self):
+        return Settings(
+            njt_api_token="test_token",
+            discovery_interval_minutes=30,
+            journey_update_interval_minutes=15,
+            data_staleness_seconds=60,
+            environment="testing",
+            data_disk_path="/mnt/disks/data",
+        )
+
+    @pytest.fixture
+    def mock_apns_service(self):
+        service = AsyncMock()
+        service.send_update = AsyncMock()
+        return service
+
+    @pytest.fixture
+    def scheduler_service(self, test_settings, mock_apns_service):
+        with patch("trackrat.services.scheduler.NJTransitClient"):
+            return SchedulerService(
+                settings=test_settings, apns_service=mock_apns_service
+            )
+
+    @staticmethod
+    def _session_context(session):
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    @staticmethod
+    async def _run_task_func(db, task_name, minimum_interval_seconds, task_func):
+        await task_func()
+        return True
+
+    @pytest.mark.asyncio
+    async def test_logs_disk_usage_and_database_size(self, scheduler_service):
+        """A healthy check logs both the disk usage and DB size events."""
+        freshness_session = AsyncMock()
+        work_session = AsyncMock()
+        db_result = Mock()
+        db_result.scalar.return_value = 5368709120  # 5 GiB
+        work_session.execute = AsyncMock(return_value=db_result)
+
+        with (
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch("trackrat.services.scheduler.get_disk_usage") as mock_get_disk_usage,
+            patch("trackrat.services.scheduler.logger") as mock_logger,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check",
+                side_effect=self._run_task_func,
+            ) as mock_freshness,
+        ):
+            mock_get_session.side_effect = [
+                self._session_context(freshness_session),
+                self._session_context(work_session),
+            ]
+            mock_get_disk_usage.return_value = {
+                "usage_percent": 86.2,
+                "used_gb": 49.0,
+                "total_gb": 59.0,
+                "free_gb": 10.0,
+            }
+
+            await scheduler_service.check_resource_usage()
+
+            mock_get_disk_usage.assert_called_once_with("/mnt/disks/data")
+            mock_logger.info.assert_any_call(
+                "data_disk_usage_check",
+                usage_percent=86.2,
+                used_gb=49.0,
+                total_gb=59.0,
+            )
+            mock_logger.info.assert_any_call("database_size_check", size_gb=5.0)
+
+            call_kwargs = mock_freshness.call_args.kwargs
+            assert call_kwargs["task_name"] == "resource_usage_check"
+            assert call_kwargs["minimum_interval_seconds"] == 780  # (15-2)*60
+
+    @pytest.mark.asyncio
+    async def test_warns_when_disk_path_unavailable(self, scheduler_service):
+        """If the data disk mount isn't visible, warn instead of failing silently."""
+        freshness_session = AsyncMock()
+        work_session = AsyncMock()
+        db_result = Mock()
+        db_result.scalar.return_value = 0
+        work_session.execute = AsyncMock(return_value=db_result)
+
+        with (
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch("trackrat.services.scheduler.get_disk_usage", return_value={}),
+            patch("trackrat.services.scheduler.logger") as mock_logger,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check",
+                side_effect=self._run_task_func,
+            ),
+        ):
+            mock_get_session.side_effect = [
+                self._session_context(freshness_session),
+                self._session_context(work_session),
+            ]
+
+            await scheduler_service.check_resource_usage()
+
+            mock_logger.warning.assert_any_call(
+                "data_disk_usage_check_unavailable", path="/mnt/disks/data"
+            )
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_fresh(self, scheduler_service):
+        """No disk/db work should happen when the freshness check says skip."""
+        with (
+            patch("trackrat.services.scheduler.get_session") as mock_get_session,
+            patch("trackrat.services.scheduler.get_disk_usage") as mock_get_disk_usage,
+            patch(
+                "trackrat.services.scheduler.run_with_freshness_check",
+                return_value=False,
+            ),
+        ):
+            mock_db = AsyncMock()
+            mock_get_session.return_value.__aenter__.return_value = mock_db
+
+            await scheduler_service.check_resource_usage()
+
+            mock_get_disk_usage.assert_not_called()

--- a/backend_v2/tests/unit/test_system_stats.py
+++ b/backend_v2/tests/unit/test_system_stats.py
@@ -192,3 +192,17 @@ class TestGetSystemStats:
         assert "disk" in result
         assert "memory" not in result
         assert "cpu" not in result
+
+    def test_uses_custom_disk_path(self) -> None:
+        """Should pass disk_path through to get_disk_usage instead of hardcoding '/'."""
+        with patch("trackrat.utils.system_stats.get_disk_usage") as mock_get_disk_usage:
+            mock_get_disk_usage.return_value = {
+                "total_gb": 59.0,
+                "used_gb": 50.7,
+                "free_gb": 8.3,
+                "usage_percent": 86.0,
+            }
+            result = get_system_stats(disk_path="/mnt/disks/data")
+
+        mock_get_disk_usage.assert_called_once_with("/mnt/disks/data")
+        assert result["disk"]["usage_percent"] == 86.0

--- a/infra_v2/terraform/metrics.tf
+++ b/infra_v2/terraform/metrics.tf
@@ -173,3 +173,59 @@ resource "google_logging_metric" "provider_auth_failures" {
 
   depends_on = [google_project_service.apis["logging.googleapis.com"]]
 }
+
+# =============================================================================
+# DATA DISK USAGE METRIC
+# Tracks: persistent data disk utilization, logged periodically by
+# SchedulerService.check_resource_usage (services/scheduler.py).
+# Drives the "Data Disk Usage" alerts in monitoring.tf.
+# =============================================================================
+resource "google_logging_metric" "data_disk_usage_percent" {
+  count = local.metrics_enabled ? 1 : 0
+
+  name        = "data_disk_usage_percent"
+  description = "Persistent data disk utilization percentage"
+  filter = join(" AND ", [
+    "logName=\"projects/${var.project_id}/logs/cos_containers\"",
+    "jsonPayload._HOSTNAME=~\"^trackrat-${var.environment}-\"",
+    "jsonPayload.event=\"data_disk_usage_check\"",
+  ])
+
+  metric_descriptor {
+    metric_kind = "GAUGE"
+    value_type  = "DOUBLE"
+    unit        = "%"
+  }
+
+  value_extractor = "EXTRACT(jsonPayload.usage_percent)"
+
+  depends_on = [google_project_service.apis["logging.googleapis.com"]]
+}
+
+# =============================================================================
+# DATABASE SIZE METRIC
+# Tracks: Postgres database size in GB, for trend visibility (no alert —
+# see the "Data Disk Usage" alerts in monitoring.tf for the actual paging
+# signal, since the disk is what actually runs out of space).
+# =============================================================================
+resource "google_logging_metric" "database_size_gb" {
+  count = local.metrics_enabled ? 1 : 0
+
+  name        = "database_size_gb"
+  description = "Postgres database size in GB"
+  filter = join(" AND ", [
+    "logName=\"projects/${var.project_id}/logs/cos_containers\"",
+    "jsonPayload._HOSTNAME=~\"^trackrat-${var.environment}-\"",
+    "jsonPayload.event=\"database_size_check\"",
+  ])
+
+  metric_descriptor {
+    metric_kind = "GAUGE"
+    value_type  = "DOUBLE"
+    unit        = "GBy"
+  }
+
+  value_extractor = "EXTRACT(jsonPayload.size_gb)"
+
+  depends_on = [google_project_service.apis["logging.googleapis.com"]]
+}

--- a/infra_v2/terraform/monitoring.tf
+++ b/infra_v2/terraform/monitoring.tf
@@ -127,3 +127,87 @@ resource "google_monitoring_alert_policy" "provider_auth_failure" {
     time_sleep.wait_provider_auth_metric,
   ]
 }
+
+# Alert policies - data disk utilization on the persistent disk.
+# Backed by google_logging_metric.data_disk_usage_percent (see metrics.tf),
+# populated by SchedulerService.check_resource_usage every 15 minutes.
+# Two tiers (warn at 75%, page at 85%) so slow growth is caught well before
+# the disk fills silently, as happened in issue #1344.
+resource "time_sleep" "wait_disk_usage_metric" {
+  count = var.environment == "production" ? 1 : 0
+
+  depends_on      = [google_logging_metric.data_disk_usage_percent]
+  create_duration = "60s"
+
+  triggers = {
+    metric_name = google_logging_metric.data_disk_usage_percent[0].name
+  }
+}
+
+resource "google_monitoring_alert_policy" "data_disk_usage_warning" {
+  count = var.environment == "production" ? 1 : 0
+
+  display_name = "Data Disk Usage Warning (75%)"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Data disk usage above 75%"
+
+    condition_threshold {
+      filter          = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.data_disk_usage_percent[0].name}\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 75
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = "1800s"
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].name]
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  depends_on = [
+    google_project_service.apis["monitoring.googleapis.com"],
+    time_sleep.wait_disk_usage_metric,
+  ]
+}
+
+resource "google_monitoring_alert_policy" "data_disk_usage_critical" {
+  count = var.environment == "production" ? 1 : 0
+
+  display_name = "Data Disk Usage Critical (85%)"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Data disk usage above 85%"
+
+    condition_threshold {
+      filter          = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.data_disk_usage_percent[0].name}\""
+      comparison      = "COMPARISON_GT"
+      threshold_value = 85
+      duration        = "0s"
+
+      aggregations {
+        alignment_period   = "1800s"
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].name]
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+
+  depends_on = [
+    google_project_service.apis["monitoring.googleapis.com"],
+    time_sleep.wait_disk_usage_metric,
+  ]
+}


### PR DESCRIPTION
## Summary

The production data disk reached **86% (49/59 GB)** with no automated warning — it was only found by manually SSHing in and running `df -h`. `infra_v2/terraform/monitoring.tf` had only an uptime check and a provider-auth-failure alert; nothing watched disk or database size.

Closes #1344.

There is no ops/monitoring agent installed on the COS instances (confirmed — no `ops-agent`, `stackdriver`, `node_exporter`, etc. anywhere in `infra_v2/`), so GCE's built-in disk metrics don't include filesystem-level "percent used". Rather than standing up a new agent, this follows the codebase's existing pattern (`provider_auth_failures` in `metrics.tf`): the app logs a structured event, a `google_logging_metric` turns it into a Cloud Monitoring metric, and an alert policy watches it.

While tracing the existing disk checks (`/health`, `/admin/stats`, `/metrics`), I found they all called `get_disk_usage("/")` — the container's boot filesystem, not the mounted persistent disk at `/mnt/disks/data` where Postgres actually lives. The `api` container also never mounted the data disk at all. That's the same root cause as the alerting gap (nothing was actually watching the disk that fills up), so it's fixed as part of this change rather than left silently wrong.

## Changes

### Backend (`backend_v2/`)
- **`settings.py`** — new `data_disk_path` setting (default `/mnt/disks/data`, env `TRACKRAT_DATA_DISK_PATH`).
- **`services/scheduler.py`** — new `check_resource_usage` task, scheduled every 15 minutes (same freshness-check/coordination pattern as other periodic tasks). Logs `data_disk_usage_check` (usage_percent/used_gb/total_gb) via `get_disk_usage(settings.data_disk_path)`, and `database_size_check` (size_gb) via `SELECT pg_database_size(current_database())`. Logs `data_disk_usage_check_unavailable` if the mount isn't visible instead of failing silently.
- **`api/health.py`**, **`api/admin.py`**, **`utils/metrics.py`** — disk checks now use `settings.data_disk_path` instead of hardcoded `"/"`, so `/health`, `/admin/stats`(`.json`), and the `/metrics` Prometheus gauges reflect the actual data disk.
- **`utils/system_stats.py`** — `get_system_stats()` takes an optional `disk_path` parameter (default `"/"`, backward compatible).
- **`docker-compose.yml`** — mounts the persistent disk read-only into the `api` container (previously only the `db` container could see it) and passes `TRACKRAT_DATA_DISK_PATH`.

### Infra (`infra_v2/terraform/`)
- **`metrics.tf`** — two new log-based metrics: `data_disk_usage_percent` (GAUGE, drives alerting) and `database_size_gb` (GAUGE, trend visibility only — the disk, not the DB size number, is what actually runs out of space).
- **`monitoring.tf`** — two alert policies on `data_disk_usage_percent`: **Warning at 75%** and **Critical at 85%**, following the existing `provider_auth_failure` pattern (same `time_sleep` propagation-delay workaround, same notification channel).

## Test coverage

- `tests/unit/services/test_scheduler.py` — new `TestCheckResourceUsage` class: logs both events on a healthy check, warns (doesn't crash) when the disk path is unavailable, and does no work when the freshness check says skip. Also updated `test_scheduler_start_creates_all_jobs` to include the new job.
- `tests/unit/test_system_stats.py` — new test asserting `get_system_stats` forwards `disk_path` to `get_disk_usage` instead of hardcoding `/`.
- Ran `black`, `ruff`, and `mypy` on all changed files — clean. Full `pytest tests/unit/services/test_scheduler.py tests/unit/test_system_stats.py tests/unit/api/test_admin.py tests/test_api_health.py` — 86 passed.
- DB-backed integration tests (`tests/unit/services/test_gtfs_materialize.py`, etc.) require a live Postgres instance not available in this sandbox — pre-existing environment limitation, unrelated to this change.

## Design notes

- **Two-tier alerts, not one.** The issue explicitly asked for warn-at-75/page-at-85; implemented as two separate `google_monitoring_alert_policy` resources (rather than one policy with a `severity` field) to avoid depending on provider-version-specific schema support.
- **`database_size_gb` has no alert.** The issue calls it out as "optional... for trend visibility" — the disk is the thing that actually runs out of space, so alerting lives on `data_disk_usage_percent` only.
- **15-minute cadence**, matching the existing congestion-cache precompute job — frequent enough to catch a slow fill well before it's critical, without adding meaningful load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019dL2CNB5g3TSc3LT5AAKS9)_